### PR TITLE
Pumi cast fix + Improve MatrixConstantCoefficient/VectorConstantCoefficient

### DIFF
--- a/README
+++ b/README
@@ -102,6 +102,13 @@ to find more detail of the MFEM libirary.
        Therefore, if one overwrite Eval method, SWIG reroute the
        call to the Python side.
 
+       V/M ConstantCoefficeint supports natrual python object as input
+          MatrixConstantCoefficient([[1,2], [2,3]])
+          VecotrConstantCoefficient([1,2,3])
+
+          Note: thie argument is first tested if it can be converted using
+	        np.array(x,  dtype=float)
+
   4-3) mfem::GridFunction
        GetNodalValues(i) will perform GetNodalValue(Vector(), i) and
        return numpy array of Vector()

--- a/mfem/__init__.py
+++ b/mfem/__init__.py
@@ -20,5 +20,5 @@ def debug_print(message):
     
     print(message)
 
-__version__ = '4.0.1'
+__version__ = '4.0.2'
 

--- a/mfem/_par/coefficient.i
+++ b/mfem/_par/coefficient.i
@@ -57,7 +57,36 @@ import_array();
 %feature("notabstract") MatrixFunctionCoefficient;
 %feature("notabstract") MatrixConstantCoefficient;
 
-namespace mfem { 
+namespace mfem {
+%pythonprepend MatrixConstantCoefficient::MatrixConstantCoefficient(const DenseMatrix &m) %{
+   try:
+      import numpy as np
+      value = np.array(m, copy=False, dtype=float)
+      can_np_array = True
+   except:
+      can_np_array = False
+
+   if can_np_array:
+      v = mfem._par.vector.Vector(np.transpose(value).flatten())
+      m = mfem._par.densemat.DenseMatrix(v.GetData(), value.shape[0], value.shape[1])       
+      self._value = (v,m)
+   else:
+      pass 
+%}
+%pythonprepend VectorConstantCoefficient::VectorConstantCoefficient(const Vector &v) %{
+   try:
+      import numpy as np
+      value = np.array(v, copy=False, dtype=float).flatten()
+      can_np_array = True
+   except:
+      can_np_array = False
+
+   if can_np_array:
+      v = mfem._par.vector.Vector(value)
+      self._value = v
+   else:
+      pass 
+%}
 %pythonprepend DeltaCoefficient::SetWeight %{
     w.thisown=0 
 %}

--- a/mfem/_par/coefficient.py
+++ b/mfem/_par/coefficient.py
@@ -386,6 +386,21 @@ class VectorConstantCoefficient(VectorCoefficient):
 
     def __init__(self, v):
         r"""__init__(VectorConstantCoefficient self, Vector v) -> VectorConstantCoefficient"""
+
+        try:
+           import numpy as np
+           value = np.array(v, copy=False, dtype=float).flatten()
+           can_np_array = True
+        except:
+           can_np_array = False
+
+        if can_np_array:
+           v = mfem._par.vector.Vector(value)
+           self._value = v
+        else:
+           pass 
+
+
         _coefficient.VectorConstantCoefficient_swiginit(self, _coefficient.new_VectorConstantCoefficient(v))
 
     def Eval(self, *args):
@@ -708,6 +723,22 @@ class MatrixConstantCoefficient(MatrixCoefficient):
 
     def __init__(self, m):
         r"""__init__(MatrixConstantCoefficient self, DenseMatrix m) -> MatrixConstantCoefficient"""
+
+        try:
+           import numpy as np
+           value = np.array(m, copy=False, dtype=float)
+           can_np_array = True
+        except:
+           can_np_array = False
+
+        if can_np_array:
+           v = mfem._par.vector.Vector(np.transpose(value).flatten())
+           m = mfem._par.densemat.DenseMatrix(v.GetData(), value.shape[0], value.shape[1])       
+           self._value = (v,m)
+        else:
+           pass 
+
+
         _coefficient.MatrixConstantCoefficient_swiginit(self, _coefficient.new_MatrixConstantCoefficient(m))
 
     def Eval(self, *args):

--- a/mfem/_par/pumi.i
+++ b/mfem/_par/pumi.i
@@ -23,6 +23,14 @@
 
 %include "../common/mfem_config.i"
 
+#ifndef MFEM_USE_MPI
+   #define MFEM_USE_MPI  YES
+#endif
+
+#ifndef MFEM_USE_PUMI
+   #define MFEM_USE_PUMI YES
+#endif
+
 #ifdef MFEM_USE_MPI
 %include mpi4py/mpi4py.i
 %mpi4py_typemap(Comm, MPI_Comm);

--- a/mfem/_par/pumi.py
+++ b/mfem/_par/pumi.py
@@ -191,7 +191,78 @@ import mfem._par.communication
 import mfem._par.sets
 
 def ParMesh2ParPumiMesh(pmesh):
-    r"""ParMesh2ParPumiMesh(ParMesh pmesh) -> mfem::ParPumiMesh *"""
+    r"""ParMesh2ParPumiMesh(ParMesh pmesh) -> ParPumiMesh"""
     return _pumi.ParMesh2ParPumiMesh(pmesh)
+class PumiMesh(mfem._par.mesh.Mesh):
+    r"""Proxy of C++ mfem::PumiMesh class."""
+
+    thisown = property(lambda x: x.this.own(), lambda x, v: x.this.own(v), doc="The membership flag")
+    __repr__ = _swig_repr
+
+    def __init__(self, apf_mesh, generate_edges=0, refine=1, fix_orientation=True):
+        r"""__init__(PumiMesh self, apf::Mesh2 * apf_mesh, int generate_edges=0, int refine=1, bool fix_orientation=True) -> PumiMesh"""
+        _pumi.PumiMesh_swiginit(self, _pumi.new_PumiMesh(apf_mesh, generate_edges, refine, fix_orientation))
+
+    def Load(self, *args):
+        r"""
+        Load(PumiMesh self, std::istream & input, int generate_edges=0, int refine=1, bool fix_orientation=True)
+        Load(PumiMesh self, std::istream & input, int generate_edges=0, int refine=1)
+        Load(PumiMesh self, std::istream & input, int generate_edges=0)
+        Load(PumiMesh self, std::istream & input)
+        Load(PumiMesh self, apf::Mesh2 * apf_mesh, int generate_edges=0, int refine=1, bool fix_orientation=True)
+        """
+        return _pumi.PumiMesh_Load(self, *args)
+    __swig_destroy__ = _pumi.delete_PumiMesh
+
+# Register PumiMesh in _pumi:
+_pumi.PumiMesh_swigregister(PumiMesh)
+
+class ParPumiMesh(mfem._par.pmesh.ParMesh):
+    r"""Proxy of C++ mfem::ParPumiMesh class."""
+
+    thisown = property(lambda x: x.this.own(), lambda x, v: x.this.own(v), doc="The membership flag")
+    __repr__ = _swig_repr
+
+    def __init__(self, comm, apf_mesh):
+        r"""__init__(ParPumiMesh self, MPI_Comm comm, apf::Mesh2 * apf_mesh) -> ParPumiMesh"""
+        _pumi.ParPumiMesh_swiginit(self, _pumi.new_ParPumiMesh(comm, apf_mesh))
+
+    def FieldMFEMtoPUMI(self, *args):
+        r"""
+        FieldMFEMtoPUMI(ParPumiMesh self, apf::Mesh2 * apf_mesh, ParGridFunction Vel, ParGridFunction Pr, apf::Field * VelField, apf::Field * PrField, apf::Field * VelMagField)
+        FieldMFEMtoPUMI(ParPumiMesh self, apf::Mesh2 * apf_mesh, ParGridFunction Pr, apf::Field * PrField, apf::Field * PrMagField)
+        """
+        return _pumi.ParPumiMesh_FieldMFEMtoPUMI(self, *args)
+
+    def VectorFieldMFEMtoPUMI(self, apf_mesh, Vel, VelField, VelMagField):
+        r"""VectorFieldMFEMtoPUMI(ParPumiMesh self, apf::Mesh2 * apf_mesh, ParGridFunction Vel, apf::Field * VelField, apf::Field * VelMagField)"""
+        return _pumi.ParPumiMesh_VectorFieldMFEMtoPUMI(self, apf_mesh, Vel, VelField, VelMagField)
+
+    def UpdateMesh(self, AdaptedpMesh):
+        r"""UpdateMesh(ParPumiMesh self, ParMesh AdaptedpMesh)"""
+        return _pumi.ParPumiMesh_UpdateMesh(self, AdaptedpMesh)
+
+    def FieldPUMItoMFEM(self, apf_mesh, ScalarField, Pr):
+        r"""FieldPUMItoMFEM(ParPumiMesh self, apf::Mesh2 * apf_mesh, apf::Field * ScalarField, ParGridFunction Pr)"""
+        return _pumi.ParPumiMesh_FieldPUMItoMFEM(self, apf_mesh, ScalarField, Pr)
+    __swig_destroy__ = _pumi.delete_ParPumiMesh
+
+# Register ParPumiMesh in _pumi:
+_pumi.ParPumiMesh_swigregister(ParPumiMesh)
+
+class GridFunctionPumi(mfem._par.gridfunc.GridFunction):
+    r"""Proxy of C++ mfem::GridFunctionPumi class."""
+
+    thisown = property(lambda x: x.this.own(), lambda x, v: x.this.own(v), doc="The membership flag")
+    __repr__ = _swig_repr
+
+    def __init__(self, m, PumiM, v_num_loc, mesh_order):
+        r"""__init__(GridFunctionPumi self, Mesh m, apf::Mesh2 * PumiM, apf::Numbering * v_num_loc, int const mesh_order) -> GridFunctionPumi"""
+        _pumi.GridFunctionPumi_swiginit(self, _pumi.new_GridFunctionPumi(m, PumiM, v_num_loc, mesh_order))
+    __swig_destroy__ = _pumi.delete_GridFunctionPumi
+
+# Register GridFunctionPumi in _pumi:
+_pumi.GridFunctionPumi_swigregister(GridFunctionPumi)
+
 
 

--- a/mfem/_par/pumi_wrap.cxx
+++ b/mfem/_par/pumi_wrap.cxx
@@ -3069,26 +3069,37 @@ namespace Swig {
 #define SWIGTYPE_p_GroupId swig_types[1]
 #define SWIGTYPE_p_MPI_Comm swig_types[2]
 #define SWIGTYPE_p_PyMFEM__wFILE swig_types[3]
-#define SWIGTYPE_p_char swig_types[4]
-#define SWIGTYPE_p_double swig_types[5]
-#define SWIGTYPE_p_doublep swig_types[6]
-#define SWIGTYPE_p_hex_t swig_types[7]
-#define SWIGTYPE_p_int swig_types[8]
-#define SWIGTYPE_p_intp swig_types[9]
-#define SWIGTYPE_p_mfem__GridFunction swig_types[10]
-#define SWIGTYPE_p_mfem__IntegrationRule swig_types[11]
-#define SWIGTYPE_p_mfem__L2_FECollection swig_types[12]
-#define SWIGTYPE_p_mfem__OperatorHandle swig_types[13]
-#define SWIGTYPE_p_mfem__ParGridFunction swig_types[14]
-#define SWIGTYPE_p_mfem__ParMesh swig_types[15]
-#define SWIGTYPE_p_mfem__ParPumiMesh swig_types[16]
-#define SWIGTYPE_p_pri_t swig_types[17]
-#define SWIGTYPE_p_quad_t swig_types[18]
-#define SWIGTYPE_p_seg_t swig_types[19]
-#define SWIGTYPE_p_tet_t swig_types[20]
-#define SWIGTYPE_p_tri_t swig_types[21]
-static swig_type_info *swig_types[23];
-static swig_module_info swig_module = {swig_types, 22, 0, 0, 0, 0};
+#define SWIGTYPE_p_apf__Field swig_types[4]
+#define SWIGTYPE_p_apf__Mesh2 swig_types[5]
+#define SWIGTYPE_p_apf__Numbering swig_types[6]
+#define SWIGTYPE_p_char swig_types[7]
+#define SWIGTYPE_p_double swig_types[8]
+#define SWIGTYPE_p_doublep swig_types[9]
+#define SWIGTYPE_p_hex_t swig_types[10]
+#define SWIGTYPE_p_int swig_types[11]
+#define SWIGTYPE_p_intp swig_types[12]
+#define SWIGTYPE_p_mfem__GridFunction swig_types[13]
+#define SWIGTYPE_p_mfem__GridFunctionPumi swig_types[14]
+#define SWIGTYPE_p_mfem__HypreParVector swig_types[15]
+#define SWIGTYPE_p_mfem__IntegrationRule swig_types[16]
+#define SWIGTYPE_p_mfem__L2_FECollection swig_types[17]
+#define SWIGTYPE_p_mfem__LinearForm swig_types[18]
+#define SWIGTYPE_p_mfem__Mesh swig_types[19]
+#define SWIGTYPE_p_mfem__OperatorHandle swig_types[20]
+#define SWIGTYPE_p_mfem__ParGridFunction swig_types[21]
+#define SWIGTYPE_p_mfem__ParMesh swig_types[22]
+#define SWIGTYPE_p_mfem__ParPumiMesh swig_types[23]
+#define SWIGTYPE_p_mfem__PumiMesh swig_types[24]
+#define SWIGTYPE_p_mfem__QuadratureFunction swig_types[25]
+#define SWIGTYPE_p_mfem__Vector swig_types[26]
+#define SWIGTYPE_p_pri_t swig_types[27]
+#define SWIGTYPE_p_quad_t swig_types[28]
+#define SWIGTYPE_p_seg_t swig_types[29]
+#define SWIGTYPE_p_std__istream swig_types[30]
+#define SWIGTYPE_p_tet_t swig_types[31]
+#define SWIGTYPE_p_tri_t swig_types[32]
+static swig_type_info *swig_types[34];
+static swig_module_info swig_module = {swig_types, 33, 0, 0, 0, 0};
 #define SWIG_TypeQuery(name) SWIG_TypeQueryModule(&swig_module, &swig_module, name)
 #define SWIG_MangledTypeQuery(name) SWIG_MangledTypeQueryModule(&swig_module, &swig_module, name)
 
@@ -3466,6 +3477,39 @@ SWIGINTERN doublep *doublep_frompointer(double *t){
   }
 
 
+SWIGINTERN int
+SWIG_AsVal_bool (PyObject *obj, bool *val)
+{
+  int r;
+  if (!PyBool_Check(obj))
+    return SWIG_ERROR;
+  r = PyObject_IsTrue(obj);
+  if (r == -1)
+    return SWIG_ERROR;
+  if (val) *val = r ? true : false;
+  return SWIG_OK;
+}
+
+
+SWIGINTERN int
+SWIG_AsPtr_MPI_Comm (PyObject * input, MPI_Comm **p) {
+  if (input == Py_None) {
+    if (p) *p = NULL;
+    return SWIG_OK;
+  } else if (PyObject_TypeCheck(input,&PyMPIComm_Type)) {
+    if (p) *p = PyMPIComm_Get(input);
+    return SWIG_OK;
+  } else {
+    void *argp = NULL;
+    int res = SWIG_ConvertPtr(input,&argp,SWIGTYPE_p_MPI_Comm, 0);
+    if (!SWIG_IsOK(res)) return res;
+    if (!argp) return SWIG_ValueError;
+    if (p) *p = static_cast< MPI_Comm* >(argp);
+    return SWIG_OK;
+  }
+}
+
+
 
 /* ---------------------------------------------------
  * C++ director class methods
@@ -3794,6 +3838,1478 @@ fail:
 }
 
 
+SWIGINTERN PyObject *_wrap_new_PumiMesh__SWIG_0(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
+  PyObject *resultobj = 0;
+  apf::Mesh2 *arg1 = (apf::Mesh2 *) 0 ;
+  int arg2 ;
+  int arg3 ;
+  bool arg4 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  bool val4 ;
+  int ecode4 = 0 ;
+  mfem::PumiMesh *result = 0 ;
+  
+  if ((nobjs < 4) || (nobjs > 4)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_apf__Mesh2, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "new_PumiMesh" "', argument " "1"" of type '" "apf::Mesh2 *""'"); 
+  }
+  arg1 = reinterpret_cast< apf::Mesh2 * >(argp1);
+  {
+    if ((PyArray_PyIntAsInt(swig_obj[1]) == -1) && PyErr_Occurred()) {
+      SWIG_exception_fail(SWIG_TypeError, "Input must be integer");
+    };  
+    arg2 = PyArray_PyIntAsInt(swig_obj[1]);
+  }
+  {
+    if ((PyArray_PyIntAsInt(swig_obj[2]) == -1) && PyErr_Occurred()) {
+      SWIG_exception_fail(SWIG_TypeError, "Input must be integer");
+    };  
+    arg3 = PyArray_PyIntAsInt(swig_obj[2]);
+  }
+  ecode4 = SWIG_AsVal_bool(swig_obj[3], &val4);
+  if (!SWIG_IsOK(ecode4)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode4), "in method '" "new_PumiMesh" "', argument " "4"" of type '" "bool""'");
+  } 
+  arg4 = static_cast< bool >(val4);
+  {
+    try {
+      result = (mfem::PumiMesh *)new mfem::PumiMesh(arg1,arg2,arg3,arg4); 
+    }
+    catch (Swig::DirectorException &e) {
+      SWIG_fail; 
+    }    
+  }
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__PumiMesh, SWIG_POINTER_NEW |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_new_PumiMesh__SWIG_1(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
+  PyObject *resultobj = 0;
+  apf::Mesh2 *arg1 = (apf::Mesh2 *) 0 ;
+  int arg2 ;
+  int arg3 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  mfem::PumiMesh *result = 0 ;
+  
+  if ((nobjs < 3) || (nobjs > 3)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_apf__Mesh2, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "new_PumiMesh" "', argument " "1"" of type '" "apf::Mesh2 *""'"); 
+  }
+  arg1 = reinterpret_cast< apf::Mesh2 * >(argp1);
+  {
+    if ((PyArray_PyIntAsInt(swig_obj[1]) == -1) && PyErr_Occurred()) {
+      SWIG_exception_fail(SWIG_TypeError, "Input must be integer");
+    };  
+    arg2 = PyArray_PyIntAsInt(swig_obj[1]);
+  }
+  {
+    if ((PyArray_PyIntAsInt(swig_obj[2]) == -1) && PyErr_Occurred()) {
+      SWIG_exception_fail(SWIG_TypeError, "Input must be integer");
+    };  
+    arg3 = PyArray_PyIntAsInt(swig_obj[2]);
+  }
+  {
+    try {
+      result = (mfem::PumiMesh *)new mfem::PumiMesh(arg1,arg2,arg3); 
+    }
+    catch (Swig::DirectorException &e) {
+      SWIG_fail; 
+    }    
+  }
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__PumiMesh, SWIG_POINTER_NEW |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_new_PumiMesh__SWIG_2(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
+  PyObject *resultobj = 0;
+  apf::Mesh2 *arg1 = (apf::Mesh2 *) 0 ;
+  int arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  mfem::PumiMesh *result = 0 ;
+  
+  if ((nobjs < 2) || (nobjs > 2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_apf__Mesh2, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "new_PumiMesh" "', argument " "1"" of type '" "apf::Mesh2 *""'"); 
+  }
+  arg1 = reinterpret_cast< apf::Mesh2 * >(argp1);
+  {
+    if ((PyArray_PyIntAsInt(swig_obj[1]) == -1) && PyErr_Occurred()) {
+      SWIG_exception_fail(SWIG_TypeError, "Input must be integer");
+    };  
+    arg2 = PyArray_PyIntAsInt(swig_obj[1]);
+  }
+  {
+    try {
+      result = (mfem::PumiMesh *)new mfem::PumiMesh(arg1,arg2); 
+    }
+    catch (Swig::DirectorException &e) {
+      SWIG_fail; 
+    }    
+  }
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__PumiMesh, SWIG_POINTER_NEW |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_new_PumiMesh__SWIG_3(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
+  PyObject *resultobj = 0;
+  apf::Mesh2 *arg1 = (apf::Mesh2 *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  mfem::PumiMesh *result = 0 ;
+  
+  if ((nobjs < 1) || (nobjs > 1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_apf__Mesh2, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "new_PumiMesh" "', argument " "1"" of type '" "apf::Mesh2 *""'"); 
+  }
+  arg1 = reinterpret_cast< apf::Mesh2 * >(argp1);
+  {
+    try {
+      result = (mfem::PumiMesh *)new mfem::PumiMesh(arg1); 
+    }
+    catch (Swig::DirectorException &e) {
+      SWIG_fail; 
+    }    
+  }
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__PumiMesh, SWIG_POINTER_NEW |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_new_PumiMesh(PyObject *self, PyObject *args) {
+  Py_ssize_t argc;
+  PyObject *argv[5] = {
+    0
+  };
+  
+  if (!(argc = SWIG_Python_UnpackTuple(args, "new_PumiMesh", 0, 4, argv))) SWIG_fail;
+  --argc;
+  if (argc == 1) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_apf__Mesh2, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      return _wrap_new_PumiMesh__SWIG_3(self, argc, argv);
+    }
+  }
+  if (argc == 2) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_apf__Mesh2, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      {
+        if ((PyArray_PyIntAsInt(argv[1]) == -1) && PyErr_Occurred()) {
+          PyErr_Clear();
+          _v = 0;
+        } else {
+          _v = 1;    
+        }
+      }
+      if (_v) {
+        return _wrap_new_PumiMesh__SWIG_2(self, argc, argv);
+      }
+    }
+  }
+  if (argc == 3) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_apf__Mesh2, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      {
+        if ((PyArray_PyIntAsInt(argv[1]) == -1) && PyErr_Occurred()) {
+          PyErr_Clear();
+          _v = 0;
+        } else {
+          _v = 1;    
+        }
+      }
+      if (_v) {
+        {
+          if ((PyArray_PyIntAsInt(argv[2]) == -1) && PyErr_Occurred()) {
+            PyErr_Clear();
+            _v = 0;
+          } else {
+            _v = 1;    
+          }
+        }
+        if (_v) {
+          return _wrap_new_PumiMesh__SWIG_1(self, argc, argv);
+        }
+      }
+    }
+  }
+  if (argc == 4) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_apf__Mesh2, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      {
+        if ((PyArray_PyIntAsInt(argv[1]) == -1) && PyErr_Occurred()) {
+          PyErr_Clear();
+          _v = 0;
+        } else {
+          _v = 1;    
+        }
+      }
+      if (_v) {
+        {
+          if ((PyArray_PyIntAsInt(argv[2]) == -1) && PyErr_Occurred()) {
+            PyErr_Clear();
+            _v = 0;
+          } else {
+            _v = 1;    
+          }
+        }
+        if (_v) {
+          {
+            int res = SWIG_AsVal_bool(argv[3], NULL);
+            _v = SWIG_CheckState(res);
+          }
+          if (_v) {
+            return _wrap_new_PumiMesh__SWIG_0(self, argc, argv);
+          }
+        }
+      }
+    }
+  }
+  
+fail:
+  SWIG_Python_RaiseOrModifyTypeError("Wrong number or type of arguments for overloaded function 'new_PumiMesh'.\n"
+    "  Possible C/C++ prototypes are:\n"
+    "    mfem::PumiMesh::PumiMesh(apf::Mesh2 *,int,int,bool)\n"
+    "    mfem::PumiMesh::PumiMesh(apf::Mesh2 *,int,int)\n"
+    "    mfem::PumiMesh::PumiMesh(apf::Mesh2 *,int)\n"
+    "    mfem::PumiMesh::PumiMesh(apf::Mesh2 *)\n");
+  return 0;
+}
+
+
+SWIGINTERN PyObject *_wrap_PumiMesh_Load__SWIG_0_0(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
+  PyObject *resultobj = 0;
+  mfem::PumiMesh *arg1 = (mfem::PumiMesh *) 0 ;
+  std::istream *arg2 = 0 ;
+  int arg3 ;
+  int arg4 ;
+  bool arg5 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  bool val5 ;
+  int ecode5 = 0 ;
+  
+  if ((nobjs < 5) || (nobjs > 5)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_mfem__PumiMesh, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "PumiMesh_Load" "', argument " "1"" of type '" "mfem::PumiMesh *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::PumiMesh * >(argp1);
+  res2 = SWIG_ConvertPtr(swig_obj[1], &argp2, SWIGTYPE_p_std__istream,  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "PumiMesh_Load" "', argument " "2"" of type '" "std::istream &""'"); 
+  }
+  if (!argp2) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "PumiMesh_Load" "', argument " "2"" of type '" "std::istream &""'"); 
+  }
+  arg2 = reinterpret_cast< std::istream * >(argp2);
+  {
+    if ((PyArray_PyIntAsInt(swig_obj[2]) == -1) && PyErr_Occurred()) {
+      SWIG_exception_fail(SWIG_TypeError, "Input must be integer");
+    };  
+    arg3 = PyArray_PyIntAsInt(swig_obj[2]);
+  }
+  {
+    if ((PyArray_PyIntAsInt(swig_obj[3]) == -1) && PyErr_Occurred()) {
+      SWIG_exception_fail(SWIG_TypeError, "Input must be integer");
+    };  
+    arg4 = PyArray_PyIntAsInt(swig_obj[3]);
+  }
+  ecode5 = SWIG_AsVal_bool(swig_obj[4], &val5);
+  if (!SWIG_IsOK(ecode5)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode5), "in method '" "PumiMesh_Load" "', argument " "5"" of type '" "bool""'");
+  } 
+  arg5 = static_cast< bool >(val5);
+  {
+    try {
+      (arg1)->Load(*arg2,arg3,arg4,arg5); 
+    }
+    catch (Swig::DirectorException &e) {
+      SWIG_fail; 
+    }    
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_PumiMesh_Load__SWIG_0_1(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
+  PyObject *resultobj = 0;
+  mfem::PumiMesh *arg1 = (mfem::PumiMesh *) 0 ;
+  std::istream *arg2 = 0 ;
+  int arg3 ;
+  int arg4 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  
+  if ((nobjs < 4) || (nobjs > 4)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_mfem__PumiMesh, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "PumiMesh_Load" "', argument " "1"" of type '" "mfem::PumiMesh *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::PumiMesh * >(argp1);
+  res2 = SWIG_ConvertPtr(swig_obj[1], &argp2, SWIGTYPE_p_std__istream,  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "PumiMesh_Load" "', argument " "2"" of type '" "std::istream &""'"); 
+  }
+  if (!argp2) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "PumiMesh_Load" "', argument " "2"" of type '" "std::istream &""'"); 
+  }
+  arg2 = reinterpret_cast< std::istream * >(argp2);
+  {
+    if ((PyArray_PyIntAsInt(swig_obj[2]) == -1) && PyErr_Occurred()) {
+      SWIG_exception_fail(SWIG_TypeError, "Input must be integer");
+    };  
+    arg3 = PyArray_PyIntAsInt(swig_obj[2]);
+  }
+  {
+    if ((PyArray_PyIntAsInt(swig_obj[3]) == -1) && PyErr_Occurred()) {
+      SWIG_exception_fail(SWIG_TypeError, "Input must be integer");
+    };  
+    arg4 = PyArray_PyIntAsInt(swig_obj[3]);
+  }
+  {
+    try {
+      (arg1)->Load(*arg2,arg3,arg4); 
+    }
+    catch (Swig::DirectorException &e) {
+      SWIG_fail; 
+    }    
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_PumiMesh_Load__SWIG_0_2(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
+  PyObject *resultobj = 0;
+  mfem::PumiMesh *arg1 = (mfem::PumiMesh *) 0 ;
+  std::istream *arg2 = 0 ;
+  int arg3 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  
+  if ((nobjs < 3) || (nobjs > 3)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_mfem__PumiMesh, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "PumiMesh_Load" "', argument " "1"" of type '" "mfem::PumiMesh *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::PumiMesh * >(argp1);
+  res2 = SWIG_ConvertPtr(swig_obj[1], &argp2, SWIGTYPE_p_std__istream,  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "PumiMesh_Load" "', argument " "2"" of type '" "std::istream &""'"); 
+  }
+  if (!argp2) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "PumiMesh_Load" "', argument " "2"" of type '" "std::istream &""'"); 
+  }
+  arg2 = reinterpret_cast< std::istream * >(argp2);
+  {
+    if ((PyArray_PyIntAsInt(swig_obj[2]) == -1) && PyErr_Occurred()) {
+      SWIG_exception_fail(SWIG_TypeError, "Input must be integer");
+    };  
+    arg3 = PyArray_PyIntAsInt(swig_obj[2]);
+  }
+  {
+    try {
+      (arg1)->Load(*arg2,arg3); 
+    }
+    catch (Swig::DirectorException &e) {
+      SWIG_fail; 
+    }    
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_PumiMesh_Load__SWIG_0_3(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
+  PyObject *resultobj = 0;
+  mfem::PumiMesh *arg1 = (mfem::PumiMesh *) 0 ;
+  std::istream *arg2 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  
+  if ((nobjs < 2) || (nobjs > 2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_mfem__PumiMesh, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "PumiMesh_Load" "', argument " "1"" of type '" "mfem::PumiMesh *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::PumiMesh * >(argp1);
+  res2 = SWIG_ConvertPtr(swig_obj[1], &argp2, SWIGTYPE_p_std__istream,  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "PumiMesh_Load" "', argument " "2"" of type '" "std::istream &""'"); 
+  }
+  if (!argp2) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "PumiMesh_Load" "', argument " "2"" of type '" "std::istream &""'"); 
+  }
+  arg2 = reinterpret_cast< std::istream * >(argp2);
+  {
+    try {
+      (arg1)->Load(*arg2); 
+    }
+    catch (Swig::DirectorException &e) {
+      SWIG_fail; 
+    }    
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_PumiMesh_Load__SWIG_1(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
+  PyObject *resultobj = 0;
+  mfem::PumiMesh *arg1 = (mfem::PumiMesh *) 0 ;
+  apf::Mesh2 *arg2 = (apf::Mesh2 *) 0 ;
+  int arg3 ;
+  int arg4 ;
+  bool arg5 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  bool val5 ;
+  int ecode5 = 0 ;
+  
+  if ((nobjs < 5) || (nobjs > 5)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_mfem__PumiMesh, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "PumiMesh_Load" "', argument " "1"" of type '" "mfem::PumiMesh *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::PumiMesh * >(argp1);
+  res2 = SWIG_ConvertPtr(swig_obj[1], &argp2,SWIGTYPE_p_apf__Mesh2, 0 |  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "PumiMesh_Load" "', argument " "2"" of type '" "apf::Mesh2 *""'"); 
+  }
+  arg2 = reinterpret_cast< apf::Mesh2 * >(argp2);
+  {
+    if ((PyArray_PyIntAsInt(swig_obj[2]) == -1) && PyErr_Occurred()) {
+      SWIG_exception_fail(SWIG_TypeError, "Input must be integer");
+    };  
+    arg3 = PyArray_PyIntAsInt(swig_obj[2]);
+  }
+  {
+    if ((PyArray_PyIntAsInt(swig_obj[3]) == -1) && PyErr_Occurred()) {
+      SWIG_exception_fail(SWIG_TypeError, "Input must be integer");
+    };  
+    arg4 = PyArray_PyIntAsInt(swig_obj[3]);
+  }
+  ecode5 = SWIG_AsVal_bool(swig_obj[4], &val5);
+  if (!SWIG_IsOK(ecode5)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode5), "in method '" "PumiMesh_Load" "', argument " "5"" of type '" "bool""'");
+  } 
+  arg5 = static_cast< bool >(val5);
+  {
+    try {
+      (arg1)->Load(arg2,arg3,arg4,arg5); 
+    }
+    catch (Swig::DirectorException &e) {
+      SWIG_fail; 
+    }    
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_PumiMesh_Load__SWIG_2(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
+  PyObject *resultobj = 0;
+  mfem::PumiMesh *arg1 = (mfem::PumiMesh *) 0 ;
+  apf::Mesh2 *arg2 = (apf::Mesh2 *) 0 ;
+  int arg3 ;
+  int arg4 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  
+  if ((nobjs < 4) || (nobjs > 4)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_mfem__PumiMesh, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "PumiMesh_Load" "', argument " "1"" of type '" "mfem::PumiMesh *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::PumiMesh * >(argp1);
+  res2 = SWIG_ConvertPtr(swig_obj[1], &argp2,SWIGTYPE_p_apf__Mesh2, 0 |  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "PumiMesh_Load" "', argument " "2"" of type '" "apf::Mesh2 *""'"); 
+  }
+  arg2 = reinterpret_cast< apf::Mesh2 * >(argp2);
+  {
+    if ((PyArray_PyIntAsInt(swig_obj[2]) == -1) && PyErr_Occurred()) {
+      SWIG_exception_fail(SWIG_TypeError, "Input must be integer");
+    };  
+    arg3 = PyArray_PyIntAsInt(swig_obj[2]);
+  }
+  {
+    if ((PyArray_PyIntAsInt(swig_obj[3]) == -1) && PyErr_Occurred()) {
+      SWIG_exception_fail(SWIG_TypeError, "Input must be integer");
+    };  
+    arg4 = PyArray_PyIntAsInt(swig_obj[3]);
+  }
+  {
+    try {
+      (arg1)->Load(arg2,arg3,arg4); 
+    }
+    catch (Swig::DirectorException &e) {
+      SWIG_fail; 
+    }    
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_PumiMesh_Load__SWIG_3(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
+  PyObject *resultobj = 0;
+  mfem::PumiMesh *arg1 = (mfem::PumiMesh *) 0 ;
+  apf::Mesh2 *arg2 = (apf::Mesh2 *) 0 ;
+  int arg3 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  
+  if ((nobjs < 3) || (nobjs > 3)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_mfem__PumiMesh, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "PumiMesh_Load" "', argument " "1"" of type '" "mfem::PumiMesh *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::PumiMesh * >(argp1);
+  res2 = SWIG_ConvertPtr(swig_obj[1], &argp2,SWIGTYPE_p_apf__Mesh2, 0 |  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "PumiMesh_Load" "', argument " "2"" of type '" "apf::Mesh2 *""'"); 
+  }
+  arg2 = reinterpret_cast< apf::Mesh2 * >(argp2);
+  {
+    if ((PyArray_PyIntAsInt(swig_obj[2]) == -1) && PyErr_Occurred()) {
+      SWIG_exception_fail(SWIG_TypeError, "Input must be integer");
+    };  
+    arg3 = PyArray_PyIntAsInt(swig_obj[2]);
+  }
+  {
+    try {
+      (arg1)->Load(arg2,arg3); 
+    }
+    catch (Swig::DirectorException &e) {
+      SWIG_fail; 
+    }    
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_PumiMesh_Load__SWIG_4(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
+  PyObject *resultobj = 0;
+  mfem::PumiMesh *arg1 = (mfem::PumiMesh *) 0 ;
+  apf::Mesh2 *arg2 = (apf::Mesh2 *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  
+  if ((nobjs < 2) || (nobjs > 2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_mfem__PumiMesh, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "PumiMesh_Load" "', argument " "1"" of type '" "mfem::PumiMesh *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::PumiMesh * >(argp1);
+  res2 = SWIG_ConvertPtr(swig_obj[1], &argp2,SWIGTYPE_p_apf__Mesh2, 0 |  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "PumiMesh_Load" "', argument " "2"" of type '" "apf::Mesh2 *""'"); 
+  }
+  arg2 = reinterpret_cast< apf::Mesh2 * >(argp2);
+  {
+    try {
+      (arg1)->Load(arg2); 
+    }
+    catch (Swig::DirectorException &e) {
+      SWIG_fail; 
+    }    
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_PumiMesh_Load(PyObject *self, PyObject *args) {
+  Py_ssize_t argc;
+  PyObject *argv[6] = {
+    0
+  };
+  
+  if (!(argc = SWIG_Python_UnpackTuple(args, "PumiMesh_Load", 0, 5, argv))) SWIG_fail;
+  --argc;
+  if (argc == 2) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_mfem__PumiMesh, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      void *vptr = 0;
+      int res = SWIG_ConvertPtr(argv[1], &vptr, SWIGTYPE_p_std__istream, SWIG_POINTER_NO_NULL);
+      _v = SWIG_CheckState(res);
+      if (_v) {
+        return _wrap_PumiMesh_Load__SWIG_0_3(self, argc, argv);
+      }
+    }
+  }
+  if (argc == 2) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_mfem__PumiMesh, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      void *vptr = 0;
+      int res = SWIG_ConvertPtr(argv[1], &vptr, SWIGTYPE_p_apf__Mesh2, 0);
+      _v = SWIG_CheckState(res);
+      if (_v) {
+        return _wrap_PumiMesh_Load__SWIG_4(self, argc, argv);
+      }
+    }
+  }
+  if (argc == 3) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_mfem__PumiMesh, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      void *vptr = 0;
+      int res = SWIG_ConvertPtr(argv[1], &vptr, SWIGTYPE_p_apf__Mesh2, 0);
+      _v = SWIG_CheckState(res);
+      if (_v) {
+        {
+          if ((PyArray_PyIntAsInt(argv[2]) == -1) && PyErr_Occurred()) {
+            PyErr_Clear();
+            _v = 0;
+          } else {
+            _v = 1;    
+          }
+        }
+        if (_v) {
+          return _wrap_PumiMesh_Load__SWIG_3(self, argc, argv);
+        }
+      }
+    }
+  }
+  if (argc == 3) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_mfem__PumiMesh, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      void *vptr = 0;
+      int res = SWIG_ConvertPtr(argv[1], &vptr, SWIGTYPE_p_std__istream, SWIG_POINTER_NO_NULL);
+      _v = SWIG_CheckState(res);
+      if (_v) {
+        {
+          if ((PyArray_PyIntAsInt(argv[2]) == -1) && PyErr_Occurred()) {
+            PyErr_Clear();
+            _v = 0;
+          } else {
+            _v = 1;    
+          }
+        }
+        if (_v) {
+          return _wrap_PumiMesh_Load__SWIG_0_2(self, argc, argv);
+        }
+      }
+    }
+  }
+  if (argc == 4) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_mfem__PumiMesh, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      void *vptr = 0;
+      int res = SWIG_ConvertPtr(argv[1], &vptr, SWIGTYPE_p_std__istream, SWIG_POINTER_NO_NULL);
+      _v = SWIG_CheckState(res);
+      if (_v) {
+        {
+          if ((PyArray_PyIntAsInt(argv[2]) == -1) && PyErr_Occurred()) {
+            PyErr_Clear();
+            _v = 0;
+          } else {
+            _v = 1;    
+          }
+        }
+        if (_v) {
+          {
+            if ((PyArray_PyIntAsInt(argv[3]) == -1) && PyErr_Occurred()) {
+              PyErr_Clear();
+              _v = 0;
+            } else {
+              _v = 1;    
+            }
+          }
+          if (_v) {
+            return _wrap_PumiMesh_Load__SWIG_0_1(self, argc, argv);
+          }
+        }
+      }
+    }
+  }
+  if (argc == 4) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_mfem__PumiMesh, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      void *vptr = 0;
+      int res = SWIG_ConvertPtr(argv[1], &vptr, SWIGTYPE_p_apf__Mesh2, 0);
+      _v = SWIG_CheckState(res);
+      if (_v) {
+        {
+          if ((PyArray_PyIntAsInt(argv[2]) == -1) && PyErr_Occurred()) {
+            PyErr_Clear();
+            _v = 0;
+          } else {
+            _v = 1;    
+          }
+        }
+        if (_v) {
+          {
+            if ((PyArray_PyIntAsInt(argv[3]) == -1) && PyErr_Occurred()) {
+              PyErr_Clear();
+              _v = 0;
+            } else {
+              _v = 1;    
+            }
+          }
+          if (_v) {
+            return _wrap_PumiMesh_Load__SWIG_2(self, argc, argv);
+          }
+        }
+      }
+    }
+  }
+  if (argc == 5) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_mfem__PumiMesh, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      void *vptr = 0;
+      int res = SWIG_ConvertPtr(argv[1], &vptr, SWIGTYPE_p_apf__Mesh2, 0);
+      _v = SWIG_CheckState(res);
+      if (_v) {
+        {
+          if ((PyArray_PyIntAsInt(argv[2]) == -1) && PyErr_Occurred()) {
+            PyErr_Clear();
+            _v = 0;
+          } else {
+            _v = 1;    
+          }
+        }
+        if (_v) {
+          {
+            if ((PyArray_PyIntAsInt(argv[3]) == -1) && PyErr_Occurred()) {
+              PyErr_Clear();
+              _v = 0;
+            } else {
+              _v = 1;    
+            }
+          }
+          if (_v) {
+            {
+              int res = SWIG_AsVal_bool(argv[4], NULL);
+              _v = SWIG_CheckState(res);
+            }
+            if (_v) {
+              return _wrap_PumiMesh_Load__SWIG_1(self, argc, argv);
+            }
+          }
+        }
+      }
+    }
+  }
+  if (argc == 5) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_mfem__PumiMesh, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      void *vptr = 0;
+      int res = SWIG_ConvertPtr(argv[1], &vptr, SWIGTYPE_p_std__istream, SWIG_POINTER_NO_NULL);
+      _v = SWIG_CheckState(res);
+      if (_v) {
+        {
+          if ((PyArray_PyIntAsInt(argv[2]) == -1) && PyErr_Occurred()) {
+            PyErr_Clear();
+            _v = 0;
+          } else {
+            _v = 1;    
+          }
+        }
+        if (_v) {
+          {
+            if ((PyArray_PyIntAsInt(argv[3]) == -1) && PyErr_Occurred()) {
+              PyErr_Clear();
+              _v = 0;
+            } else {
+              _v = 1;    
+            }
+          }
+          if (_v) {
+            {
+              int res = SWIG_AsVal_bool(argv[4], NULL);
+              _v = SWIG_CheckState(res);
+            }
+            if (_v) {
+              return _wrap_PumiMesh_Load__SWIG_0_0(self, argc, argv);
+            }
+          }
+        }
+      }
+    }
+  }
+  
+fail:
+  SWIG_Python_RaiseOrModifyTypeError("Wrong number or type of arguments for overloaded function 'PumiMesh_Load'.\n"
+    "  Possible C/C++ prototypes are:\n"
+    "    Load(std::istream &,int,int,bool)\n"
+    "    Load(std::istream &,int,int)\n"
+    "    Load(std::istream &,int)\n"
+    "    Load(std::istream &)\n"
+    "    mfem::PumiMesh::Load(apf::Mesh2 *,int,int,bool)\n"
+    "    mfem::PumiMesh::Load(apf::Mesh2 *,int,int)\n"
+    "    mfem::PumiMesh::Load(apf::Mesh2 *,int)\n"
+    "    mfem::PumiMesh::Load(apf::Mesh2 *)\n");
+  return 0;
+}
+
+
+SWIGINTERN PyObject *_wrap_delete_PumiMesh(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  mfem::PumiMesh *arg1 = (mfem::PumiMesh *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject *swig_obj[1] ;
+  
+  if (!args) SWIG_fail;
+  swig_obj[0] = args;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_mfem__PumiMesh, SWIG_POINTER_DISOWN |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "delete_PumiMesh" "', argument " "1"" of type '" "mfem::PumiMesh *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::PumiMesh * >(argp1);
+  {
+    try {
+      delete arg1; 
+    }
+    catch (Swig::DirectorException &e) {
+      SWIG_fail; 
+    }    
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *PumiMesh_swigregister(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *obj;
+  if (!SWIG_Python_UnpackTuple(args, "swigregister", 1, 1, &obj)) return NULL;
+  SWIG_TypeNewClientData(SWIGTYPE_p_mfem__PumiMesh, SWIG_NewClientData(obj));
+  return SWIG_Py_Void();
+}
+
+SWIGINTERN PyObject *PumiMesh_swiginit(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  return SWIG_Python_InitShadowInstance(args);
+}
+
+SWIGINTERN PyObject *_wrap_new_ParPumiMesh(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  MPI_Comm arg1 ;
+  apf::Mesh2 *arg2 = (apf::Mesh2 *) 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  PyObject *swig_obj[2] ;
+  mfem::ParPumiMesh *result = 0 ;
+  
+  if (!SWIG_Python_UnpackTuple(args, "new_ParPumiMesh", 2, 2, swig_obj)) SWIG_fail;
+  {
+    MPI_Comm *ptr = (MPI_Comm *)0;
+    int res = SWIG_AsPtr_MPI_Comm(swig_obj[0], &ptr);
+    if (!SWIG_IsOK(res) || !ptr) {
+      SWIG_exception_fail(SWIG_ArgError((ptr ? res : SWIG_TypeError)), "in method '" "new_ParPumiMesh" "', argument " "1"" of type '" "MPI_Comm""'"); 
+    }
+    arg1 = *ptr;
+    if (SWIG_IsNewObj(res)) delete ptr;
+  }
+  res2 = SWIG_ConvertPtr(swig_obj[1], &argp2,SWIGTYPE_p_apf__Mesh2, 0 |  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "new_ParPumiMesh" "', argument " "2"" of type '" "apf::Mesh2 *""'"); 
+  }
+  arg2 = reinterpret_cast< apf::Mesh2 * >(argp2);
+  {
+    try {
+      result = (mfem::ParPumiMesh *)new mfem::ParPumiMesh(arg1,arg2); 
+    }
+    catch (Swig::DirectorException &e) {
+      SWIG_fail; 
+    }    
+  }
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__ParPumiMesh, SWIG_POINTER_NEW |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_ParPumiMesh_FieldMFEMtoPUMI__SWIG_0(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
+  PyObject *resultobj = 0;
+  mfem::ParPumiMesh *arg1 = (mfem::ParPumiMesh *) 0 ;
+  apf::Mesh2 *arg2 = (apf::Mesh2 *) 0 ;
+  mfem::ParGridFunction *arg3 = (mfem::ParGridFunction *) 0 ;
+  mfem::ParGridFunction *arg4 = (mfem::ParGridFunction *) 0 ;
+  apf::Field *arg5 = (apf::Field *) 0 ;
+  apf::Field *arg6 = (apf::Field *) 0 ;
+  apf::Field *arg7 = (apf::Field *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  void *argp3 = 0 ;
+  int res3 = 0 ;
+  void *argp4 = 0 ;
+  int res4 = 0 ;
+  void *argp5 = 0 ;
+  int res5 = 0 ;
+  void *argp6 = 0 ;
+  int res6 = 0 ;
+  void *argp7 = 0 ;
+  int res7 = 0 ;
+  
+  if ((nobjs < 7) || (nobjs > 7)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_mfem__ParPumiMesh, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "ParPumiMesh_FieldMFEMtoPUMI" "', argument " "1"" of type '" "mfem::ParPumiMesh *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::ParPumiMesh * >(argp1);
+  res2 = SWIG_ConvertPtr(swig_obj[1], &argp2,SWIGTYPE_p_apf__Mesh2, 0 |  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "ParPumiMesh_FieldMFEMtoPUMI" "', argument " "2"" of type '" "apf::Mesh2 *""'"); 
+  }
+  arg2 = reinterpret_cast< apf::Mesh2 * >(argp2);
+  res3 = SWIG_ConvertPtr(swig_obj[2], &argp3,SWIGTYPE_p_mfem__ParGridFunction, 0 |  0 );
+  if (!SWIG_IsOK(res3)) {
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "ParPumiMesh_FieldMFEMtoPUMI" "', argument " "3"" of type '" "mfem::ParGridFunction *""'"); 
+  }
+  arg3 = reinterpret_cast< mfem::ParGridFunction * >(argp3);
+  res4 = SWIG_ConvertPtr(swig_obj[3], &argp4,SWIGTYPE_p_mfem__ParGridFunction, 0 |  0 );
+  if (!SWIG_IsOK(res4)) {
+    SWIG_exception_fail(SWIG_ArgError(res4), "in method '" "ParPumiMesh_FieldMFEMtoPUMI" "', argument " "4"" of type '" "mfem::ParGridFunction *""'"); 
+  }
+  arg4 = reinterpret_cast< mfem::ParGridFunction * >(argp4);
+  res5 = SWIG_ConvertPtr(swig_obj[4], &argp5,SWIGTYPE_p_apf__Field, 0 |  0 );
+  if (!SWIG_IsOK(res5)) {
+    SWIG_exception_fail(SWIG_ArgError(res5), "in method '" "ParPumiMesh_FieldMFEMtoPUMI" "', argument " "5"" of type '" "apf::Field *""'"); 
+  }
+  arg5 = reinterpret_cast< apf::Field * >(argp5);
+  res6 = SWIG_ConvertPtr(swig_obj[5], &argp6,SWIGTYPE_p_apf__Field, 0 |  0 );
+  if (!SWIG_IsOK(res6)) {
+    SWIG_exception_fail(SWIG_ArgError(res6), "in method '" "ParPumiMesh_FieldMFEMtoPUMI" "', argument " "6"" of type '" "apf::Field *""'"); 
+  }
+  arg6 = reinterpret_cast< apf::Field * >(argp6);
+  res7 = SWIG_ConvertPtr(swig_obj[6], &argp7,SWIGTYPE_p_apf__Field, 0 |  0 );
+  if (!SWIG_IsOK(res7)) {
+    SWIG_exception_fail(SWIG_ArgError(res7), "in method '" "ParPumiMesh_FieldMFEMtoPUMI" "', argument " "7"" of type '" "apf::Field *""'"); 
+  }
+  arg7 = reinterpret_cast< apf::Field * >(argp7);
+  {
+    try {
+      (arg1)->FieldMFEMtoPUMI(arg2,arg3,arg4,arg5,arg6,arg7); 
+    }
+    catch (Swig::DirectorException &e) {
+      SWIG_fail; 
+    }    
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_ParPumiMesh_FieldMFEMtoPUMI__SWIG_1(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
+  PyObject *resultobj = 0;
+  mfem::ParPumiMesh *arg1 = (mfem::ParPumiMesh *) 0 ;
+  apf::Mesh2 *arg2 = (apf::Mesh2 *) 0 ;
+  mfem::ParGridFunction *arg3 = (mfem::ParGridFunction *) 0 ;
+  apf::Field *arg4 = (apf::Field *) 0 ;
+  apf::Field *arg5 = (apf::Field *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  void *argp3 = 0 ;
+  int res3 = 0 ;
+  void *argp4 = 0 ;
+  int res4 = 0 ;
+  void *argp5 = 0 ;
+  int res5 = 0 ;
+  
+  if ((nobjs < 5) || (nobjs > 5)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_mfem__ParPumiMesh, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "ParPumiMesh_FieldMFEMtoPUMI" "', argument " "1"" of type '" "mfem::ParPumiMesh *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::ParPumiMesh * >(argp1);
+  res2 = SWIG_ConvertPtr(swig_obj[1], &argp2,SWIGTYPE_p_apf__Mesh2, 0 |  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "ParPumiMesh_FieldMFEMtoPUMI" "', argument " "2"" of type '" "apf::Mesh2 *""'"); 
+  }
+  arg2 = reinterpret_cast< apf::Mesh2 * >(argp2);
+  res3 = SWIG_ConvertPtr(swig_obj[2], &argp3,SWIGTYPE_p_mfem__ParGridFunction, 0 |  0 );
+  if (!SWIG_IsOK(res3)) {
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "ParPumiMesh_FieldMFEMtoPUMI" "', argument " "3"" of type '" "mfem::ParGridFunction *""'"); 
+  }
+  arg3 = reinterpret_cast< mfem::ParGridFunction * >(argp3);
+  res4 = SWIG_ConvertPtr(swig_obj[3], &argp4,SWIGTYPE_p_apf__Field, 0 |  0 );
+  if (!SWIG_IsOK(res4)) {
+    SWIG_exception_fail(SWIG_ArgError(res4), "in method '" "ParPumiMesh_FieldMFEMtoPUMI" "', argument " "4"" of type '" "apf::Field *""'"); 
+  }
+  arg4 = reinterpret_cast< apf::Field * >(argp4);
+  res5 = SWIG_ConvertPtr(swig_obj[4], &argp5,SWIGTYPE_p_apf__Field, 0 |  0 );
+  if (!SWIG_IsOK(res5)) {
+    SWIG_exception_fail(SWIG_ArgError(res5), "in method '" "ParPumiMesh_FieldMFEMtoPUMI" "', argument " "5"" of type '" "apf::Field *""'"); 
+  }
+  arg5 = reinterpret_cast< apf::Field * >(argp5);
+  {
+    try {
+      (arg1)->FieldMFEMtoPUMI(arg2,arg3,arg4,arg5); 
+    }
+    catch (Swig::DirectorException &e) {
+      SWIG_fail; 
+    }    
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_ParPumiMesh_FieldMFEMtoPUMI(PyObject *self, PyObject *args) {
+  Py_ssize_t argc;
+  PyObject *argv[8] = {
+    0
+  };
+  
+  if (!(argc = SWIG_Python_UnpackTuple(args, "ParPumiMesh_FieldMFEMtoPUMI", 0, 7, argv))) SWIG_fail;
+  --argc;
+  if (argc == 5) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_mfem__ParPumiMesh, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      void *vptr = 0;
+      int res = SWIG_ConvertPtr(argv[1], &vptr, SWIGTYPE_p_apf__Mesh2, 0);
+      _v = SWIG_CheckState(res);
+      if (_v) {
+        void *vptr = 0;
+        int res = SWIG_ConvertPtr(argv[2], &vptr, SWIGTYPE_p_mfem__ParGridFunction, 0);
+        _v = SWIG_CheckState(res);
+        if (_v) {
+          void *vptr = 0;
+          int res = SWIG_ConvertPtr(argv[3], &vptr, SWIGTYPE_p_apf__Field, 0);
+          _v = SWIG_CheckState(res);
+          if (_v) {
+            void *vptr = 0;
+            int res = SWIG_ConvertPtr(argv[4], &vptr, SWIGTYPE_p_apf__Field, 0);
+            _v = SWIG_CheckState(res);
+            if (_v) {
+              return _wrap_ParPumiMesh_FieldMFEMtoPUMI__SWIG_1(self, argc, argv);
+            }
+          }
+        }
+      }
+    }
+  }
+  if (argc == 7) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_mfem__ParPumiMesh, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      void *vptr = 0;
+      int res = SWIG_ConvertPtr(argv[1], &vptr, SWIGTYPE_p_apf__Mesh2, 0);
+      _v = SWIG_CheckState(res);
+      if (_v) {
+        void *vptr = 0;
+        int res = SWIG_ConvertPtr(argv[2], &vptr, SWIGTYPE_p_mfem__ParGridFunction, 0);
+        _v = SWIG_CheckState(res);
+        if (_v) {
+          void *vptr = 0;
+          int res = SWIG_ConvertPtr(argv[3], &vptr, SWIGTYPE_p_mfem__ParGridFunction, 0);
+          _v = SWIG_CheckState(res);
+          if (_v) {
+            void *vptr = 0;
+            int res = SWIG_ConvertPtr(argv[4], &vptr, SWIGTYPE_p_apf__Field, 0);
+            _v = SWIG_CheckState(res);
+            if (_v) {
+              void *vptr = 0;
+              int res = SWIG_ConvertPtr(argv[5], &vptr, SWIGTYPE_p_apf__Field, 0);
+              _v = SWIG_CheckState(res);
+              if (_v) {
+                void *vptr = 0;
+                int res = SWIG_ConvertPtr(argv[6], &vptr, SWIGTYPE_p_apf__Field, 0);
+                _v = SWIG_CheckState(res);
+                if (_v) {
+                  return _wrap_ParPumiMesh_FieldMFEMtoPUMI__SWIG_0(self, argc, argv);
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  
+fail:
+  SWIG_Python_RaiseOrModifyTypeError("Wrong number or type of arguments for overloaded function 'ParPumiMesh_FieldMFEMtoPUMI'.\n"
+    "  Possible C/C++ prototypes are:\n"
+    "    mfem::ParPumiMesh::FieldMFEMtoPUMI(apf::Mesh2 *,mfem::ParGridFunction *,mfem::ParGridFunction *,apf::Field *,apf::Field *,apf::Field *)\n"
+    "    mfem::ParPumiMesh::FieldMFEMtoPUMI(apf::Mesh2 *,mfem::ParGridFunction *,apf::Field *,apf::Field *)\n");
+  return 0;
+}
+
+
+SWIGINTERN PyObject *_wrap_ParPumiMesh_VectorFieldMFEMtoPUMI(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  mfem::ParPumiMesh *arg1 = (mfem::ParPumiMesh *) 0 ;
+  apf::Mesh2 *arg2 = (apf::Mesh2 *) 0 ;
+  mfem::ParGridFunction *arg3 = (mfem::ParGridFunction *) 0 ;
+  apf::Field *arg4 = (apf::Field *) 0 ;
+  apf::Field *arg5 = (apf::Field *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  void *argp3 = 0 ;
+  int res3 = 0 ;
+  void *argp4 = 0 ;
+  int res4 = 0 ;
+  void *argp5 = 0 ;
+  int res5 = 0 ;
+  PyObject *swig_obj[5] ;
+  
+  if (!SWIG_Python_UnpackTuple(args, "ParPumiMesh_VectorFieldMFEMtoPUMI", 5, 5, swig_obj)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_mfem__ParPumiMesh, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "ParPumiMesh_VectorFieldMFEMtoPUMI" "', argument " "1"" of type '" "mfem::ParPumiMesh *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::ParPumiMesh * >(argp1);
+  res2 = SWIG_ConvertPtr(swig_obj[1], &argp2,SWIGTYPE_p_apf__Mesh2, 0 |  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "ParPumiMesh_VectorFieldMFEMtoPUMI" "', argument " "2"" of type '" "apf::Mesh2 *""'"); 
+  }
+  arg2 = reinterpret_cast< apf::Mesh2 * >(argp2);
+  res3 = SWIG_ConvertPtr(swig_obj[2], &argp3,SWIGTYPE_p_mfem__ParGridFunction, 0 |  0 );
+  if (!SWIG_IsOK(res3)) {
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "ParPumiMesh_VectorFieldMFEMtoPUMI" "', argument " "3"" of type '" "mfem::ParGridFunction *""'"); 
+  }
+  arg3 = reinterpret_cast< mfem::ParGridFunction * >(argp3);
+  res4 = SWIG_ConvertPtr(swig_obj[3], &argp4,SWIGTYPE_p_apf__Field, 0 |  0 );
+  if (!SWIG_IsOK(res4)) {
+    SWIG_exception_fail(SWIG_ArgError(res4), "in method '" "ParPumiMesh_VectorFieldMFEMtoPUMI" "', argument " "4"" of type '" "apf::Field *""'"); 
+  }
+  arg4 = reinterpret_cast< apf::Field * >(argp4);
+  res5 = SWIG_ConvertPtr(swig_obj[4], &argp5,SWIGTYPE_p_apf__Field, 0 |  0 );
+  if (!SWIG_IsOK(res5)) {
+    SWIG_exception_fail(SWIG_ArgError(res5), "in method '" "ParPumiMesh_VectorFieldMFEMtoPUMI" "', argument " "5"" of type '" "apf::Field *""'"); 
+  }
+  arg5 = reinterpret_cast< apf::Field * >(argp5);
+  {
+    try {
+      (arg1)->VectorFieldMFEMtoPUMI(arg2,arg3,arg4,arg5); 
+    }
+    catch (Swig::DirectorException &e) {
+      SWIG_fail; 
+    }    
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_ParPumiMesh_UpdateMesh(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  mfem::ParPumiMesh *arg1 = (mfem::ParPumiMesh *) 0 ;
+  mfem::ParMesh *arg2 = (mfem::ParMesh *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  PyObject *swig_obj[2] ;
+  
+  if (!SWIG_Python_UnpackTuple(args, "ParPumiMesh_UpdateMesh", 2, 2, swig_obj)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_mfem__ParPumiMesh, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "ParPumiMesh_UpdateMesh" "', argument " "1"" of type '" "mfem::ParPumiMesh *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::ParPumiMesh * >(argp1);
+  res2 = SWIG_ConvertPtr(swig_obj[1], &argp2,SWIGTYPE_p_mfem__ParMesh, 0 |  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "ParPumiMesh_UpdateMesh" "', argument " "2"" of type '" "mfem::ParMesh const *""'"); 
+  }
+  arg2 = reinterpret_cast< mfem::ParMesh * >(argp2);
+  {
+    try {
+      (arg1)->UpdateMesh((mfem::ParMesh const *)arg2); 
+    }
+    catch (Swig::DirectorException &e) {
+      SWIG_fail; 
+    }    
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_ParPumiMesh_FieldPUMItoMFEM(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  mfem::ParPumiMesh *arg1 = (mfem::ParPumiMesh *) 0 ;
+  apf::Mesh2 *arg2 = (apf::Mesh2 *) 0 ;
+  apf::Field *arg3 = (apf::Field *) 0 ;
+  mfem::ParGridFunction *arg4 = (mfem::ParGridFunction *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  void *argp3 = 0 ;
+  int res3 = 0 ;
+  void *argp4 = 0 ;
+  int res4 = 0 ;
+  PyObject *swig_obj[4] ;
+  
+  if (!SWIG_Python_UnpackTuple(args, "ParPumiMesh_FieldPUMItoMFEM", 4, 4, swig_obj)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_mfem__ParPumiMesh, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "ParPumiMesh_FieldPUMItoMFEM" "', argument " "1"" of type '" "mfem::ParPumiMesh *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::ParPumiMesh * >(argp1);
+  res2 = SWIG_ConvertPtr(swig_obj[1], &argp2,SWIGTYPE_p_apf__Mesh2, 0 |  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "ParPumiMesh_FieldPUMItoMFEM" "', argument " "2"" of type '" "apf::Mesh2 *""'"); 
+  }
+  arg2 = reinterpret_cast< apf::Mesh2 * >(argp2);
+  res3 = SWIG_ConvertPtr(swig_obj[2], &argp3,SWIGTYPE_p_apf__Field, 0 |  0 );
+  if (!SWIG_IsOK(res3)) {
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "ParPumiMesh_FieldPUMItoMFEM" "', argument " "3"" of type '" "apf::Field *""'"); 
+  }
+  arg3 = reinterpret_cast< apf::Field * >(argp3);
+  res4 = SWIG_ConvertPtr(swig_obj[3], &argp4,SWIGTYPE_p_mfem__ParGridFunction, 0 |  0 );
+  if (!SWIG_IsOK(res4)) {
+    SWIG_exception_fail(SWIG_ArgError(res4), "in method '" "ParPumiMesh_FieldPUMItoMFEM" "', argument " "4"" of type '" "mfem::ParGridFunction *""'"); 
+  }
+  arg4 = reinterpret_cast< mfem::ParGridFunction * >(argp4);
+  {
+    try {
+      (arg1)->FieldPUMItoMFEM(arg2,arg3,arg4); 
+    }
+    catch (Swig::DirectorException &e) {
+      SWIG_fail; 
+    }    
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_delete_ParPumiMesh(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  mfem::ParPumiMesh *arg1 = (mfem::ParPumiMesh *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject *swig_obj[1] ;
+  
+  if (!args) SWIG_fail;
+  swig_obj[0] = args;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_mfem__ParPumiMesh, SWIG_POINTER_DISOWN |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "delete_ParPumiMesh" "', argument " "1"" of type '" "mfem::ParPumiMesh *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::ParPumiMesh * >(argp1);
+  {
+    try {
+      delete arg1; 
+    }
+    catch (Swig::DirectorException &e) {
+      SWIG_fail; 
+    }    
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *ParPumiMesh_swigregister(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *obj;
+  if (!SWIG_Python_UnpackTuple(args, "swigregister", 1, 1, &obj)) return NULL;
+  SWIG_TypeNewClientData(SWIGTYPE_p_mfem__ParPumiMesh, SWIG_NewClientData(obj));
+  return SWIG_Py_Void();
+}
+
+SWIGINTERN PyObject *ParPumiMesh_swiginit(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  return SWIG_Python_InitShadowInstance(args);
+}
+
+SWIGINTERN PyObject *_wrap_new_GridFunctionPumi(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  mfem::Mesh *arg1 = (mfem::Mesh *) 0 ;
+  apf::Mesh2 *arg2 = (apf::Mesh2 *) 0 ;
+  apf::Numbering *arg3 = (apf::Numbering *) 0 ;
+  int arg4 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  void *argp3 = 0 ;
+  int res3 = 0 ;
+  PyObject *swig_obj[4] ;
+  mfem::GridFunctionPumi *result = 0 ;
+  
+  if (!SWIG_Python_UnpackTuple(args, "new_GridFunctionPumi", 4, 4, swig_obj)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_mfem__Mesh, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "new_GridFunctionPumi" "', argument " "1"" of type '" "mfem::Mesh *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::Mesh * >(argp1);
+  res2 = SWIG_ConvertPtr(swig_obj[1], &argp2,SWIGTYPE_p_apf__Mesh2, 0 |  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "new_GridFunctionPumi" "', argument " "2"" of type '" "apf::Mesh2 *""'"); 
+  }
+  arg2 = reinterpret_cast< apf::Mesh2 * >(argp2);
+  res3 = SWIG_ConvertPtr(swig_obj[2], &argp3,SWIGTYPE_p_apf__Numbering, 0 |  0 );
+  if (!SWIG_IsOK(res3)) {
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "new_GridFunctionPumi" "', argument " "3"" of type '" "apf::Numbering *""'"); 
+  }
+  arg3 = reinterpret_cast< apf::Numbering * >(argp3);
+  {
+    if ((PyArray_PyIntAsInt(swig_obj[3]) == -1) && PyErr_Occurred()) {
+      SWIG_exception_fail(SWIG_TypeError, "Input must be integer");
+    };  
+    arg4 = PyArray_PyIntAsInt(swig_obj[3]);
+  }
+  {
+    try {
+      result = (mfem::GridFunctionPumi *)new mfem::GridFunctionPumi(arg1,arg2,arg3,arg4); 
+    }
+    catch (Swig::DirectorException &e) {
+      SWIG_fail; 
+    }    
+  }
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__GridFunctionPumi, SWIG_POINTER_NEW |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_delete_GridFunctionPumi(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  mfem::GridFunctionPumi *arg1 = (mfem::GridFunctionPumi *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject *swig_obj[1] ;
+  
+  if (!args) SWIG_fail;
+  swig_obj[0] = args;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_mfem__GridFunctionPumi, SWIG_POINTER_DISOWN |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "delete_GridFunctionPumi" "', argument " "1"" of type '" "mfem::GridFunctionPumi *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::GridFunctionPumi * >(argp1);
+  {
+    try {
+      delete arg1; 
+    }
+    catch (Swig::DirectorException &e) {
+      SWIG_fail; 
+    }    
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *GridFunctionPumi_swigregister(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *obj;
+  if (!SWIG_Python_UnpackTuple(args, "swigregister", 1, 1, &obj)) return NULL;
+  SWIG_TypeNewClientData(SWIGTYPE_p_mfem__GridFunctionPumi, SWIG_NewClientData(obj));
+  return SWIG_Py_Void();
+}
+
+SWIGINTERN PyObject *GridFunctionPumi_swiginit(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  return SWIG_Python_InitShadowInstance(args);
+}
+
 static PyMethodDef SwigMethods[] = {
 	 { "SWIG_PyInstanceMethod_New", SWIG_PyInstanceMethod_New, METH_O, NULL},
 	 { "new_intp", _wrap_new_intp, METH_NOARGS, "new_intp() -> intp"},
@@ -3812,7 +5328,33 @@ static PyMethodDef SwigMethods[] = {
 	 { "doublep_frompointer", _wrap_doublep_frompointer, METH_O, "doublep_frompointer(double * t) -> doublep"},
 	 { "doublep_swigregister", doublep_swigregister, METH_O, NULL},
 	 { "doublep_swiginit", doublep_swiginit, METH_VARARGS, NULL},
-	 { "ParMesh2ParPumiMesh", _wrap_ParMesh2ParPumiMesh, METH_O, "ParMesh2ParPumiMesh(ParMesh pmesh) -> mfem::ParPumiMesh *"},
+	 { "ParMesh2ParPumiMesh", _wrap_ParMesh2ParPumiMesh, METH_O, "ParMesh2ParPumiMesh(ParMesh pmesh) -> ParPumiMesh"},
+	 { "new_PumiMesh", _wrap_new_PumiMesh, METH_VARARGS, "PumiMesh(apf::Mesh2 * apf_mesh, int generate_edges=0, int refine=1, bool fix_orientation=True)"},
+	 { "PumiMesh_Load", _wrap_PumiMesh_Load, METH_VARARGS, "\n"
+		"PumiMesh_Load(PumiMesh self, std::istream & input, int generate_edges=0, int refine=1, bool fix_orientation=True)\n"
+		"PumiMesh_Load(PumiMesh self, std::istream & input, int generate_edges=0, int refine=1)\n"
+		"PumiMesh_Load(PumiMesh self, std::istream & input, int generate_edges=0)\n"
+		"PumiMesh_Load(PumiMesh self, std::istream & input)\n"
+		"PumiMesh_Load(PumiMesh self, apf::Mesh2 * apf_mesh, int generate_edges=0, int refine=1, bool fix_orientation=True)\n"
+		""},
+	 { "delete_PumiMesh", _wrap_delete_PumiMesh, METH_O, "delete_PumiMesh(PumiMesh self)"},
+	 { "PumiMesh_swigregister", PumiMesh_swigregister, METH_O, NULL},
+	 { "PumiMesh_swiginit", PumiMesh_swiginit, METH_VARARGS, NULL},
+	 { "new_ParPumiMesh", _wrap_new_ParPumiMesh, METH_VARARGS, "new_ParPumiMesh(MPI_Comm comm, apf::Mesh2 * apf_mesh) -> ParPumiMesh"},
+	 { "ParPumiMesh_FieldMFEMtoPUMI", _wrap_ParPumiMesh_FieldMFEMtoPUMI, METH_VARARGS, "\n"
+		"ParPumiMesh_FieldMFEMtoPUMI(ParPumiMesh self, apf::Mesh2 * apf_mesh, ParGridFunction Vel, ParGridFunction Pr, apf::Field * VelField, apf::Field * PrField, apf::Field * VelMagField)\n"
+		"ParPumiMesh_FieldMFEMtoPUMI(ParPumiMesh self, apf::Mesh2 * apf_mesh, ParGridFunction Pr, apf::Field * PrField, apf::Field * PrMagField)\n"
+		""},
+	 { "ParPumiMesh_VectorFieldMFEMtoPUMI", _wrap_ParPumiMesh_VectorFieldMFEMtoPUMI, METH_VARARGS, "ParPumiMesh_VectorFieldMFEMtoPUMI(ParPumiMesh self, apf::Mesh2 * apf_mesh, ParGridFunction Vel, apf::Field * VelField, apf::Field * VelMagField)"},
+	 { "ParPumiMesh_UpdateMesh", _wrap_ParPumiMesh_UpdateMesh, METH_VARARGS, "ParPumiMesh_UpdateMesh(ParPumiMesh self, ParMesh AdaptedpMesh)"},
+	 { "ParPumiMesh_FieldPUMItoMFEM", _wrap_ParPumiMesh_FieldPUMItoMFEM, METH_VARARGS, "ParPumiMesh_FieldPUMItoMFEM(ParPumiMesh self, apf::Mesh2 * apf_mesh, apf::Field * ScalarField, ParGridFunction Pr)"},
+	 { "delete_ParPumiMesh", _wrap_delete_ParPumiMesh, METH_O, "delete_ParPumiMesh(ParPumiMesh self)"},
+	 { "ParPumiMesh_swigregister", ParPumiMesh_swigregister, METH_O, NULL},
+	 { "ParPumiMesh_swiginit", ParPumiMesh_swiginit, METH_VARARGS, NULL},
+	 { "new_GridFunctionPumi", _wrap_new_GridFunctionPumi, METH_VARARGS, "new_GridFunctionPumi(Mesh m, apf::Mesh2 * PumiM, apf::Numbering * v_num_loc, int const mesh_order) -> GridFunctionPumi"},
+	 { "delete_GridFunctionPumi", _wrap_delete_GridFunctionPumi, METH_O, "delete_GridFunctionPumi(GridFunctionPumi self)"},
+	 { "GridFunctionPumi_swigregister", GridFunctionPumi_swigregister, METH_O, NULL},
+	 { "GridFunctionPumi_swiginit", GridFunctionPumi_swiginit, METH_VARARGS, NULL},
 	 { NULL, NULL, 0, NULL }
 };
 
@@ -3823,11 +5365,44 @@ static PyMethodDef SwigMethods_proxydocs[] = {
 
 /* -------- TYPE CONVERSION AND EQUIVALENCE RULES (BEGIN) -------- */
 
+static void *_p_mfem__HypreParVectorTo_p_mfem__Vector(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::Vector *)  ((mfem::HypreParVector *) x));
+}
+static void *_p_mfem__GridFunctionTo_p_mfem__Vector(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::Vector *)  ((mfem::GridFunction *) x));
+}
+static void *_p_mfem__QuadratureFunctionTo_p_mfem__Vector(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::Vector *)  ((mfem::QuadratureFunction *) x));
+}
+static void *_p_mfem__ParGridFunctionTo_p_mfem__Vector(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::Vector *) (mfem::GridFunction *) ((mfem::ParGridFunction *) x));
+}
+static void *_p_mfem__GridFunctionPumiTo_p_mfem__Vector(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::Vector *) (mfem::GridFunction *) ((mfem::GridFunctionPumi *) x));
+}
+static void *_p_mfem__LinearFormTo_p_mfem__Vector(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::Vector *)  ((mfem::LinearForm *) x));
+}
+static void *_p_mfem__ParPumiMeshTo_p_mfem__ParMesh(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::ParMesh *)  ((mfem::ParPumiMesh *) x));
+}
 static void *_p_mfem__ParGridFunctionTo_p_mfem__GridFunction(void *x, int *SWIGUNUSEDPARM(newmemory)) {
     return (void *)((mfem::GridFunction *)  ((mfem::ParGridFunction *) x));
 }
+static void *_p_mfem__GridFunctionPumiTo_p_mfem__GridFunction(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::GridFunction *)  ((mfem::GridFunctionPumi *) x));
+}
 static void *_p_intpTo_p_int(void *x, int *SWIGUNUSEDPARM(newmemory)) {
     return (void *)((int *)  ((intp *) x));
+}
+static void *_p_mfem__ParMeshTo_p_mfem__Mesh(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::Mesh *)  ((mfem::ParMesh *) x));
+}
+static void *_p_mfem__PumiMeshTo_p_mfem__Mesh(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::Mesh *)  ((mfem::PumiMesh *) x));
+}
+static void *_p_mfem__ParPumiMeshTo_p_mfem__Mesh(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::Mesh *) (mfem::ParMesh *) ((mfem::ParPumiMesh *) x));
 }
 static void *_p_doublepTo_p_double(void *x, int *SWIGUNUSEDPARM(newmemory)) {
     return (void *)((double *)  ((doublep *) x));
@@ -3836,6 +5411,9 @@ static swig_type_info _swigt__p_CommGroup = {"_p_CommGroup", "CommGroup *", 0, 0
 static swig_type_info _swigt__p_GroupId = {"_p_GroupId", "GroupId *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_MPI_Comm = {"_p_MPI_Comm", "MPI_Comm *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_PyMFEM__wFILE = {"_p_PyMFEM__wFILE", "PyMFEM::wFILE *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_apf__Field = {"_p_apf__Field", "apf::Field *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_apf__Mesh2 = {"_p_apf__Mesh2", "apf::Mesh2 *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_apf__Numbering = {"_p_apf__Numbering", "apf::Numbering *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_char = {"_p_char", "char *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_double = {"_p_double", "double *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_doublep = {"_p_doublep", "doublep *", 0, 0, (void*)0, 0};
@@ -3843,15 +5421,23 @@ static swig_type_info _swigt__p_hex_t = {"_p_hex_t", "hex_t *", 0, 0, (void*)0, 
 static swig_type_info _swigt__p_int = {"_p_int", "int *|HYPRE_Int *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_intp = {"_p_intp", "intp *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_mfem__GridFunction = {"_p_mfem__GridFunction", "mfem::GridFunction *", 0, 0, (void*)0, 0};
-static swig_type_info _swigt__p_mfem__ParGridFunction = {"_p_mfem__ParGridFunction", 0, 0, 0, 0, 0};
+static swig_type_info _swigt__p_mfem__GridFunctionPumi = {"_p_mfem__GridFunctionPumi", "mfem::GridFunctionPumi *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_mfem__IntegrationRule = {"_p_mfem__IntegrationRule", "mfem::IntegrationRule *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_mfem__L2_FECollection = {"_p_mfem__L2_FECollection", "mfem::L2_FECollection *|mfem::DG_FECollection *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_mfem__Mesh = {"_p_mfem__Mesh", "mfem::Mesh *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_mfem__OperatorHandle = {"_p_mfem__OperatorHandle", "mfem::OperatorPtr *|mfem::OperatorHandle *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_mfem__ParGridFunction = {"_p_mfem__ParGridFunction", "mfem::ParGridFunction *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_mfem__ParMesh = {"_p_mfem__ParMesh", "mfem::ParMesh *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_mfem__ParPumiMesh = {"_p_mfem__ParPumiMesh", "mfem::ParPumiMesh *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_mfem__PumiMesh = {"_p_mfem__PumiMesh", "mfem::PumiMesh *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_mfem__Vector = {"_p_mfem__Vector", "mfem::Vector *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_mfem__HypreParVector = {"_p_mfem__HypreParVector", 0, 0, 0, 0, 0};
+static swig_type_info _swigt__p_mfem__QuadratureFunction = {"_p_mfem__QuadratureFunction", 0, 0, 0, 0, 0};
+static swig_type_info _swigt__p_mfem__LinearForm = {"_p_mfem__LinearForm", 0, 0, 0, 0, 0};
 static swig_type_info _swigt__p_pri_t = {"_p_pri_t", "pri_t *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_quad_t = {"_p_quad_t", "quad_t *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_seg_t = {"_p_seg_t", "seg_t *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_std__istream = {"_p_std__istream", "std::istream *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_tet_t = {"_p_tet_t", "tet_t *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_tri_t = {"_p_tri_t", "tri_t *", 0, 0, (void*)0, 0};
 
@@ -3860,6 +5446,9 @@ static swig_type_info *swig_type_initial[] = {
   &_swigt__p_GroupId,
   &_swigt__p_MPI_Comm,
   &_swigt__p_PyMFEM__wFILE,
+  &_swigt__p_apf__Field,
+  &_swigt__p_apf__Mesh2,
+  &_swigt__p_apf__Numbering,
   &_swigt__p_char,
   &_swigt__p_double,
   &_swigt__p_doublep,
@@ -3867,15 +5456,23 @@ static swig_type_info *swig_type_initial[] = {
   &_swigt__p_int,
   &_swigt__p_intp,
   &_swigt__p_mfem__GridFunction,
+  &_swigt__p_mfem__GridFunctionPumi,
+  &_swigt__p_mfem__HypreParVector,
   &_swigt__p_mfem__IntegrationRule,
   &_swigt__p_mfem__L2_FECollection,
+  &_swigt__p_mfem__LinearForm,
+  &_swigt__p_mfem__Mesh,
   &_swigt__p_mfem__OperatorHandle,
   &_swigt__p_mfem__ParGridFunction,
   &_swigt__p_mfem__ParMesh,
   &_swigt__p_mfem__ParPumiMesh,
+  &_swigt__p_mfem__PumiMesh,
+  &_swigt__p_mfem__QuadratureFunction,
+  &_swigt__p_mfem__Vector,
   &_swigt__p_pri_t,
   &_swigt__p_quad_t,
   &_swigt__p_seg_t,
+  &_swigt__p_std__istream,
   &_swigt__p_tet_t,
   &_swigt__p_tri_t,
 };
@@ -3884,22 +5481,33 @@ static swig_cast_info _swigc__p_CommGroup[] = {  {&_swigt__p_CommGroup, 0, 0, 0}
 static swig_cast_info _swigc__p_GroupId[] = {  {&_swigt__p_GroupId, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_MPI_Comm[] = {  {&_swigt__p_MPI_Comm, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_PyMFEM__wFILE[] = {  {&_swigt__p_PyMFEM__wFILE, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_apf__Field[] = {  {&_swigt__p_apf__Field, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_apf__Mesh2[] = {  {&_swigt__p_apf__Mesh2, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_apf__Numbering[] = {  {&_swigt__p_apf__Numbering, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_char[] = {  {&_swigt__p_char, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_double[] = {  {&_swigt__p_double, 0, 0, 0},  {&_swigt__p_doublep, _p_doublepTo_p_double, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_doublep[] = {  {&_swigt__p_doublep, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_hex_t[] = {  {&_swigt__p_hex_t, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_int[] = {  {&_swigt__p_intp, _p_intpTo_p_int, 0, 0},  {&_swigt__p_int, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_intp[] = {  {&_swigt__p_intp, 0, 0, 0},{0, 0, 0, 0}};
-static swig_cast_info _swigc__p_mfem__ParGridFunction[] = {{&_swigt__p_mfem__ParGridFunction, 0, 0, 0},{0, 0, 0, 0}};
-static swig_cast_info _swigc__p_mfem__GridFunction[] = {  {&_swigt__p_mfem__GridFunction, 0, 0, 0},  {&_swigt__p_mfem__ParGridFunction, _p_mfem__ParGridFunctionTo_p_mfem__GridFunction, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_mfem__GridFunction[] = {  {&_swigt__p_mfem__GridFunction, 0, 0, 0},  {&_swigt__p_mfem__ParGridFunction, _p_mfem__ParGridFunctionTo_p_mfem__GridFunction, 0, 0},  {&_swigt__p_mfem__GridFunctionPumi, _p_mfem__GridFunctionPumiTo_p_mfem__GridFunction, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_mfem__GridFunctionPumi[] = {  {&_swigt__p_mfem__GridFunctionPumi, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_mfem__IntegrationRule[] = {  {&_swigt__p_mfem__IntegrationRule, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_mfem__L2_FECollection[] = {  {&_swigt__p_mfem__L2_FECollection, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_mfem__Mesh[] = {  {&_swigt__p_mfem__ParMesh, _p_mfem__ParMeshTo_p_mfem__Mesh, 0, 0},  {&_swigt__p_mfem__ParPumiMesh, _p_mfem__ParPumiMeshTo_p_mfem__Mesh, 0, 0},  {&_swigt__p_mfem__PumiMesh, _p_mfem__PumiMeshTo_p_mfem__Mesh, 0, 0},  {&_swigt__p_mfem__Mesh, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_mfem__OperatorHandle[] = {  {&_swigt__p_mfem__OperatorHandle, 0, 0, 0},{0, 0, 0, 0}};
-static swig_cast_info _swigc__p_mfem__ParMesh[] = {  {&_swigt__p_mfem__ParMesh, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_mfem__ParGridFunction[] = {  {&_swigt__p_mfem__ParGridFunction, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_mfem__ParMesh[] = {  {&_swigt__p_mfem__ParMesh, 0, 0, 0},  {&_swigt__p_mfem__ParPumiMesh, _p_mfem__ParPumiMeshTo_p_mfem__ParMesh, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_mfem__ParPumiMesh[] = {  {&_swigt__p_mfem__ParPumiMesh, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_mfem__PumiMesh[] = {  {&_swigt__p_mfem__PumiMesh, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_mfem__HypreParVector[] = {{&_swigt__p_mfem__HypreParVector, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_mfem__QuadratureFunction[] = {{&_swigt__p_mfem__QuadratureFunction, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_mfem__LinearForm[] = {{&_swigt__p_mfem__LinearForm, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_mfem__Vector[] = {  {&_swigt__p_mfem__HypreParVector, _p_mfem__HypreParVectorTo_p_mfem__Vector, 0, 0},  {&_swigt__p_mfem__Vector, 0, 0, 0},  {&_swigt__p_mfem__GridFunction, _p_mfem__GridFunctionTo_p_mfem__Vector, 0, 0},  {&_swigt__p_mfem__ParGridFunction, _p_mfem__ParGridFunctionTo_p_mfem__Vector, 0, 0},  {&_swigt__p_mfem__GridFunctionPumi, _p_mfem__GridFunctionPumiTo_p_mfem__Vector, 0, 0},  {&_swigt__p_mfem__QuadratureFunction, _p_mfem__QuadratureFunctionTo_p_mfem__Vector, 0, 0},  {&_swigt__p_mfem__LinearForm, _p_mfem__LinearFormTo_p_mfem__Vector, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_pri_t[] = {  {&_swigt__p_pri_t, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_quad_t[] = {  {&_swigt__p_quad_t, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_seg_t[] = {  {&_swigt__p_seg_t, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_std__istream[] = {  {&_swigt__p_std__istream, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_tet_t[] = {  {&_swigt__p_tet_t, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_tri_t[] = {  {&_swigt__p_tri_t, 0, 0, 0},{0, 0, 0, 0}};
 
@@ -3908,6 +5516,9 @@ static swig_cast_info *swig_cast_initial[] = {
   _swigc__p_GroupId,
   _swigc__p_MPI_Comm,
   _swigc__p_PyMFEM__wFILE,
+  _swigc__p_apf__Field,
+  _swigc__p_apf__Mesh2,
+  _swigc__p_apf__Numbering,
   _swigc__p_char,
   _swigc__p_double,
   _swigc__p_doublep,
@@ -3915,15 +5526,23 @@ static swig_cast_info *swig_cast_initial[] = {
   _swigc__p_int,
   _swigc__p_intp,
   _swigc__p_mfem__GridFunction,
+  _swigc__p_mfem__GridFunctionPumi,
+  _swigc__p_mfem__HypreParVector,
   _swigc__p_mfem__IntegrationRule,
   _swigc__p_mfem__L2_FECollection,
+  _swigc__p_mfem__LinearForm,
+  _swigc__p_mfem__Mesh,
   _swigc__p_mfem__OperatorHandle,
   _swigc__p_mfem__ParGridFunction,
   _swigc__p_mfem__ParMesh,
   _swigc__p_mfem__ParPumiMesh,
+  _swigc__p_mfem__PumiMesh,
+  _swigc__p_mfem__QuadratureFunction,
+  _swigc__p_mfem__Vector,
   _swigc__p_pri_t,
   _swigc__p_quad_t,
   _swigc__p_seg_t,
+  _swigc__p_std__istream,
   _swigc__p_tet_t,
   _swigc__p_tri_t,
 };

--- a/mfem/_ser/coefficient.i
+++ b/mfem/_ser/coefficient.i
@@ -49,13 +49,36 @@ import_array();
 
 %ignore Function;
 //%ignore DeltaCoefficient;
-%feature("notabstract") VectorFunctionCoefficient;
-%feature("notabstract") VectorConstantCoefficient;
-%feature("notabstract") VectorDeltaCoefficient;
-%feature("notabstract") MatrixFunctionCoefficient;
-%feature("notabstract") MatrixConstantCoefficient;
+namespace mfem {
+%pythonprepend MatrixConstantCoefficient::MatrixConstantCoefficient(const DenseMatrix &m) %{
+   try:
+      import numpy as np
+      value = np.array(m, copy=False, dtype=float)
+      can_np_array = True
+   except:
+      can_np_array = False
 
-namespace mfem { 
+   if can_np_array:
+      v = mfem._ser.vector.Vector(np.transpose(value).flatten())
+      m = mfem._ser.densemat.DenseMatrix(v.GetData(), value.shape[0], value.shape[1])       
+      self._value = (v,m)
+   else:
+      pass 
+%}
+%pythonprepend VectorConstantCoefficient::VectorConstantCoefficient(const Vector &v) %{
+   try:
+      import numpy as np
+      value = np.array(v, copy=False, dtype=float).flatten()
+      can_np_array = True
+   except:
+      can_np_array = False
+
+   if can_np_array:
+      v = mfem._ser.vector.Vector(value)
+      self._value = v
+   else:
+      pass 
+%}
 %pythonprepend DeltaCoefficient::SetWeight %{
     w.thisown=0 
 %}
@@ -76,6 +99,13 @@ namespace mfem {
 %}
   
 }
+
+%feature("notabstract") mfem::VectorFunctionCoefficient;
+%feature("notabstract") mfem::VectorConstantCoefficient;
+%feature("notabstract") mfem::VectorDeltaCoefficient;
+%feature("notabstract") mfem::MatrixFunctionCoefficient;
+%feature("notabstract") mfem::MatrixConstantCoefficient;
+
 
 /*
 %exception {

--- a/mfem/_ser/coefficient.py
+++ b/mfem/_ser/coefficient.py
@@ -362,6 +362,21 @@ class VectorConstantCoefficient(VectorCoefficient):
 
     def __init__(self, v):
         r"""__init__(VectorConstantCoefficient self, Vector v) -> VectorConstantCoefficient"""
+
+        try:
+           import numpy as np
+           value = np.array(v, copy=False, dtype=float).flatten()
+           can_np_array = True
+        except:
+           can_np_array = False
+
+        if can_np_array:
+           v = mfem._ser.vector.Vector(value)
+           self._value = v
+        else:
+           pass 
+
+
         _coefficient.VectorConstantCoefficient_swiginit(self, _coefficient.new_VectorConstantCoefficient(v))
 
     def Eval(self, *args):
@@ -684,6 +699,22 @@ class MatrixConstantCoefficient(MatrixCoefficient):
 
     def __init__(self, m):
         r"""__init__(MatrixConstantCoefficient self, DenseMatrix m) -> MatrixConstantCoefficient"""
+
+        try:
+           import numpy as np
+           value = np.array(m, copy=False, dtype=float)
+           can_np_array = True
+        except:
+           can_np_array = False
+
+        if can_np_array:
+           v = mfem._ser.vector.Vector(np.transpose(value).flatten())
+           m = mfem._ser.densemat.DenseMatrix(v.GetData(), value.shape[0], value.shape[1])       
+           self._value = (v,m)
+        else:
+           pass 
+
+
         _coefficient.MatrixConstantCoefficient_swiginit(self, _coefficient.new_MatrixConstantCoefficient(m))
 
     def Eval(self, *args):


### PR DESCRIPTION
this pull add
* support Python native numbers as an input to Matrix/VectorConstantCoefficient 
** coefficient = mfem.MatrixConstatantCoefficient([[1,0], [0,1]])

* fixed makefile to run SWIG with PUMI always to generate a wrapper code.

* increment version to 4.0.2 (from 4.0.1)