### PR TITLE
Fix bilininteg baseclass

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -1,4 +1,8 @@
 	<<<  Change Log. >>>
+2020 11.29
+        * bilininteg.i is adjusted so that NonlinearIntegrator is properly recognized
+	  as a base class of BilinearIntegrator class. This allows to use SetIntOrder
+	  and some others in BilinearIntegrator
 2020 11.23
         * Mesh.GetElementCenterArray is added, which returns numpy array
 2020 11.21

--- a/mfem/__init__.py
+++ b/mfem/__init__.py
@@ -20,5 +20,5 @@ def debug_print(message):
     
     print(message)
 
-__version__ = '4.2.0.0'
+__version__ = '4.2.0.1'
 

--- a/mfem/__init__.py
+++ b/mfem/__init__.py
@@ -20,5 +20,5 @@ def debug_print(message):
     
     print(message)
 
-__version__ = '4.2.0.c1'
+__version__ = '4.2.0.0'
 

--- a/mfem/_par/bilininteg.i
+++ b/mfem/_par/bilininteg.i
@@ -30,6 +30,7 @@ import_array();
 %import "eltrans.i"
 %import "linearform.i"
 %import "fe.i"
+%import "nonlininteg.i"
 %include "../common/exception_director.i"
  //%template(IntegrationPointArray) mfem::Array<mfem::IntegrationPoint>;
 

--- a/mfem/_par/bilininteg.py
+++ b/mfem/_par/bilininteg.py
@@ -95,7 +95,8 @@ import mfem._par.handle
 import mfem._par.hypre
 import mfem._par.restriction
 import mfem._par.linearform
-class BilinearFormIntegrator(object):
+import mfem._par.nonlininteg
+class BilinearFormIntegrator(mfem._par.nonlininteg.NonlinearFormIntegrator):
     r"""Proxy of C++ mfem::BilinearFormIntegrator class."""
 
     thisown = property(lambda x: x.this.own(), lambda x, v: x.this.own(v), doc="The membership flag")
@@ -111,7 +112,8 @@ class BilinearFormIntegrator(object):
 
     def AssemblePA(self, *args):
         r"""
-        AssemblePA(BilinearFormIntegrator self)
+        AssemblePA(BilinearFormIntegrator self, FiniteElementSpace fes)
+        AssemblePA(BilinearFormIntegrator self, FiniteElementSpace trial_fes, FiniteElementSpace test_fes)
         AssemblePA(BilinearFormIntegrator self, FiniteElementSpace fes)
         AssemblePA(BilinearFormIntegrator self, FiniteElementSpace trial_fes, FiniteElementSpace test_fes)
         """
@@ -279,7 +281,8 @@ class TransposeIntegrator(BilinearFormIntegrator):
 
     def AssemblePA(self, *args):
         r"""
-        AssemblePA(TransposeIntegrator self)
+        AssemblePA(TransposeIntegrator self, FiniteElementSpace fes)
+        AssemblePA(TransposeIntegrator self, FiniteElementSpace trial_fes, FiniteElementSpace test_fes)
         AssemblePA(TransposeIntegrator self, FiniteElementSpace fes)
         """
         return _bilininteg.TransposeIntegrator_AssemblePA(self, *args)
@@ -1424,7 +1427,8 @@ class GradientIntegrator(BilinearFormIntegrator):
 
     def AssemblePA(self, *args):
         r"""
-        AssemblePA(GradientIntegrator self)
+        AssemblePA(GradientIntegrator self, FiniteElementSpace fes)
+        AssemblePA(GradientIntegrator self, FiniteElementSpace trial_fes, FiniteElementSpace test_fes)
         AssemblePA(GradientIntegrator self, FiniteElementSpace trial_fes, FiniteElementSpace test_fes)
         """
         return _bilininteg.GradientIntegrator_AssemblePA(self, *args)
@@ -1508,7 +1512,8 @@ class DiffusionIntegrator(BilinearFormIntegrator):
 
     def AssemblePA(self, *args):
         r"""
-        AssemblePA(DiffusionIntegrator self)
+        AssemblePA(DiffusionIntegrator self, FiniteElementSpace fes)
+        AssemblePA(DiffusionIntegrator self, FiniteElementSpace trial_fes, FiniteElementSpace test_fes)
         AssemblePA(DiffusionIntegrator self, FiniteElementSpace fes)
         """
         return _bilininteg.DiffusionIntegrator_AssemblePA(self, *args)
@@ -1589,7 +1594,8 @@ class MassIntegrator(BilinearFormIntegrator):
 
     def AssemblePA(self, *args):
         r"""
-        AssemblePA(MassIntegrator self)
+        AssemblePA(MassIntegrator self, FiniteElementSpace fes)
+        AssemblePA(MassIntegrator self, FiniteElementSpace trial_fes, FiniteElementSpace test_fes)
         AssemblePA(MassIntegrator self, FiniteElementSpace fes)
         """
         return _bilininteg.MassIntegrator_AssemblePA(self, *args)
@@ -1674,7 +1680,8 @@ class ConvectionIntegrator(BilinearFormIntegrator):
 
     def AssemblePA(self, *args):
         r"""
-        AssemblePA(ConvectionIntegrator self)
+        AssemblePA(ConvectionIntegrator self, FiniteElementSpace fes)
+        AssemblePA(ConvectionIntegrator self, FiniteElementSpace trial_fes, FiniteElementSpace test_fes)
         AssemblePA(ConvectionIntegrator self, FiniteElementSpace arg2)
         """
         return _bilininteg.ConvectionIntegrator_AssemblePA(self, *args)
@@ -1769,7 +1776,8 @@ class VectorMassIntegrator(BilinearFormIntegrator):
 
     def AssemblePA(self, *args):
         r"""
-        AssemblePA(VectorMassIntegrator self)
+        AssemblePA(VectorMassIntegrator self, FiniteElementSpace fes)
+        AssemblePA(VectorMassIntegrator self, FiniteElementSpace trial_fes, FiniteElementSpace test_fes)
         AssemblePA(VectorMassIntegrator self, FiniteElementSpace fes)
         """
         return _bilininteg.VectorMassIntegrator_AssemblePA(self, *args)
@@ -1950,7 +1958,8 @@ class CurlCurlIntegrator(BilinearFormIntegrator):
 
     def AssemblePA(self, *args):
         r"""
-        AssemblePA(CurlCurlIntegrator self)
+        AssemblePA(CurlCurlIntegrator self, FiniteElementSpace fes)
+        AssemblePA(CurlCurlIntegrator self, FiniteElementSpace trial_fes, FiniteElementSpace test_fes)
         AssemblePA(CurlCurlIntegrator self, FiniteElementSpace fes)
         """
         return _bilininteg.CurlCurlIntegrator_AssemblePA(self, *args)
@@ -2032,7 +2041,8 @@ class VectorFEMassIntegrator(BilinearFormIntegrator):
 
     def AssemblePA(self, *args):
         r"""
-        AssemblePA(VectorFEMassIntegrator self)
+        AssemblePA(VectorFEMassIntegrator self, FiniteElementSpace fes)
+        AssemblePA(VectorFEMassIntegrator self, FiniteElementSpace trial_fes, FiniteElementSpace test_fes)
         AssemblePA(VectorFEMassIntegrator self, FiniteElementSpace fes)
         AssemblePA(VectorFEMassIntegrator self, FiniteElementSpace trial_fes, FiniteElementSpace test_fes)
         """
@@ -2074,7 +2084,8 @@ class VectorDivergenceIntegrator(BilinearFormIntegrator):
 
     def AssemblePA(self, *args):
         r"""
-        AssemblePA(VectorDivergenceIntegrator self)
+        AssemblePA(VectorDivergenceIntegrator self, FiniteElementSpace fes)
+        AssemblePA(VectorDivergenceIntegrator self, FiniteElementSpace trial_fes, FiniteElementSpace test_fes)
         AssemblePA(VectorDivergenceIntegrator self, FiniteElementSpace trial_fes, FiniteElementSpace test_fes)
         """
         return _bilininteg.VectorDivergenceIntegrator_AssemblePA(self, *args)
@@ -2153,7 +2164,8 @@ class VectorDiffusionIntegrator(BilinearFormIntegrator):
 
     def AssemblePA(self, *args):
         r"""
-        AssemblePA(VectorDiffusionIntegrator self)
+        AssemblePA(VectorDiffusionIntegrator self, FiniteElementSpace fes)
+        AssemblePA(VectorDiffusionIntegrator self, FiniteElementSpace trial_fes, FiniteElementSpace test_fes)
         AssemblePA(VectorDiffusionIntegrator self, FiniteElementSpace fes)
         """
         return _bilininteg.VectorDiffusionIntegrator_AssemblePA(self, *args)
@@ -2240,6 +2252,14 @@ class DGTraceIntegrator(BilinearFormIntegrator):
         """
         return _bilininteg.DGTraceIntegrator_AssembleFaceMatrix(self, *args)
     AssembleFaceMatrix = _swig_new_instance_method(_bilininteg.DGTraceIntegrator_AssembleFaceMatrix)
+
+    def AssemblePA(self, *args):
+        r"""
+        AssemblePA(DGTraceIntegrator self, FiniteElementSpace fes)
+        AssemblePA(DGTraceIntegrator self, FiniteElementSpace trial_fes, FiniteElementSpace test_fes)
+        """
+        return _bilininteg.DGTraceIntegrator_AssemblePA(self, *args)
+    AssemblePA = _swig_new_instance_method(_bilininteg.DGTraceIntegrator_AssemblePA)
 
     def AssemblePAInteriorFaces(self, fes):
         r"""AssemblePAInteriorFaces(DGTraceIntegrator self, FiniteElementSpace fes)"""

--- a/mfem/_par/bilininteg_wrap.cxx
+++ b/mfem/_par/bilininteg_wrap.cxx
@@ -3166,190 +3166,193 @@ namespace Swig {
 #define SWIGTYPE_p_mfem__H1_TetrahedronElement swig_types[66]
 #define SWIGTYPE_p_mfem__H1_TriangleElement swig_types[67]
 #define SWIGTYPE_p_mfem__H1_WedgeElement swig_types[68]
-#define SWIGTYPE_p_mfem__HypreParVector swig_types[69]
-#define SWIGTYPE_p_mfem__IdentityInterpolator swig_types[70]
-#define SWIGTYPE_p_mfem__IdentityMatrixCoefficient swig_types[71]
-#define SWIGTYPE_p_mfem__InnerProductCoefficient swig_types[72]
-#define SWIGTYPE_p_mfem__IntegrationRule swig_types[73]
-#define SWIGTYPE_p_mfem__InverseIntegrator swig_types[74]
-#define SWIGTYPE_p_mfem__InverseMatrixCoefficient swig_types[75]
-#define SWIGTYPE_p_mfem__IsoparametricTransformation swig_types[76]
-#define SWIGTYPE_p_mfem__L2Pos_HexahedronElement swig_types[77]
-#define SWIGTYPE_p_mfem__L2Pos_QuadrilateralElement swig_types[78]
-#define SWIGTYPE_p_mfem__L2Pos_SegmentElement swig_types[79]
-#define SWIGTYPE_p_mfem__L2Pos_TetrahedronElement swig_types[80]
-#define SWIGTYPE_p_mfem__L2Pos_TriangleElement swig_types[81]
-#define SWIGTYPE_p_mfem__L2Pos_WedgeElement swig_types[82]
-#define SWIGTYPE_p_mfem__L2_FECollection swig_types[83]
-#define SWIGTYPE_p_mfem__L2_HexahedronElement swig_types[84]
-#define SWIGTYPE_p_mfem__L2_QuadrilateralElement swig_types[85]
-#define SWIGTYPE_p_mfem__L2_SegmentElement swig_types[86]
-#define SWIGTYPE_p_mfem__L2_TetrahedronElement swig_types[87]
-#define SWIGTYPE_p_mfem__L2_TriangleElement swig_types[88]
-#define SWIGTYPE_p_mfem__L2_WedgeElement swig_types[89]
-#define SWIGTYPE_p_mfem__Lagrange1DFiniteElement swig_types[90]
-#define SWIGTYPE_p_mfem__LagrangeHexFiniteElement swig_types[91]
-#define SWIGTYPE_p_mfem__Linear1DFiniteElement swig_types[92]
-#define SWIGTYPE_p_mfem__Linear2DFiniteElement swig_types[93]
-#define SWIGTYPE_p_mfem__Linear3DFiniteElement swig_types[94]
-#define SWIGTYPE_p_mfem__LinearForm swig_types[95]
-#define SWIGTYPE_p_mfem__LumpedIntegrator swig_types[96]
-#define SWIGTYPE_p_mfem__MassIntegrator swig_types[97]
-#define SWIGTYPE_p_mfem__MatrixArrayCoefficient swig_types[98]
-#define SWIGTYPE_p_mfem__MatrixCoefficient swig_types[99]
-#define SWIGTYPE_p_mfem__MatrixConstantCoefficient swig_types[100]
-#define SWIGTYPE_p_mfem__MatrixFunctionCoefficient swig_types[101]
-#define SWIGTYPE_p_mfem__MatrixPyCoefficientBase swig_types[102]
-#define SWIGTYPE_p_mfem__MatrixRestrictedCoefficient swig_types[103]
-#define SWIGTYPE_p_mfem__MatrixSumCoefficient swig_types[104]
-#define SWIGTYPE_p_mfem__MatrixVectorProductCoefficient swig_types[105]
-#define SWIGTYPE_p_mfem__MixedCrossCurlCurlIntegrator swig_types[106]
-#define SWIGTYPE_p_mfem__MixedCrossCurlGradIntegrator swig_types[107]
-#define SWIGTYPE_p_mfem__MixedCrossCurlIntegrator swig_types[108]
-#define SWIGTYPE_p_mfem__MixedCrossGradCurlIntegrator swig_types[109]
-#define SWIGTYPE_p_mfem__MixedCrossGradGradIntegrator swig_types[110]
-#define SWIGTYPE_p_mfem__MixedCrossGradIntegrator swig_types[111]
-#define SWIGTYPE_p_mfem__MixedCrossProductIntegrator swig_types[112]
-#define SWIGTYPE_p_mfem__MixedCurlCurlIntegrator swig_types[113]
-#define SWIGTYPE_p_mfem__MixedDirectionalDerivativeIntegrator swig_types[114]
-#define SWIGTYPE_p_mfem__MixedDivGradIntegrator swig_types[115]
-#define SWIGTYPE_p_mfem__MixedDotProductIntegrator swig_types[116]
-#define SWIGTYPE_p_mfem__MixedGradDivIntegrator swig_types[117]
-#define SWIGTYPE_p_mfem__MixedGradGradIntegrator swig_types[118]
-#define SWIGTYPE_p_mfem__MixedScalarCrossCurlIntegrator swig_types[119]
-#define SWIGTYPE_p_mfem__MixedScalarCrossGradIntegrator swig_types[120]
-#define SWIGTYPE_p_mfem__MixedScalarCrossProductIntegrator swig_types[121]
-#define SWIGTYPE_p_mfem__MixedScalarCurlIntegrator swig_types[122]
-#define SWIGTYPE_p_mfem__MixedScalarDerivativeIntegrator swig_types[123]
-#define SWIGTYPE_p_mfem__MixedScalarDivergenceIntegrator swig_types[124]
-#define SWIGTYPE_p_mfem__MixedScalarIntegrator swig_types[125]
-#define SWIGTYPE_p_mfem__MixedScalarMassIntegrator swig_types[126]
-#define SWIGTYPE_p_mfem__MixedScalarVectorIntegrator swig_types[127]
-#define SWIGTYPE_p_mfem__MixedScalarWeakCrossProductIntegrator swig_types[128]
-#define SWIGTYPE_p_mfem__MixedScalarWeakCurlCrossIntegrator swig_types[129]
-#define SWIGTYPE_p_mfem__MixedScalarWeakCurlIntegrator swig_types[130]
-#define SWIGTYPE_p_mfem__MixedScalarWeakDerivativeIntegrator swig_types[131]
-#define SWIGTYPE_p_mfem__MixedScalarWeakDivergenceIntegrator swig_types[132]
-#define SWIGTYPE_p_mfem__MixedScalarWeakGradientIntegrator swig_types[133]
-#define SWIGTYPE_p_mfem__MixedVectorCurlIntegrator swig_types[134]
-#define SWIGTYPE_p_mfem__MixedVectorDivergenceIntegrator swig_types[135]
-#define SWIGTYPE_p_mfem__MixedVectorGradientIntegrator swig_types[136]
-#define SWIGTYPE_p_mfem__MixedVectorIntegrator swig_types[137]
-#define SWIGTYPE_p_mfem__MixedVectorMassIntegrator swig_types[138]
-#define SWIGTYPE_p_mfem__MixedVectorProductIntegrator swig_types[139]
-#define SWIGTYPE_p_mfem__MixedVectorWeakCurlIntegrator swig_types[140]
-#define SWIGTYPE_p_mfem__MixedVectorWeakDivergenceIntegrator swig_types[141]
-#define SWIGTYPE_p_mfem__MixedWeakCurlCrossIntegrator swig_types[142]
-#define SWIGTYPE_p_mfem__MixedWeakDivCrossIntegrator swig_types[143]
-#define SWIGTYPE_p_mfem__MixedWeakGradDotIntegrator swig_types[144]
-#define SWIGTYPE_p_mfem__ND_HexahedronElement swig_types[145]
-#define SWIGTYPE_p_mfem__ND_QuadrilateralElement swig_types[146]
-#define SWIGTYPE_p_mfem__ND_SegmentElement swig_types[147]
-#define SWIGTYPE_p_mfem__ND_TetrahedronElement swig_types[148]
-#define SWIGTYPE_p_mfem__ND_TriangleElement swig_types[149]
-#define SWIGTYPE_p_mfem__NURBS1DFiniteElement swig_types[150]
-#define SWIGTYPE_p_mfem__NURBS2DFiniteElement swig_types[151]
-#define SWIGTYPE_p_mfem__NURBS3DFiniteElement swig_types[152]
-#define SWIGTYPE_p_mfem__NURBSFiniteElement swig_types[153]
-#define SWIGTYPE_p_mfem__Nedelec1HexFiniteElement swig_types[154]
-#define SWIGTYPE_p_mfem__Nedelec1TetFiniteElement swig_types[155]
-#define SWIGTYPE_p_mfem__NodalFiniteElement swig_types[156]
-#define SWIGTYPE_p_mfem__NodalTensorFiniteElement swig_types[157]
-#define SWIGTYPE_p_mfem__NodeExtrudeCoefficient swig_types[158]
-#define SWIGTYPE_p_mfem__NormalInterpolator swig_types[159]
-#define SWIGTYPE_p_mfem__NormalTraceJumpIntegrator swig_types[160]
-#define SWIGTYPE_p_mfem__NormalizedVectorCoefficient swig_types[161]
-#define SWIGTYPE_p_mfem__OperatorHandle swig_types[162]
-#define SWIGTYPE_p_mfem__OuterProductCoefficient swig_types[163]
-#define SWIGTYPE_p_mfem__P0HexFiniteElement swig_types[164]
-#define SWIGTYPE_p_mfem__P0QuadFiniteElement swig_types[165]
-#define SWIGTYPE_p_mfem__P0SegmentFiniteElement swig_types[166]
-#define SWIGTYPE_p_mfem__P0TetFiniteElement swig_types[167]
-#define SWIGTYPE_p_mfem__P0TriangleFiniteElement swig_types[168]
-#define SWIGTYPE_p_mfem__P0WedgeFiniteElement swig_types[169]
-#define SWIGTYPE_p_mfem__P1OnQuadFiniteElement swig_types[170]
-#define SWIGTYPE_p_mfem__P1SegmentFiniteElement swig_types[171]
-#define SWIGTYPE_p_mfem__P1TetNonConfFiniteElement swig_types[172]
-#define SWIGTYPE_p_mfem__P2SegmentFiniteElement swig_types[173]
-#define SWIGTYPE_p_mfem__PWConstCoefficient swig_types[174]
-#define SWIGTYPE_p_mfem__PointFiniteElement swig_types[175]
-#define SWIGTYPE_p_mfem__PositiveFiniteElement swig_types[176]
-#define SWIGTYPE_p_mfem__PositiveTensorFiniteElement swig_types[177]
-#define SWIGTYPE_p_mfem__PowerCoefficient swig_types[178]
-#define SWIGTYPE_p_mfem__ProductCoefficient swig_types[179]
-#define SWIGTYPE_p_mfem__PyCoefficientBase swig_types[180]
-#define SWIGTYPE_p_mfem__Quad1DFiniteElement swig_types[181]
-#define SWIGTYPE_p_mfem__Quad2DFiniteElement swig_types[182]
-#define SWIGTYPE_p_mfem__QuadPos1DFiniteElement swig_types[183]
-#define SWIGTYPE_p_mfem__Quadratic3DFiniteElement swig_types[184]
-#define SWIGTYPE_p_mfem__QuadratureFunction swig_types[185]
-#define SWIGTYPE_p_mfem__QuadratureFunctionCoefficient swig_types[186]
-#define SWIGTYPE_p_mfem__RT0HexFiniteElement swig_types[187]
-#define SWIGTYPE_p_mfem__RT0QuadFiniteElement swig_types[188]
-#define SWIGTYPE_p_mfem__RT0TetFiniteElement swig_types[189]
-#define SWIGTYPE_p_mfem__RT0TriangleFiniteElement swig_types[190]
-#define SWIGTYPE_p_mfem__RT1HexFiniteElement swig_types[191]
-#define SWIGTYPE_p_mfem__RT1QuadFiniteElement swig_types[192]
-#define SWIGTYPE_p_mfem__RT1TriangleFiniteElement swig_types[193]
-#define SWIGTYPE_p_mfem__RT2QuadFiniteElement swig_types[194]
-#define SWIGTYPE_p_mfem__RT2TriangleFiniteElement swig_types[195]
-#define SWIGTYPE_p_mfem__RT_HexahedronElement swig_types[196]
-#define SWIGTYPE_p_mfem__RT_QuadrilateralElement swig_types[197]
-#define SWIGTYPE_p_mfem__RT_TetrahedronElement swig_types[198]
-#define SWIGTYPE_p_mfem__RT_TriangleElement swig_types[199]
-#define SWIGTYPE_p_mfem__RatioCoefficient swig_types[200]
-#define SWIGTYPE_p_mfem__RefinedBiLinear2DFiniteElement swig_types[201]
-#define SWIGTYPE_p_mfem__RefinedLinear1DFiniteElement swig_types[202]
-#define SWIGTYPE_p_mfem__RefinedLinear2DFiniteElement swig_types[203]
-#define SWIGTYPE_p_mfem__RefinedLinear3DFiniteElement swig_types[204]
-#define SWIGTYPE_p_mfem__RefinedTriLinear3DFiniteElement swig_types[205]
-#define SWIGTYPE_p_mfem__RestrictedCoefficient swig_types[206]
-#define SWIGTYPE_p_mfem__RotTriLinearHexFiniteElement swig_types[207]
-#define SWIGTYPE_p_mfem__ScalarFiniteElement swig_types[208]
-#define SWIGTYPE_p_mfem__ScalarMatrixProductCoefficient swig_types[209]
-#define SWIGTYPE_p_mfem__ScalarProductInterpolator swig_types[210]
-#define SWIGTYPE_p_mfem__ScalarVectorProductCoefficient swig_types[211]
-#define SWIGTYPE_p_mfem__ScalarVectorProductInterpolator swig_types[212]
-#define SWIGTYPE_p_mfem__SumCoefficient swig_types[213]
-#define SWIGTYPE_p_mfem__SumIntegrator swig_types[214]
-#define SWIGTYPE_p_mfem__TraceJumpIntegrator swig_types[215]
-#define SWIGTYPE_p_mfem__TransformedCoefficient swig_types[216]
-#define SWIGTYPE_p_mfem__TransposeIntegrator swig_types[217]
-#define SWIGTYPE_p_mfem__TransposeMatrixCoefficient swig_types[218]
-#define SWIGTYPE_p_mfem__TriLinear3DFiniteElement swig_types[219]
-#define SWIGTYPE_p_mfem__Vector swig_types[220]
-#define SWIGTYPE_p_mfem__VectorArrayCoefficient swig_types[221]
-#define SWIGTYPE_p_mfem__VectorCoefficient swig_types[222]
-#define SWIGTYPE_p_mfem__VectorConstantCoefficient swig_types[223]
-#define SWIGTYPE_p_mfem__VectorCrossProductCoefficient swig_types[224]
-#define SWIGTYPE_p_mfem__VectorCrossProductInterpolator swig_types[225]
-#define SWIGTYPE_p_mfem__VectorCurlCurlIntegrator swig_types[226]
-#define SWIGTYPE_p_mfem__VectorDeltaCoefficient swig_types[227]
-#define SWIGTYPE_p_mfem__VectorDiffusionIntegrator swig_types[228]
-#define SWIGTYPE_p_mfem__VectorDivergenceIntegrator swig_types[229]
-#define SWIGTYPE_p_mfem__VectorFECurlIntegrator swig_types[230]
-#define SWIGTYPE_p_mfem__VectorFEDivergenceIntegrator swig_types[231]
-#define SWIGTYPE_p_mfem__VectorFEMassIntegrator swig_types[232]
-#define SWIGTYPE_p_mfem__VectorFEWeakDivergenceIntegrator swig_types[233]
-#define SWIGTYPE_p_mfem__VectorFiniteElement swig_types[234]
-#define SWIGTYPE_p_mfem__VectorFunctionCoefficient swig_types[235]
-#define SWIGTYPE_p_mfem__VectorGridFunctionCoefficient swig_types[236]
-#define SWIGTYPE_p_mfem__VectorInnerProductInterpolator swig_types[237]
-#define SWIGTYPE_p_mfem__VectorMassIntegrator swig_types[238]
-#define SWIGTYPE_p_mfem__VectorPyCoefficientBase swig_types[239]
-#define SWIGTYPE_p_mfem__VectorQuadratureFunctionCoefficient swig_types[240]
-#define SWIGTYPE_p_mfem__VectorRestrictedCoefficient swig_types[241]
-#define SWIGTYPE_p_mfem__VectorRotProductCoefficient swig_types[242]
-#define SWIGTYPE_p_mfem__VectorScalarProductInterpolator swig_types[243]
-#define SWIGTYPE_p_mfem__VectorSumCoefficient swig_types[244]
-#define SWIGTYPE_p_mfem__VectorTensorFiniteElement swig_types[245]
-#define SWIGTYPE_p_pri_t swig_types[246]
-#define SWIGTYPE_p_quad_t swig_types[247]
-#define SWIGTYPE_p_seg_t swig_types[248]
-#define SWIGTYPE_p_tet_t swig_types[249]
-#define SWIGTYPE_p_tri_t swig_types[250]
-static swig_type_info *swig_types[252];
-static swig_module_info swig_module = {swig_types, 251, 0, 0, 0, 0};
+#define SWIGTYPE_p_mfem__HyperelasticNLFIntegrator swig_types[69]
+#define SWIGTYPE_p_mfem__HypreParVector swig_types[70]
+#define SWIGTYPE_p_mfem__IdentityInterpolator swig_types[71]
+#define SWIGTYPE_p_mfem__IdentityMatrixCoefficient swig_types[72]
+#define SWIGTYPE_p_mfem__InnerProductCoefficient swig_types[73]
+#define SWIGTYPE_p_mfem__IntegrationRule swig_types[74]
+#define SWIGTYPE_p_mfem__InverseIntegrator swig_types[75]
+#define SWIGTYPE_p_mfem__InverseMatrixCoefficient swig_types[76]
+#define SWIGTYPE_p_mfem__IsoparametricTransformation swig_types[77]
+#define SWIGTYPE_p_mfem__L2Pos_HexahedronElement swig_types[78]
+#define SWIGTYPE_p_mfem__L2Pos_QuadrilateralElement swig_types[79]
+#define SWIGTYPE_p_mfem__L2Pos_SegmentElement swig_types[80]
+#define SWIGTYPE_p_mfem__L2Pos_TetrahedronElement swig_types[81]
+#define SWIGTYPE_p_mfem__L2Pos_TriangleElement swig_types[82]
+#define SWIGTYPE_p_mfem__L2Pos_WedgeElement swig_types[83]
+#define SWIGTYPE_p_mfem__L2_FECollection swig_types[84]
+#define SWIGTYPE_p_mfem__L2_HexahedronElement swig_types[85]
+#define SWIGTYPE_p_mfem__L2_QuadrilateralElement swig_types[86]
+#define SWIGTYPE_p_mfem__L2_SegmentElement swig_types[87]
+#define SWIGTYPE_p_mfem__L2_TetrahedronElement swig_types[88]
+#define SWIGTYPE_p_mfem__L2_TriangleElement swig_types[89]
+#define SWIGTYPE_p_mfem__L2_WedgeElement swig_types[90]
+#define SWIGTYPE_p_mfem__Lagrange1DFiniteElement swig_types[91]
+#define SWIGTYPE_p_mfem__LagrangeHexFiniteElement swig_types[92]
+#define SWIGTYPE_p_mfem__Linear1DFiniteElement swig_types[93]
+#define SWIGTYPE_p_mfem__Linear2DFiniteElement swig_types[94]
+#define SWIGTYPE_p_mfem__Linear3DFiniteElement swig_types[95]
+#define SWIGTYPE_p_mfem__LinearForm swig_types[96]
+#define SWIGTYPE_p_mfem__LumpedIntegrator swig_types[97]
+#define SWIGTYPE_p_mfem__MassIntegrator swig_types[98]
+#define SWIGTYPE_p_mfem__MatrixArrayCoefficient swig_types[99]
+#define SWIGTYPE_p_mfem__MatrixCoefficient swig_types[100]
+#define SWIGTYPE_p_mfem__MatrixConstantCoefficient swig_types[101]
+#define SWIGTYPE_p_mfem__MatrixFunctionCoefficient swig_types[102]
+#define SWIGTYPE_p_mfem__MatrixPyCoefficientBase swig_types[103]
+#define SWIGTYPE_p_mfem__MatrixRestrictedCoefficient swig_types[104]
+#define SWIGTYPE_p_mfem__MatrixSumCoefficient swig_types[105]
+#define SWIGTYPE_p_mfem__MatrixVectorProductCoefficient swig_types[106]
+#define SWIGTYPE_p_mfem__MixedCrossCurlCurlIntegrator swig_types[107]
+#define SWIGTYPE_p_mfem__MixedCrossCurlGradIntegrator swig_types[108]
+#define SWIGTYPE_p_mfem__MixedCrossCurlIntegrator swig_types[109]
+#define SWIGTYPE_p_mfem__MixedCrossGradCurlIntegrator swig_types[110]
+#define SWIGTYPE_p_mfem__MixedCrossGradGradIntegrator swig_types[111]
+#define SWIGTYPE_p_mfem__MixedCrossGradIntegrator swig_types[112]
+#define SWIGTYPE_p_mfem__MixedCrossProductIntegrator swig_types[113]
+#define SWIGTYPE_p_mfem__MixedCurlCurlIntegrator swig_types[114]
+#define SWIGTYPE_p_mfem__MixedDirectionalDerivativeIntegrator swig_types[115]
+#define SWIGTYPE_p_mfem__MixedDivGradIntegrator swig_types[116]
+#define SWIGTYPE_p_mfem__MixedDotProductIntegrator swig_types[117]
+#define SWIGTYPE_p_mfem__MixedGradDivIntegrator swig_types[118]
+#define SWIGTYPE_p_mfem__MixedGradGradIntegrator swig_types[119]
+#define SWIGTYPE_p_mfem__MixedScalarCrossCurlIntegrator swig_types[120]
+#define SWIGTYPE_p_mfem__MixedScalarCrossGradIntegrator swig_types[121]
+#define SWIGTYPE_p_mfem__MixedScalarCrossProductIntegrator swig_types[122]
+#define SWIGTYPE_p_mfem__MixedScalarCurlIntegrator swig_types[123]
+#define SWIGTYPE_p_mfem__MixedScalarDerivativeIntegrator swig_types[124]
+#define SWIGTYPE_p_mfem__MixedScalarDivergenceIntegrator swig_types[125]
+#define SWIGTYPE_p_mfem__MixedScalarIntegrator swig_types[126]
+#define SWIGTYPE_p_mfem__MixedScalarMassIntegrator swig_types[127]
+#define SWIGTYPE_p_mfem__MixedScalarVectorIntegrator swig_types[128]
+#define SWIGTYPE_p_mfem__MixedScalarWeakCrossProductIntegrator swig_types[129]
+#define SWIGTYPE_p_mfem__MixedScalarWeakCurlCrossIntegrator swig_types[130]
+#define SWIGTYPE_p_mfem__MixedScalarWeakCurlIntegrator swig_types[131]
+#define SWIGTYPE_p_mfem__MixedScalarWeakDerivativeIntegrator swig_types[132]
+#define SWIGTYPE_p_mfem__MixedScalarWeakDivergenceIntegrator swig_types[133]
+#define SWIGTYPE_p_mfem__MixedScalarWeakGradientIntegrator swig_types[134]
+#define SWIGTYPE_p_mfem__MixedVectorCurlIntegrator swig_types[135]
+#define SWIGTYPE_p_mfem__MixedVectorDivergenceIntegrator swig_types[136]
+#define SWIGTYPE_p_mfem__MixedVectorGradientIntegrator swig_types[137]
+#define SWIGTYPE_p_mfem__MixedVectorIntegrator swig_types[138]
+#define SWIGTYPE_p_mfem__MixedVectorMassIntegrator swig_types[139]
+#define SWIGTYPE_p_mfem__MixedVectorProductIntegrator swig_types[140]
+#define SWIGTYPE_p_mfem__MixedVectorWeakCurlIntegrator swig_types[141]
+#define SWIGTYPE_p_mfem__MixedVectorWeakDivergenceIntegrator swig_types[142]
+#define SWIGTYPE_p_mfem__MixedWeakCurlCrossIntegrator swig_types[143]
+#define SWIGTYPE_p_mfem__MixedWeakDivCrossIntegrator swig_types[144]
+#define SWIGTYPE_p_mfem__MixedWeakGradDotIntegrator swig_types[145]
+#define SWIGTYPE_p_mfem__ND_HexahedronElement swig_types[146]
+#define SWIGTYPE_p_mfem__ND_QuadrilateralElement swig_types[147]
+#define SWIGTYPE_p_mfem__ND_SegmentElement swig_types[148]
+#define SWIGTYPE_p_mfem__ND_TetrahedronElement swig_types[149]
+#define SWIGTYPE_p_mfem__ND_TriangleElement swig_types[150]
+#define SWIGTYPE_p_mfem__NURBS1DFiniteElement swig_types[151]
+#define SWIGTYPE_p_mfem__NURBS2DFiniteElement swig_types[152]
+#define SWIGTYPE_p_mfem__NURBS3DFiniteElement swig_types[153]
+#define SWIGTYPE_p_mfem__NURBSFiniteElement swig_types[154]
+#define SWIGTYPE_p_mfem__Nedelec1HexFiniteElement swig_types[155]
+#define SWIGTYPE_p_mfem__Nedelec1TetFiniteElement swig_types[156]
+#define SWIGTYPE_p_mfem__NodalFiniteElement swig_types[157]
+#define SWIGTYPE_p_mfem__NodalTensorFiniteElement swig_types[158]
+#define SWIGTYPE_p_mfem__NodeExtrudeCoefficient swig_types[159]
+#define SWIGTYPE_p_mfem__NonlinearFormIntegrator swig_types[160]
+#define SWIGTYPE_p_mfem__NormalInterpolator swig_types[161]
+#define SWIGTYPE_p_mfem__NormalTraceJumpIntegrator swig_types[162]
+#define SWIGTYPE_p_mfem__NormalizedVectorCoefficient swig_types[163]
+#define SWIGTYPE_p_mfem__OperatorHandle swig_types[164]
+#define SWIGTYPE_p_mfem__OuterProductCoefficient swig_types[165]
+#define SWIGTYPE_p_mfem__P0HexFiniteElement swig_types[166]
+#define SWIGTYPE_p_mfem__P0QuadFiniteElement swig_types[167]
+#define SWIGTYPE_p_mfem__P0SegmentFiniteElement swig_types[168]
+#define SWIGTYPE_p_mfem__P0TetFiniteElement swig_types[169]
+#define SWIGTYPE_p_mfem__P0TriangleFiniteElement swig_types[170]
+#define SWIGTYPE_p_mfem__P0WedgeFiniteElement swig_types[171]
+#define SWIGTYPE_p_mfem__P1OnQuadFiniteElement swig_types[172]
+#define SWIGTYPE_p_mfem__P1SegmentFiniteElement swig_types[173]
+#define SWIGTYPE_p_mfem__P1TetNonConfFiniteElement swig_types[174]
+#define SWIGTYPE_p_mfem__P2SegmentFiniteElement swig_types[175]
+#define SWIGTYPE_p_mfem__PWConstCoefficient swig_types[176]
+#define SWIGTYPE_p_mfem__PointFiniteElement swig_types[177]
+#define SWIGTYPE_p_mfem__PositiveFiniteElement swig_types[178]
+#define SWIGTYPE_p_mfem__PositiveTensorFiniteElement swig_types[179]
+#define SWIGTYPE_p_mfem__PowerCoefficient swig_types[180]
+#define SWIGTYPE_p_mfem__ProductCoefficient swig_types[181]
+#define SWIGTYPE_p_mfem__PyCoefficientBase swig_types[182]
+#define SWIGTYPE_p_mfem__Quad1DFiniteElement swig_types[183]
+#define SWIGTYPE_p_mfem__Quad2DFiniteElement swig_types[184]
+#define SWIGTYPE_p_mfem__QuadPos1DFiniteElement swig_types[185]
+#define SWIGTYPE_p_mfem__Quadratic3DFiniteElement swig_types[186]
+#define SWIGTYPE_p_mfem__QuadratureFunction swig_types[187]
+#define SWIGTYPE_p_mfem__QuadratureFunctionCoefficient swig_types[188]
+#define SWIGTYPE_p_mfem__RT0HexFiniteElement swig_types[189]
+#define SWIGTYPE_p_mfem__RT0QuadFiniteElement swig_types[190]
+#define SWIGTYPE_p_mfem__RT0TetFiniteElement swig_types[191]
+#define SWIGTYPE_p_mfem__RT0TriangleFiniteElement swig_types[192]
+#define SWIGTYPE_p_mfem__RT1HexFiniteElement swig_types[193]
+#define SWIGTYPE_p_mfem__RT1QuadFiniteElement swig_types[194]
+#define SWIGTYPE_p_mfem__RT1TriangleFiniteElement swig_types[195]
+#define SWIGTYPE_p_mfem__RT2QuadFiniteElement swig_types[196]
+#define SWIGTYPE_p_mfem__RT2TriangleFiniteElement swig_types[197]
+#define SWIGTYPE_p_mfem__RT_HexahedronElement swig_types[198]
+#define SWIGTYPE_p_mfem__RT_QuadrilateralElement swig_types[199]
+#define SWIGTYPE_p_mfem__RT_TetrahedronElement swig_types[200]
+#define SWIGTYPE_p_mfem__RT_TriangleElement swig_types[201]
+#define SWIGTYPE_p_mfem__RatioCoefficient swig_types[202]
+#define SWIGTYPE_p_mfem__RefinedBiLinear2DFiniteElement swig_types[203]
+#define SWIGTYPE_p_mfem__RefinedLinear1DFiniteElement swig_types[204]
+#define SWIGTYPE_p_mfem__RefinedLinear2DFiniteElement swig_types[205]
+#define SWIGTYPE_p_mfem__RefinedLinear3DFiniteElement swig_types[206]
+#define SWIGTYPE_p_mfem__RefinedTriLinear3DFiniteElement swig_types[207]
+#define SWIGTYPE_p_mfem__RestrictedCoefficient swig_types[208]
+#define SWIGTYPE_p_mfem__RotTriLinearHexFiniteElement swig_types[209]
+#define SWIGTYPE_p_mfem__ScalarFiniteElement swig_types[210]
+#define SWIGTYPE_p_mfem__ScalarMatrixProductCoefficient swig_types[211]
+#define SWIGTYPE_p_mfem__ScalarProductInterpolator swig_types[212]
+#define SWIGTYPE_p_mfem__ScalarVectorProductCoefficient swig_types[213]
+#define SWIGTYPE_p_mfem__ScalarVectorProductInterpolator swig_types[214]
+#define SWIGTYPE_p_mfem__SumCoefficient swig_types[215]
+#define SWIGTYPE_p_mfem__SumIntegrator swig_types[216]
+#define SWIGTYPE_p_mfem__TraceJumpIntegrator swig_types[217]
+#define SWIGTYPE_p_mfem__TransformedCoefficient swig_types[218]
+#define SWIGTYPE_p_mfem__TransposeIntegrator swig_types[219]
+#define SWIGTYPE_p_mfem__TransposeMatrixCoefficient swig_types[220]
+#define SWIGTYPE_p_mfem__TriLinear3DFiniteElement swig_types[221]
+#define SWIGTYPE_p_mfem__Vector swig_types[222]
+#define SWIGTYPE_p_mfem__VectorArrayCoefficient swig_types[223]
+#define SWIGTYPE_p_mfem__VectorCoefficient swig_types[224]
+#define SWIGTYPE_p_mfem__VectorConstantCoefficient swig_types[225]
+#define SWIGTYPE_p_mfem__VectorConvectionNLFIntegrator swig_types[226]
+#define SWIGTYPE_p_mfem__VectorCrossProductCoefficient swig_types[227]
+#define SWIGTYPE_p_mfem__VectorCrossProductInterpolator swig_types[228]
+#define SWIGTYPE_p_mfem__VectorCurlCurlIntegrator swig_types[229]
+#define SWIGTYPE_p_mfem__VectorDeltaCoefficient swig_types[230]
+#define SWIGTYPE_p_mfem__VectorDiffusionIntegrator swig_types[231]
+#define SWIGTYPE_p_mfem__VectorDivergenceIntegrator swig_types[232]
+#define SWIGTYPE_p_mfem__VectorFECurlIntegrator swig_types[233]
+#define SWIGTYPE_p_mfem__VectorFEDivergenceIntegrator swig_types[234]
+#define SWIGTYPE_p_mfem__VectorFEMassIntegrator swig_types[235]
+#define SWIGTYPE_p_mfem__VectorFEWeakDivergenceIntegrator swig_types[236]
+#define SWIGTYPE_p_mfem__VectorFiniteElement swig_types[237]
+#define SWIGTYPE_p_mfem__VectorFunctionCoefficient swig_types[238]
+#define SWIGTYPE_p_mfem__VectorGridFunctionCoefficient swig_types[239]
+#define SWIGTYPE_p_mfem__VectorInnerProductInterpolator swig_types[240]
+#define SWIGTYPE_p_mfem__VectorMassIntegrator swig_types[241]
+#define SWIGTYPE_p_mfem__VectorPyCoefficientBase swig_types[242]
+#define SWIGTYPE_p_mfem__VectorQuadratureFunctionCoefficient swig_types[243]
+#define SWIGTYPE_p_mfem__VectorRestrictedCoefficient swig_types[244]
+#define SWIGTYPE_p_mfem__VectorRotProductCoefficient swig_types[245]
+#define SWIGTYPE_p_mfem__VectorScalarProductInterpolator swig_types[246]
+#define SWIGTYPE_p_mfem__VectorSumCoefficient swig_types[247]
+#define SWIGTYPE_p_mfem__VectorTensorFiniteElement swig_types[248]
+#define SWIGTYPE_p_pri_t swig_types[249]
+#define SWIGTYPE_p_quad_t swig_types[250]
+#define SWIGTYPE_p_seg_t swig_types[251]
+#define SWIGTYPE_p_tet_t swig_types[252]
+#define SWIGTYPE_p_tri_t swig_types[253]
+static swig_type_info *swig_types[255];
+static swig_module_info swig_module = {swig_types, 254, 0, 0, 0, 0};
 #define SWIG_TypeQuery(name) SWIG_TypeQueryModule(&swig_module, &swig_module, name)
 #define SWIG_MangledTypeQuery(name) SWIG_MangledTypeQueryModule(&swig_module, &swig_module, name)
 
@@ -3701,550 +3704,6 @@ SwigDirector_BilinearFormIntegrator::SwigDirector_BilinearFormIntegrator(PyObjec
 
 
 
-void SwigDirector_BilinearFormIntegrator::AssemblePA(mfem::FiniteElementSpace const &fes) {
-  swig::SwigVar_PyObject obj0;
-  obj0 = SWIG_NewPointerObj(SWIG_as_voidptr(&fes), SWIGTYPE_p_mfem__FiniteElementSpace,  0 );
-  if (!swig_get_self()) {
-    Swig::DirectorException::raise("'self' uninitialized, maybe you forgot to call BilinearFormIntegrator.__init__.");
-  }
-#if defined(SWIG_PYTHON_DIRECTOR_VTABLE)
-  const size_t swig_method_index = 0;
-  const char *const swig_method_name = "AssemblePA";
-  PyObject *method = swig_get_method(swig_method_index, swig_method_name);
-  swig::SwigVar_PyObject result = PyObject_CallFunctionObjArgs(method ,(PyObject *)obj0, NULL);
-#else
-  swig::SwigVar_PyObject swig_method_name = SWIG_Python_str_FromChar("AssemblePA");
-  swig::SwigVar_PyObject result = PyObject_CallMethodObjArgs(swig_get_self(), (PyObject *) swig_method_name ,(PyObject *)obj0, NULL);
-#endif
-  if (!result) {
-    PyObject *error = PyErr_Occurred();
-    {
-      if (error != NULL) {
-        throw Swig::DirectorMethodException();
-      }
-    }
-  }
-}
-
-
-void SwigDirector_BilinearFormIntegrator::AssemblePA(mfem::FiniteElementSpace const &trial_fes, mfem::FiniteElementSpace const &test_fes) {
-  swig::SwigVar_PyObject obj0;
-  obj0 = SWIG_NewPointerObj(SWIG_as_voidptr(&trial_fes), SWIGTYPE_p_mfem__FiniteElementSpace,  0 );
-  swig::SwigVar_PyObject obj1;
-  obj1 = SWIG_NewPointerObj(SWIG_as_voidptr(&test_fes), SWIGTYPE_p_mfem__FiniteElementSpace,  0 );
-  if (!swig_get_self()) {
-    Swig::DirectorException::raise("'self' uninitialized, maybe you forgot to call BilinearFormIntegrator.__init__.");
-  }
-#if defined(SWIG_PYTHON_DIRECTOR_VTABLE)
-  const size_t swig_method_index = 1;
-  const char *const swig_method_name = "AssemblePA";
-  PyObject *method = swig_get_method(swig_method_index, swig_method_name);
-  swig::SwigVar_PyObject result = PyObject_CallFunctionObjArgs(method ,(PyObject *)obj0,(PyObject *)obj1, NULL);
-#else
-  swig::SwigVar_PyObject swig_method_name = SWIG_Python_str_FromChar("AssemblePA");
-  swig::SwigVar_PyObject result = PyObject_CallMethodObjArgs(swig_get_self(), (PyObject *) swig_method_name ,(PyObject *)obj0,(PyObject *)obj1, NULL);
-#endif
-  if (!result) {
-    PyObject *error = PyErr_Occurred();
-    {
-      if (error != NULL) {
-        throw Swig::DirectorMethodException();
-      }
-    }
-  }
-}
-
-
-void SwigDirector_BilinearFormIntegrator::AssemblePAInteriorFaces(mfem::FiniteElementSpace const &fes) {
-  swig::SwigVar_PyObject obj0;
-  obj0 = SWIG_NewPointerObj(SWIG_as_voidptr(&fes), SWIGTYPE_p_mfem__FiniteElementSpace,  0 );
-  if (!swig_get_self()) {
-    Swig::DirectorException::raise("'self' uninitialized, maybe you forgot to call BilinearFormIntegrator.__init__.");
-  }
-#if defined(SWIG_PYTHON_DIRECTOR_VTABLE)
-  const size_t swig_method_index = 2;
-  const char *const swig_method_name = "AssemblePAInteriorFaces";
-  PyObject *method = swig_get_method(swig_method_index, swig_method_name);
-  swig::SwigVar_PyObject result = PyObject_CallFunctionObjArgs(method ,(PyObject *)obj0, NULL);
-#else
-  swig::SwigVar_PyObject swig_method_name = SWIG_Python_str_FromChar("AssemblePAInteriorFaces");
-  swig::SwigVar_PyObject result = PyObject_CallMethodObjArgs(swig_get_self(), (PyObject *) swig_method_name ,(PyObject *)obj0, NULL);
-#endif
-  if (!result) {
-    PyObject *error = PyErr_Occurred();
-    {
-      if (error != NULL) {
-        throw Swig::DirectorMethodException();
-      }
-    }
-  }
-}
-
-
-void SwigDirector_BilinearFormIntegrator::AssemblePABoundaryFaces(mfem::FiniteElementSpace const &fes) {
-  swig::SwigVar_PyObject obj0;
-  obj0 = SWIG_NewPointerObj(SWIG_as_voidptr(&fes), SWIGTYPE_p_mfem__FiniteElementSpace,  0 );
-  if (!swig_get_self()) {
-    Swig::DirectorException::raise("'self' uninitialized, maybe you forgot to call BilinearFormIntegrator.__init__.");
-  }
-#if defined(SWIG_PYTHON_DIRECTOR_VTABLE)
-  const size_t swig_method_index = 3;
-  const char *const swig_method_name = "AssemblePABoundaryFaces";
-  PyObject *method = swig_get_method(swig_method_index, swig_method_name);
-  swig::SwigVar_PyObject result = PyObject_CallFunctionObjArgs(method ,(PyObject *)obj0, NULL);
-#else
-  swig::SwigVar_PyObject swig_method_name = SWIG_Python_str_FromChar("AssemblePABoundaryFaces");
-  swig::SwigVar_PyObject result = PyObject_CallMethodObjArgs(swig_get_self(), (PyObject *) swig_method_name ,(PyObject *)obj0, NULL);
-#endif
-  if (!result) {
-    PyObject *error = PyErr_Occurred();
-    {
-      if (error != NULL) {
-        throw Swig::DirectorMethodException();
-      }
-    }
-  }
-}
-
-
-void SwigDirector_BilinearFormIntegrator::AssembleDiagonalPA(mfem::Vector &diag) {
-  swig::SwigVar_PyObject obj0;
-  obj0 = SWIG_NewPointerObj(SWIG_as_voidptr(&diag), SWIGTYPE_p_mfem__Vector,  0 );
-  if (!swig_get_self()) {
-    Swig::DirectorException::raise("'self' uninitialized, maybe you forgot to call BilinearFormIntegrator.__init__.");
-  }
-#if defined(SWIG_PYTHON_DIRECTOR_VTABLE)
-  const size_t swig_method_index = 4;
-  const char *const swig_method_name = "AssembleDiagonalPA";
-  PyObject *method = swig_get_method(swig_method_index, swig_method_name);
-  swig::SwigVar_PyObject result = PyObject_CallFunctionObjArgs(method ,(PyObject *)obj0, NULL);
-#else
-  swig::SwigVar_PyObject swig_method_name = SWIG_Python_str_FromChar("AssembleDiagonalPA");
-  swig::SwigVar_PyObject result = PyObject_CallMethodObjArgs(swig_get_self(), (PyObject *) swig_method_name ,(PyObject *)obj0, NULL);
-#endif
-  if (!result) {
-    PyObject *error = PyErr_Occurred();
-    {
-      if (error != NULL) {
-        throw Swig::DirectorMethodException();
-      }
-    }
-  }
-}
-
-
-void SwigDirector_BilinearFormIntegrator::AssembleDiagonalPA_ADAt(mfem::Vector const &D, mfem::Vector &diag) {
-  swig::SwigVar_PyObject obj0;
-  obj0 = SWIG_NewPointerObj(SWIG_as_voidptr(&D), SWIGTYPE_p_mfem__Vector,  0 );
-  swig::SwigVar_PyObject obj1;
-  obj1 = SWIG_NewPointerObj(SWIG_as_voidptr(&diag), SWIGTYPE_p_mfem__Vector,  0 );
-  if (!swig_get_self()) {
-    Swig::DirectorException::raise("'self' uninitialized, maybe you forgot to call BilinearFormIntegrator.__init__.");
-  }
-#if defined(SWIG_PYTHON_DIRECTOR_VTABLE)
-  const size_t swig_method_index = 5;
-  const char *const swig_method_name = "AssembleDiagonalPA_ADAt";
-  PyObject *method = swig_get_method(swig_method_index, swig_method_name);
-  swig::SwigVar_PyObject result = PyObject_CallFunctionObjArgs(method ,(PyObject *)obj0,(PyObject *)obj1, NULL);
-#else
-  swig::SwigVar_PyObject swig_method_name = SWIG_Python_str_FromChar("AssembleDiagonalPA_ADAt");
-  swig::SwigVar_PyObject result = PyObject_CallMethodObjArgs(swig_get_self(), (PyObject *) swig_method_name ,(PyObject *)obj0,(PyObject *)obj1, NULL);
-#endif
-  if (!result) {
-    PyObject *error = PyErr_Occurred();
-    {
-      if (error != NULL) {
-        throw Swig::DirectorMethodException();
-      }
-    }
-  }
-}
-
-
-void SwigDirector_BilinearFormIntegrator::AddMultPA(mfem::Vector const &x, mfem::Vector &y) const {
-  swig::SwigVar_PyObject obj0;
-  obj0 = SWIG_NewPointerObj(SWIG_as_voidptr(&x), SWIGTYPE_p_mfem__Vector,  0 );
-  swig::SwigVar_PyObject obj1;
-  obj1 = SWIG_NewPointerObj(SWIG_as_voidptr(&y), SWIGTYPE_p_mfem__Vector,  0 );
-  if (!swig_get_self()) {
-    Swig::DirectorException::raise("'self' uninitialized, maybe you forgot to call BilinearFormIntegrator.__init__.");
-  }
-#if defined(SWIG_PYTHON_DIRECTOR_VTABLE)
-  const size_t swig_method_index = 6;
-  const char *const swig_method_name = "AddMultPA";
-  PyObject *method = swig_get_method(swig_method_index, swig_method_name);
-  swig::SwigVar_PyObject result = PyObject_CallFunctionObjArgs(method ,(PyObject *)obj0,(PyObject *)obj1, NULL);
-#else
-  swig::SwigVar_PyObject swig_method_name = SWIG_Python_str_FromChar("AddMultPA");
-  swig::SwigVar_PyObject result = PyObject_CallMethodObjArgs(swig_get_self(), (PyObject *) swig_method_name ,(PyObject *)obj0,(PyObject *)obj1, NULL);
-#endif
-  if (!result) {
-    PyObject *error = PyErr_Occurred();
-    {
-      if (error != NULL) {
-        throw Swig::DirectorMethodException();
-      }
-    }
-  }
-}
-
-
-void SwigDirector_BilinearFormIntegrator::AddMultTransposePA(mfem::Vector const &x, mfem::Vector &y) const {
-  swig::SwigVar_PyObject obj0;
-  obj0 = SWIG_NewPointerObj(SWIG_as_voidptr(&x), SWIGTYPE_p_mfem__Vector,  0 );
-  swig::SwigVar_PyObject obj1;
-  obj1 = SWIG_NewPointerObj(SWIG_as_voidptr(&y), SWIGTYPE_p_mfem__Vector,  0 );
-  if (!swig_get_self()) {
-    Swig::DirectorException::raise("'self' uninitialized, maybe you forgot to call BilinearFormIntegrator.__init__.");
-  }
-#if defined(SWIG_PYTHON_DIRECTOR_VTABLE)
-  const size_t swig_method_index = 7;
-  const char *const swig_method_name = "AddMultTransposePA";
-  PyObject *method = swig_get_method(swig_method_index, swig_method_name);
-  swig::SwigVar_PyObject result = PyObject_CallFunctionObjArgs(method ,(PyObject *)obj0,(PyObject *)obj1, NULL);
-#else
-  swig::SwigVar_PyObject swig_method_name = SWIG_Python_str_FromChar("AddMultTransposePA");
-  swig::SwigVar_PyObject result = PyObject_CallMethodObjArgs(swig_get_self(), (PyObject *) swig_method_name ,(PyObject *)obj0,(PyObject *)obj1, NULL);
-#endif
-  if (!result) {
-    PyObject *error = PyErr_Occurred();
-    {
-      if (error != NULL) {
-        throw Swig::DirectorMethodException();
-      }
-    }
-  }
-}
-
-
-void SwigDirector_BilinearFormIntegrator::AssembleEA(mfem::FiniteElementSpace const &fes, mfem::Vector &emat, bool const add) {
-  swig::SwigVar_PyObject obj0;
-  obj0 = SWIG_NewPointerObj(SWIG_as_voidptr(&fes), SWIGTYPE_p_mfem__FiniteElementSpace,  0 );
-  swig::SwigVar_PyObject obj1;
-  obj1 = SWIG_NewPointerObj(SWIG_as_voidptr(&emat), SWIGTYPE_p_mfem__Vector,  0 );
-  swig::SwigVar_PyObject obj2;
-  obj2 = SWIG_From_bool(static_cast< bool >(add));
-  if (!swig_get_self()) {
-    Swig::DirectorException::raise("'self' uninitialized, maybe you forgot to call BilinearFormIntegrator.__init__.");
-  }
-#if defined(SWIG_PYTHON_DIRECTOR_VTABLE)
-  const size_t swig_method_index = 8;
-  const char *const swig_method_name = "AssembleEA";
-  PyObject *method = swig_get_method(swig_method_index, swig_method_name);
-  swig::SwigVar_PyObject result = PyObject_CallFunctionObjArgs(method ,(PyObject *)obj0,(PyObject *)obj1,(PyObject *)obj2, NULL);
-#else
-  swig::SwigVar_PyObject swig_method_name = SWIG_Python_str_FromChar("AssembleEA");
-  swig::SwigVar_PyObject result = PyObject_CallMethodObjArgs(swig_get_self(), (PyObject *) swig_method_name ,(PyObject *)obj0,(PyObject *)obj1,(PyObject *)obj2, NULL);
-#endif
-  if (!result) {
-    PyObject *error = PyErr_Occurred();
-    {
-      if (error != NULL) {
-        throw Swig::DirectorMethodException();
-      }
-    }
-  }
-}
-
-
-void SwigDirector_BilinearFormIntegrator::AssembleMF(mfem::FiniteElementSpace const &fes) {
-  swig::SwigVar_PyObject obj0;
-  obj0 = SWIG_NewPointerObj(SWIG_as_voidptr(&fes), SWIGTYPE_p_mfem__FiniteElementSpace,  0 );
-  if (!swig_get_self()) {
-    Swig::DirectorException::raise("'self' uninitialized, maybe you forgot to call BilinearFormIntegrator.__init__.");
-  }
-#if defined(SWIG_PYTHON_DIRECTOR_VTABLE)
-  const size_t swig_method_index = 9;
-  const char *const swig_method_name = "AssembleMF";
-  PyObject *method = swig_get_method(swig_method_index, swig_method_name);
-  swig::SwigVar_PyObject result = PyObject_CallFunctionObjArgs(method ,(PyObject *)obj0, NULL);
-#else
-  swig::SwigVar_PyObject swig_method_name = SWIG_Python_str_FromChar("AssembleMF");
-  swig::SwigVar_PyObject result = PyObject_CallMethodObjArgs(swig_get_self(), (PyObject *) swig_method_name ,(PyObject *)obj0, NULL);
-#endif
-  if (!result) {
-    PyObject *error = PyErr_Occurred();
-    {
-      if (error != NULL) {
-        throw Swig::DirectorMethodException();
-      }
-    }
-  }
-}
-
-
-void SwigDirector_BilinearFormIntegrator::AddMultMF(mfem::Vector const &x, mfem::Vector &y) const {
-  swig::SwigVar_PyObject obj0;
-  obj0 = SWIG_NewPointerObj(SWIG_as_voidptr(&x), SWIGTYPE_p_mfem__Vector,  0 );
-  swig::SwigVar_PyObject obj1;
-  obj1 = SWIG_NewPointerObj(SWIG_as_voidptr(&y), SWIGTYPE_p_mfem__Vector,  0 );
-  if (!swig_get_self()) {
-    Swig::DirectorException::raise("'self' uninitialized, maybe you forgot to call BilinearFormIntegrator.__init__.");
-  }
-#if defined(SWIG_PYTHON_DIRECTOR_VTABLE)
-  const size_t swig_method_index = 10;
-  const char *const swig_method_name = "AddMultMF";
-  PyObject *method = swig_get_method(swig_method_index, swig_method_name);
-  swig::SwigVar_PyObject result = PyObject_CallFunctionObjArgs(method ,(PyObject *)obj0,(PyObject *)obj1, NULL);
-#else
-  swig::SwigVar_PyObject swig_method_name = SWIG_Python_str_FromChar("AddMultMF");
-  swig::SwigVar_PyObject result = PyObject_CallMethodObjArgs(swig_get_self(), (PyObject *) swig_method_name ,(PyObject *)obj0,(PyObject *)obj1, NULL);
-#endif
-  if (!result) {
-    PyObject *error = PyErr_Occurred();
-    {
-      if (error != NULL) {
-        throw Swig::DirectorMethodException();
-      }
-    }
-  }
-}
-
-
-void SwigDirector_BilinearFormIntegrator::AddMultTransposeMF(mfem::Vector const &x, mfem::Vector &y) const {
-  swig::SwigVar_PyObject obj0;
-  obj0 = SWIG_NewPointerObj(SWIG_as_voidptr(&x), SWIGTYPE_p_mfem__Vector,  0 );
-  swig::SwigVar_PyObject obj1;
-  obj1 = SWIG_NewPointerObj(SWIG_as_voidptr(&y), SWIGTYPE_p_mfem__Vector,  0 );
-  if (!swig_get_self()) {
-    Swig::DirectorException::raise("'self' uninitialized, maybe you forgot to call BilinearFormIntegrator.__init__.");
-  }
-#if defined(SWIG_PYTHON_DIRECTOR_VTABLE)
-  const size_t swig_method_index = 11;
-  const char *const swig_method_name = "AddMultTransposeMF";
-  PyObject *method = swig_get_method(swig_method_index, swig_method_name);
-  swig::SwigVar_PyObject result = PyObject_CallFunctionObjArgs(method ,(PyObject *)obj0,(PyObject *)obj1, NULL);
-#else
-  swig::SwigVar_PyObject swig_method_name = SWIG_Python_str_FromChar("AddMultTransposeMF");
-  swig::SwigVar_PyObject result = PyObject_CallMethodObjArgs(swig_get_self(), (PyObject *) swig_method_name ,(PyObject *)obj0,(PyObject *)obj1, NULL);
-#endif
-  if (!result) {
-    PyObject *error = PyErr_Occurred();
-    {
-      if (error != NULL) {
-        throw Swig::DirectorMethodException();
-      }
-    }
-  }
-}
-
-
-void SwigDirector_BilinearFormIntegrator::AssembleDiagonalMF(mfem::Vector &diag) {
-  swig::SwigVar_PyObject obj0;
-  obj0 = SWIG_NewPointerObj(SWIG_as_voidptr(&diag), SWIGTYPE_p_mfem__Vector,  0 );
-  if (!swig_get_self()) {
-    Swig::DirectorException::raise("'self' uninitialized, maybe you forgot to call BilinearFormIntegrator.__init__.");
-  }
-#if defined(SWIG_PYTHON_DIRECTOR_VTABLE)
-  const size_t swig_method_index = 12;
-  const char *const swig_method_name = "AssembleDiagonalMF";
-  PyObject *method = swig_get_method(swig_method_index, swig_method_name);
-  swig::SwigVar_PyObject result = PyObject_CallFunctionObjArgs(method ,(PyObject *)obj0, NULL);
-#else
-  swig::SwigVar_PyObject swig_method_name = SWIG_Python_str_FromChar("AssembleDiagonalMF");
-  swig::SwigVar_PyObject result = PyObject_CallMethodObjArgs(swig_get_self(), (PyObject *) swig_method_name ,(PyObject *)obj0, NULL);
-#endif
-  if (!result) {
-    PyObject *error = PyErr_Occurred();
-    {
-      if (error != NULL) {
-        throw Swig::DirectorMethodException();
-      }
-    }
-  }
-}
-
-
-void SwigDirector_BilinearFormIntegrator::AssembleEAInteriorFaces(mfem::FiniteElementSpace const &fes, mfem::Vector &ea_data_int, mfem::Vector &ea_data_ext, bool const add) {
-  swig::SwigVar_PyObject obj0;
-  obj0 = SWIG_NewPointerObj(SWIG_as_voidptr(&fes), SWIGTYPE_p_mfem__FiniteElementSpace,  0 );
-  swig::SwigVar_PyObject obj1;
-  obj1 = SWIG_NewPointerObj(SWIG_as_voidptr(&ea_data_int), SWIGTYPE_p_mfem__Vector,  0 );
-  swig::SwigVar_PyObject obj2;
-  obj2 = SWIG_NewPointerObj(SWIG_as_voidptr(&ea_data_ext), SWIGTYPE_p_mfem__Vector,  0 );
-  swig::SwigVar_PyObject obj3;
-  obj3 = SWIG_From_bool(static_cast< bool >(add));
-  if (!swig_get_self()) {
-    Swig::DirectorException::raise("'self' uninitialized, maybe you forgot to call BilinearFormIntegrator.__init__.");
-  }
-#if defined(SWIG_PYTHON_DIRECTOR_VTABLE)
-  const size_t swig_method_index = 13;
-  const char *const swig_method_name = "AssembleEAInteriorFaces";
-  PyObject *method = swig_get_method(swig_method_index, swig_method_name);
-  swig::SwigVar_PyObject result = PyObject_CallFunctionObjArgs(method ,(PyObject *)obj0,(PyObject *)obj1,(PyObject *)obj2,(PyObject *)obj3, NULL);
-#else
-  swig::SwigVar_PyObject swig_method_name = SWIG_Python_str_FromChar("AssembleEAInteriorFaces");
-  swig::SwigVar_PyObject result = PyObject_CallMethodObjArgs(swig_get_self(), (PyObject *) swig_method_name ,(PyObject *)obj0,(PyObject *)obj1,(PyObject *)obj2,(PyObject *)obj3, NULL);
-#endif
-  if (!result) {
-    PyObject *error = PyErr_Occurred();
-    {
-      if (error != NULL) {
-        throw Swig::DirectorMethodException();
-      }
-    }
-  }
-}
-
-
-void SwigDirector_BilinearFormIntegrator::AssembleEABoundaryFaces(mfem::FiniteElementSpace const &fes, mfem::Vector &ea_data_bdr, bool const add) {
-  swig::SwigVar_PyObject obj0;
-  obj0 = SWIG_NewPointerObj(SWIG_as_voidptr(&fes), SWIGTYPE_p_mfem__FiniteElementSpace,  0 );
-  swig::SwigVar_PyObject obj1;
-  obj1 = SWIG_NewPointerObj(SWIG_as_voidptr(&ea_data_bdr), SWIGTYPE_p_mfem__Vector,  0 );
-  swig::SwigVar_PyObject obj2;
-  obj2 = SWIG_From_bool(static_cast< bool >(add));
-  if (!swig_get_self()) {
-    Swig::DirectorException::raise("'self' uninitialized, maybe you forgot to call BilinearFormIntegrator.__init__.");
-  }
-#if defined(SWIG_PYTHON_DIRECTOR_VTABLE)
-  const size_t swig_method_index = 14;
-  const char *const swig_method_name = "AssembleEABoundaryFaces";
-  PyObject *method = swig_get_method(swig_method_index, swig_method_name);
-  swig::SwigVar_PyObject result = PyObject_CallFunctionObjArgs(method ,(PyObject *)obj0,(PyObject *)obj1,(PyObject *)obj2, NULL);
-#else
-  swig::SwigVar_PyObject swig_method_name = SWIG_Python_str_FromChar("AssembleEABoundaryFaces");
-  swig::SwigVar_PyObject result = PyObject_CallMethodObjArgs(swig_get_self(), (PyObject *) swig_method_name ,(PyObject *)obj0,(PyObject *)obj1,(PyObject *)obj2, NULL);
-#endif
-  if (!result) {
-    PyObject *error = PyErr_Occurred();
-    {
-      if (error != NULL) {
-        throw Swig::DirectorMethodException();
-      }
-    }
-  }
-}
-
-
-void SwigDirector_BilinearFormIntegrator::AssembleElementMatrix(mfem::FiniteElement const &el, mfem::ElementTransformation &Trans, mfem::DenseMatrix &elmat) {
-  swig::SwigVar_PyObject obj0;
-  obj0 = SWIG_NewPointerObj(SWIG_as_voidptr(&el), SWIGTYPE_p_mfem__FiniteElement,  0 );
-  swig::SwigVar_PyObject obj1;
-  obj1 = SWIG_NewPointerObj(SWIG_as_voidptr(&Trans), SWIGTYPE_p_mfem__ElementTransformation,  0 );
-  swig::SwigVar_PyObject obj2;
-  obj2 = SWIG_NewPointerObj(SWIG_as_voidptr(&elmat), SWIGTYPE_p_mfem__DenseMatrix,  0 );
-  if (!swig_get_self()) {
-    Swig::DirectorException::raise("'self' uninitialized, maybe you forgot to call BilinearFormIntegrator.__init__.");
-  }
-#if defined(SWIG_PYTHON_DIRECTOR_VTABLE)
-  const size_t swig_method_index = 15;
-  const char *const swig_method_name = "AssembleElementMatrix";
-  PyObject *method = swig_get_method(swig_method_index, swig_method_name);
-  swig::SwigVar_PyObject result = PyObject_CallFunctionObjArgs(method ,(PyObject *)obj0,(PyObject *)obj1,(PyObject *)obj2, NULL);
-#else
-  swig::SwigVar_PyObject swig_method_name = SWIG_Python_str_FromChar("AssembleElementMatrix");
-  swig::SwigVar_PyObject result = PyObject_CallMethodObjArgs(swig_get_self(), (PyObject *) swig_method_name ,(PyObject *)obj0,(PyObject *)obj1,(PyObject *)obj2, NULL);
-#endif
-  if (!result) {
-    PyObject *error = PyErr_Occurred();
-    {
-      if (error != NULL) {
-        throw Swig::DirectorMethodException();
-      }
-    }
-  }
-}
-
-
-void SwigDirector_BilinearFormIntegrator::AssembleElementMatrix2(mfem::FiniteElement const &trial_fe, mfem::FiniteElement const &test_fe, mfem::ElementTransformation &Trans, mfem::DenseMatrix &elmat) {
-  swig::SwigVar_PyObject obj0;
-  obj0 = SWIG_NewPointerObj(SWIG_as_voidptr(&trial_fe), SWIGTYPE_p_mfem__FiniteElement,  0 );
-  swig::SwigVar_PyObject obj1;
-  obj1 = SWIG_NewPointerObj(SWIG_as_voidptr(&test_fe), SWIGTYPE_p_mfem__FiniteElement,  0 );
-  swig::SwigVar_PyObject obj2;
-  obj2 = SWIG_NewPointerObj(SWIG_as_voidptr(&Trans), SWIGTYPE_p_mfem__ElementTransformation,  0 );
-  swig::SwigVar_PyObject obj3;
-  obj3 = SWIG_NewPointerObj(SWIG_as_voidptr(&elmat), SWIGTYPE_p_mfem__DenseMatrix,  0 );
-  if (!swig_get_self()) {
-    Swig::DirectorException::raise("'self' uninitialized, maybe you forgot to call BilinearFormIntegrator.__init__.");
-  }
-#if defined(SWIG_PYTHON_DIRECTOR_VTABLE)
-  const size_t swig_method_index = 16;
-  const char *const swig_method_name = "AssembleElementMatrix2";
-  PyObject *method = swig_get_method(swig_method_index, swig_method_name);
-  swig::SwigVar_PyObject result = PyObject_CallFunctionObjArgs(method ,(PyObject *)obj0,(PyObject *)obj1,(PyObject *)obj2,(PyObject *)obj3, NULL);
-#else
-  swig::SwigVar_PyObject swig_method_name = SWIG_Python_str_FromChar("AssembleElementMatrix2");
-  swig::SwigVar_PyObject result = PyObject_CallMethodObjArgs(swig_get_self(), (PyObject *) swig_method_name ,(PyObject *)obj0,(PyObject *)obj1,(PyObject *)obj2,(PyObject *)obj3, NULL);
-#endif
-  if (!result) {
-    PyObject *error = PyErr_Occurred();
-    {
-      if (error != NULL) {
-        throw Swig::DirectorMethodException();
-      }
-    }
-  }
-}
-
-
-void SwigDirector_BilinearFormIntegrator::AssembleFaceMatrix(mfem::FiniteElement const &el1, mfem::FiniteElement const &el2, mfem::FaceElementTransformations &Trans, mfem::DenseMatrix &elmat) {
-  swig::SwigVar_PyObject obj0;
-  obj0 = SWIG_NewPointerObj(SWIG_as_voidptr(&el1), SWIGTYPE_p_mfem__FiniteElement,  0 );
-  swig::SwigVar_PyObject obj1;
-  obj1 = SWIG_NewPointerObj(SWIG_as_voidptr(&el2), SWIGTYPE_p_mfem__FiniteElement,  0 );
-  swig::SwigVar_PyObject obj2;
-  obj2 = SWIG_NewPointerObj(SWIG_as_voidptr(&Trans), SWIGTYPE_p_mfem__FaceElementTransformations,  0 );
-  swig::SwigVar_PyObject obj3;
-  obj3 = SWIG_NewPointerObj(SWIG_as_voidptr(&elmat), SWIGTYPE_p_mfem__DenseMatrix,  0 );
-  if (!swig_get_self()) {
-    Swig::DirectorException::raise("'self' uninitialized, maybe you forgot to call BilinearFormIntegrator.__init__.");
-  }
-#if defined(SWIG_PYTHON_DIRECTOR_VTABLE)
-  const size_t swig_method_index = 17;
-  const char *const swig_method_name = "AssembleFaceMatrix";
-  PyObject *method = swig_get_method(swig_method_index, swig_method_name);
-  swig::SwigVar_PyObject result = PyObject_CallFunctionObjArgs(method ,(PyObject *)obj0,(PyObject *)obj1,(PyObject *)obj2,(PyObject *)obj3, NULL);
-#else
-  swig::SwigVar_PyObject swig_method_name = SWIG_Python_str_FromChar("AssembleFaceMatrix");
-  swig::SwigVar_PyObject result = PyObject_CallMethodObjArgs(swig_get_self(), (PyObject *) swig_method_name ,(PyObject *)obj0,(PyObject *)obj1,(PyObject *)obj2,(PyObject *)obj3, NULL);
-#endif
-  if (!result) {
-    PyObject *error = PyErr_Occurred();
-    {
-      if (error != NULL) {
-        throw Swig::DirectorMethodException();
-      }
-    }
-  }
-}
-
-
-void SwigDirector_BilinearFormIntegrator::AssembleFaceMatrix(mfem::FiniteElement const &trial_face_fe, mfem::FiniteElement const &test_fe1, mfem::FiniteElement const &test_fe2, mfem::FaceElementTransformations &Trans, mfem::DenseMatrix &elmat) {
-  swig::SwigVar_PyObject obj0;
-  obj0 = SWIG_NewPointerObj(SWIG_as_voidptr(&trial_face_fe), SWIGTYPE_p_mfem__FiniteElement,  0 );
-  swig::SwigVar_PyObject obj1;
-  obj1 = SWIG_NewPointerObj(SWIG_as_voidptr(&test_fe1), SWIGTYPE_p_mfem__FiniteElement,  0 );
-  swig::SwigVar_PyObject obj2;
-  obj2 = SWIG_NewPointerObj(SWIG_as_voidptr(&test_fe2), SWIGTYPE_p_mfem__FiniteElement,  0 );
-  swig::SwigVar_PyObject obj3;
-  obj3 = SWIG_NewPointerObj(SWIG_as_voidptr(&Trans), SWIGTYPE_p_mfem__FaceElementTransformations,  0 );
-  swig::SwigVar_PyObject obj4;
-  obj4 = SWIG_NewPointerObj(SWIG_as_voidptr(&elmat), SWIGTYPE_p_mfem__DenseMatrix,  0 );
-  if (!swig_get_self()) {
-    Swig::DirectorException::raise("'self' uninitialized, maybe you forgot to call BilinearFormIntegrator.__init__.");
-  }
-#if defined(SWIG_PYTHON_DIRECTOR_VTABLE)
-  const size_t swig_method_index = 18;
-  const char *const swig_method_name = "AssembleFaceMatrix";
-  PyObject *method = swig_get_method(swig_method_index, swig_method_name);
-  swig::SwigVar_PyObject result = PyObject_CallFunctionObjArgs(method ,(PyObject *)obj0,(PyObject *)obj1,(PyObject *)obj2,(PyObject *)obj3,(PyObject *)obj4, NULL);
-#else
-  swig::SwigVar_PyObject swig_method_name = SWIG_Python_str_FromChar("AssembleFaceMatrix");
-  swig::SwigVar_PyObject result = PyObject_CallMethodObjArgs(swig_get_self(), (PyObject *) swig_method_name ,(PyObject *)obj0,(PyObject *)obj1,(PyObject *)obj2,(PyObject *)obj3,(PyObject *)obj4, NULL);
-#endif
-  if (!result) {
-    PyObject *error = PyErr_Occurred();
-    {
-      if (error != NULL) {
-        throw Swig::DirectorMethodException();
-      }
-    }
-  }
-}
-
-
 void SwigDirector_BilinearFormIntegrator::AssembleElementVector(mfem::FiniteElement const &el, mfem::ElementTransformation &Tr, mfem::Vector const &elfun, mfem::Vector &elvect) {
   swig::SwigVar_PyObject obj0;
   obj0 = SWIG_NewPointerObj(SWIG_as_voidptr(&el), SWIGTYPE_p_mfem__FiniteElement,  0 );
@@ -4258,7 +3717,7 @@ void SwigDirector_BilinearFormIntegrator::AssembleElementVector(mfem::FiniteElem
     Swig::DirectorException::raise("'self' uninitialized, maybe you forgot to call BilinearFormIntegrator.__init__.");
   }
 #if defined(SWIG_PYTHON_DIRECTOR_VTABLE)
-  const size_t swig_method_index = 19;
+  const size_t swig_method_index = 0;
   const char *const swig_method_name = "AssembleElementVector";
   PyObject *method = swig_get_method(swig_method_index, swig_method_name);
   swig::SwigVar_PyObject result = PyObject_CallFunctionObjArgs(method ,(PyObject *)obj0,(PyObject *)obj1,(PyObject *)obj2,(PyObject *)obj3, NULL);
@@ -4292,7 +3751,7 @@ void SwigDirector_BilinearFormIntegrator::AssembleFaceVector(mfem::FiniteElement
     Swig::DirectorException::raise("'self' uninitialized, maybe you forgot to call BilinearFormIntegrator.__init__.");
   }
 #if defined(SWIG_PYTHON_DIRECTOR_VTABLE)
-  const size_t swig_method_index = 20;
+  const size_t swig_method_index = 1;
   const char *const swig_method_name = "AssembleFaceVector";
   PyObject *method = swig_get_method(swig_method_index, swig_method_name);
   swig::SwigVar_PyObject result = PyObject_CallFunctionObjArgs(method ,(PyObject *)obj0,(PyObject *)obj1,(PyObject *)obj2,(PyObject *)obj3,(PyObject *)obj4, NULL);
@@ -4324,7 +3783,7 @@ void SwigDirector_BilinearFormIntegrator::AssembleElementGrad(mfem::FiniteElemen
     Swig::DirectorException::raise("'self' uninitialized, maybe you forgot to call BilinearFormIntegrator.__init__.");
   }
 #if defined(SWIG_PYTHON_DIRECTOR_VTABLE)
-  const size_t swig_method_index = 21;
+  const size_t swig_method_index = 2;
   const char *const swig_method_name = "AssembleElementGrad";
   PyObject *method = swig_get_method(swig_method_index, swig_method_name);
   swig::SwigVar_PyObject result = PyObject_CallFunctionObjArgs(method ,(PyObject *)obj0,(PyObject *)obj1,(PyObject *)obj2,(PyObject *)obj3, NULL);
@@ -4358,12 +3817,598 @@ void SwigDirector_BilinearFormIntegrator::AssembleFaceGrad(mfem::FiniteElement c
     Swig::DirectorException::raise("'self' uninitialized, maybe you forgot to call BilinearFormIntegrator.__init__.");
   }
 #if defined(SWIG_PYTHON_DIRECTOR_VTABLE)
-  const size_t swig_method_index = 22;
+  const size_t swig_method_index = 3;
   const char *const swig_method_name = "AssembleFaceGrad";
   PyObject *method = swig_get_method(swig_method_index, swig_method_name);
   swig::SwigVar_PyObject result = PyObject_CallFunctionObjArgs(method ,(PyObject *)obj0,(PyObject *)obj1,(PyObject *)obj2,(PyObject *)obj3,(PyObject *)obj4, NULL);
 #else
   swig::SwigVar_PyObject swig_method_name = SWIG_Python_str_FromChar("AssembleFaceGrad");
+  swig::SwigVar_PyObject result = PyObject_CallMethodObjArgs(swig_get_self(), (PyObject *) swig_method_name ,(PyObject *)obj0,(PyObject *)obj1,(PyObject *)obj2,(PyObject *)obj3,(PyObject *)obj4, NULL);
+#endif
+  if (!result) {
+    PyObject *error = PyErr_Occurred();
+    {
+      if (error != NULL) {
+        throw Swig::DirectorMethodException();
+      }
+    }
+  }
+}
+
+
+double SwigDirector_BilinearFormIntegrator::GetElementEnergy(mfem::FiniteElement const &el, mfem::ElementTransformation &Tr, mfem::Vector const &elfun) {
+  double c_result = SwigValueInit< double >() ;
+  
+  swig::SwigVar_PyObject obj0;
+  obj0 = SWIG_NewPointerObj(SWIG_as_voidptr(&el), SWIGTYPE_p_mfem__FiniteElement,  0 );
+  swig::SwigVar_PyObject obj1;
+  obj1 = SWIG_NewPointerObj(SWIG_as_voidptr(&Tr), SWIGTYPE_p_mfem__ElementTransformation,  0 );
+  swig::SwigVar_PyObject obj2;
+  obj2 = SWIG_NewPointerObj(SWIG_as_voidptr(&elfun), SWIGTYPE_p_mfem__Vector,  0 );
+  if (!swig_get_self()) {
+    Swig::DirectorException::raise("'self' uninitialized, maybe you forgot to call BilinearFormIntegrator.__init__.");
+  }
+#if defined(SWIG_PYTHON_DIRECTOR_VTABLE)
+  const size_t swig_method_index = 4;
+  const char *const swig_method_name = "GetElementEnergy";
+  PyObject *method = swig_get_method(swig_method_index, swig_method_name);
+  swig::SwigVar_PyObject result = PyObject_CallFunctionObjArgs(method ,(PyObject *)obj0,(PyObject *)obj1,(PyObject *)obj2, NULL);
+#else
+  swig::SwigVar_PyObject swig_method_name = SWIG_Python_str_FromChar("GetElementEnergy");
+  swig::SwigVar_PyObject result = PyObject_CallMethodObjArgs(swig_get_self(), (PyObject *) swig_method_name ,(PyObject *)obj0,(PyObject *)obj1,(PyObject *)obj2, NULL);
+#endif
+  if (!result) {
+    PyObject *error = PyErr_Occurred();
+    {
+      if (error != NULL) {
+        throw Swig::DirectorMethodException();
+      }
+    }
+  }
+  double swig_val;
+  int swig_res = SWIG_AsVal_double(result, &swig_val);
+  if (!SWIG_IsOK(swig_res)) {
+    Swig::DirectorTypeMismatchException::raise(SWIG_ErrorType(SWIG_ArgError(swig_res)), "in output value of type '""double""'");
+  }
+  c_result = static_cast< double >(swig_val);
+  return (double) c_result;
+}
+
+
+void SwigDirector_BilinearFormIntegrator::AssemblePA(mfem::FiniteElementSpace const &fes) {
+  swig::SwigVar_PyObject obj0;
+  obj0 = SWIG_NewPointerObj(SWIG_as_voidptr(&fes), SWIGTYPE_p_mfem__FiniteElementSpace,  0 );
+  if (!swig_get_self()) {
+    Swig::DirectorException::raise("'self' uninitialized, maybe you forgot to call BilinearFormIntegrator.__init__.");
+  }
+#if defined(SWIG_PYTHON_DIRECTOR_VTABLE)
+  const size_t swig_method_index = 5;
+  const char *const swig_method_name = "AssemblePA";
+  PyObject *method = swig_get_method(swig_method_index, swig_method_name);
+  swig::SwigVar_PyObject result = PyObject_CallFunctionObjArgs(method ,(PyObject *)obj0, NULL);
+#else
+  swig::SwigVar_PyObject swig_method_name = SWIG_Python_str_FromChar("AssemblePA");
+  swig::SwigVar_PyObject result = PyObject_CallMethodObjArgs(swig_get_self(), (PyObject *) swig_method_name ,(PyObject *)obj0, NULL);
+#endif
+  if (!result) {
+    PyObject *error = PyErr_Occurred();
+    {
+      if (error != NULL) {
+        throw Swig::DirectorMethodException();
+      }
+    }
+  }
+}
+
+
+void SwigDirector_BilinearFormIntegrator::AssemblePA(mfem::FiniteElementSpace const &trial_fes, mfem::FiniteElementSpace const &test_fes) {
+  swig::SwigVar_PyObject obj0;
+  obj0 = SWIG_NewPointerObj(SWIG_as_voidptr(&trial_fes), SWIGTYPE_p_mfem__FiniteElementSpace,  0 );
+  swig::SwigVar_PyObject obj1;
+  obj1 = SWIG_NewPointerObj(SWIG_as_voidptr(&test_fes), SWIGTYPE_p_mfem__FiniteElementSpace,  0 );
+  if (!swig_get_self()) {
+    Swig::DirectorException::raise("'self' uninitialized, maybe you forgot to call BilinearFormIntegrator.__init__.");
+  }
+#if defined(SWIG_PYTHON_DIRECTOR_VTABLE)
+  const size_t swig_method_index = 6;
+  const char *const swig_method_name = "AssemblePA";
+  PyObject *method = swig_get_method(swig_method_index, swig_method_name);
+  swig::SwigVar_PyObject result = PyObject_CallFunctionObjArgs(method ,(PyObject *)obj0,(PyObject *)obj1, NULL);
+#else
+  swig::SwigVar_PyObject swig_method_name = SWIG_Python_str_FromChar("AssemblePA");
+  swig::SwigVar_PyObject result = PyObject_CallMethodObjArgs(swig_get_self(), (PyObject *) swig_method_name ,(PyObject *)obj0,(PyObject *)obj1, NULL);
+#endif
+  if (!result) {
+    PyObject *error = PyErr_Occurred();
+    {
+      if (error != NULL) {
+        throw Swig::DirectorMethodException();
+      }
+    }
+  }
+}
+
+
+void SwigDirector_BilinearFormIntegrator::AddMultPA(mfem::Vector const &x, mfem::Vector &y) const {
+  swig::SwigVar_PyObject obj0;
+  obj0 = SWIG_NewPointerObj(SWIG_as_voidptr(&x), SWIGTYPE_p_mfem__Vector,  0 );
+  swig::SwigVar_PyObject obj1;
+  obj1 = SWIG_NewPointerObj(SWIG_as_voidptr(&y), SWIGTYPE_p_mfem__Vector,  0 );
+  if (!swig_get_self()) {
+    Swig::DirectorException::raise("'self' uninitialized, maybe you forgot to call BilinearFormIntegrator.__init__.");
+  }
+#if defined(SWIG_PYTHON_DIRECTOR_VTABLE)
+  const size_t swig_method_index = 7;
+  const char *const swig_method_name = "AddMultPA";
+  PyObject *method = swig_get_method(swig_method_index, swig_method_name);
+  swig::SwigVar_PyObject result = PyObject_CallFunctionObjArgs(method ,(PyObject *)obj0,(PyObject *)obj1, NULL);
+#else
+  swig::SwigVar_PyObject swig_method_name = SWIG_Python_str_FromChar("AddMultPA");
+  swig::SwigVar_PyObject result = PyObject_CallMethodObjArgs(swig_get_self(), (PyObject *) swig_method_name ,(PyObject *)obj0,(PyObject *)obj1, NULL);
+#endif
+  if (!result) {
+    PyObject *error = PyErr_Occurred();
+    {
+      if (error != NULL) {
+        throw Swig::DirectorMethodException();
+      }
+    }
+  }
+}
+
+
+SwigDirector_BilinearFormIntegrator::~SwigDirector_BilinearFormIntegrator() {
+}
+
+void SwigDirector_BilinearFormIntegrator::AssemblePAInteriorFaces(mfem::FiniteElementSpace const &fes) {
+  swig::SwigVar_PyObject obj0;
+  obj0 = SWIG_NewPointerObj(SWIG_as_voidptr(&fes), SWIGTYPE_p_mfem__FiniteElementSpace,  0 );
+  if (!swig_get_self()) {
+    Swig::DirectorException::raise("'self' uninitialized, maybe you forgot to call BilinearFormIntegrator.__init__.");
+  }
+#if defined(SWIG_PYTHON_DIRECTOR_VTABLE)
+  const size_t swig_method_index = 8;
+  const char *const swig_method_name = "AssemblePAInteriorFaces";
+  PyObject *method = swig_get_method(swig_method_index, swig_method_name);
+  swig::SwigVar_PyObject result = PyObject_CallFunctionObjArgs(method ,(PyObject *)obj0, NULL);
+#else
+  swig::SwigVar_PyObject swig_method_name = SWIG_Python_str_FromChar("AssemblePAInteriorFaces");
+  swig::SwigVar_PyObject result = PyObject_CallMethodObjArgs(swig_get_self(), (PyObject *) swig_method_name ,(PyObject *)obj0, NULL);
+#endif
+  if (!result) {
+    PyObject *error = PyErr_Occurred();
+    {
+      if (error != NULL) {
+        throw Swig::DirectorMethodException();
+      }
+    }
+  }
+}
+
+
+void SwigDirector_BilinearFormIntegrator::AssemblePABoundaryFaces(mfem::FiniteElementSpace const &fes) {
+  swig::SwigVar_PyObject obj0;
+  obj0 = SWIG_NewPointerObj(SWIG_as_voidptr(&fes), SWIGTYPE_p_mfem__FiniteElementSpace,  0 );
+  if (!swig_get_self()) {
+    Swig::DirectorException::raise("'self' uninitialized, maybe you forgot to call BilinearFormIntegrator.__init__.");
+  }
+#if defined(SWIG_PYTHON_DIRECTOR_VTABLE)
+  const size_t swig_method_index = 9;
+  const char *const swig_method_name = "AssemblePABoundaryFaces";
+  PyObject *method = swig_get_method(swig_method_index, swig_method_name);
+  swig::SwigVar_PyObject result = PyObject_CallFunctionObjArgs(method ,(PyObject *)obj0, NULL);
+#else
+  swig::SwigVar_PyObject swig_method_name = SWIG_Python_str_FromChar("AssemblePABoundaryFaces");
+  swig::SwigVar_PyObject result = PyObject_CallMethodObjArgs(swig_get_self(), (PyObject *) swig_method_name ,(PyObject *)obj0, NULL);
+#endif
+  if (!result) {
+    PyObject *error = PyErr_Occurred();
+    {
+      if (error != NULL) {
+        throw Swig::DirectorMethodException();
+      }
+    }
+  }
+}
+
+
+void SwigDirector_BilinearFormIntegrator::AssembleDiagonalPA(mfem::Vector &diag) {
+  swig::SwigVar_PyObject obj0;
+  obj0 = SWIG_NewPointerObj(SWIG_as_voidptr(&diag), SWIGTYPE_p_mfem__Vector,  0 );
+  if (!swig_get_self()) {
+    Swig::DirectorException::raise("'self' uninitialized, maybe you forgot to call BilinearFormIntegrator.__init__.");
+  }
+#if defined(SWIG_PYTHON_DIRECTOR_VTABLE)
+  const size_t swig_method_index = 10;
+  const char *const swig_method_name = "AssembleDiagonalPA";
+  PyObject *method = swig_get_method(swig_method_index, swig_method_name);
+  swig::SwigVar_PyObject result = PyObject_CallFunctionObjArgs(method ,(PyObject *)obj0, NULL);
+#else
+  swig::SwigVar_PyObject swig_method_name = SWIG_Python_str_FromChar("AssembleDiagonalPA");
+  swig::SwigVar_PyObject result = PyObject_CallMethodObjArgs(swig_get_self(), (PyObject *) swig_method_name ,(PyObject *)obj0, NULL);
+#endif
+  if (!result) {
+    PyObject *error = PyErr_Occurred();
+    {
+      if (error != NULL) {
+        throw Swig::DirectorMethodException();
+      }
+    }
+  }
+}
+
+
+void SwigDirector_BilinearFormIntegrator::AssembleDiagonalPA_ADAt(mfem::Vector const &D, mfem::Vector &diag) {
+  swig::SwigVar_PyObject obj0;
+  obj0 = SWIG_NewPointerObj(SWIG_as_voidptr(&D), SWIGTYPE_p_mfem__Vector,  0 );
+  swig::SwigVar_PyObject obj1;
+  obj1 = SWIG_NewPointerObj(SWIG_as_voidptr(&diag), SWIGTYPE_p_mfem__Vector,  0 );
+  if (!swig_get_self()) {
+    Swig::DirectorException::raise("'self' uninitialized, maybe you forgot to call BilinearFormIntegrator.__init__.");
+  }
+#if defined(SWIG_PYTHON_DIRECTOR_VTABLE)
+  const size_t swig_method_index = 11;
+  const char *const swig_method_name = "AssembleDiagonalPA_ADAt";
+  PyObject *method = swig_get_method(swig_method_index, swig_method_name);
+  swig::SwigVar_PyObject result = PyObject_CallFunctionObjArgs(method ,(PyObject *)obj0,(PyObject *)obj1, NULL);
+#else
+  swig::SwigVar_PyObject swig_method_name = SWIG_Python_str_FromChar("AssembleDiagonalPA_ADAt");
+  swig::SwigVar_PyObject result = PyObject_CallMethodObjArgs(swig_get_self(), (PyObject *) swig_method_name ,(PyObject *)obj0,(PyObject *)obj1, NULL);
+#endif
+  if (!result) {
+    PyObject *error = PyErr_Occurred();
+    {
+      if (error != NULL) {
+        throw Swig::DirectorMethodException();
+      }
+    }
+  }
+}
+
+
+void SwigDirector_BilinearFormIntegrator::AddMultTransposePA(mfem::Vector const &x, mfem::Vector &y) const {
+  swig::SwigVar_PyObject obj0;
+  obj0 = SWIG_NewPointerObj(SWIG_as_voidptr(&x), SWIGTYPE_p_mfem__Vector,  0 );
+  swig::SwigVar_PyObject obj1;
+  obj1 = SWIG_NewPointerObj(SWIG_as_voidptr(&y), SWIGTYPE_p_mfem__Vector,  0 );
+  if (!swig_get_self()) {
+    Swig::DirectorException::raise("'self' uninitialized, maybe you forgot to call BilinearFormIntegrator.__init__.");
+  }
+#if defined(SWIG_PYTHON_DIRECTOR_VTABLE)
+  const size_t swig_method_index = 12;
+  const char *const swig_method_name = "AddMultTransposePA";
+  PyObject *method = swig_get_method(swig_method_index, swig_method_name);
+  swig::SwigVar_PyObject result = PyObject_CallFunctionObjArgs(method ,(PyObject *)obj0,(PyObject *)obj1, NULL);
+#else
+  swig::SwigVar_PyObject swig_method_name = SWIG_Python_str_FromChar("AddMultTransposePA");
+  swig::SwigVar_PyObject result = PyObject_CallMethodObjArgs(swig_get_self(), (PyObject *) swig_method_name ,(PyObject *)obj0,(PyObject *)obj1, NULL);
+#endif
+  if (!result) {
+    PyObject *error = PyErr_Occurred();
+    {
+      if (error != NULL) {
+        throw Swig::DirectorMethodException();
+      }
+    }
+  }
+}
+
+
+void SwigDirector_BilinearFormIntegrator::AssembleEA(mfem::FiniteElementSpace const &fes, mfem::Vector &emat, bool const add) {
+  swig::SwigVar_PyObject obj0;
+  obj0 = SWIG_NewPointerObj(SWIG_as_voidptr(&fes), SWIGTYPE_p_mfem__FiniteElementSpace,  0 );
+  swig::SwigVar_PyObject obj1;
+  obj1 = SWIG_NewPointerObj(SWIG_as_voidptr(&emat), SWIGTYPE_p_mfem__Vector,  0 );
+  swig::SwigVar_PyObject obj2;
+  obj2 = SWIG_From_bool(static_cast< bool >(add));
+  if (!swig_get_self()) {
+    Swig::DirectorException::raise("'self' uninitialized, maybe you forgot to call BilinearFormIntegrator.__init__.");
+  }
+#if defined(SWIG_PYTHON_DIRECTOR_VTABLE)
+  const size_t swig_method_index = 13;
+  const char *const swig_method_name = "AssembleEA";
+  PyObject *method = swig_get_method(swig_method_index, swig_method_name);
+  swig::SwigVar_PyObject result = PyObject_CallFunctionObjArgs(method ,(PyObject *)obj0,(PyObject *)obj1,(PyObject *)obj2, NULL);
+#else
+  swig::SwigVar_PyObject swig_method_name = SWIG_Python_str_FromChar("AssembleEA");
+  swig::SwigVar_PyObject result = PyObject_CallMethodObjArgs(swig_get_self(), (PyObject *) swig_method_name ,(PyObject *)obj0,(PyObject *)obj1,(PyObject *)obj2, NULL);
+#endif
+  if (!result) {
+    PyObject *error = PyErr_Occurred();
+    {
+      if (error != NULL) {
+        throw Swig::DirectorMethodException();
+      }
+    }
+  }
+}
+
+
+void SwigDirector_BilinearFormIntegrator::AssembleMF(mfem::FiniteElementSpace const &fes) {
+  swig::SwigVar_PyObject obj0;
+  obj0 = SWIG_NewPointerObj(SWIG_as_voidptr(&fes), SWIGTYPE_p_mfem__FiniteElementSpace,  0 );
+  if (!swig_get_self()) {
+    Swig::DirectorException::raise("'self' uninitialized, maybe you forgot to call BilinearFormIntegrator.__init__.");
+  }
+#if defined(SWIG_PYTHON_DIRECTOR_VTABLE)
+  const size_t swig_method_index = 14;
+  const char *const swig_method_name = "AssembleMF";
+  PyObject *method = swig_get_method(swig_method_index, swig_method_name);
+  swig::SwigVar_PyObject result = PyObject_CallFunctionObjArgs(method ,(PyObject *)obj0, NULL);
+#else
+  swig::SwigVar_PyObject swig_method_name = SWIG_Python_str_FromChar("AssembleMF");
+  swig::SwigVar_PyObject result = PyObject_CallMethodObjArgs(swig_get_self(), (PyObject *) swig_method_name ,(PyObject *)obj0, NULL);
+#endif
+  if (!result) {
+    PyObject *error = PyErr_Occurred();
+    {
+      if (error != NULL) {
+        throw Swig::DirectorMethodException();
+      }
+    }
+  }
+}
+
+
+void SwigDirector_BilinearFormIntegrator::AddMultMF(mfem::Vector const &x, mfem::Vector &y) const {
+  swig::SwigVar_PyObject obj0;
+  obj0 = SWIG_NewPointerObj(SWIG_as_voidptr(&x), SWIGTYPE_p_mfem__Vector,  0 );
+  swig::SwigVar_PyObject obj1;
+  obj1 = SWIG_NewPointerObj(SWIG_as_voidptr(&y), SWIGTYPE_p_mfem__Vector,  0 );
+  if (!swig_get_self()) {
+    Swig::DirectorException::raise("'self' uninitialized, maybe you forgot to call BilinearFormIntegrator.__init__.");
+  }
+#if defined(SWIG_PYTHON_DIRECTOR_VTABLE)
+  const size_t swig_method_index = 15;
+  const char *const swig_method_name = "AddMultMF";
+  PyObject *method = swig_get_method(swig_method_index, swig_method_name);
+  swig::SwigVar_PyObject result = PyObject_CallFunctionObjArgs(method ,(PyObject *)obj0,(PyObject *)obj1, NULL);
+#else
+  swig::SwigVar_PyObject swig_method_name = SWIG_Python_str_FromChar("AddMultMF");
+  swig::SwigVar_PyObject result = PyObject_CallMethodObjArgs(swig_get_self(), (PyObject *) swig_method_name ,(PyObject *)obj0,(PyObject *)obj1, NULL);
+#endif
+  if (!result) {
+    PyObject *error = PyErr_Occurred();
+    {
+      if (error != NULL) {
+        throw Swig::DirectorMethodException();
+      }
+    }
+  }
+}
+
+
+void SwigDirector_BilinearFormIntegrator::AddMultTransposeMF(mfem::Vector const &x, mfem::Vector &y) const {
+  swig::SwigVar_PyObject obj0;
+  obj0 = SWIG_NewPointerObj(SWIG_as_voidptr(&x), SWIGTYPE_p_mfem__Vector,  0 );
+  swig::SwigVar_PyObject obj1;
+  obj1 = SWIG_NewPointerObj(SWIG_as_voidptr(&y), SWIGTYPE_p_mfem__Vector,  0 );
+  if (!swig_get_self()) {
+    Swig::DirectorException::raise("'self' uninitialized, maybe you forgot to call BilinearFormIntegrator.__init__.");
+  }
+#if defined(SWIG_PYTHON_DIRECTOR_VTABLE)
+  const size_t swig_method_index = 16;
+  const char *const swig_method_name = "AddMultTransposeMF";
+  PyObject *method = swig_get_method(swig_method_index, swig_method_name);
+  swig::SwigVar_PyObject result = PyObject_CallFunctionObjArgs(method ,(PyObject *)obj0,(PyObject *)obj1, NULL);
+#else
+  swig::SwigVar_PyObject swig_method_name = SWIG_Python_str_FromChar("AddMultTransposeMF");
+  swig::SwigVar_PyObject result = PyObject_CallMethodObjArgs(swig_get_self(), (PyObject *) swig_method_name ,(PyObject *)obj0,(PyObject *)obj1, NULL);
+#endif
+  if (!result) {
+    PyObject *error = PyErr_Occurred();
+    {
+      if (error != NULL) {
+        throw Swig::DirectorMethodException();
+      }
+    }
+  }
+}
+
+
+void SwigDirector_BilinearFormIntegrator::AssembleDiagonalMF(mfem::Vector &diag) {
+  swig::SwigVar_PyObject obj0;
+  obj0 = SWIG_NewPointerObj(SWIG_as_voidptr(&diag), SWIGTYPE_p_mfem__Vector,  0 );
+  if (!swig_get_self()) {
+    Swig::DirectorException::raise("'self' uninitialized, maybe you forgot to call BilinearFormIntegrator.__init__.");
+  }
+#if defined(SWIG_PYTHON_DIRECTOR_VTABLE)
+  const size_t swig_method_index = 17;
+  const char *const swig_method_name = "AssembleDiagonalMF";
+  PyObject *method = swig_get_method(swig_method_index, swig_method_name);
+  swig::SwigVar_PyObject result = PyObject_CallFunctionObjArgs(method ,(PyObject *)obj0, NULL);
+#else
+  swig::SwigVar_PyObject swig_method_name = SWIG_Python_str_FromChar("AssembleDiagonalMF");
+  swig::SwigVar_PyObject result = PyObject_CallMethodObjArgs(swig_get_self(), (PyObject *) swig_method_name ,(PyObject *)obj0, NULL);
+#endif
+  if (!result) {
+    PyObject *error = PyErr_Occurred();
+    {
+      if (error != NULL) {
+        throw Swig::DirectorMethodException();
+      }
+    }
+  }
+}
+
+
+void SwigDirector_BilinearFormIntegrator::AssembleEAInteriorFaces(mfem::FiniteElementSpace const &fes, mfem::Vector &ea_data_int, mfem::Vector &ea_data_ext, bool const add) {
+  swig::SwigVar_PyObject obj0;
+  obj0 = SWIG_NewPointerObj(SWIG_as_voidptr(&fes), SWIGTYPE_p_mfem__FiniteElementSpace,  0 );
+  swig::SwigVar_PyObject obj1;
+  obj1 = SWIG_NewPointerObj(SWIG_as_voidptr(&ea_data_int), SWIGTYPE_p_mfem__Vector,  0 );
+  swig::SwigVar_PyObject obj2;
+  obj2 = SWIG_NewPointerObj(SWIG_as_voidptr(&ea_data_ext), SWIGTYPE_p_mfem__Vector,  0 );
+  swig::SwigVar_PyObject obj3;
+  obj3 = SWIG_From_bool(static_cast< bool >(add));
+  if (!swig_get_self()) {
+    Swig::DirectorException::raise("'self' uninitialized, maybe you forgot to call BilinearFormIntegrator.__init__.");
+  }
+#if defined(SWIG_PYTHON_DIRECTOR_VTABLE)
+  const size_t swig_method_index = 18;
+  const char *const swig_method_name = "AssembleEAInteriorFaces";
+  PyObject *method = swig_get_method(swig_method_index, swig_method_name);
+  swig::SwigVar_PyObject result = PyObject_CallFunctionObjArgs(method ,(PyObject *)obj0,(PyObject *)obj1,(PyObject *)obj2,(PyObject *)obj3, NULL);
+#else
+  swig::SwigVar_PyObject swig_method_name = SWIG_Python_str_FromChar("AssembleEAInteriorFaces");
+  swig::SwigVar_PyObject result = PyObject_CallMethodObjArgs(swig_get_self(), (PyObject *) swig_method_name ,(PyObject *)obj0,(PyObject *)obj1,(PyObject *)obj2,(PyObject *)obj3, NULL);
+#endif
+  if (!result) {
+    PyObject *error = PyErr_Occurred();
+    {
+      if (error != NULL) {
+        throw Swig::DirectorMethodException();
+      }
+    }
+  }
+}
+
+
+void SwigDirector_BilinearFormIntegrator::AssembleEABoundaryFaces(mfem::FiniteElementSpace const &fes, mfem::Vector &ea_data_bdr, bool const add) {
+  swig::SwigVar_PyObject obj0;
+  obj0 = SWIG_NewPointerObj(SWIG_as_voidptr(&fes), SWIGTYPE_p_mfem__FiniteElementSpace,  0 );
+  swig::SwigVar_PyObject obj1;
+  obj1 = SWIG_NewPointerObj(SWIG_as_voidptr(&ea_data_bdr), SWIGTYPE_p_mfem__Vector,  0 );
+  swig::SwigVar_PyObject obj2;
+  obj2 = SWIG_From_bool(static_cast< bool >(add));
+  if (!swig_get_self()) {
+    Swig::DirectorException::raise("'self' uninitialized, maybe you forgot to call BilinearFormIntegrator.__init__.");
+  }
+#if defined(SWIG_PYTHON_DIRECTOR_VTABLE)
+  const size_t swig_method_index = 19;
+  const char *const swig_method_name = "AssembleEABoundaryFaces";
+  PyObject *method = swig_get_method(swig_method_index, swig_method_name);
+  swig::SwigVar_PyObject result = PyObject_CallFunctionObjArgs(method ,(PyObject *)obj0,(PyObject *)obj1,(PyObject *)obj2, NULL);
+#else
+  swig::SwigVar_PyObject swig_method_name = SWIG_Python_str_FromChar("AssembleEABoundaryFaces");
+  swig::SwigVar_PyObject result = PyObject_CallMethodObjArgs(swig_get_self(), (PyObject *) swig_method_name ,(PyObject *)obj0,(PyObject *)obj1,(PyObject *)obj2, NULL);
+#endif
+  if (!result) {
+    PyObject *error = PyErr_Occurred();
+    {
+      if (error != NULL) {
+        throw Swig::DirectorMethodException();
+      }
+    }
+  }
+}
+
+
+void SwigDirector_BilinearFormIntegrator::AssembleElementMatrix(mfem::FiniteElement const &el, mfem::ElementTransformation &Trans, mfem::DenseMatrix &elmat) {
+  swig::SwigVar_PyObject obj0;
+  obj0 = SWIG_NewPointerObj(SWIG_as_voidptr(&el), SWIGTYPE_p_mfem__FiniteElement,  0 );
+  swig::SwigVar_PyObject obj1;
+  obj1 = SWIG_NewPointerObj(SWIG_as_voidptr(&Trans), SWIGTYPE_p_mfem__ElementTransformation,  0 );
+  swig::SwigVar_PyObject obj2;
+  obj2 = SWIG_NewPointerObj(SWIG_as_voidptr(&elmat), SWIGTYPE_p_mfem__DenseMatrix,  0 );
+  if (!swig_get_self()) {
+    Swig::DirectorException::raise("'self' uninitialized, maybe you forgot to call BilinearFormIntegrator.__init__.");
+  }
+#if defined(SWIG_PYTHON_DIRECTOR_VTABLE)
+  const size_t swig_method_index = 20;
+  const char *const swig_method_name = "AssembleElementMatrix";
+  PyObject *method = swig_get_method(swig_method_index, swig_method_name);
+  swig::SwigVar_PyObject result = PyObject_CallFunctionObjArgs(method ,(PyObject *)obj0,(PyObject *)obj1,(PyObject *)obj2, NULL);
+#else
+  swig::SwigVar_PyObject swig_method_name = SWIG_Python_str_FromChar("AssembleElementMatrix");
+  swig::SwigVar_PyObject result = PyObject_CallMethodObjArgs(swig_get_self(), (PyObject *) swig_method_name ,(PyObject *)obj0,(PyObject *)obj1,(PyObject *)obj2, NULL);
+#endif
+  if (!result) {
+    PyObject *error = PyErr_Occurred();
+    {
+      if (error != NULL) {
+        throw Swig::DirectorMethodException();
+      }
+    }
+  }
+}
+
+
+void SwigDirector_BilinearFormIntegrator::AssembleElementMatrix2(mfem::FiniteElement const &trial_fe, mfem::FiniteElement const &test_fe, mfem::ElementTransformation &Trans, mfem::DenseMatrix &elmat) {
+  swig::SwigVar_PyObject obj0;
+  obj0 = SWIG_NewPointerObj(SWIG_as_voidptr(&trial_fe), SWIGTYPE_p_mfem__FiniteElement,  0 );
+  swig::SwigVar_PyObject obj1;
+  obj1 = SWIG_NewPointerObj(SWIG_as_voidptr(&test_fe), SWIGTYPE_p_mfem__FiniteElement,  0 );
+  swig::SwigVar_PyObject obj2;
+  obj2 = SWIG_NewPointerObj(SWIG_as_voidptr(&Trans), SWIGTYPE_p_mfem__ElementTransformation,  0 );
+  swig::SwigVar_PyObject obj3;
+  obj3 = SWIG_NewPointerObj(SWIG_as_voidptr(&elmat), SWIGTYPE_p_mfem__DenseMatrix,  0 );
+  if (!swig_get_self()) {
+    Swig::DirectorException::raise("'self' uninitialized, maybe you forgot to call BilinearFormIntegrator.__init__.");
+  }
+#if defined(SWIG_PYTHON_DIRECTOR_VTABLE)
+  const size_t swig_method_index = 21;
+  const char *const swig_method_name = "AssembleElementMatrix2";
+  PyObject *method = swig_get_method(swig_method_index, swig_method_name);
+  swig::SwigVar_PyObject result = PyObject_CallFunctionObjArgs(method ,(PyObject *)obj0,(PyObject *)obj1,(PyObject *)obj2,(PyObject *)obj3, NULL);
+#else
+  swig::SwigVar_PyObject swig_method_name = SWIG_Python_str_FromChar("AssembleElementMatrix2");
+  swig::SwigVar_PyObject result = PyObject_CallMethodObjArgs(swig_get_self(), (PyObject *) swig_method_name ,(PyObject *)obj0,(PyObject *)obj1,(PyObject *)obj2,(PyObject *)obj3, NULL);
+#endif
+  if (!result) {
+    PyObject *error = PyErr_Occurred();
+    {
+      if (error != NULL) {
+        throw Swig::DirectorMethodException();
+      }
+    }
+  }
+}
+
+
+void SwigDirector_BilinearFormIntegrator::AssembleFaceMatrix(mfem::FiniteElement const &el1, mfem::FiniteElement const &el2, mfem::FaceElementTransformations &Trans, mfem::DenseMatrix &elmat) {
+  swig::SwigVar_PyObject obj0;
+  obj0 = SWIG_NewPointerObj(SWIG_as_voidptr(&el1), SWIGTYPE_p_mfem__FiniteElement,  0 );
+  swig::SwigVar_PyObject obj1;
+  obj1 = SWIG_NewPointerObj(SWIG_as_voidptr(&el2), SWIGTYPE_p_mfem__FiniteElement,  0 );
+  swig::SwigVar_PyObject obj2;
+  obj2 = SWIG_NewPointerObj(SWIG_as_voidptr(&Trans), SWIGTYPE_p_mfem__FaceElementTransformations,  0 );
+  swig::SwigVar_PyObject obj3;
+  obj3 = SWIG_NewPointerObj(SWIG_as_voidptr(&elmat), SWIGTYPE_p_mfem__DenseMatrix,  0 );
+  if (!swig_get_self()) {
+    Swig::DirectorException::raise("'self' uninitialized, maybe you forgot to call BilinearFormIntegrator.__init__.");
+  }
+#if defined(SWIG_PYTHON_DIRECTOR_VTABLE)
+  const size_t swig_method_index = 22;
+  const char *const swig_method_name = "AssembleFaceMatrix";
+  PyObject *method = swig_get_method(swig_method_index, swig_method_name);
+  swig::SwigVar_PyObject result = PyObject_CallFunctionObjArgs(method ,(PyObject *)obj0,(PyObject *)obj1,(PyObject *)obj2,(PyObject *)obj3, NULL);
+#else
+  swig::SwigVar_PyObject swig_method_name = SWIG_Python_str_FromChar("AssembleFaceMatrix");
+  swig::SwigVar_PyObject result = PyObject_CallMethodObjArgs(swig_get_self(), (PyObject *) swig_method_name ,(PyObject *)obj0,(PyObject *)obj1,(PyObject *)obj2,(PyObject *)obj3, NULL);
+#endif
+  if (!result) {
+    PyObject *error = PyErr_Occurred();
+    {
+      if (error != NULL) {
+        throw Swig::DirectorMethodException();
+      }
+    }
+  }
+}
+
+
+void SwigDirector_BilinearFormIntegrator::AssembleFaceMatrix(mfem::FiniteElement const &trial_face_fe, mfem::FiniteElement const &test_fe1, mfem::FiniteElement const &test_fe2, mfem::FaceElementTransformations &Trans, mfem::DenseMatrix &elmat) {
+  swig::SwigVar_PyObject obj0;
+  obj0 = SWIG_NewPointerObj(SWIG_as_voidptr(&trial_face_fe), SWIGTYPE_p_mfem__FiniteElement,  0 );
+  swig::SwigVar_PyObject obj1;
+  obj1 = SWIG_NewPointerObj(SWIG_as_voidptr(&test_fe1), SWIGTYPE_p_mfem__FiniteElement,  0 );
+  swig::SwigVar_PyObject obj2;
+  obj2 = SWIG_NewPointerObj(SWIG_as_voidptr(&test_fe2), SWIGTYPE_p_mfem__FiniteElement,  0 );
+  swig::SwigVar_PyObject obj3;
+  obj3 = SWIG_NewPointerObj(SWIG_as_voidptr(&Trans), SWIGTYPE_p_mfem__FaceElementTransformations,  0 );
+  swig::SwigVar_PyObject obj4;
+  obj4 = SWIG_NewPointerObj(SWIG_as_voidptr(&elmat), SWIGTYPE_p_mfem__DenseMatrix,  0 );
+  if (!swig_get_self()) {
+    Swig::DirectorException::raise("'self' uninitialized, maybe you forgot to call BilinearFormIntegrator.__init__.");
+  }
+#if defined(SWIG_PYTHON_DIRECTOR_VTABLE)
+  const size_t swig_method_index = 23;
+  const char *const swig_method_name = "AssembleFaceMatrix";
+  PyObject *method = swig_get_method(swig_method_index, swig_method_name);
+  swig::SwigVar_PyObject result = PyObject_CallFunctionObjArgs(method ,(PyObject *)obj0,(PyObject *)obj1,(PyObject *)obj2,(PyObject *)obj3,(PyObject *)obj4, NULL);
+#else
+  swig::SwigVar_PyObject swig_method_name = SWIG_Python_str_FromChar("AssembleFaceMatrix");
   swig::SwigVar_PyObject result = PyObject_CallMethodObjArgs(swig_get_self(), (PyObject *) swig_method_name ,(PyObject *)obj0,(PyObject *)obj1,(PyObject *)obj2,(PyObject *)obj3,(PyObject *)obj4, NULL);
 #endif
   if (!result) {
@@ -4394,7 +4439,7 @@ void SwigDirector_BilinearFormIntegrator::ComputeElementFlux(mfem::FiniteElement
     Swig::DirectorException::raise("'self' uninitialized, maybe you forgot to call BilinearFormIntegrator.__init__.");
   }
 #if defined(SWIG_PYTHON_DIRECTOR_VTABLE)
-  const size_t swig_method_index = 23;
+  const size_t swig_method_index = 24;
   const char *const swig_method_name = "ComputeElementFlux";
   PyObject *method = swig_get_method(swig_method_index, swig_method_name);
   swig::SwigVar_PyObject result = PyObject_CallFunctionObjArgs(method ,(PyObject *)obj0,(PyObject *)obj1,(PyObject *)obj2,(PyObject *)obj3,(PyObject *)obj4,(PyObject *)obj5, NULL);
@@ -4428,7 +4473,7 @@ double SwigDirector_BilinearFormIntegrator::ComputeFluxEnergy(mfem::FiniteElemen
     Swig::DirectorException::raise("'self' uninitialized, maybe you forgot to call BilinearFormIntegrator.__init__.");
   }
 #if defined(SWIG_PYTHON_DIRECTOR_VTABLE)
-  const size_t swig_method_index = 24;
+  const size_t swig_method_index = 25;
   const char *const swig_method_name = "ComputeFluxEnergy";
   PyObject *method = swig_get_method(swig_method_index, swig_method_name);
   swig::SwigVar_PyObject result = PyObject_CallFunctionObjArgs(method ,(PyObject *)obj0,(PyObject *)obj1,(PyObject *)obj2,(PyObject *)obj3, NULL);
@@ -4453,9 +4498,6 @@ double SwigDirector_BilinearFormIntegrator::ComputeFluxEnergy(mfem::FiniteElemen
   return (double) c_result;
 }
 
-
-SwigDirector_BilinearFormIntegrator::~SwigDirector_BilinearFormIntegrator() {
-}
 
 #ifdef __cplusplus
 extern "C" {
@@ -4551,8 +4593,134 @@ SWIGINTERN PyObject *_wrap_new_BilinearFormIntegrator(PyObject *SWIGUNUSEDPARM(s
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__BilinearFormIntegrator, SWIG_POINTER_NEW |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_BilinearFormIntegrator_AssemblePA__SWIG_0_0(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
+  PyObject *resultobj = 0;
+  mfem::BilinearFormIntegrator *arg1 = (mfem::BilinearFormIntegrator *) 0 ;
+  mfem::FiniteElementSpace *arg2 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  Swig::Director *director = 0;
+  bool upcall = false;
+  
+  if ((nobjs < 2) || (nobjs > 2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_mfem__BilinearFormIntegrator, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "BilinearFormIntegrator_AssemblePA" "', argument " "1"" of type '" "mfem::BilinearFormIntegrator *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::BilinearFormIntegrator * >(argp1);
+  res2 = SWIG_ConvertPtr(swig_obj[1], &argp2, SWIGTYPE_p_mfem__FiniteElementSpace,  0  | 0);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "BilinearFormIntegrator_AssemblePA" "', argument " "2"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  if (!argp2) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "BilinearFormIntegrator_AssemblePA" "', argument " "2"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  arg2 = reinterpret_cast< mfem::FiniteElementSpace * >(argp2);
+  director = SWIG_DIRECTOR_CAST(arg1);
+  upcall = (director && (director->swig_get_self()==swig_obj[0]));
+  try {
+    {
+      try {
+        if (upcall) {
+          (arg1)->mfem::BilinearFormIntegrator::AssemblePA((mfem::FiniteElementSpace const &)*arg2);
+        } else {
+          (arg1)->AssemblePA((mfem::FiniteElementSpace const &)*arg2);
+        } 
+      }
+      catch (Swig::DirectorException &e) {
+        SWIG_fail; 
+      }    
+      //catch (...){
+      //  SWIG_fail;
+      //}
+      //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+      //    catch (std::exception &e) { SWIG_fail; }    
+    }
+  } catch (Swig::DirectorException&) {
+    SWIG_fail;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_BilinearFormIntegrator_AssemblePA__SWIG_0_1(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
+  PyObject *resultobj = 0;
+  mfem::BilinearFormIntegrator *arg1 = (mfem::BilinearFormIntegrator *) 0 ;
+  mfem::FiniteElementSpace *arg2 = 0 ;
+  mfem::FiniteElementSpace *arg3 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  void *argp3 = 0 ;
+  int res3 = 0 ;
+  Swig::Director *director = 0;
+  bool upcall = false;
+  
+  if ((nobjs < 3) || (nobjs > 3)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_mfem__BilinearFormIntegrator, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "BilinearFormIntegrator_AssemblePA" "', argument " "1"" of type '" "mfem::BilinearFormIntegrator *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::BilinearFormIntegrator * >(argp1);
+  res2 = SWIG_ConvertPtr(swig_obj[1], &argp2, SWIGTYPE_p_mfem__FiniteElementSpace,  0  | 0);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "BilinearFormIntegrator_AssemblePA" "', argument " "2"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  if (!argp2) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "BilinearFormIntegrator_AssemblePA" "', argument " "2"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  arg2 = reinterpret_cast< mfem::FiniteElementSpace * >(argp2);
+  res3 = SWIG_ConvertPtr(swig_obj[2], &argp3, SWIGTYPE_p_mfem__FiniteElementSpace,  0  | 0);
+  if (!SWIG_IsOK(res3)) {
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "BilinearFormIntegrator_AssemblePA" "', argument " "3"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  if (!argp3) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "BilinearFormIntegrator_AssemblePA" "', argument " "3"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  arg3 = reinterpret_cast< mfem::FiniteElementSpace * >(argp3);
+  director = SWIG_DIRECTOR_CAST(arg1);
+  upcall = (director && (director->swig_get_self()==swig_obj[0]));
+  try {
+    {
+      try {
+        if (upcall) {
+          (arg1)->mfem::BilinearFormIntegrator::AssemblePA((mfem::FiniteElementSpace const &)*arg2,(mfem::FiniteElementSpace const &)*arg3);
+        } else {
+          (arg1)->AssemblePA((mfem::FiniteElementSpace const &)*arg2,(mfem::FiniteElementSpace const &)*arg3);
+        } 
+      }
+      catch (Swig::DirectorException &e) {
+        SWIG_fail; 
+      }    
+      //catch (...){
+      //  SWIG_fail;
+      //}
+      //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+      //    catch (std::exception &e) { SWIG_fail; }    
+    }
+  } catch (Swig::DirectorException&) {
+    SWIG_fail;
+  }
+  resultobj = SWIG_Py_Void();
   return resultobj;
 fail:
   return NULL;
@@ -4598,6 +4766,11 @@ SWIGINTERN PyObject *_wrap_BilinearFormIntegrator_AssemblePA__SWIG_1(PyObject *S
       catch (Swig::DirectorException &e) {
         SWIG_fail; 
       }    
+      //catch (...){
+      //  SWIG_fail;
+      //}
+      //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+      //    catch (std::exception &e) { SWIG_fail; }    
     }
   } catch (Swig::DirectorException&) {
     SWIG_fail;
@@ -4659,6 +4832,11 @@ SWIGINTERN PyObject *_wrap_BilinearFormIntegrator_AssemblePA__SWIG_2(PyObject *S
       catch (Swig::DirectorException &e) {
         SWIG_fail; 
       }    
+      //catch (...){
+      //  SWIG_fail;
+      //}
+      //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+      //    catch (std::exception &e) { SWIG_fail; }    
     }
   } catch (Swig::DirectorException&) {
     SWIG_fail;
@@ -4687,7 +4865,37 @@ SWIGINTERN PyObject *_wrap_BilinearFormIntegrator_AssemblePA(PyObject *self, PyO
       int res = SWIG_ConvertPtr(argv[1], 0, SWIGTYPE_p_mfem__FiniteElementSpace, SWIG_POINTER_NO_NULL | 0);
       _v = SWIG_CheckState(res);
       if (_v) {
+        return _wrap_BilinearFormIntegrator_AssemblePA__SWIG_0_0(self, argc, argv);
+      }
+    }
+  }
+  if (argc == 2) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_mfem__BilinearFormIntegrator, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      int res = SWIG_ConvertPtr(argv[1], 0, SWIGTYPE_p_mfem__FiniteElementSpace, SWIG_POINTER_NO_NULL | 0);
+      _v = SWIG_CheckState(res);
+      if (_v) {
         return _wrap_BilinearFormIntegrator_AssemblePA__SWIG_1(self, argc, argv);
+      }
+    }
+  }
+  if (argc == 3) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_mfem__BilinearFormIntegrator, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      int res = SWIG_ConvertPtr(argv[1], 0, SWIGTYPE_p_mfem__FiniteElementSpace, SWIG_POINTER_NO_NULL | 0);
+      _v = SWIG_CheckState(res);
+      if (_v) {
+        int res = SWIG_ConvertPtr(argv[2], 0, SWIGTYPE_p_mfem__FiniteElementSpace, SWIG_POINTER_NO_NULL | 0);
+        _v = SWIG_CheckState(res);
+        if (_v) {
+          return _wrap_BilinearFormIntegrator_AssemblePA__SWIG_0_1(self, argc, argv);
+        }
       }
     }
   }
@@ -4712,7 +4920,8 @@ SWIGINTERN PyObject *_wrap_BilinearFormIntegrator_AssemblePA(PyObject *self, PyO
 fail:
   SWIG_Python_RaiseOrModifyTypeError("Wrong number or type of arguments for overloaded function 'BilinearFormIntegrator_AssemblePA'.\n"
     "  Possible C/C++ prototypes are:\n"
-    "    mfem::BilinearFormIntegrator::AssemblePA()\n"
+    "    AssemblePA(mfem::FiniteElementSpace const &)\n"
+    "    AssemblePA(mfem::FiniteElementSpace const &,mfem::FiniteElementSpace const &)\n"
     "    mfem::BilinearFormIntegrator::AssemblePA(mfem::FiniteElementSpace const &)\n"
     "    mfem::BilinearFormIntegrator::AssemblePA(mfem::FiniteElementSpace const &,mfem::FiniteElementSpace const &)\n");
   return 0;
@@ -4763,6 +4972,11 @@ SWIGINTERN PyObject *_wrap_BilinearFormIntegrator_AssemblePAInteriorFaces(PyObje
       catch (Swig::DirectorException &e) {
         SWIG_fail; 
       }    
+      //catch (...){
+      //  SWIG_fail;
+      //}
+      //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+      //    catch (std::exception &e) { SWIG_fail; }    
     }
   } catch (Swig::DirectorException&) {
     SWIG_fail;
@@ -4818,6 +5032,11 @@ SWIGINTERN PyObject *_wrap_BilinearFormIntegrator_AssemblePABoundaryFaces(PyObje
       catch (Swig::DirectorException &e) {
         SWIG_fail; 
       }    
+      //catch (...){
+      //  SWIG_fail;
+      //}
+      //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+      //    catch (std::exception &e) { SWIG_fail; }    
     }
   } catch (Swig::DirectorException&) {
     SWIG_fail;
@@ -4873,6 +5092,11 @@ SWIGINTERN PyObject *_wrap_BilinearFormIntegrator_AssembleDiagonalPA(PyObject *S
       catch (Swig::DirectorException &e) {
         SWIG_fail; 
       }    
+      //catch (...){
+      //  SWIG_fail;
+      //}
+      //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+      //    catch (std::exception &e) { SWIG_fail; }    
     }
   } catch (Swig::DirectorException&) {
     SWIG_fail;
@@ -4940,6 +5164,11 @@ SWIGINTERN PyObject *_wrap_BilinearFormIntegrator_AssembleDiagonalPA_ADAt(PyObje
       catch (Swig::DirectorException &e) {
         SWIG_fail; 
       }    
+      //catch (...){
+      //  SWIG_fail;
+      //}
+      //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+      //    catch (std::exception &e) { SWIG_fail; }    
     }
   } catch (Swig::DirectorException&) {
     SWIG_fail;
@@ -5007,6 +5236,11 @@ SWIGINTERN PyObject *_wrap_BilinearFormIntegrator_AddMultPA(PyObject *SWIGUNUSED
       catch (Swig::DirectorException &e) {
         SWIG_fail; 
       }    
+      //catch (...){
+      //  SWIG_fail;
+      //}
+      //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+      //    catch (std::exception &e) { SWIG_fail; }    
     }
   } catch (Swig::DirectorException&) {
     SWIG_fail;
@@ -5074,6 +5308,11 @@ SWIGINTERN PyObject *_wrap_BilinearFormIntegrator_AddMultTransposePA(PyObject *S
       catch (Swig::DirectorException &e) {
         SWIG_fail; 
       }    
+      //catch (...){
+      //  SWIG_fail;
+      //}
+      //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+      //    catch (std::exception &e) { SWIG_fail; }    
     }
   } catch (Swig::DirectorException&) {
     SWIG_fail;
@@ -5152,6 +5391,11 @@ SWIGINTERN PyObject *_wrap_BilinearFormIntegrator_AssembleEA(PyObject *SWIGUNUSE
       catch (Swig::DirectorException &e) {
         SWIG_fail; 
       }    
+      //catch (...){
+      //  SWIG_fail;
+      //}
+      //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+      //    catch (std::exception &e) { SWIG_fail; }    
     }
   } catch (Swig::DirectorException&) {
     SWIG_fail;
@@ -5207,6 +5451,11 @@ SWIGINTERN PyObject *_wrap_BilinearFormIntegrator_AssembleMF(PyObject *SWIGUNUSE
       catch (Swig::DirectorException &e) {
         SWIG_fail; 
       }    
+      //catch (...){
+      //  SWIG_fail;
+      //}
+      //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+      //    catch (std::exception &e) { SWIG_fail; }    
     }
   } catch (Swig::DirectorException&) {
     SWIG_fail;
@@ -5274,6 +5523,11 @@ SWIGINTERN PyObject *_wrap_BilinearFormIntegrator_AddMultMF(PyObject *SWIGUNUSED
       catch (Swig::DirectorException &e) {
         SWIG_fail; 
       }    
+      //catch (...){
+      //  SWIG_fail;
+      //}
+      //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+      //    catch (std::exception &e) { SWIG_fail; }    
     }
   } catch (Swig::DirectorException&) {
     SWIG_fail;
@@ -5341,6 +5595,11 @@ SWIGINTERN PyObject *_wrap_BilinearFormIntegrator_AddMultTransposeMF(PyObject *S
       catch (Swig::DirectorException &e) {
         SWIG_fail; 
       }    
+      //catch (...){
+      //  SWIG_fail;
+      //}
+      //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+      //    catch (std::exception &e) { SWIG_fail; }    
     }
   } catch (Swig::DirectorException&) {
     SWIG_fail;
@@ -5396,6 +5655,11 @@ SWIGINTERN PyObject *_wrap_BilinearFormIntegrator_AssembleDiagonalMF(PyObject *S
       catch (Swig::DirectorException &e) {
         SWIG_fail; 
       }    
+      //catch (...){
+      //  SWIG_fail;
+      //}
+      //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+      //    catch (std::exception &e) { SWIG_fail; }    
     }
   } catch (Swig::DirectorException&) {
     SWIG_fail;
@@ -5486,6 +5750,11 @@ SWIGINTERN PyObject *_wrap_BilinearFormIntegrator_AssembleEAInteriorFaces(PyObje
       catch (Swig::DirectorException &e) {
         SWIG_fail; 
       }    
+      //catch (...){
+      //  SWIG_fail;
+      //}
+      //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+      //    catch (std::exception &e) { SWIG_fail; }    
     }
   } catch (Swig::DirectorException&) {
     SWIG_fail;
@@ -5564,6 +5833,11 @@ SWIGINTERN PyObject *_wrap_BilinearFormIntegrator_AssembleEABoundaryFaces(PyObje
       catch (Swig::DirectorException &e) {
         SWIG_fail; 
       }    
+      //catch (...){
+      //  SWIG_fail;
+      //}
+      //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+      //    catch (std::exception &e) { SWIG_fail; }    
     }
   } catch (Swig::DirectorException&) {
     SWIG_fail;
@@ -5643,6 +5917,11 @@ SWIGINTERN PyObject *_wrap_BilinearFormIntegrator_AssembleElementMatrix(PyObject
       catch (Swig::DirectorException &e) {
         SWIG_fail; 
       }    
+      //catch (...){
+      //  SWIG_fail;
+      //}
+      //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+      //    catch (std::exception &e) { SWIG_fail; }    
     }
   } catch (Swig::DirectorException&) {
     SWIG_fail;
@@ -5734,6 +6013,11 @@ SWIGINTERN PyObject *_wrap_BilinearFormIntegrator_AssembleElementMatrix2(PyObjec
       catch (Swig::DirectorException &e) {
         SWIG_fail; 
       }    
+      //catch (...){
+      //  SWIG_fail;
+      //}
+      //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+      //    catch (std::exception &e) { SWIG_fail; }    
     }
   } catch (Swig::DirectorException&) {
     SWIG_fail;
@@ -5817,6 +6101,11 @@ SWIGINTERN PyObject *_wrap_BilinearFormIntegrator_AssembleFaceMatrix__SWIG_0(PyO
       catch (Swig::DirectorException &e) {
         SWIG_fail; 
       }    
+      //catch (...){
+      //  SWIG_fail;
+      //}
+      //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+      //    catch (std::exception &e) { SWIG_fail; }    
     }
   } catch (Swig::DirectorException&) {
     SWIG_fail;
@@ -5911,6 +6200,11 @@ SWIGINTERN PyObject *_wrap_BilinearFormIntegrator_AssembleFaceMatrix__SWIG_1(PyO
       catch (Swig::DirectorException &e) {
         SWIG_fail; 
       }    
+      //catch (...){
+      //  SWIG_fail;
+      //}
+      //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+      //    catch (std::exception &e) { SWIG_fail; }    
     }
   } catch (Swig::DirectorException&) {
     SWIG_fail;
@@ -6078,6 +6372,11 @@ SWIGINTERN PyObject *_wrap_BilinearFormIntegrator_AssembleElementVector(PyObject
       catch (Swig::DirectorException &e) {
         SWIG_fail; 
       }    
+      //catch (...){
+      //  SWIG_fail;
+      //}
+      //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+      //    catch (std::exception &e) { SWIG_fail; }    
     }
   } catch (Swig::DirectorException&) {
     SWIG_fail;
@@ -6181,6 +6480,11 @@ SWIGINTERN PyObject *_wrap_BilinearFormIntegrator_AssembleFaceVector(PyObject *S
       catch (Swig::DirectorException &e) {
         SWIG_fail; 
       }    
+      //catch (...){
+      //  SWIG_fail;
+      //}
+      //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+      //    catch (std::exception &e) { SWIG_fail; }    
     }
   } catch (Swig::DirectorException&) {
     SWIG_fail;
@@ -6272,6 +6576,11 @@ SWIGINTERN PyObject *_wrap_BilinearFormIntegrator_AssembleElementGrad(PyObject *
       catch (Swig::DirectorException &e) {
         SWIG_fail; 
       }    
+      //catch (...){
+      //  SWIG_fail;
+      //}
+      //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+      //    catch (std::exception &e) { SWIG_fail; }    
     }
   } catch (Swig::DirectorException&) {
     SWIG_fail;
@@ -6375,6 +6684,11 @@ SWIGINTERN PyObject *_wrap_BilinearFormIntegrator_AssembleFaceGrad(PyObject *SWI
       catch (Swig::DirectorException &e) {
         SWIG_fail; 
       }    
+      //catch (...){
+      //  SWIG_fail;
+      //}
+      //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+      //    catch (std::exception &e) { SWIG_fail; }    
     }
   } catch (Swig::DirectorException&) {
     SWIG_fail;
@@ -6489,6 +6803,11 @@ SWIGINTERN PyObject *_wrap_BilinearFormIntegrator_ComputeElementFlux(PyObject *S
       catch (Swig::DirectorException &e) {
         SWIG_fail; 
       }    
+      //catch (...){
+      //  SWIG_fail;
+      //}
+      //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+      //    catch (std::exception &e) { SWIG_fail; }    
     }
   } catch (Swig::DirectorException&) {
     SWIG_fail;
@@ -6580,6 +6899,11 @@ SWIGINTERN PyObject *_wrap_BilinearFormIntegrator_ComputeFluxEnergy(PyObject *SW
       catch (Swig::DirectorException &e) {
         SWIG_fail; 
       }    
+      //catch (...){
+      //  SWIG_fail;
+      //}
+      //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+      //    catch (std::exception &e) { SWIG_fail; }    
     }
   } catch (Swig::DirectorException&) {
     SWIG_fail;
@@ -6612,6 +6936,11 @@ SWIGINTERN PyObject *_wrap_delete_BilinearFormIntegrator(PyObject *SWIGUNUSEDPAR
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -6693,6 +7022,11 @@ SWIGINTERN PyObject *_wrap_new_TransposeIntegrator(PyObject *SWIGUNUSEDPARM(self
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__TransposeIntegrator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -6760,6 +7094,11 @@ SWIGINTERN PyObject *_wrap_TransposeIntegrator_AssembleElementMatrix(PyObject *S
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -6839,6 +7178,11 @@ SWIGINTERN PyObject *_wrap_TransposeIntegrator_AssembleElementMatrix2(PyObject *
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -6910,6 +7254,11 @@ SWIGINTERN PyObject *_wrap_TransposeIntegrator_AssembleFaceMatrix__SWIG_0_0(PyOb
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -6992,6 +7341,11 @@ SWIGINTERN PyObject *_wrap_TransposeIntegrator_AssembleFaceMatrix__SWIG_0_1(PyOb
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -7063,6 +7417,11 @@ SWIGINTERN PyObject *_wrap_TransposeIntegrator_AssembleFaceMatrix__SWIG_1(PyObje
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -7175,6 +7534,103 @@ fail:
 }
 
 
+SWIGINTERN PyObject *_wrap_TransposeIntegrator_AssemblePA__SWIG_0_0(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
+  PyObject *resultobj = 0;
+  mfem::TransposeIntegrator *arg1 = (mfem::TransposeIntegrator *) 0 ;
+  mfem::FiniteElementSpace *arg2 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  
+  if ((nobjs < 2) || (nobjs > 2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_mfem__TransposeIntegrator, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "TransposeIntegrator_AssemblePA" "', argument " "1"" of type '" "mfem::TransposeIntegrator *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::TransposeIntegrator * >(argp1);
+  res2 = SWIG_ConvertPtr(swig_obj[1], &argp2, SWIGTYPE_p_mfem__FiniteElementSpace,  0  | 0);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "TransposeIntegrator_AssemblePA" "', argument " "2"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  if (!argp2) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "TransposeIntegrator_AssemblePA" "', argument " "2"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  arg2 = reinterpret_cast< mfem::FiniteElementSpace * >(argp2);
+  {
+    try {
+      (arg1)->AssemblePA((mfem::FiniteElementSpace const &)*arg2); 
+    }
+    catch (Swig::DirectorException &e) {
+      SWIG_fail; 
+    }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_TransposeIntegrator_AssemblePA__SWIG_0_1(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
+  PyObject *resultobj = 0;
+  mfem::TransposeIntegrator *arg1 = (mfem::TransposeIntegrator *) 0 ;
+  mfem::FiniteElementSpace *arg2 = 0 ;
+  mfem::FiniteElementSpace *arg3 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  void *argp3 = 0 ;
+  int res3 = 0 ;
+  
+  if ((nobjs < 3) || (nobjs > 3)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_mfem__TransposeIntegrator, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "TransposeIntegrator_AssemblePA" "', argument " "1"" of type '" "mfem::TransposeIntegrator *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::TransposeIntegrator * >(argp1);
+  res2 = SWIG_ConvertPtr(swig_obj[1], &argp2, SWIGTYPE_p_mfem__FiniteElementSpace,  0  | 0);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "TransposeIntegrator_AssemblePA" "', argument " "2"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  if (!argp2) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "TransposeIntegrator_AssemblePA" "', argument " "2"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  arg2 = reinterpret_cast< mfem::FiniteElementSpace * >(argp2);
+  res3 = SWIG_ConvertPtr(swig_obj[2], &argp3, SWIGTYPE_p_mfem__FiniteElementSpace,  0  | 0);
+  if (!SWIG_IsOK(res3)) {
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "TransposeIntegrator_AssemblePA" "', argument " "3"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  if (!argp3) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "TransposeIntegrator_AssemblePA" "', argument " "3"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  arg3 = reinterpret_cast< mfem::FiniteElementSpace * >(argp3);
+  {
+    try {
+      (arg1)->AssemblePA((mfem::FiniteElementSpace const &)*arg2,(mfem::FiniteElementSpace const &)*arg3); 
+    }
+    catch (Swig::DirectorException &e) {
+      SWIG_fail; 
+    }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
 SWIGINTERN PyObject *_wrap_TransposeIntegrator_AssemblePA__SWIG_1(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
   PyObject *resultobj = 0;
   mfem::TransposeIntegrator *arg1 = (mfem::TransposeIntegrator *) 0 ;
@@ -7205,6 +7661,11 @@ SWIGINTERN PyObject *_wrap_TransposeIntegrator_AssemblePA__SWIG_1(PyObject *SWIG
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -7215,12 +7676,25 @@ fail:
 
 SWIGINTERN PyObject *_wrap_TransposeIntegrator_AssemblePA(PyObject *self, PyObject *args) {
   Py_ssize_t argc;
-  PyObject *argv[3] = {
+  PyObject *argv[4] = {
     0
   };
   
-  if (!(argc = SWIG_Python_UnpackTuple(args, "TransposeIntegrator_AssemblePA", 0, 2, argv))) SWIG_fail;
+  if (!(argc = SWIG_Python_UnpackTuple(args, "TransposeIntegrator_AssemblePA", 0, 3, argv))) SWIG_fail;
   --argc;
+  if (argc == 2) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_mfem__TransposeIntegrator, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      int res = SWIG_ConvertPtr(argv[1], 0, SWIGTYPE_p_mfem__FiniteElementSpace, SWIG_POINTER_NO_NULL | 0);
+      _v = SWIG_CheckState(res);
+      if (_v) {
+        return _wrap_TransposeIntegrator_AssemblePA__SWIG_0_0(self, argc, argv);
+      }
+    }
+  }
   if (argc == 2) {
     int _v;
     void *vptr = 0;
@@ -7234,11 +7708,29 @@ SWIGINTERN PyObject *_wrap_TransposeIntegrator_AssemblePA(PyObject *self, PyObje
       }
     }
   }
+  if (argc == 3) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_mfem__TransposeIntegrator, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      int res = SWIG_ConvertPtr(argv[1], 0, SWIGTYPE_p_mfem__FiniteElementSpace, SWIG_POINTER_NO_NULL | 0);
+      _v = SWIG_CheckState(res);
+      if (_v) {
+        int res = SWIG_ConvertPtr(argv[2], 0, SWIGTYPE_p_mfem__FiniteElementSpace, SWIG_POINTER_NO_NULL | 0);
+        _v = SWIG_CheckState(res);
+        if (_v) {
+          return _wrap_TransposeIntegrator_AssemblePA__SWIG_0_1(self, argc, argv);
+        }
+      }
+    }
+  }
   
 fail:
   SWIG_Python_RaiseOrModifyTypeError("Wrong number or type of arguments for overloaded function 'TransposeIntegrator_AssemblePA'.\n"
     "  Possible C/C++ prototypes are:\n"
-    "    mfem::TransposeIntegrator::AssemblePA()\n"
+    "    AssemblePA(mfem::FiniteElementSpace const &)\n"
+    "    AssemblePA(mfem::FiniteElementSpace const &,mfem::FiniteElementSpace const &)\n"
     "    mfem::TransposeIntegrator::AssemblePA(mfem::FiniteElementSpace const &)\n");
   return 0;
 }
@@ -7279,6 +7771,11 @@ SWIGINTERN PyObject *_wrap_TransposeIntegrator_AssemblePAInteriorFaces(PyObject 
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -7322,6 +7819,11 @@ SWIGINTERN PyObject *_wrap_TransposeIntegrator_AssemblePABoundaryFaces(PyObject 
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -7377,6 +7879,11 @@ SWIGINTERN PyObject *_wrap_TransposeIntegrator_AddMultTransposePA(PyObject *SWIG
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -7432,6 +7939,11 @@ SWIGINTERN PyObject *_wrap_TransposeIntegrator_AddMultPA(PyObject *SWIGUNUSEDPAR
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -7496,6 +8008,11 @@ SWIGINTERN PyObject *_wrap_TransposeIntegrator_AssembleEA(PyObject *SWIGUNUSEDPA
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -7572,6 +8089,11 @@ SWIGINTERN PyObject *_wrap_TransposeIntegrator_AssembleEAInteriorFaces(PyObject 
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -7636,6 +8158,11 @@ SWIGINTERN PyObject *_wrap_TransposeIntegrator_AssembleEABoundaryFaces(PyObject 
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -7665,6 +8192,11 @@ SWIGINTERN PyObject *_wrap_delete_TransposeIntegrator(PyObject *SWIGUNUSEDPARM(s
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -7718,6 +8250,11 @@ SWIGINTERN PyObject *_wrap_new_LumpedIntegrator(PyObject *SWIGUNUSEDPARM(self), 
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__LumpedIntegrator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -7785,6 +8322,11 @@ SWIGINTERN PyObject *_wrap_LumpedIntegrator_AssembleElementMatrix(PyObject *SWIG
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -7814,6 +8356,11 @@ SWIGINTERN PyObject *_wrap_delete_LumpedIntegrator(PyObject *SWIGUNUSEDPARM(self
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -7867,6 +8414,11 @@ SWIGINTERN PyObject *_wrap_new_InverseIntegrator(PyObject *SWIGUNUSEDPARM(self),
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__InverseIntegrator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -7934,6 +8486,11 @@ SWIGINTERN PyObject *_wrap_InverseIntegrator_AssembleElementMatrix(PyObject *SWI
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -7963,6 +8520,11 @@ SWIGINTERN PyObject *_wrap_delete_InverseIntegrator(PyObject *SWIGUNUSEDPARM(sel
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -8007,6 +8569,11 @@ SWIGINTERN PyObject *_wrap_new_SumIntegrator(PyObject *SWIGUNUSEDPARM(self), PyO
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__SumIntegrator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -8047,6 +8614,11 @@ SWIGINTERN PyObject *_wrap_SumIntegrator_AddIntegrator(PyObject *SWIGUNUSEDPARM(
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -8114,6 +8686,11 @@ SWIGINTERN PyObject *_wrap_SumIntegrator_AssembleElementMatrix(PyObject *SWIGUNU
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -8143,6 +8720,11 @@ SWIGINTERN PyObject *_wrap_delete_SumIntegrator(PyObject *SWIGUNUSEDPARM(self), 
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -8233,6 +8815,11 @@ SWIGINTERN PyObject *_wrap_MixedScalarIntegrator_AssembleElementMatrix2(PyObject
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -8300,6 +8887,11 @@ SWIGINTERN PyObject *_wrap_MixedScalarIntegrator_AssembleElementMatrix(PyObject 
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -8329,6 +8921,11 @@ SWIGINTERN PyObject *_wrap_delete_MixedScalarIntegrator(PyObject *SWIGUNUSEDPARM
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -8415,6 +9012,11 @@ SWIGINTERN PyObject *_wrap_MixedVectorIntegrator_AssembleElementMatrix2(PyObject
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -8482,6 +9084,11 @@ SWIGINTERN PyObject *_wrap_MixedVectorIntegrator_AssembleElementMatrix(PyObject 
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -8511,6 +9118,11 @@ SWIGINTERN PyObject *_wrap_delete_MixedVectorIntegrator(PyObject *SWIGUNUSEDPARM
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -8597,6 +9209,11 @@ SWIGINTERN PyObject *_wrap_MixedScalarVectorIntegrator_AssembleElementMatrix2(Py
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -8664,6 +9281,11 @@ SWIGINTERN PyObject *_wrap_MixedScalarVectorIntegrator_AssembleElementMatrix(PyO
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -8693,6 +9315,11 @@ SWIGINTERN PyObject *_wrap_delete_MixedScalarVectorIntegrator(PyObject *SWIGUNUS
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -8720,6 +9347,11 @@ SWIGINTERN PyObject *_wrap_new_MixedScalarMassIntegrator__SWIG_0(PyObject *SWIGU
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__MixedScalarMassIntegrator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -8751,6 +9383,11 @@ SWIGINTERN PyObject *_wrap_new_MixedScalarMassIntegrator__SWIG_1(PyObject *SWIGU
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__MixedScalarMassIntegrator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -8810,6 +9447,11 @@ SWIGINTERN PyObject *_wrap_delete_MixedScalarMassIntegrator(PyObject *SWIGUNUSED
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -8856,6 +9498,11 @@ SWIGINTERN PyObject *_wrap_new_MixedVectorProductIntegrator(PyObject *SWIGUNUSED
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__MixedVectorProductIntegrator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -8885,6 +9532,11 @@ SWIGINTERN PyObject *_wrap_delete_MixedVectorProductIntegrator(PyObject *SWIGUNU
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -8916,6 +9568,11 @@ SWIGINTERN PyObject *_wrap_new_MixedScalarDerivativeIntegrator__SWIG_0(PyObject 
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__MixedScalarDerivativeIntegrator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -8947,6 +9604,11 @@ SWIGINTERN PyObject *_wrap_new_MixedScalarDerivativeIntegrator__SWIG_1(PyObject 
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__MixedScalarDerivativeIntegrator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -9006,6 +9668,11 @@ SWIGINTERN PyObject *_wrap_delete_MixedScalarDerivativeIntegrator(PyObject *SWIG
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -9037,6 +9704,11 @@ SWIGINTERN PyObject *_wrap_new_MixedScalarWeakDerivativeIntegrator__SWIG_0(PyObj
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__MixedScalarWeakDerivativeIntegrator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -9068,6 +9740,11 @@ SWIGINTERN PyObject *_wrap_new_MixedScalarWeakDerivativeIntegrator__SWIG_1(PyObj
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__MixedScalarWeakDerivativeIntegrator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -9127,6 +9804,11 @@ SWIGINTERN PyObject *_wrap_delete_MixedScalarWeakDerivativeIntegrator(PyObject *
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -9158,6 +9840,11 @@ SWIGINTERN PyObject *_wrap_new_MixedScalarDivergenceIntegrator__SWIG_0(PyObject 
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__MixedScalarDivergenceIntegrator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -9189,6 +9876,11 @@ SWIGINTERN PyObject *_wrap_new_MixedScalarDivergenceIntegrator__SWIG_1(PyObject 
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__MixedScalarDivergenceIntegrator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -9248,6 +9940,11 @@ SWIGINTERN PyObject *_wrap_delete_MixedScalarDivergenceIntegrator(PyObject *SWIG
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -9294,6 +9991,11 @@ SWIGINTERN PyObject *_wrap_new_MixedVectorDivergenceIntegrator(PyObject *SWIGUNU
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__MixedVectorDivergenceIntegrator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -9323,6 +10025,11 @@ SWIGINTERN PyObject *_wrap_delete_MixedVectorDivergenceIntegrator(PyObject *SWIG
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -9354,6 +10061,11 @@ SWIGINTERN PyObject *_wrap_new_MixedScalarWeakGradientIntegrator__SWIG_0(PyObjec
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__MixedScalarWeakGradientIntegrator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -9385,6 +10097,11 @@ SWIGINTERN PyObject *_wrap_new_MixedScalarWeakGradientIntegrator__SWIG_1(PyObjec
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__MixedScalarWeakGradientIntegrator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -9444,6 +10161,11 @@ SWIGINTERN PyObject *_wrap_delete_MixedScalarWeakGradientIntegrator(PyObject *SW
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -9475,6 +10197,11 @@ SWIGINTERN PyObject *_wrap_new_MixedScalarCurlIntegrator__SWIG_0(PyObject *SWIGU
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__MixedScalarCurlIntegrator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -9506,6 +10233,11 @@ SWIGINTERN PyObject *_wrap_new_MixedScalarCurlIntegrator__SWIG_1(PyObject *SWIGU
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__MixedScalarCurlIntegrator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -9565,6 +10297,11 @@ SWIGINTERN PyObject *_wrap_delete_MixedScalarCurlIntegrator(PyObject *SWIGUNUSED
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -9596,6 +10333,11 @@ SWIGINTERN PyObject *_wrap_new_MixedScalarWeakCurlIntegrator__SWIG_0(PyObject *S
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__MixedScalarWeakCurlIntegrator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -9627,6 +10369,11 @@ SWIGINTERN PyObject *_wrap_new_MixedScalarWeakCurlIntegrator__SWIG_1(PyObject *S
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__MixedScalarWeakCurlIntegrator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -9686,6 +10433,11 @@ SWIGINTERN PyObject *_wrap_delete_MixedScalarWeakCurlIntegrator(PyObject *SWIGUN
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -9717,6 +10469,11 @@ SWIGINTERN PyObject *_wrap_new_MixedVectorMassIntegrator__SWIG_0(PyObject *SWIGU
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__MixedVectorMassIntegrator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -9748,6 +10505,11 @@ SWIGINTERN PyObject *_wrap_new_MixedVectorMassIntegrator__SWIG_1(PyObject *SWIGU
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__MixedVectorMassIntegrator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -9779,6 +10541,11 @@ SWIGINTERN PyObject *_wrap_new_MixedVectorMassIntegrator__SWIG_2(PyObject *SWIGU
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__MixedVectorMassIntegrator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -9810,6 +10577,11 @@ SWIGINTERN PyObject *_wrap_new_MixedVectorMassIntegrator__SWIG_3(PyObject *SWIGU
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__MixedVectorMassIntegrator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -9889,6 +10661,11 @@ SWIGINTERN PyObject *_wrap_delete_MixedVectorMassIntegrator(PyObject *SWIGUNUSED
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -9935,6 +10712,11 @@ SWIGINTERN PyObject *_wrap_new_MixedCrossProductIntegrator(PyObject *SWIGUNUSEDP
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__MixedCrossProductIntegrator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -9964,6 +10746,11 @@ SWIGINTERN PyObject *_wrap_delete_MixedCrossProductIntegrator(PyObject *SWIGUNUS
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -10010,6 +10797,11 @@ SWIGINTERN PyObject *_wrap_new_MixedDotProductIntegrator(PyObject *SWIGUNUSEDPAR
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__MixedDotProductIntegrator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -10066,6 +10858,11 @@ SWIGINTERN PyObject *_wrap_MixedDotProductIntegrator_VerifyFiniteElementTypes(Py
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_From_bool(static_cast< bool >(result));
   return resultobj;
@@ -10096,6 +10893,11 @@ SWIGINTERN PyObject *_wrap_MixedDotProductIntegrator_FiniteElementTypeFailureMes
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_FromCharPtr((const char *)result);
   return resultobj;
@@ -10125,6 +10927,11 @@ SWIGINTERN PyObject *_wrap_delete_MixedDotProductIntegrator(PyObject *SWIGUNUSED
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -10171,6 +10978,11 @@ SWIGINTERN PyObject *_wrap_new_MixedWeakGradDotIntegrator(PyObject *SWIGUNUSEDPA
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__MixedWeakGradDotIntegrator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -10227,6 +11039,11 @@ SWIGINTERN PyObject *_wrap_MixedWeakGradDotIntegrator_VerifyFiniteElementTypes(P
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_From_bool(static_cast< bool >(result));
   return resultobj;
@@ -10257,6 +11074,11 @@ SWIGINTERN PyObject *_wrap_MixedWeakGradDotIntegrator_FiniteElementTypeFailureMe
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_FromCharPtr((const char *)result);
   return resultobj;
@@ -10325,6 +11147,11 @@ SWIGINTERN PyObject *_wrap_MixedWeakGradDotIntegrator_GetIntegrationOrder(PyObje
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_From_int(static_cast< int >(result));
   return resultobj;
@@ -10392,6 +11219,11 @@ SWIGINTERN PyObject *_wrap_MixedWeakGradDotIntegrator_CalcShape(PyObject *SWIGUN
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -10421,6 +11253,11 @@ SWIGINTERN PyObject *_wrap_delete_MixedWeakGradDotIntegrator(PyObject *SWIGUNUSE
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -10467,6 +11304,11 @@ SWIGINTERN PyObject *_wrap_new_MixedWeakDivCrossIntegrator(PyObject *SWIGUNUSEDP
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__MixedWeakDivCrossIntegrator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -10523,6 +11365,11 @@ SWIGINTERN PyObject *_wrap_MixedWeakDivCrossIntegrator_VerifyFiniteElementTypes(
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_From_bool(static_cast< bool >(result));
   return resultobj;
@@ -10553,6 +11400,11 @@ SWIGINTERN PyObject *_wrap_MixedWeakDivCrossIntegrator_FiniteElementTypeFailureM
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_FromCharPtr((const char *)result);
   return resultobj;
@@ -10620,6 +11472,11 @@ SWIGINTERN PyObject *_wrap_MixedWeakDivCrossIntegrator_CalcTestShape(PyObject *S
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -10649,6 +11506,11 @@ SWIGINTERN PyObject *_wrap_delete_MixedWeakDivCrossIntegrator(PyObject *SWIGUNUS
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -10680,6 +11542,11 @@ SWIGINTERN PyObject *_wrap_new_MixedGradGradIntegrator__SWIG_0(PyObject *SWIGUNU
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__MixedGradGradIntegrator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -10711,6 +11578,11 @@ SWIGINTERN PyObject *_wrap_new_MixedGradGradIntegrator__SWIG_1(PyObject *SWIGUNU
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__MixedGradGradIntegrator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -10742,6 +11614,11 @@ SWIGINTERN PyObject *_wrap_new_MixedGradGradIntegrator__SWIG_2(PyObject *SWIGUNU
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__MixedGradGradIntegrator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -10773,6 +11650,11 @@ SWIGINTERN PyObject *_wrap_new_MixedGradGradIntegrator__SWIG_3(PyObject *SWIGUNU
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__MixedGradGradIntegrator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -10879,6 +11761,11 @@ SWIGINTERN PyObject *_wrap_MixedGradGradIntegrator_VerifyFiniteElementTypes(PyOb
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_From_bool(static_cast< bool >(result));
   return resultobj;
@@ -10909,6 +11796,11 @@ SWIGINTERN PyObject *_wrap_MixedGradGradIntegrator_FiniteElementTypeFailureMessa
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_FromCharPtr((const char *)result);
   return resultobj;
@@ -10977,6 +11869,11 @@ SWIGINTERN PyObject *_wrap_MixedGradGradIntegrator_GetIntegrationOrder(PyObject 
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_From_int(static_cast< int >(result));
   return resultobj;
@@ -11044,6 +11941,11 @@ SWIGINTERN PyObject *_wrap_MixedGradGradIntegrator_CalcTrialShape(PyObject *SWIG
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -11111,6 +12013,11 @@ SWIGINTERN PyObject *_wrap_MixedGradGradIntegrator_CalcTestShape(PyObject *SWIGU
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -11140,6 +12047,11 @@ SWIGINTERN PyObject *_wrap_delete_MixedGradGradIntegrator(PyObject *SWIGUNUSEDPA
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -11186,6 +12098,11 @@ SWIGINTERN PyObject *_wrap_new_MixedCrossGradGradIntegrator(PyObject *SWIGUNUSED
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__MixedCrossGradGradIntegrator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -11242,6 +12159,11 @@ SWIGINTERN PyObject *_wrap_MixedCrossGradGradIntegrator_VerifyFiniteElementTypes
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_From_bool(static_cast< bool >(result));
   return resultobj;
@@ -11272,6 +12194,11 @@ SWIGINTERN PyObject *_wrap_MixedCrossGradGradIntegrator_FiniteElementTypeFailure
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_FromCharPtr((const char *)result);
   return resultobj;
@@ -11339,6 +12266,11 @@ SWIGINTERN PyObject *_wrap_MixedCrossGradGradIntegrator_CalcTrialShape(PyObject 
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -11406,6 +12338,11 @@ SWIGINTERN PyObject *_wrap_MixedCrossGradGradIntegrator_CalcTestShape(PyObject *
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -11435,6 +12372,11 @@ SWIGINTERN PyObject *_wrap_delete_MixedCrossGradGradIntegrator(PyObject *SWIGUNU
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -11466,6 +12408,11 @@ SWIGINTERN PyObject *_wrap_new_MixedCurlCurlIntegrator__SWIG_0(PyObject *SWIGUNU
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__MixedCurlCurlIntegrator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -11497,6 +12444,11 @@ SWIGINTERN PyObject *_wrap_new_MixedCurlCurlIntegrator__SWIG_1(PyObject *SWIGUNU
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__MixedCurlCurlIntegrator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -11528,6 +12480,11 @@ SWIGINTERN PyObject *_wrap_new_MixedCurlCurlIntegrator__SWIG_2(PyObject *SWIGUNU
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__MixedCurlCurlIntegrator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -11559,6 +12516,11 @@ SWIGINTERN PyObject *_wrap_new_MixedCurlCurlIntegrator__SWIG_3(PyObject *SWIGUNU
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__MixedCurlCurlIntegrator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -11665,6 +12627,11 @@ SWIGINTERN PyObject *_wrap_MixedCurlCurlIntegrator_VerifyFiniteElementTypes(PyOb
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_From_bool(static_cast< bool >(result));
   return resultobj;
@@ -11695,6 +12662,11 @@ SWIGINTERN PyObject *_wrap_MixedCurlCurlIntegrator_FiniteElementTypeFailureMessa
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_FromCharPtr((const char *)result);
   return resultobj;
@@ -11762,6 +12734,11 @@ SWIGINTERN PyObject *_wrap_MixedCurlCurlIntegrator_CalcTrialShape(PyObject *SWIG
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -11829,6 +12806,11 @@ SWIGINTERN PyObject *_wrap_MixedCurlCurlIntegrator_CalcTestShape(PyObject *SWIGU
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -11858,6 +12840,11 @@ SWIGINTERN PyObject *_wrap_delete_MixedCurlCurlIntegrator(PyObject *SWIGUNUSEDPA
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -11904,6 +12891,11 @@ SWIGINTERN PyObject *_wrap_new_MixedCrossCurlCurlIntegrator(PyObject *SWIGUNUSED
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__MixedCrossCurlCurlIntegrator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -11960,6 +12952,11 @@ SWIGINTERN PyObject *_wrap_MixedCrossCurlCurlIntegrator_VerifyFiniteElementTypes
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_From_bool(static_cast< bool >(result));
   return resultobj;
@@ -11990,6 +12987,11 @@ SWIGINTERN PyObject *_wrap_MixedCrossCurlCurlIntegrator_FiniteElementTypeFailure
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_FromCharPtr((const char *)result);
   return resultobj;
@@ -12057,6 +13059,11 @@ SWIGINTERN PyObject *_wrap_MixedCrossCurlCurlIntegrator_CalcTrialShape(PyObject 
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -12124,6 +13131,11 @@ SWIGINTERN PyObject *_wrap_MixedCrossCurlCurlIntegrator_CalcTestShape(PyObject *
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -12153,6 +13165,11 @@ SWIGINTERN PyObject *_wrap_delete_MixedCrossCurlCurlIntegrator(PyObject *SWIGUNU
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -12199,6 +13216,11 @@ SWIGINTERN PyObject *_wrap_new_MixedCrossCurlGradIntegrator(PyObject *SWIGUNUSED
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__MixedCrossCurlGradIntegrator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -12255,6 +13277,11 @@ SWIGINTERN PyObject *_wrap_MixedCrossCurlGradIntegrator_VerifyFiniteElementTypes
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_From_bool(static_cast< bool >(result));
   return resultobj;
@@ -12285,6 +13312,11 @@ SWIGINTERN PyObject *_wrap_MixedCrossCurlGradIntegrator_FiniteElementTypeFailure
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_FromCharPtr((const char *)result);
   return resultobj;
@@ -12352,6 +13384,11 @@ SWIGINTERN PyObject *_wrap_MixedCrossCurlGradIntegrator_CalcTrialShape(PyObject 
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -12419,6 +13456,11 @@ SWIGINTERN PyObject *_wrap_MixedCrossCurlGradIntegrator_CalcTestShape(PyObject *
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -12448,6 +13490,11 @@ SWIGINTERN PyObject *_wrap_delete_MixedCrossCurlGradIntegrator(PyObject *SWIGUNU
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -12494,6 +13541,11 @@ SWIGINTERN PyObject *_wrap_new_MixedCrossGradCurlIntegrator(PyObject *SWIGUNUSED
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__MixedCrossGradCurlIntegrator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -12550,6 +13602,11 @@ SWIGINTERN PyObject *_wrap_MixedCrossGradCurlIntegrator_VerifyFiniteElementTypes
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_From_bool(static_cast< bool >(result));
   return resultobj;
@@ -12580,6 +13637,11 @@ SWIGINTERN PyObject *_wrap_MixedCrossGradCurlIntegrator_FiniteElementTypeFailure
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_FromCharPtr((const char *)result);
   return resultobj;
@@ -12647,6 +13709,11 @@ SWIGINTERN PyObject *_wrap_MixedCrossGradCurlIntegrator_CalcTrialShape(PyObject 
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -12714,6 +13781,11 @@ SWIGINTERN PyObject *_wrap_MixedCrossGradCurlIntegrator_CalcTestShape(PyObject *
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -12743,6 +13815,11 @@ SWIGINTERN PyObject *_wrap_delete_MixedCrossGradCurlIntegrator(PyObject *SWIGUNU
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -12789,6 +13866,11 @@ SWIGINTERN PyObject *_wrap_new_MixedWeakCurlCrossIntegrator(PyObject *SWIGUNUSED
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__MixedWeakCurlCrossIntegrator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -12845,6 +13927,11 @@ SWIGINTERN PyObject *_wrap_MixedWeakCurlCrossIntegrator_VerifyFiniteElementTypes
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_From_bool(static_cast< bool >(result));
   return resultobj;
@@ -12875,6 +13962,11 @@ SWIGINTERN PyObject *_wrap_MixedWeakCurlCrossIntegrator_FiniteElementTypeFailure
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_FromCharPtr((const char *)result);
   return resultobj;
@@ -12942,6 +14034,11 @@ SWIGINTERN PyObject *_wrap_MixedWeakCurlCrossIntegrator_CalcTestShape(PyObject *
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -12971,6 +14068,11 @@ SWIGINTERN PyObject *_wrap_delete_MixedWeakCurlCrossIntegrator(PyObject *SWIGUNU
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -13017,6 +14119,11 @@ SWIGINTERN PyObject *_wrap_new_MixedScalarWeakCurlCrossIntegrator(PyObject *SWIG
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__MixedScalarWeakCurlCrossIntegrator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -13073,6 +14180,11 @@ SWIGINTERN PyObject *_wrap_MixedScalarWeakCurlCrossIntegrator_VerifyFiniteElemen
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_From_bool(static_cast< bool >(result));
   return resultobj;
@@ -13103,6 +14215,11 @@ SWIGINTERN PyObject *_wrap_MixedScalarWeakCurlCrossIntegrator_FiniteElementTypeF
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_FromCharPtr((const char *)result);
   return resultobj;
@@ -13170,6 +14287,11 @@ SWIGINTERN PyObject *_wrap_MixedScalarWeakCurlCrossIntegrator_CalcShape(PyObject
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -13199,6 +14321,11 @@ SWIGINTERN PyObject *_wrap_delete_MixedScalarWeakCurlCrossIntegrator(PyObject *S
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -13245,6 +14372,11 @@ SWIGINTERN PyObject *_wrap_new_MixedCrossGradIntegrator(PyObject *SWIGUNUSEDPARM
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__MixedCrossGradIntegrator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -13301,6 +14433,11 @@ SWIGINTERN PyObject *_wrap_MixedCrossGradIntegrator_VerifyFiniteElementTypes(PyO
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_From_bool(static_cast< bool >(result));
   return resultobj;
@@ -13331,6 +14468,11 @@ SWIGINTERN PyObject *_wrap_MixedCrossGradIntegrator_FiniteElementTypeFailureMess
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_FromCharPtr((const char *)result);
   return resultobj;
@@ -13398,6 +14540,11 @@ SWIGINTERN PyObject *_wrap_MixedCrossGradIntegrator_CalcTrialShape(PyObject *SWI
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -13465,6 +14612,11 @@ SWIGINTERN PyObject *_wrap_MixedCrossGradIntegrator_CalcTestShape(PyObject *SWIG
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -13494,6 +14646,11 @@ SWIGINTERN PyObject *_wrap_delete_MixedCrossGradIntegrator(PyObject *SWIGUNUSEDP
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -13540,6 +14697,11 @@ SWIGINTERN PyObject *_wrap_new_MixedCrossCurlIntegrator(PyObject *SWIGUNUSEDPARM
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__MixedCrossCurlIntegrator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -13596,6 +14758,11 @@ SWIGINTERN PyObject *_wrap_MixedCrossCurlIntegrator_VerifyFiniteElementTypes(PyO
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_From_bool(static_cast< bool >(result));
   return resultobj;
@@ -13626,6 +14793,11 @@ SWIGINTERN PyObject *_wrap_MixedCrossCurlIntegrator_FiniteElementTypeFailureMess
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_FromCharPtr((const char *)result);
   return resultobj;
@@ -13693,6 +14865,11 @@ SWIGINTERN PyObject *_wrap_MixedCrossCurlIntegrator_CalcTrialShape(PyObject *SWI
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -13722,6 +14899,11 @@ SWIGINTERN PyObject *_wrap_delete_MixedCrossCurlIntegrator(PyObject *SWIGUNUSEDP
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -13768,6 +14950,11 @@ SWIGINTERN PyObject *_wrap_new_MixedScalarCrossCurlIntegrator(PyObject *SWIGUNUS
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__MixedScalarCrossCurlIntegrator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -13824,6 +15011,11 @@ SWIGINTERN PyObject *_wrap_MixedScalarCrossCurlIntegrator_VerifyFiniteElementTyp
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_From_bool(static_cast< bool >(result));
   return resultobj;
@@ -13854,6 +15046,11 @@ SWIGINTERN PyObject *_wrap_MixedScalarCrossCurlIntegrator_FiniteElementTypeFailu
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_FromCharPtr((const char *)result);
   return resultobj;
@@ -13921,6 +15118,11 @@ SWIGINTERN PyObject *_wrap_MixedScalarCrossCurlIntegrator_CalcShape(PyObject *SW
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -13950,6 +15152,11 @@ SWIGINTERN PyObject *_wrap_delete_MixedScalarCrossCurlIntegrator(PyObject *SWIGU
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -13996,6 +15203,11 @@ SWIGINTERN PyObject *_wrap_new_MixedScalarCrossGradIntegrator(PyObject *SWIGUNUS
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__MixedScalarCrossGradIntegrator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -14052,6 +15264,11 @@ SWIGINTERN PyObject *_wrap_MixedScalarCrossGradIntegrator_VerifyFiniteElementTyp
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_From_bool(static_cast< bool >(result));
   return resultobj;
@@ -14082,6 +15299,11 @@ SWIGINTERN PyObject *_wrap_MixedScalarCrossGradIntegrator_FiniteElementTypeFailu
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_FromCharPtr((const char *)result);
   return resultobj;
@@ -14149,6 +15371,11 @@ SWIGINTERN PyObject *_wrap_MixedScalarCrossGradIntegrator_CalcVShape(PyObject *S
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -14178,6 +15405,11 @@ SWIGINTERN PyObject *_wrap_delete_MixedScalarCrossGradIntegrator(PyObject *SWIGU
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -14224,6 +15456,11 @@ SWIGINTERN PyObject *_wrap_new_MixedScalarCrossProductIntegrator(PyObject *SWIGU
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__MixedScalarCrossProductIntegrator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -14280,6 +15517,11 @@ SWIGINTERN PyObject *_wrap_MixedScalarCrossProductIntegrator_VerifyFiniteElement
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_From_bool(static_cast< bool >(result));
   return resultobj;
@@ -14310,6 +15552,11 @@ SWIGINTERN PyObject *_wrap_MixedScalarCrossProductIntegrator_FiniteElementTypeFa
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_FromCharPtr((const char *)result);
   return resultobj;
@@ -14339,6 +15586,11 @@ SWIGINTERN PyObject *_wrap_delete_MixedScalarCrossProductIntegrator(PyObject *SW
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -14385,6 +15637,11 @@ SWIGINTERN PyObject *_wrap_new_MixedScalarWeakCrossProductIntegrator(PyObject *S
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__MixedScalarWeakCrossProductIntegrator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -14441,6 +15698,11 @@ SWIGINTERN PyObject *_wrap_MixedScalarWeakCrossProductIntegrator_VerifyFiniteEle
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_From_bool(static_cast< bool >(result));
   return resultobj;
@@ -14471,6 +15733,11 @@ SWIGINTERN PyObject *_wrap_MixedScalarWeakCrossProductIntegrator_FiniteElementTy
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_FromCharPtr((const char *)result);
   return resultobj;
@@ -14538,6 +15805,11 @@ SWIGINTERN PyObject *_wrap_MixedScalarWeakCrossProductIntegrator_CalcShape(PyObj
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -14567,6 +15839,11 @@ SWIGINTERN PyObject *_wrap_delete_MixedScalarWeakCrossProductIntegrator(PyObject
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -14613,6 +15890,11 @@ SWIGINTERN PyObject *_wrap_new_MixedDirectionalDerivativeIntegrator(PyObject *SW
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__MixedDirectionalDerivativeIntegrator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -14669,6 +15951,11 @@ SWIGINTERN PyObject *_wrap_MixedDirectionalDerivativeIntegrator_VerifyFiniteElem
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_From_bool(static_cast< bool >(result));
   return resultobj;
@@ -14699,6 +15986,11 @@ SWIGINTERN PyObject *_wrap_MixedDirectionalDerivativeIntegrator_FiniteElementTyp
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_FromCharPtr((const char *)result);
   return resultobj;
@@ -14766,6 +16058,11 @@ SWIGINTERN PyObject *_wrap_MixedDirectionalDerivativeIntegrator_CalcVShape(PyObj
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -14795,6 +16092,11 @@ SWIGINTERN PyObject *_wrap_delete_MixedDirectionalDerivativeIntegrator(PyObject 
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -14841,6 +16143,11 @@ SWIGINTERN PyObject *_wrap_new_MixedGradDivIntegrator(PyObject *SWIGUNUSEDPARM(s
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__MixedGradDivIntegrator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -14897,6 +16204,11 @@ SWIGINTERN PyObject *_wrap_MixedGradDivIntegrator_VerifyFiniteElementTypes(PyObj
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_From_bool(static_cast< bool >(result));
   return resultobj;
@@ -14927,6 +16239,11 @@ SWIGINTERN PyObject *_wrap_MixedGradDivIntegrator_FiniteElementTypeFailureMessag
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_FromCharPtr((const char *)result);
   return resultobj;
@@ -14994,6 +16311,11 @@ SWIGINTERN PyObject *_wrap_MixedGradDivIntegrator_CalcVShape(PyObject *SWIGUNUSE
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -15061,6 +16383,11 @@ SWIGINTERN PyObject *_wrap_MixedGradDivIntegrator_CalcShape(PyObject *SWIGUNUSED
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -15090,6 +16417,11 @@ SWIGINTERN PyObject *_wrap_delete_MixedGradDivIntegrator(PyObject *SWIGUNUSEDPAR
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -15136,6 +16468,11 @@ SWIGINTERN PyObject *_wrap_new_MixedDivGradIntegrator(PyObject *SWIGUNUSEDPARM(s
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__MixedDivGradIntegrator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -15192,6 +16529,11 @@ SWIGINTERN PyObject *_wrap_MixedDivGradIntegrator_VerifyFiniteElementTypes(PyObj
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_From_bool(static_cast< bool >(result));
   return resultobj;
@@ -15222,6 +16564,11 @@ SWIGINTERN PyObject *_wrap_MixedDivGradIntegrator_FiniteElementTypeFailureMessag
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_FromCharPtr((const char *)result);
   return resultobj;
@@ -15289,6 +16636,11 @@ SWIGINTERN PyObject *_wrap_MixedDivGradIntegrator_CalcVShape(PyObject *SWIGUNUSE
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -15356,6 +16708,11 @@ SWIGINTERN PyObject *_wrap_MixedDivGradIntegrator_CalcShape(PyObject *SWIGUNUSED
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -15385,6 +16742,11 @@ SWIGINTERN PyObject *_wrap_delete_MixedDivGradIntegrator(PyObject *SWIGUNUSEDPAR
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -15431,6 +16793,11 @@ SWIGINTERN PyObject *_wrap_new_MixedScalarWeakDivergenceIntegrator(PyObject *SWI
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__MixedScalarWeakDivergenceIntegrator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -15487,6 +16854,11 @@ SWIGINTERN PyObject *_wrap_MixedScalarWeakDivergenceIntegrator_VerifyFiniteEleme
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_From_bool(static_cast< bool >(result));
   return resultobj;
@@ -15517,6 +16889,11 @@ SWIGINTERN PyObject *_wrap_MixedScalarWeakDivergenceIntegrator_FiniteElementType
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_FromCharPtr((const char *)result);
   return resultobj;
@@ -15584,6 +16961,11 @@ SWIGINTERN PyObject *_wrap_MixedScalarWeakDivergenceIntegrator_CalcVShape(PyObje
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -15613,6 +16995,11 @@ SWIGINTERN PyObject *_wrap_delete_MixedScalarWeakDivergenceIntegrator(PyObject *
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -15644,6 +17031,11 @@ SWIGINTERN PyObject *_wrap_new_MixedVectorGradientIntegrator__SWIG_0(PyObject *S
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__MixedVectorGradientIntegrator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -15675,6 +17067,11 @@ SWIGINTERN PyObject *_wrap_new_MixedVectorGradientIntegrator__SWIG_1(PyObject *S
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__MixedVectorGradientIntegrator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -15706,6 +17103,11 @@ SWIGINTERN PyObject *_wrap_new_MixedVectorGradientIntegrator__SWIG_2(PyObject *S
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__MixedVectorGradientIntegrator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -15737,6 +17139,11 @@ SWIGINTERN PyObject *_wrap_new_MixedVectorGradientIntegrator__SWIG_3(PyObject *S
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__MixedVectorGradientIntegrator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -15816,6 +17223,11 @@ SWIGINTERN PyObject *_wrap_delete_MixedVectorGradientIntegrator(PyObject *SWIGUN
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -15847,6 +17259,11 @@ SWIGINTERN PyObject *_wrap_new_MixedVectorCurlIntegrator__SWIG_0(PyObject *SWIGU
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__MixedVectorCurlIntegrator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -15878,6 +17295,11 @@ SWIGINTERN PyObject *_wrap_new_MixedVectorCurlIntegrator__SWIG_1(PyObject *SWIGU
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__MixedVectorCurlIntegrator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -15909,6 +17331,11 @@ SWIGINTERN PyObject *_wrap_new_MixedVectorCurlIntegrator__SWIG_2(PyObject *SWIGU
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__MixedVectorCurlIntegrator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -15940,6 +17367,11 @@ SWIGINTERN PyObject *_wrap_new_MixedVectorCurlIntegrator__SWIG_3(PyObject *SWIGU
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__MixedVectorCurlIntegrator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -16019,6 +17451,11 @@ SWIGINTERN PyObject *_wrap_delete_MixedVectorCurlIntegrator(PyObject *SWIGUNUSED
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -16050,6 +17487,11 @@ SWIGINTERN PyObject *_wrap_new_MixedVectorWeakCurlIntegrator__SWIG_0(PyObject *S
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__MixedVectorWeakCurlIntegrator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -16081,6 +17523,11 @@ SWIGINTERN PyObject *_wrap_new_MixedVectorWeakCurlIntegrator__SWIG_1(PyObject *S
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__MixedVectorWeakCurlIntegrator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -16112,6 +17559,11 @@ SWIGINTERN PyObject *_wrap_new_MixedVectorWeakCurlIntegrator__SWIG_2(PyObject *S
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__MixedVectorWeakCurlIntegrator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -16143,6 +17595,11 @@ SWIGINTERN PyObject *_wrap_new_MixedVectorWeakCurlIntegrator__SWIG_3(PyObject *S
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__MixedVectorWeakCurlIntegrator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -16222,6 +17679,11 @@ SWIGINTERN PyObject *_wrap_delete_MixedVectorWeakCurlIntegrator(PyObject *SWIGUN
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -16253,6 +17715,11 @@ SWIGINTERN PyObject *_wrap_new_MixedVectorWeakDivergenceIntegrator__SWIG_0(PyObj
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__MixedVectorWeakDivergenceIntegrator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -16284,6 +17751,11 @@ SWIGINTERN PyObject *_wrap_new_MixedVectorWeakDivergenceIntegrator__SWIG_1(PyObj
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__MixedVectorWeakDivergenceIntegrator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -16315,6 +17787,11 @@ SWIGINTERN PyObject *_wrap_new_MixedVectorWeakDivergenceIntegrator__SWIG_2(PyObj
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__MixedVectorWeakDivergenceIntegrator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -16346,6 +17823,11 @@ SWIGINTERN PyObject *_wrap_new_MixedVectorWeakDivergenceIntegrator__SWIG_3(PyObj
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__MixedVectorWeakDivergenceIntegrator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -16425,6 +17907,11 @@ SWIGINTERN PyObject *_wrap_delete_MixedVectorWeakDivergenceIntegrator(PyObject *
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -16456,6 +17943,11 @@ SWIGINTERN PyObject *_wrap_new_GradientIntegrator__SWIG_0(PyObject *SWIGUNUSEDPA
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__GradientIntegrator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -16484,6 +17976,11 @@ SWIGINTERN PyObject *_wrap_new_GradientIntegrator__SWIG_1(PyObject *SWIGUNUSEDPA
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__GradientIntegrator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -16515,6 +18012,11 @@ SWIGINTERN PyObject *_wrap_new_GradientIntegrator__SWIG_2(PyObject *SWIGUNUSEDPA
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__GradientIntegrator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -16634,6 +18136,108 @@ SWIGINTERN PyObject *_wrap_GradientIntegrator_AssembleElementMatrix2(PyObject *S
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_GradientIntegrator_AssemblePA__SWIG_0_0(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
+  PyObject *resultobj = 0;
+  mfem::GradientIntegrator *arg1 = (mfem::GradientIntegrator *) 0 ;
+  mfem::FiniteElementSpace *arg2 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  
+  if ((nobjs < 2) || (nobjs > 2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_mfem__GradientIntegrator, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "GradientIntegrator_AssemblePA" "', argument " "1"" of type '" "mfem::GradientIntegrator *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::GradientIntegrator * >(argp1);
+  res2 = SWIG_ConvertPtr(swig_obj[1], &argp2, SWIGTYPE_p_mfem__FiniteElementSpace,  0  | 0);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "GradientIntegrator_AssemblePA" "', argument " "2"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  if (!argp2) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "GradientIntegrator_AssemblePA" "', argument " "2"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  arg2 = reinterpret_cast< mfem::FiniteElementSpace * >(argp2);
+  {
+    try {
+      (arg1)->AssemblePA((mfem::FiniteElementSpace const &)*arg2); 
+    }
+    catch (Swig::DirectorException &e) {
+      SWIG_fail; 
+    }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_GradientIntegrator_AssemblePA__SWIG_0_1(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
+  PyObject *resultobj = 0;
+  mfem::GradientIntegrator *arg1 = (mfem::GradientIntegrator *) 0 ;
+  mfem::FiniteElementSpace *arg2 = 0 ;
+  mfem::FiniteElementSpace *arg3 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  void *argp3 = 0 ;
+  int res3 = 0 ;
+  
+  if ((nobjs < 3) || (nobjs > 3)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_mfem__GradientIntegrator, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "GradientIntegrator_AssemblePA" "', argument " "1"" of type '" "mfem::GradientIntegrator *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::GradientIntegrator * >(argp1);
+  res2 = SWIG_ConvertPtr(swig_obj[1], &argp2, SWIGTYPE_p_mfem__FiniteElementSpace,  0  | 0);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "GradientIntegrator_AssemblePA" "', argument " "2"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  if (!argp2) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "GradientIntegrator_AssemblePA" "', argument " "2"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  arg2 = reinterpret_cast< mfem::FiniteElementSpace * >(argp2);
+  res3 = SWIG_ConvertPtr(swig_obj[2], &argp3, SWIGTYPE_p_mfem__FiniteElementSpace,  0  | 0);
+  if (!SWIG_IsOK(res3)) {
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "GradientIntegrator_AssemblePA" "', argument " "3"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  if (!argp3) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "GradientIntegrator_AssemblePA" "', argument " "3"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  arg3 = reinterpret_cast< mfem::FiniteElementSpace * >(argp3);
+  {
+    try {
+      (arg1)->AssemblePA((mfem::FiniteElementSpace const &)*arg2,(mfem::FiniteElementSpace const &)*arg3); 
+    }
+    catch (Swig::DirectorException &e) {
+      SWIG_fail; 
+    }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -16683,6 +18287,11 @@ SWIGINTERN PyObject *_wrap_GradientIntegrator_AssemblePA__SWIG_1(PyObject *SWIGU
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -16699,6 +18308,36 @@ SWIGINTERN PyObject *_wrap_GradientIntegrator_AssemblePA(PyObject *self, PyObjec
   
   if (!(argc = SWIG_Python_UnpackTuple(args, "GradientIntegrator_AssemblePA", 0, 3, argv))) SWIG_fail;
   --argc;
+  if (argc == 2) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_mfem__GradientIntegrator, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      int res = SWIG_ConvertPtr(argv[1], 0, SWIGTYPE_p_mfem__FiniteElementSpace, SWIG_POINTER_NO_NULL | 0);
+      _v = SWIG_CheckState(res);
+      if (_v) {
+        return _wrap_GradientIntegrator_AssemblePA__SWIG_0_0(self, argc, argv);
+      }
+    }
+  }
+  if (argc == 3) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_mfem__GradientIntegrator, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      int res = SWIG_ConvertPtr(argv[1], 0, SWIGTYPE_p_mfem__FiniteElementSpace, SWIG_POINTER_NO_NULL | 0);
+      _v = SWIG_CheckState(res);
+      if (_v) {
+        int res = SWIG_ConvertPtr(argv[2], 0, SWIGTYPE_p_mfem__FiniteElementSpace, SWIG_POINTER_NO_NULL | 0);
+        _v = SWIG_CheckState(res);
+        if (_v) {
+          return _wrap_GradientIntegrator_AssemblePA__SWIG_0_1(self, argc, argv);
+        }
+      }
+    }
+  }
   if (argc == 3) {
     int _v;
     void *vptr = 0;
@@ -16720,7 +18359,8 @@ SWIGINTERN PyObject *_wrap_GradientIntegrator_AssemblePA(PyObject *self, PyObjec
 fail:
   SWIG_Python_RaiseOrModifyTypeError("Wrong number or type of arguments for overloaded function 'GradientIntegrator_AssemblePA'.\n"
     "  Possible C/C++ prototypes are:\n"
-    "    mfem::GradientIntegrator::AssemblePA()\n"
+    "    AssemblePA(mfem::FiniteElementSpace const &)\n"
+    "    AssemblePA(mfem::FiniteElementSpace const &,mfem::FiniteElementSpace const &)\n"
     "    mfem::GradientIntegrator::AssemblePA(mfem::FiniteElementSpace const &,mfem::FiniteElementSpace const &)\n");
   return 0;
 }
@@ -16773,6 +18413,11 @@ SWIGINTERN PyObject *_wrap_GradientIntegrator_AddMultPA(PyObject *SWIGUNUSEDPARM
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -16828,6 +18473,11 @@ SWIGINTERN PyObject *_wrap_GradientIntegrator_AddMultTransposePA(PyObject *SWIGU
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -16887,6 +18537,11 @@ SWIGINTERN PyObject *_wrap_GradientIntegrator_GetRule(PyObject *SWIGUNUSEDPARM(s
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__IntegrationRule, 0 |  0 );
   return resultobj;
@@ -16916,6 +18571,11 @@ SWIGINTERN PyObject *_wrap_delete_GradientIntegrator(PyObject *SWIGUNUSEDPARM(se
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -16947,6 +18607,11 @@ SWIGINTERN PyObject *_wrap_new_DiffusionIntegrator__SWIG_0(PyObject *SWIGUNUSEDP
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__DiffusionIntegrator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -16978,6 +18643,11 @@ SWIGINTERN PyObject *_wrap_new_DiffusionIntegrator__SWIG_1(PyObject *SWIGUNUSEDP
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__DiffusionIntegrator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -17009,6 +18679,11 @@ SWIGINTERN PyObject *_wrap_new_DiffusionIntegrator__SWIG_2(PyObject *SWIGUNUSEDP
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__DiffusionIntegrator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -17040,6 +18715,11 @@ SWIGINTERN PyObject *_wrap_new_DiffusionIntegrator__SWIG_3(PyObject *SWIGUNUSEDP
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__DiffusionIntegrator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -17119,6 +18799,11 @@ SWIGINTERN PyObject *_wrap_delete_DiffusionIntegrator(PyObject *SWIGUNUSEDPARM(s
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -17186,6 +18871,11 @@ SWIGINTERN PyObject *_wrap_DiffusionIntegrator_AssembleElementMatrix(PyObject *S
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -17265,6 +18955,11 @@ SWIGINTERN PyObject *_wrap_DiffusionIntegrator_AssembleElementMatrix2(PyObject *
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -17344,6 +19039,11 @@ SWIGINTERN PyObject *_wrap_DiffusionIntegrator_AssembleElementVector(PyObject *S
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -17446,6 +19146,11 @@ SWIGINTERN PyObject *_wrap_DiffusionIntegrator_ComputeElementFlux(PyObject *SWIG
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -17525,8 +19230,110 @@ SWIGINTERN PyObject *_wrap_DiffusionIntegrator_ComputeFluxEnergy(PyObject *SWIGU
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_From_double(static_cast< double >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_DiffusionIntegrator_AssemblePA__SWIG_0_0(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
+  PyObject *resultobj = 0;
+  mfem::DiffusionIntegrator *arg1 = (mfem::DiffusionIntegrator *) 0 ;
+  mfem::FiniteElementSpace *arg2 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  
+  if ((nobjs < 2) || (nobjs > 2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_mfem__DiffusionIntegrator, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "DiffusionIntegrator_AssemblePA" "', argument " "1"" of type '" "mfem::DiffusionIntegrator *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::DiffusionIntegrator * >(argp1);
+  res2 = SWIG_ConvertPtr(swig_obj[1], &argp2, SWIGTYPE_p_mfem__FiniteElementSpace,  0  | 0);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "DiffusionIntegrator_AssemblePA" "', argument " "2"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  if (!argp2) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "DiffusionIntegrator_AssemblePA" "', argument " "2"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  arg2 = reinterpret_cast< mfem::FiniteElementSpace * >(argp2);
+  {
+    try {
+      (arg1)->AssemblePA((mfem::FiniteElementSpace const &)*arg2); 
+    }
+    catch (Swig::DirectorException &e) {
+      SWIG_fail; 
+    }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_DiffusionIntegrator_AssemblePA__SWIG_0_1(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
+  PyObject *resultobj = 0;
+  mfem::DiffusionIntegrator *arg1 = (mfem::DiffusionIntegrator *) 0 ;
+  mfem::FiniteElementSpace *arg2 = 0 ;
+  mfem::FiniteElementSpace *arg3 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  void *argp3 = 0 ;
+  int res3 = 0 ;
+  
+  if ((nobjs < 3) || (nobjs > 3)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_mfem__DiffusionIntegrator, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "DiffusionIntegrator_AssemblePA" "', argument " "1"" of type '" "mfem::DiffusionIntegrator *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::DiffusionIntegrator * >(argp1);
+  res2 = SWIG_ConvertPtr(swig_obj[1], &argp2, SWIGTYPE_p_mfem__FiniteElementSpace,  0  | 0);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "DiffusionIntegrator_AssemblePA" "', argument " "2"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  if (!argp2) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "DiffusionIntegrator_AssemblePA" "', argument " "2"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  arg2 = reinterpret_cast< mfem::FiniteElementSpace * >(argp2);
+  res3 = SWIG_ConvertPtr(swig_obj[2], &argp3, SWIGTYPE_p_mfem__FiniteElementSpace,  0  | 0);
+  if (!SWIG_IsOK(res3)) {
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "DiffusionIntegrator_AssemblePA" "', argument " "3"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  if (!argp3) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "DiffusionIntegrator_AssemblePA" "', argument " "3"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  arg3 = reinterpret_cast< mfem::FiniteElementSpace * >(argp3);
+  {
+    try {
+      (arg1)->AssemblePA((mfem::FiniteElementSpace const &)*arg2,(mfem::FiniteElementSpace const &)*arg3); 
+    }
+    catch (Swig::DirectorException &e) {
+      SWIG_fail; 
+    }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
+  }
+  resultobj = SWIG_Py_Void();
   return resultobj;
 fail:
   return NULL;
@@ -17568,6 +19375,11 @@ SWIGINTERN PyObject *_wrap_DiffusionIntegrator_AssembleMF(PyObject *SWIGUNUSEDPA
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -17606,6 +19418,11 @@ SWIGINTERN PyObject *_wrap_DiffusionIntegrator_AssemblePA__SWIG_1(PyObject *SWIG
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -17616,12 +19433,25 @@ fail:
 
 SWIGINTERN PyObject *_wrap_DiffusionIntegrator_AssemblePA(PyObject *self, PyObject *args) {
   Py_ssize_t argc;
-  PyObject *argv[3] = {
+  PyObject *argv[4] = {
     0
   };
   
-  if (!(argc = SWIG_Python_UnpackTuple(args, "DiffusionIntegrator_AssemblePA", 0, 2, argv))) SWIG_fail;
+  if (!(argc = SWIG_Python_UnpackTuple(args, "DiffusionIntegrator_AssemblePA", 0, 3, argv))) SWIG_fail;
   --argc;
+  if (argc == 2) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_mfem__DiffusionIntegrator, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      int res = SWIG_ConvertPtr(argv[1], 0, SWIGTYPE_p_mfem__FiniteElementSpace, SWIG_POINTER_NO_NULL | 0);
+      _v = SWIG_CheckState(res);
+      if (_v) {
+        return _wrap_DiffusionIntegrator_AssemblePA__SWIG_0_0(self, argc, argv);
+      }
+    }
+  }
   if (argc == 2) {
     int _v;
     void *vptr = 0;
@@ -17635,11 +19465,29 @@ SWIGINTERN PyObject *_wrap_DiffusionIntegrator_AssemblePA(PyObject *self, PyObje
       }
     }
   }
+  if (argc == 3) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_mfem__DiffusionIntegrator, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      int res = SWIG_ConvertPtr(argv[1], 0, SWIGTYPE_p_mfem__FiniteElementSpace, SWIG_POINTER_NO_NULL | 0);
+      _v = SWIG_CheckState(res);
+      if (_v) {
+        int res = SWIG_ConvertPtr(argv[2], 0, SWIGTYPE_p_mfem__FiniteElementSpace, SWIG_POINTER_NO_NULL | 0);
+        _v = SWIG_CheckState(res);
+        if (_v) {
+          return _wrap_DiffusionIntegrator_AssemblePA__SWIG_0_1(self, argc, argv);
+        }
+      }
+    }
+  }
   
 fail:
   SWIG_Python_RaiseOrModifyTypeError("Wrong number or type of arguments for overloaded function 'DiffusionIntegrator_AssemblePA'.\n"
     "  Possible C/C++ prototypes are:\n"
-    "    mfem::DiffusionIntegrator::AssemblePA()\n"
+    "    AssemblePA(mfem::FiniteElementSpace const &)\n"
+    "    AssemblePA(mfem::FiniteElementSpace const &,mfem::FiniteElementSpace const &)\n"
     "    mfem::DiffusionIntegrator::AssemblePA(mfem::FiniteElementSpace const &)\n");
   return 0;
 }
@@ -17701,6 +19549,11 @@ SWIGINTERN PyObject *_wrap_DiffusionIntegrator_AssembleEA(PyObject *SWIGUNUSEDPA
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -17744,6 +19597,11 @@ SWIGINTERN PyObject *_wrap_DiffusionIntegrator_AssembleDiagonalPA(PyObject *SWIG
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -17787,6 +19645,11 @@ SWIGINTERN PyObject *_wrap_DiffusionIntegrator_AssembleDiagonalMF(PyObject *SWIG
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -17842,6 +19705,11 @@ SWIGINTERN PyObject *_wrap_DiffusionIntegrator_AddMultMF(PyObject *SWIGUNUSEDPAR
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -17897,6 +19765,11 @@ SWIGINTERN PyObject *_wrap_DiffusionIntegrator_AddMultPA(PyObject *SWIGUNUSEDPAR
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -17944,6 +19817,11 @@ SWIGINTERN PyObject *_wrap_DiffusionIntegrator_GetRule(PyObject *SWIGUNUSEDPARM(
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__IntegrationRule, 0 |  0 );
   return resultobj;
@@ -17985,6 +19863,11 @@ SWIGINTERN PyObject *_wrap_new_MassIntegrator__SWIG_0(PyObject *SWIGUNUSEDPARM(s
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__MassIntegrator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -18026,6 +19909,11 @@ SWIGINTERN PyObject *_wrap_new_MassIntegrator__SWIG_1(PyObject *SWIGUNUSEDPARM(s
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__MassIntegrator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -18102,6 +19990,11 @@ SWIGINTERN PyObject *_wrap_delete_MassIntegrator(PyObject *SWIGUNUSEDPARM(self),
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -18169,6 +20062,11 @@ SWIGINTERN PyObject *_wrap_MassIntegrator_AssembleElementMatrix(PyObject *SWIGUN
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -18248,6 +20146,108 @@ SWIGINTERN PyObject *_wrap_MassIntegrator_AssembleElementMatrix2(PyObject *SWIGU
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_MassIntegrator_AssemblePA__SWIG_0_0(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
+  PyObject *resultobj = 0;
+  mfem::MassIntegrator *arg1 = (mfem::MassIntegrator *) 0 ;
+  mfem::FiniteElementSpace *arg2 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  
+  if ((nobjs < 2) || (nobjs > 2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_mfem__MassIntegrator, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "MassIntegrator_AssemblePA" "', argument " "1"" of type '" "mfem::MassIntegrator *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::MassIntegrator * >(argp1);
+  res2 = SWIG_ConvertPtr(swig_obj[1], &argp2, SWIGTYPE_p_mfem__FiniteElementSpace,  0  | 0);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "MassIntegrator_AssemblePA" "', argument " "2"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  if (!argp2) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "MassIntegrator_AssemblePA" "', argument " "2"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  arg2 = reinterpret_cast< mfem::FiniteElementSpace * >(argp2);
+  {
+    try {
+      (arg1)->AssemblePA((mfem::FiniteElementSpace const &)*arg2); 
+    }
+    catch (Swig::DirectorException &e) {
+      SWIG_fail; 
+    }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_MassIntegrator_AssemblePA__SWIG_0_1(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
+  PyObject *resultobj = 0;
+  mfem::MassIntegrator *arg1 = (mfem::MassIntegrator *) 0 ;
+  mfem::FiniteElementSpace *arg2 = 0 ;
+  mfem::FiniteElementSpace *arg3 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  void *argp3 = 0 ;
+  int res3 = 0 ;
+  
+  if ((nobjs < 3) || (nobjs > 3)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_mfem__MassIntegrator, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "MassIntegrator_AssemblePA" "', argument " "1"" of type '" "mfem::MassIntegrator *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::MassIntegrator * >(argp1);
+  res2 = SWIG_ConvertPtr(swig_obj[1], &argp2, SWIGTYPE_p_mfem__FiniteElementSpace,  0  | 0);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "MassIntegrator_AssemblePA" "', argument " "2"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  if (!argp2) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "MassIntegrator_AssemblePA" "', argument " "2"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  arg2 = reinterpret_cast< mfem::FiniteElementSpace * >(argp2);
+  res3 = SWIG_ConvertPtr(swig_obj[2], &argp3, SWIGTYPE_p_mfem__FiniteElementSpace,  0  | 0);
+  if (!SWIG_IsOK(res3)) {
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "MassIntegrator_AssemblePA" "', argument " "3"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  if (!argp3) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "MassIntegrator_AssemblePA" "', argument " "3"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  arg3 = reinterpret_cast< mfem::FiniteElementSpace * >(argp3);
+  {
+    try {
+      (arg1)->AssemblePA((mfem::FiniteElementSpace const &)*arg2,(mfem::FiniteElementSpace const &)*arg3); 
+    }
+    catch (Swig::DirectorException &e) {
+      SWIG_fail; 
+    }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -18291,6 +20291,11 @@ SWIGINTERN PyObject *_wrap_MassIntegrator_AssembleMF(PyObject *SWIGUNUSEDPARM(se
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -18329,6 +20334,11 @@ SWIGINTERN PyObject *_wrap_MassIntegrator_AssemblePA__SWIG_1(PyObject *SWIGUNUSE
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -18339,12 +20349,25 @@ fail:
 
 SWIGINTERN PyObject *_wrap_MassIntegrator_AssemblePA(PyObject *self, PyObject *args) {
   Py_ssize_t argc;
-  PyObject *argv[3] = {
+  PyObject *argv[4] = {
     0
   };
   
-  if (!(argc = SWIG_Python_UnpackTuple(args, "MassIntegrator_AssemblePA", 0, 2, argv))) SWIG_fail;
+  if (!(argc = SWIG_Python_UnpackTuple(args, "MassIntegrator_AssemblePA", 0, 3, argv))) SWIG_fail;
   --argc;
+  if (argc == 2) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_mfem__MassIntegrator, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      int res = SWIG_ConvertPtr(argv[1], 0, SWIGTYPE_p_mfem__FiniteElementSpace, SWIG_POINTER_NO_NULL | 0);
+      _v = SWIG_CheckState(res);
+      if (_v) {
+        return _wrap_MassIntegrator_AssemblePA__SWIG_0_0(self, argc, argv);
+      }
+    }
+  }
   if (argc == 2) {
     int _v;
     void *vptr = 0;
@@ -18358,11 +20381,29 @@ SWIGINTERN PyObject *_wrap_MassIntegrator_AssemblePA(PyObject *self, PyObject *a
       }
     }
   }
+  if (argc == 3) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_mfem__MassIntegrator, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      int res = SWIG_ConvertPtr(argv[1], 0, SWIGTYPE_p_mfem__FiniteElementSpace, SWIG_POINTER_NO_NULL | 0);
+      _v = SWIG_CheckState(res);
+      if (_v) {
+        int res = SWIG_ConvertPtr(argv[2], 0, SWIGTYPE_p_mfem__FiniteElementSpace, SWIG_POINTER_NO_NULL | 0);
+        _v = SWIG_CheckState(res);
+        if (_v) {
+          return _wrap_MassIntegrator_AssemblePA__SWIG_0_1(self, argc, argv);
+        }
+      }
+    }
+  }
   
 fail:
   SWIG_Python_RaiseOrModifyTypeError("Wrong number or type of arguments for overloaded function 'MassIntegrator_AssemblePA'.\n"
     "  Possible C/C++ prototypes are:\n"
-    "    mfem::MassIntegrator::AssemblePA()\n"
+    "    AssemblePA(mfem::FiniteElementSpace const &)\n"
+    "    AssemblePA(mfem::FiniteElementSpace const &,mfem::FiniteElementSpace const &)\n"
     "    mfem::MassIntegrator::AssemblePA(mfem::FiniteElementSpace const &)\n");
   return 0;
 }
@@ -18424,6 +20465,11 @@ SWIGINTERN PyObject *_wrap_MassIntegrator_AssembleEA(PyObject *SWIGUNUSEDPARM(se
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -18467,6 +20513,11 @@ SWIGINTERN PyObject *_wrap_MassIntegrator_AssembleDiagonalPA(PyObject *SWIGUNUSE
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -18510,6 +20561,11 @@ SWIGINTERN PyObject *_wrap_MassIntegrator_AssembleDiagonalMF(PyObject *SWIGUNUSE
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -18565,6 +20621,11 @@ SWIGINTERN PyObject *_wrap_MassIntegrator_AddMultMF(PyObject *SWIGUNUSEDPARM(sel
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -18620,6 +20681,11 @@ SWIGINTERN PyObject *_wrap_MassIntegrator_AddMultPA(PyObject *SWIGUNUSEDPARM(sel
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -18679,6 +20745,11 @@ SWIGINTERN PyObject *_wrap_MassIntegrator_GetRule(PyObject *SWIGUNUSEDPARM(self)
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__IntegrationRule, 0 |  0 );
   return resultobj;
@@ -18725,6 +20796,11 @@ SWIGINTERN PyObject *_wrap_new_BoundaryMassIntegrator(PyObject *SWIGUNUSEDPARM(s
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__BoundaryMassIntegrator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -18796,6 +20872,11 @@ SWIGINTERN PyObject *_wrap_BoundaryMassIntegrator_AssembleFaceMatrix__SWIG_0_0(P
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -18878,6 +20959,11 @@ SWIGINTERN PyObject *_wrap_BoundaryMassIntegrator_AssembleFaceMatrix__SWIG_0_1(P
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -18949,6 +21035,11 @@ SWIGINTERN PyObject *_wrap_BoundaryMassIntegrator_AssembleFaceMatrix__SWIG_1(PyO
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -19082,6 +21173,11 @@ SWIGINTERN PyObject *_wrap_delete_BoundaryMassIntegrator(PyObject *SWIGUNUSEDPAR
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -19139,6 +21235,11 @@ SWIGINTERN PyObject *_wrap_new_ConvectionIntegrator(PyObject *SWIGUNUSEDPARM(sel
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__ConvectionIntegrator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -19206,6 +21307,108 @@ SWIGINTERN PyObject *_wrap_ConvectionIntegrator_AssembleElementMatrix(PyObject *
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_ConvectionIntegrator_AssemblePA__SWIG_0_0(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
+  PyObject *resultobj = 0;
+  mfem::ConvectionIntegrator *arg1 = (mfem::ConvectionIntegrator *) 0 ;
+  mfem::FiniteElementSpace *arg2 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  
+  if ((nobjs < 2) || (nobjs > 2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_mfem__ConvectionIntegrator, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "ConvectionIntegrator_AssemblePA" "', argument " "1"" of type '" "mfem::ConvectionIntegrator *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::ConvectionIntegrator * >(argp1);
+  res2 = SWIG_ConvertPtr(swig_obj[1], &argp2, SWIGTYPE_p_mfem__FiniteElementSpace,  0  | 0);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "ConvectionIntegrator_AssemblePA" "', argument " "2"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  if (!argp2) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "ConvectionIntegrator_AssemblePA" "', argument " "2"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  arg2 = reinterpret_cast< mfem::FiniteElementSpace * >(argp2);
+  {
+    try {
+      (arg1)->AssemblePA((mfem::FiniteElementSpace const &)*arg2); 
+    }
+    catch (Swig::DirectorException &e) {
+      SWIG_fail; 
+    }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_ConvectionIntegrator_AssemblePA__SWIG_0_1(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
+  PyObject *resultobj = 0;
+  mfem::ConvectionIntegrator *arg1 = (mfem::ConvectionIntegrator *) 0 ;
+  mfem::FiniteElementSpace *arg2 = 0 ;
+  mfem::FiniteElementSpace *arg3 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  void *argp3 = 0 ;
+  int res3 = 0 ;
+  
+  if ((nobjs < 3) || (nobjs > 3)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_mfem__ConvectionIntegrator, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "ConvectionIntegrator_AssemblePA" "', argument " "1"" of type '" "mfem::ConvectionIntegrator *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::ConvectionIntegrator * >(argp1);
+  res2 = SWIG_ConvertPtr(swig_obj[1], &argp2, SWIGTYPE_p_mfem__FiniteElementSpace,  0  | 0);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "ConvectionIntegrator_AssemblePA" "', argument " "2"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  if (!argp2) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "ConvectionIntegrator_AssemblePA" "', argument " "2"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  arg2 = reinterpret_cast< mfem::FiniteElementSpace * >(argp2);
+  res3 = SWIG_ConvertPtr(swig_obj[2], &argp3, SWIGTYPE_p_mfem__FiniteElementSpace,  0  | 0);
+  if (!SWIG_IsOK(res3)) {
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "ConvectionIntegrator_AssemblePA" "', argument " "3"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  if (!argp3) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "ConvectionIntegrator_AssemblePA" "', argument " "3"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  arg3 = reinterpret_cast< mfem::FiniteElementSpace * >(argp3);
+  {
+    try {
+      (arg1)->AssemblePA((mfem::FiniteElementSpace const &)*arg2,(mfem::FiniteElementSpace const &)*arg3); 
+    }
+    catch (Swig::DirectorException &e) {
+      SWIG_fail; 
+    }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -19244,6 +21447,11 @@ SWIGINTERN PyObject *_wrap_ConvectionIntegrator_AssemblePA__SWIG_1(PyObject *SWI
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -19254,12 +21462,25 @@ fail:
 
 SWIGINTERN PyObject *_wrap_ConvectionIntegrator_AssemblePA(PyObject *self, PyObject *args) {
   Py_ssize_t argc;
-  PyObject *argv[3] = {
+  PyObject *argv[4] = {
     0
   };
   
-  if (!(argc = SWIG_Python_UnpackTuple(args, "ConvectionIntegrator_AssemblePA", 0, 2, argv))) SWIG_fail;
+  if (!(argc = SWIG_Python_UnpackTuple(args, "ConvectionIntegrator_AssemblePA", 0, 3, argv))) SWIG_fail;
   --argc;
+  if (argc == 2) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_mfem__ConvectionIntegrator, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      int res = SWIG_ConvertPtr(argv[1], 0, SWIGTYPE_p_mfem__FiniteElementSpace, SWIG_POINTER_NO_NULL | 0);
+      _v = SWIG_CheckState(res);
+      if (_v) {
+        return _wrap_ConvectionIntegrator_AssemblePA__SWIG_0_0(self, argc, argv);
+      }
+    }
+  }
   if (argc == 2) {
     int _v;
     void *vptr = 0;
@@ -19273,11 +21494,29 @@ SWIGINTERN PyObject *_wrap_ConvectionIntegrator_AssemblePA(PyObject *self, PyObj
       }
     }
   }
+  if (argc == 3) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_mfem__ConvectionIntegrator, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      int res = SWIG_ConvertPtr(argv[1], 0, SWIGTYPE_p_mfem__FiniteElementSpace, SWIG_POINTER_NO_NULL | 0);
+      _v = SWIG_CheckState(res);
+      if (_v) {
+        int res = SWIG_ConvertPtr(argv[2], 0, SWIGTYPE_p_mfem__FiniteElementSpace, SWIG_POINTER_NO_NULL | 0);
+        _v = SWIG_CheckState(res);
+        if (_v) {
+          return _wrap_ConvectionIntegrator_AssemblePA__SWIG_0_1(self, argc, argv);
+        }
+      }
+    }
+  }
   
 fail:
   SWIG_Python_RaiseOrModifyTypeError("Wrong number or type of arguments for overloaded function 'ConvectionIntegrator_AssemblePA'.\n"
     "  Possible C/C++ prototypes are:\n"
-    "    mfem::ConvectionIntegrator::AssemblePA()\n"
+    "    AssemblePA(mfem::FiniteElementSpace const &)\n"
+    "    AssemblePA(mfem::FiniteElementSpace const &,mfem::FiniteElementSpace const &)\n"
     "    mfem::ConvectionIntegrator::AssemblePA(mfem::FiniteElementSpace const &)\n");
   return 0;
 }
@@ -19339,6 +21578,11 @@ SWIGINTERN PyObject *_wrap_ConvectionIntegrator_AssembleEA(PyObject *SWIGUNUSEDP
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -19394,6 +21638,11 @@ SWIGINTERN PyObject *_wrap_ConvectionIntegrator_AddMultPA(PyObject *SWIGUNUSEDPA
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -19436,6 +21685,11 @@ SWIGINTERN PyObject *_wrap_ConvectionIntegrator_GetRule__SWIG_0(PyObject *SWIGUN
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__IntegrationRule, 0 |  0 );
   return resultobj;
@@ -19489,6 +21743,11 @@ SWIGINTERN PyObject *_wrap_ConvectionIntegrator_GetRule__SWIG_1(PyObject *SWIGUN
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__IntegrationRule, 0 |  0 );
   return resultobj;
@@ -19566,6 +21825,11 @@ SWIGINTERN PyObject *_wrap_delete_ConvectionIntegrator(PyObject *SWIGUNUSEDPARM(
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -19623,6 +21887,11 @@ SWIGINTERN PyObject *_wrap_new_GroupConvectionIntegrator(PyObject *SWIGUNUSEDPAR
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__GroupConvectionIntegrator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -19690,6 +21959,11 @@ SWIGINTERN PyObject *_wrap_GroupConvectionIntegrator_AssembleElementMatrix(PyObj
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -19719,6 +21993,11 @@ SWIGINTERN PyObject *_wrap_delete_GroupConvectionIntegrator(PyObject *SWIGUNUSED
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -19750,6 +22029,11 @@ SWIGINTERN PyObject *_wrap_new_VectorMassIntegrator__SWIG_0(PyObject *SWIGUNUSED
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__VectorMassIntegrator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -19790,6 +22074,11 @@ SWIGINTERN PyObject *_wrap_new_VectorMassIntegrator__SWIG_1(PyObject *SWIGUNUSED
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__VectorMassIntegrator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -19829,6 +22118,11 @@ SWIGINTERN PyObject *_wrap_new_VectorMassIntegrator__SWIG_2(PyObject *SWIGUNUSED
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__VectorMassIntegrator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -19869,6 +22163,11 @@ SWIGINTERN PyObject *_wrap_new_VectorMassIntegrator__SWIG_3(PyObject *SWIGUNUSED
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__VectorMassIntegrator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -19909,6 +22208,11 @@ SWIGINTERN PyObject *_wrap_new_VectorMassIntegrator__SWIG_4(PyObject *SWIGUNUSED
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__VectorMassIntegrator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -20042,6 +22346,11 @@ SWIGINTERN PyObject *_wrap_delete_VectorMassIntegrator(PyObject *SWIGUNUSEDPARM(
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -20072,6 +22381,11 @@ SWIGINTERN PyObject *_wrap_VectorMassIntegrator_GetVDim(PyObject *SWIGUNUSEDPARM
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_From_int(static_cast< int >(result));
   return resultobj;
@@ -20111,6 +22425,11 @@ SWIGINTERN PyObject *_wrap_VectorMassIntegrator_SetVDim(PyObject *SWIGUNUSEDPARM
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -20178,6 +22497,11 @@ SWIGINTERN PyObject *_wrap_VectorMassIntegrator_AssembleElementMatrix(PyObject *
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -20257,6 +22581,108 @@ SWIGINTERN PyObject *_wrap_VectorMassIntegrator_AssembleElementMatrix2(PyObject 
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_VectorMassIntegrator_AssemblePA__SWIG_0_0(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
+  PyObject *resultobj = 0;
+  mfem::VectorMassIntegrator *arg1 = (mfem::VectorMassIntegrator *) 0 ;
+  mfem::FiniteElementSpace *arg2 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  
+  if ((nobjs < 2) || (nobjs > 2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_mfem__VectorMassIntegrator, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "VectorMassIntegrator_AssemblePA" "', argument " "1"" of type '" "mfem::VectorMassIntegrator *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::VectorMassIntegrator * >(argp1);
+  res2 = SWIG_ConvertPtr(swig_obj[1], &argp2, SWIGTYPE_p_mfem__FiniteElementSpace,  0  | 0);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "VectorMassIntegrator_AssemblePA" "', argument " "2"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  if (!argp2) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "VectorMassIntegrator_AssemblePA" "', argument " "2"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  arg2 = reinterpret_cast< mfem::FiniteElementSpace * >(argp2);
+  {
+    try {
+      (arg1)->AssemblePA((mfem::FiniteElementSpace const &)*arg2); 
+    }
+    catch (Swig::DirectorException &e) {
+      SWIG_fail; 
+    }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_VectorMassIntegrator_AssemblePA__SWIG_0_1(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
+  PyObject *resultobj = 0;
+  mfem::VectorMassIntegrator *arg1 = (mfem::VectorMassIntegrator *) 0 ;
+  mfem::FiniteElementSpace *arg2 = 0 ;
+  mfem::FiniteElementSpace *arg3 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  void *argp3 = 0 ;
+  int res3 = 0 ;
+  
+  if ((nobjs < 3) || (nobjs > 3)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_mfem__VectorMassIntegrator, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "VectorMassIntegrator_AssemblePA" "', argument " "1"" of type '" "mfem::VectorMassIntegrator *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::VectorMassIntegrator * >(argp1);
+  res2 = SWIG_ConvertPtr(swig_obj[1], &argp2, SWIGTYPE_p_mfem__FiniteElementSpace,  0  | 0);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "VectorMassIntegrator_AssemblePA" "', argument " "2"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  if (!argp2) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "VectorMassIntegrator_AssemblePA" "', argument " "2"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  arg2 = reinterpret_cast< mfem::FiniteElementSpace * >(argp2);
+  res3 = SWIG_ConvertPtr(swig_obj[2], &argp3, SWIGTYPE_p_mfem__FiniteElementSpace,  0  | 0);
+  if (!SWIG_IsOK(res3)) {
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "VectorMassIntegrator_AssemblePA" "', argument " "3"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  if (!argp3) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "VectorMassIntegrator_AssemblePA" "', argument " "3"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  arg3 = reinterpret_cast< mfem::FiniteElementSpace * >(argp3);
+  {
+    try {
+      (arg1)->AssemblePA((mfem::FiniteElementSpace const &)*arg2,(mfem::FiniteElementSpace const &)*arg3); 
+    }
+    catch (Swig::DirectorException &e) {
+      SWIG_fail; 
+    }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -20295,6 +22721,11 @@ SWIGINTERN PyObject *_wrap_VectorMassIntegrator_AssemblePA__SWIG_1(PyObject *SWI
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -20305,12 +22736,25 @@ fail:
 
 SWIGINTERN PyObject *_wrap_VectorMassIntegrator_AssemblePA(PyObject *self, PyObject *args) {
   Py_ssize_t argc;
-  PyObject *argv[3] = {
+  PyObject *argv[4] = {
     0
   };
   
-  if (!(argc = SWIG_Python_UnpackTuple(args, "VectorMassIntegrator_AssemblePA", 0, 2, argv))) SWIG_fail;
+  if (!(argc = SWIG_Python_UnpackTuple(args, "VectorMassIntegrator_AssemblePA", 0, 3, argv))) SWIG_fail;
   --argc;
+  if (argc == 2) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_mfem__VectorMassIntegrator, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      int res = SWIG_ConvertPtr(argv[1], 0, SWIGTYPE_p_mfem__FiniteElementSpace, SWIG_POINTER_NO_NULL | 0);
+      _v = SWIG_CheckState(res);
+      if (_v) {
+        return _wrap_VectorMassIntegrator_AssemblePA__SWIG_0_0(self, argc, argv);
+      }
+    }
+  }
   if (argc == 2) {
     int _v;
     void *vptr = 0;
@@ -20324,11 +22768,29 @@ SWIGINTERN PyObject *_wrap_VectorMassIntegrator_AssemblePA(PyObject *self, PyObj
       }
     }
   }
+  if (argc == 3) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_mfem__VectorMassIntegrator, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      int res = SWIG_ConvertPtr(argv[1], 0, SWIGTYPE_p_mfem__FiniteElementSpace, SWIG_POINTER_NO_NULL | 0);
+      _v = SWIG_CheckState(res);
+      if (_v) {
+        int res = SWIG_ConvertPtr(argv[2], 0, SWIGTYPE_p_mfem__FiniteElementSpace, SWIG_POINTER_NO_NULL | 0);
+        _v = SWIG_CheckState(res);
+        if (_v) {
+          return _wrap_VectorMassIntegrator_AssemblePA__SWIG_0_1(self, argc, argv);
+        }
+      }
+    }
+  }
   
 fail:
   SWIG_Python_RaiseOrModifyTypeError("Wrong number or type of arguments for overloaded function 'VectorMassIntegrator_AssemblePA'.\n"
     "  Possible C/C++ prototypes are:\n"
-    "    mfem::VectorMassIntegrator::AssemblePA()\n"
+    "    AssemblePA(mfem::FiniteElementSpace const &)\n"
+    "    AssemblePA(mfem::FiniteElementSpace const &,mfem::FiniteElementSpace const &)\n"
     "    mfem::VectorMassIntegrator::AssemblePA(mfem::FiniteElementSpace const &)\n");
   return 0;
 }
@@ -20369,6 +22831,11 @@ SWIGINTERN PyObject *_wrap_VectorMassIntegrator_AssembleMF(PyObject *SWIGUNUSEDP
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -20412,6 +22879,11 @@ SWIGINTERN PyObject *_wrap_VectorMassIntegrator_AssembleDiagonalPA(PyObject *SWI
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -20455,6 +22927,11 @@ SWIGINTERN PyObject *_wrap_VectorMassIntegrator_AssembleDiagonalMF(PyObject *SWI
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -20510,6 +22987,11 @@ SWIGINTERN PyObject *_wrap_VectorMassIntegrator_AddMultPA(PyObject *SWIGUNUSEDPA
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -20565,6 +23047,11 @@ SWIGINTERN PyObject *_wrap_VectorMassIntegrator_AddMultMF(PyObject *SWIGUNUSEDPA
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -20596,6 +23083,11 @@ SWIGINTERN PyObject *_wrap_new_VectorFEDivergenceIntegrator__SWIG_0(PyObject *SW
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__VectorFEDivergenceIntegrator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -20627,6 +23119,11 @@ SWIGINTERN PyObject *_wrap_new_VectorFEDivergenceIntegrator__SWIG_1(PyObject *SW
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__VectorFEDivergenceIntegrator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -20724,6 +23221,11 @@ SWIGINTERN PyObject *_wrap_VectorFEDivergenceIntegrator_AssembleElementMatrix(Py
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -20803,6 +23305,11 @@ SWIGINTERN PyObject *_wrap_VectorFEDivergenceIntegrator_AssembleElementMatrix2(P
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -20858,6 +23365,11 @@ SWIGINTERN PyObject *_wrap_VectorFEDivergenceIntegrator_AssembleDiagonalPA_ADAt(
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -20887,6 +23399,11 @@ SWIGINTERN PyObject *_wrap_delete_VectorFEDivergenceIntegrator(PyObject *SWIGUNU
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -20918,6 +23435,11 @@ SWIGINTERN PyObject *_wrap_new_VectorFEWeakDivergenceIntegrator__SWIG_0(PyObject
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__VectorFEWeakDivergenceIntegrator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -20949,6 +23471,11 @@ SWIGINTERN PyObject *_wrap_new_VectorFEWeakDivergenceIntegrator__SWIG_1(PyObject
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__VectorFEWeakDivergenceIntegrator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -21046,6 +23573,11 @@ SWIGINTERN PyObject *_wrap_VectorFEWeakDivergenceIntegrator_AssembleElementMatri
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -21125,6 +23657,11 @@ SWIGINTERN PyObject *_wrap_VectorFEWeakDivergenceIntegrator_AssembleElementMatri
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -21154,6 +23691,11 @@ SWIGINTERN PyObject *_wrap_delete_VectorFEWeakDivergenceIntegrator(PyObject *SWI
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -21185,6 +23727,11 @@ SWIGINTERN PyObject *_wrap_new_VectorFECurlIntegrator__SWIG_0(PyObject *SWIGUNUS
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__VectorFECurlIntegrator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -21216,6 +23763,11 @@ SWIGINTERN PyObject *_wrap_new_VectorFECurlIntegrator__SWIG_1(PyObject *SWIGUNUS
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__VectorFECurlIntegrator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -21313,6 +23865,11 @@ SWIGINTERN PyObject *_wrap_VectorFECurlIntegrator_AssembleElementMatrix(PyObject
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -21392,6 +23949,11 @@ SWIGINTERN PyObject *_wrap_VectorFECurlIntegrator_AssembleElementMatrix2(PyObjec
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -21421,6 +23983,11 @@ SWIGINTERN PyObject *_wrap_delete_VectorFECurlIntegrator(PyObject *SWIGUNUSEDPAR
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -21475,6 +24042,11 @@ SWIGINTERN PyObject *_wrap_new_DerivativeIntegrator(PyObject *SWIGUNUSEDPARM(sel
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__DerivativeIntegrator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -21542,6 +24114,11 @@ SWIGINTERN PyObject *_wrap_DerivativeIntegrator_AssembleElementMatrix(PyObject *
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -21621,6 +24198,11 @@ SWIGINTERN PyObject *_wrap_DerivativeIntegrator_AssembleElementMatrix2(PyObject 
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -21650,6 +24232,11 @@ SWIGINTERN PyObject *_wrap_delete_DerivativeIntegrator(PyObject *SWIGUNUSEDPARM(
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -21681,6 +24268,11 @@ SWIGINTERN PyObject *_wrap_new_CurlCurlIntegrator__SWIG_0(PyObject *SWIGUNUSEDPA
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__CurlCurlIntegrator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -21722,6 +24314,11 @@ SWIGINTERN PyObject *_wrap_new_CurlCurlIntegrator__SWIG_1(PyObject *SWIGUNUSEDPA
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__CurlCurlIntegrator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -21763,6 +24360,11 @@ SWIGINTERN PyObject *_wrap_new_CurlCurlIntegrator__SWIG_2(PyObject *SWIGUNUSEDPA
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__CurlCurlIntegrator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -21804,6 +24406,11 @@ SWIGINTERN PyObject *_wrap_new_CurlCurlIntegrator__SWIG_3(PyObject *SWIGUNUSEDPA
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__CurlCurlIntegrator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -21945,6 +24552,11 @@ SWIGINTERN PyObject *_wrap_CurlCurlIntegrator_AssembleElementMatrix(PyObject *SW
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -22045,6 +24657,11 @@ SWIGINTERN PyObject *_wrap_CurlCurlIntegrator_ComputeElementFlux(PyObject *SWIGU
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -22124,8 +24741,110 @@ SWIGINTERN PyObject *_wrap_CurlCurlIntegrator_ComputeFluxEnergy(PyObject *SWIGUN
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_From_double(static_cast< double >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_CurlCurlIntegrator_AssemblePA__SWIG_0_0(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
+  PyObject *resultobj = 0;
+  mfem::CurlCurlIntegrator *arg1 = (mfem::CurlCurlIntegrator *) 0 ;
+  mfem::FiniteElementSpace *arg2 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  
+  if ((nobjs < 2) || (nobjs > 2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_mfem__CurlCurlIntegrator, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "CurlCurlIntegrator_AssemblePA" "', argument " "1"" of type '" "mfem::CurlCurlIntegrator *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::CurlCurlIntegrator * >(argp1);
+  res2 = SWIG_ConvertPtr(swig_obj[1], &argp2, SWIGTYPE_p_mfem__FiniteElementSpace,  0  | 0);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "CurlCurlIntegrator_AssemblePA" "', argument " "2"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  if (!argp2) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "CurlCurlIntegrator_AssemblePA" "', argument " "2"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  arg2 = reinterpret_cast< mfem::FiniteElementSpace * >(argp2);
+  {
+    try {
+      (arg1)->AssemblePA((mfem::FiniteElementSpace const &)*arg2); 
+    }
+    catch (Swig::DirectorException &e) {
+      SWIG_fail; 
+    }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_CurlCurlIntegrator_AssemblePA__SWIG_0_1(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
+  PyObject *resultobj = 0;
+  mfem::CurlCurlIntegrator *arg1 = (mfem::CurlCurlIntegrator *) 0 ;
+  mfem::FiniteElementSpace *arg2 = 0 ;
+  mfem::FiniteElementSpace *arg3 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  void *argp3 = 0 ;
+  int res3 = 0 ;
+  
+  if ((nobjs < 3) || (nobjs > 3)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_mfem__CurlCurlIntegrator, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "CurlCurlIntegrator_AssemblePA" "', argument " "1"" of type '" "mfem::CurlCurlIntegrator *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::CurlCurlIntegrator * >(argp1);
+  res2 = SWIG_ConvertPtr(swig_obj[1], &argp2, SWIGTYPE_p_mfem__FiniteElementSpace,  0  | 0);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "CurlCurlIntegrator_AssemblePA" "', argument " "2"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  if (!argp2) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "CurlCurlIntegrator_AssemblePA" "', argument " "2"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  arg2 = reinterpret_cast< mfem::FiniteElementSpace * >(argp2);
+  res3 = SWIG_ConvertPtr(swig_obj[2], &argp3, SWIGTYPE_p_mfem__FiniteElementSpace,  0  | 0);
+  if (!SWIG_IsOK(res3)) {
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "CurlCurlIntegrator_AssemblePA" "', argument " "3"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  if (!argp3) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "CurlCurlIntegrator_AssemblePA" "', argument " "3"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  arg3 = reinterpret_cast< mfem::FiniteElementSpace * >(argp3);
+  {
+    try {
+      (arg1)->AssemblePA((mfem::FiniteElementSpace const &)*arg2,(mfem::FiniteElementSpace const &)*arg3); 
+    }
+    catch (Swig::DirectorException &e) {
+      SWIG_fail; 
+    }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
+  }
+  resultobj = SWIG_Py_Void();
   return resultobj;
 fail:
   return NULL;
@@ -22162,6 +24881,11 @@ SWIGINTERN PyObject *_wrap_CurlCurlIntegrator_AssemblePA__SWIG_1(PyObject *SWIGU
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -22172,12 +24896,25 @@ fail:
 
 SWIGINTERN PyObject *_wrap_CurlCurlIntegrator_AssemblePA(PyObject *self, PyObject *args) {
   Py_ssize_t argc;
-  PyObject *argv[3] = {
+  PyObject *argv[4] = {
     0
   };
   
-  if (!(argc = SWIG_Python_UnpackTuple(args, "CurlCurlIntegrator_AssemblePA", 0, 2, argv))) SWIG_fail;
+  if (!(argc = SWIG_Python_UnpackTuple(args, "CurlCurlIntegrator_AssemblePA", 0, 3, argv))) SWIG_fail;
   --argc;
+  if (argc == 2) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_mfem__CurlCurlIntegrator, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      int res = SWIG_ConvertPtr(argv[1], 0, SWIGTYPE_p_mfem__FiniteElementSpace, SWIG_POINTER_NO_NULL | 0);
+      _v = SWIG_CheckState(res);
+      if (_v) {
+        return _wrap_CurlCurlIntegrator_AssemblePA__SWIG_0_0(self, argc, argv);
+      }
+    }
+  }
   if (argc == 2) {
     int _v;
     void *vptr = 0;
@@ -22191,11 +24928,29 @@ SWIGINTERN PyObject *_wrap_CurlCurlIntegrator_AssemblePA(PyObject *self, PyObjec
       }
     }
   }
+  if (argc == 3) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_mfem__CurlCurlIntegrator, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      int res = SWIG_ConvertPtr(argv[1], 0, SWIGTYPE_p_mfem__FiniteElementSpace, SWIG_POINTER_NO_NULL | 0);
+      _v = SWIG_CheckState(res);
+      if (_v) {
+        int res = SWIG_ConvertPtr(argv[2], 0, SWIGTYPE_p_mfem__FiniteElementSpace, SWIG_POINTER_NO_NULL | 0);
+        _v = SWIG_CheckState(res);
+        if (_v) {
+          return _wrap_CurlCurlIntegrator_AssemblePA__SWIG_0_1(self, argc, argv);
+        }
+      }
+    }
+  }
   
 fail:
   SWIG_Python_RaiseOrModifyTypeError("Wrong number or type of arguments for overloaded function 'CurlCurlIntegrator_AssemblePA'.\n"
     "  Possible C/C++ prototypes are:\n"
-    "    mfem::CurlCurlIntegrator::AssemblePA()\n"
+    "    AssemblePA(mfem::FiniteElementSpace const &)\n"
+    "    AssemblePA(mfem::FiniteElementSpace const &,mfem::FiniteElementSpace const &)\n"
     "    mfem::CurlCurlIntegrator::AssemblePA(mfem::FiniteElementSpace const &)\n");
   return 0;
 }
@@ -22248,6 +25003,11 @@ SWIGINTERN PyObject *_wrap_CurlCurlIntegrator_AddMultPA(PyObject *SWIGUNUSEDPARM
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -22291,6 +25051,11 @@ SWIGINTERN PyObject *_wrap_CurlCurlIntegrator_AssembleDiagonalPA(PyObject *SWIGU
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -22320,6 +25085,11 @@ SWIGINTERN PyObject *_wrap_delete_CurlCurlIntegrator(PyObject *SWIGUNUSEDPARM(se
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -22351,6 +25121,11 @@ SWIGINTERN PyObject *_wrap_new_VectorCurlCurlIntegrator__SWIG_0(PyObject *SWIGUN
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__VectorCurlCurlIntegrator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -22382,6 +25157,11 @@ SWIGINTERN PyObject *_wrap_new_VectorCurlCurlIntegrator__SWIG_1(PyObject *SWIGUN
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__VectorCurlCurlIntegrator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -22479,6 +25259,11 @@ SWIGINTERN PyObject *_wrap_VectorCurlCurlIntegrator_AssembleElementMatrix(PyObje
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -22547,6 +25332,11 @@ SWIGINTERN PyObject *_wrap_VectorCurlCurlIntegrator_GetElementEnergy(PyObject *S
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_From_double(static_cast< double >(result));
   return resultobj;
@@ -22576,6 +25366,11 @@ SWIGINTERN PyObject *_wrap_delete_VectorCurlCurlIntegrator(PyObject *SWIGUNUSEDP
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -22607,6 +25402,11 @@ SWIGINTERN PyObject *_wrap_new_VectorFEMassIntegrator__SWIG_0(PyObject *SWIGUNUS
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__VectorFEMassIntegrator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -22635,6 +25435,11 @@ SWIGINTERN PyObject *_wrap_new_VectorFEMassIntegrator__SWIG_1(PyObject *SWIGUNUS
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__VectorFEMassIntegrator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -22666,6 +25471,11 @@ SWIGINTERN PyObject *_wrap_new_VectorFEMassIntegrator__SWIG_2(PyObject *SWIGUNUS
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__VectorFEMassIntegrator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -22694,6 +25504,11 @@ SWIGINTERN PyObject *_wrap_new_VectorFEMassIntegrator__SWIG_3(PyObject *SWIGUNUS
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__VectorFEMassIntegrator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -22725,6 +25540,11 @@ SWIGINTERN PyObject *_wrap_new_VectorFEMassIntegrator__SWIG_4(PyObject *SWIGUNUS
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__VectorFEMassIntegrator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -22753,6 +25573,11 @@ SWIGINTERN PyObject *_wrap_new_VectorFEMassIntegrator__SWIG_5(PyObject *SWIGUNUS
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__VectorFEMassIntegrator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -22784,6 +25609,11 @@ SWIGINTERN PyObject *_wrap_new_VectorFEMassIntegrator__SWIG_6(PyObject *SWIGUNUS
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__VectorFEMassIntegrator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -22931,6 +25761,11 @@ SWIGINTERN PyObject *_wrap_VectorFEMassIntegrator_AssembleElementMatrix(PyObject
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -23010,6 +25845,108 @@ SWIGINTERN PyObject *_wrap_VectorFEMassIntegrator_AssembleElementMatrix2(PyObjec
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_VectorFEMassIntegrator_AssemblePA__SWIG_0_0(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
+  PyObject *resultobj = 0;
+  mfem::VectorFEMassIntegrator *arg1 = (mfem::VectorFEMassIntegrator *) 0 ;
+  mfem::FiniteElementSpace *arg2 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  
+  if ((nobjs < 2) || (nobjs > 2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_mfem__VectorFEMassIntegrator, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "VectorFEMassIntegrator_AssemblePA" "', argument " "1"" of type '" "mfem::VectorFEMassIntegrator *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::VectorFEMassIntegrator * >(argp1);
+  res2 = SWIG_ConvertPtr(swig_obj[1], &argp2, SWIGTYPE_p_mfem__FiniteElementSpace,  0  | 0);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "VectorFEMassIntegrator_AssemblePA" "', argument " "2"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  if (!argp2) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "VectorFEMassIntegrator_AssemblePA" "', argument " "2"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  arg2 = reinterpret_cast< mfem::FiniteElementSpace * >(argp2);
+  {
+    try {
+      (arg1)->AssemblePA((mfem::FiniteElementSpace const &)*arg2); 
+    }
+    catch (Swig::DirectorException &e) {
+      SWIG_fail; 
+    }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_VectorFEMassIntegrator_AssemblePA__SWIG_0_1(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
+  PyObject *resultobj = 0;
+  mfem::VectorFEMassIntegrator *arg1 = (mfem::VectorFEMassIntegrator *) 0 ;
+  mfem::FiniteElementSpace *arg2 = 0 ;
+  mfem::FiniteElementSpace *arg3 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  void *argp3 = 0 ;
+  int res3 = 0 ;
+  
+  if ((nobjs < 3) || (nobjs > 3)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_mfem__VectorFEMassIntegrator, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "VectorFEMassIntegrator_AssemblePA" "', argument " "1"" of type '" "mfem::VectorFEMassIntegrator *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::VectorFEMassIntegrator * >(argp1);
+  res2 = SWIG_ConvertPtr(swig_obj[1], &argp2, SWIGTYPE_p_mfem__FiniteElementSpace,  0  | 0);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "VectorFEMassIntegrator_AssemblePA" "', argument " "2"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  if (!argp2) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "VectorFEMassIntegrator_AssemblePA" "', argument " "2"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  arg2 = reinterpret_cast< mfem::FiniteElementSpace * >(argp2);
+  res3 = SWIG_ConvertPtr(swig_obj[2], &argp3, SWIGTYPE_p_mfem__FiniteElementSpace,  0  | 0);
+  if (!SWIG_IsOK(res3)) {
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "VectorFEMassIntegrator_AssemblePA" "', argument " "3"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  if (!argp3) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "VectorFEMassIntegrator_AssemblePA" "', argument " "3"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  arg3 = reinterpret_cast< mfem::FiniteElementSpace * >(argp3);
+  {
+    try {
+      (arg1)->AssemblePA((mfem::FiniteElementSpace const &)*arg2,(mfem::FiniteElementSpace const &)*arg3); 
+    }
+    catch (Swig::DirectorException &e) {
+      SWIG_fail; 
+    }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -23048,6 +25985,11 @@ SWIGINTERN PyObject *_wrap_VectorFEMassIntegrator_AssemblePA__SWIG_1(PyObject *S
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -23097,6 +26039,11 @@ SWIGINTERN PyObject *_wrap_VectorFEMassIntegrator_AssemblePA__SWIG_2(PyObject *S
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -23122,7 +26069,37 @@ SWIGINTERN PyObject *_wrap_VectorFEMassIntegrator_AssemblePA(PyObject *self, PyO
       int res = SWIG_ConvertPtr(argv[1], 0, SWIGTYPE_p_mfem__FiniteElementSpace, SWIG_POINTER_NO_NULL | 0);
       _v = SWIG_CheckState(res);
       if (_v) {
+        return _wrap_VectorFEMassIntegrator_AssemblePA__SWIG_0_0(self, argc, argv);
+      }
+    }
+  }
+  if (argc == 2) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_mfem__VectorFEMassIntegrator, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      int res = SWIG_ConvertPtr(argv[1], 0, SWIGTYPE_p_mfem__FiniteElementSpace, SWIG_POINTER_NO_NULL | 0);
+      _v = SWIG_CheckState(res);
+      if (_v) {
         return _wrap_VectorFEMassIntegrator_AssemblePA__SWIG_1(self, argc, argv);
+      }
+    }
+  }
+  if (argc == 3) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_mfem__VectorFEMassIntegrator, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      int res = SWIG_ConvertPtr(argv[1], 0, SWIGTYPE_p_mfem__FiniteElementSpace, SWIG_POINTER_NO_NULL | 0);
+      _v = SWIG_CheckState(res);
+      if (_v) {
+        int res = SWIG_ConvertPtr(argv[2], 0, SWIGTYPE_p_mfem__FiniteElementSpace, SWIG_POINTER_NO_NULL | 0);
+        _v = SWIG_CheckState(res);
+        if (_v) {
+          return _wrap_VectorFEMassIntegrator_AssemblePA__SWIG_0_1(self, argc, argv);
+        }
       }
     }
   }
@@ -23147,7 +26124,8 @@ SWIGINTERN PyObject *_wrap_VectorFEMassIntegrator_AssemblePA(PyObject *self, PyO
 fail:
   SWIG_Python_RaiseOrModifyTypeError("Wrong number or type of arguments for overloaded function 'VectorFEMassIntegrator_AssemblePA'.\n"
     "  Possible C/C++ prototypes are:\n"
-    "    mfem::VectorFEMassIntegrator::AssemblePA()\n"
+    "    AssemblePA(mfem::FiniteElementSpace const &)\n"
+    "    AssemblePA(mfem::FiniteElementSpace const &,mfem::FiniteElementSpace const &)\n"
     "    mfem::VectorFEMassIntegrator::AssemblePA(mfem::FiniteElementSpace const &)\n"
     "    mfem::VectorFEMassIntegrator::AssemblePA(mfem::FiniteElementSpace const &,mfem::FiniteElementSpace const &)\n");
   return 0;
@@ -23201,6 +26179,11 @@ SWIGINTERN PyObject *_wrap_VectorFEMassIntegrator_AddMultPA(PyObject *SWIGUNUSED
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -23244,6 +26227,11 @@ SWIGINTERN PyObject *_wrap_VectorFEMassIntegrator_AssembleDiagonalPA(PyObject *S
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -23273,6 +26261,11 @@ SWIGINTERN PyObject *_wrap_delete_VectorFEMassIntegrator(PyObject *SWIGUNUSEDPAR
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -23304,6 +26297,11 @@ SWIGINTERN PyObject *_wrap_new_VectorDivergenceIntegrator__SWIG_0(PyObject *SWIG
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__VectorDivergenceIntegrator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -23332,6 +26330,11 @@ SWIGINTERN PyObject *_wrap_new_VectorDivergenceIntegrator__SWIG_1(PyObject *SWIG
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__VectorDivergenceIntegrator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -23363,6 +26366,11 @@ SWIGINTERN PyObject *_wrap_new_VectorDivergenceIntegrator__SWIG_2(PyObject *SWIG
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__VectorDivergenceIntegrator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -23482,6 +26490,108 @@ SWIGINTERN PyObject *_wrap_VectorDivergenceIntegrator_AssembleElementMatrix2(PyO
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_VectorDivergenceIntegrator_AssemblePA__SWIG_0_0(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
+  PyObject *resultobj = 0;
+  mfem::VectorDivergenceIntegrator *arg1 = (mfem::VectorDivergenceIntegrator *) 0 ;
+  mfem::FiniteElementSpace *arg2 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  
+  if ((nobjs < 2) || (nobjs > 2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_mfem__VectorDivergenceIntegrator, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "VectorDivergenceIntegrator_AssemblePA" "', argument " "1"" of type '" "mfem::VectorDivergenceIntegrator *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::VectorDivergenceIntegrator * >(argp1);
+  res2 = SWIG_ConvertPtr(swig_obj[1], &argp2, SWIGTYPE_p_mfem__FiniteElementSpace,  0  | 0);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "VectorDivergenceIntegrator_AssemblePA" "', argument " "2"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  if (!argp2) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "VectorDivergenceIntegrator_AssemblePA" "', argument " "2"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  arg2 = reinterpret_cast< mfem::FiniteElementSpace * >(argp2);
+  {
+    try {
+      (arg1)->AssemblePA((mfem::FiniteElementSpace const &)*arg2); 
+    }
+    catch (Swig::DirectorException &e) {
+      SWIG_fail; 
+    }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_VectorDivergenceIntegrator_AssemblePA__SWIG_0_1(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
+  PyObject *resultobj = 0;
+  mfem::VectorDivergenceIntegrator *arg1 = (mfem::VectorDivergenceIntegrator *) 0 ;
+  mfem::FiniteElementSpace *arg2 = 0 ;
+  mfem::FiniteElementSpace *arg3 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  void *argp3 = 0 ;
+  int res3 = 0 ;
+  
+  if ((nobjs < 3) || (nobjs > 3)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_mfem__VectorDivergenceIntegrator, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "VectorDivergenceIntegrator_AssemblePA" "', argument " "1"" of type '" "mfem::VectorDivergenceIntegrator *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::VectorDivergenceIntegrator * >(argp1);
+  res2 = SWIG_ConvertPtr(swig_obj[1], &argp2, SWIGTYPE_p_mfem__FiniteElementSpace,  0  | 0);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "VectorDivergenceIntegrator_AssemblePA" "', argument " "2"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  if (!argp2) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "VectorDivergenceIntegrator_AssemblePA" "', argument " "2"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  arg2 = reinterpret_cast< mfem::FiniteElementSpace * >(argp2);
+  res3 = SWIG_ConvertPtr(swig_obj[2], &argp3, SWIGTYPE_p_mfem__FiniteElementSpace,  0  | 0);
+  if (!SWIG_IsOK(res3)) {
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "VectorDivergenceIntegrator_AssemblePA" "', argument " "3"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  if (!argp3) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "VectorDivergenceIntegrator_AssemblePA" "', argument " "3"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  arg3 = reinterpret_cast< mfem::FiniteElementSpace * >(argp3);
+  {
+    try {
+      (arg1)->AssemblePA((mfem::FiniteElementSpace const &)*arg2,(mfem::FiniteElementSpace const &)*arg3); 
+    }
+    catch (Swig::DirectorException &e) {
+      SWIG_fail; 
+    }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -23531,6 +26641,11 @@ SWIGINTERN PyObject *_wrap_VectorDivergenceIntegrator_AssemblePA__SWIG_1(PyObjec
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -23547,6 +26662,36 @@ SWIGINTERN PyObject *_wrap_VectorDivergenceIntegrator_AssemblePA(PyObject *self,
   
   if (!(argc = SWIG_Python_UnpackTuple(args, "VectorDivergenceIntegrator_AssemblePA", 0, 3, argv))) SWIG_fail;
   --argc;
+  if (argc == 2) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_mfem__VectorDivergenceIntegrator, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      int res = SWIG_ConvertPtr(argv[1], 0, SWIGTYPE_p_mfem__FiniteElementSpace, SWIG_POINTER_NO_NULL | 0);
+      _v = SWIG_CheckState(res);
+      if (_v) {
+        return _wrap_VectorDivergenceIntegrator_AssemblePA__SWIG_0_0(self, argc, argv);
+      }
+    }
+  }
+  if (argc == 3) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_mfem__VectorDivergenceIntegrator, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      int res = SWIG_ConvertPtr(argv[1], 0, SWIGTYPE_p_mfem__FiniteElementSpace, SWIG_POINTER_NO_NULL | 0);
+      _v = SWIG_CheckState(res);
+      if (_v) {
+        int res = SWIG_ConvertPtr(argv[2], 0, SWIGTYPE_p_mfem__FiniteElementSpace, SWIG_POINTER_NO_NULL | 0);
+        _v = SWIG_CheckState(res);
+        if (_v) {
+          return _wrap_VectorDivergenceIntegrator_AssemblePA__SWIG_0_1(self, argc, argv);
+        }
+      }
+    }
+  }
   if (argc == 3) {
     int _v;
     void *vptr = 0;
@@ -23568,7 +26713,8 @@ SWIGINTERN PyObject *_wrap_VectorDivergenceIntegrator_AssemblePA(PyObject *self,
 fail:
   SWIG_Python_RaiseOrModifyTypeError("Wrong number or type of arguments for overloaded function 'VectorDivergenceIntegrator_AssemblePA'.\n"
     "  Possible C/C++ prototypes are:\n"
-    "    mfem::VectorDivergenceIntegrator::AssemblePA()\n"
+    "    AssemblePA(mfem::FiniteElementSpace const &)\n"
+    "    AssemblePA(mfem::FiniteElementSpace const &,mfem::FiniteElementSpace const &)\n"
     "    mfem::VectorDivergenceIntegrator::AssemblePA(mfem::FiniteElementSpace const &,mfem::FiniteElementSpace const &)\n");
   return 0;
 }
@@ -23621,6 +26767,11 @@ SWIGINTERN PyObject *_wrap_VectorDivergenceIntegrator_AddMultPA(PyObject *SWIGUN
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -23676,6 +26827,11 @@ SWIGINTERN PyObject *_wrap_VectorDivergenceIntegrator_AddMultTransposePA(PyObjec
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -23735,6 +26891,11 @@ SWIGINTERN PyObject *_wrap_VectorDivergenceIntegrator_GetRule(PyObject *SWIGUNUS
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__IntegrationRule, 0 |  0 );
   return resultobj;
@@ -23764,6 +26925,11 @@ SWIGINTERN PyObject *_wrap_delete_VectorDivergenceIntegrator(PyObject *SWIGUNUSE
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -23795,6 +26961,11 @@ SWIGINTERN PyObject *_wrap_new_DivDivIntegrator__SWIG_0(PyObject *SWIGUNUSEDPARM
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__DivDivIntegrator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -23826,6 +26997,11 @@ SWIGINTERN PyObject *_wrap_new_DivDivIntegrator__SWIG_1(PyObject *SWIGUNUSEDPARM
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__DivDivIntegrator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -23923,6 +27099,11 @@ SWIGINTERN PyObject *_wrap_DivDivIntegrator_AssembleElementMatrix(PyObject *SWIG
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -23952,6 +27133,11 @@ SWIGINTERN PyObject *_wrap_delete_DivDivIntegrator(PyObject *SWIGUNUSEDPARM(self
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -23983,6 +27169,11 @@ SWIGINTERN PyObject *_wrap_new_VectorDiffusionIntegrator__SWIG_0(PyObject *SWIGU
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__VectorDiffusionIntegrator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -24014,6 +27205,11 @@ SWIGINTERN PyObject *_wrap_new_VectorDiffusionIntegrator__SWIG_1(PyObject *SWIGU
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__VectorDiffusionIntegrator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -24073,6 +27269,11 @@ SWIGINTERN PyObject *_wrap_delete_VectorDiffusionIntegrator(PyObject *SWIGUNUSED
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -24140,6 +27341,11 @@ SWIGINTERN PyObject *_wrap_VectorDiffusionIntegrator_AssembleElementMatrix(PyObj
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -24219,6 +27425,108 @@ SWIGINTERN PyObject *_wrap_VectorDiffusionIntegrator_AssembleElementVector(PyObj
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_VectorDiffusionIntegrator_AssemblePA__SWIG_0_0(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
+  PyObject *resultobj = 0;
+  mfem::VectorDiffusionIntegrator *arg1 = (mfem::VectorDiffusionIntegrator *) 0 ;
+  mfem::FiniteElementSpace *arg2 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  
+  if ((nobjs < 2) || (nobjs > 2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_mfem__VectorDiffusionIntegrator, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "VectorDiffusionIntegrator_AssemblePA" "', argument " "1"" of type '" "mfem::VectorDiffusionIntegrator *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::VectorDiffusionIntegrator * >(argp1);
+  res2 = SWIG_ConvertPtr(swig_obj[1], &argp2, SWIGTYPE_p_mfem__FiniteElementSpace,  0  | 0);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "VectorDiffusionIntegrator_AssemblePA" "', argument " "2"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  if (!argp2) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "VectorDiffusionIntegrator_AssemblePA" "', argument " "2"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  arg2 = reinterpret_cast< mfem::FiniteElementSpace * >(argp2);
+  {
+    try {
+      (arg1)->AssemblePA((mfem::FiniteElementSpace const &)*arg2); 
+    }
+    catch (Swig::DirectorException &e) {
+      SWIG_fail; 
+    }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_VectorDiffusionIntegrator_AssemblePA__SWIG_0_1(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
+  PyObject *resultobj = 0;
+  mfem::VectorDiffusionIntegrator *arg1 = (mfem::VectorDiffusionIntegrator *) 0 ;
+  mfem::FiniteElementSpace *arg2 = 0 ;
+  mfem::FiniteElementSpace *arg3 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  void *argp3 = 0 ;
+  int res3 = 0 ;
+  
+  if ((nobjs < 3) || (nobjs > 3)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_mfem__VectorDiffusionIntegrator, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "VectorDiffusionIntegrator_AssemblePA" "', argument " "1"" of type '" "mfem::VectorDiffusionIntegrator *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::VectorDiffusionIntegrator * >(argp1);
+  res2 = SWIG_ConvertPtr(swig_obj[1], &argp2, SWIGTYPE_p_mfem__FiniteElementSpace,  0  | 0);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "VectorDiffusionIntegrator_AssemblePA" "', argument " "2"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  if (!argp2) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "VectorDiffusionIntegrator_AssemblePA" "', argument " "2"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  arg2 = reinterpret_cast< mfem::FiniteElementSpace * >(argp2);
+  res3 = SWIG_ConvertPtr(swig_obj[2], &argp3, SWIGTYPE_p_mfem__FiniteElementSpace,  0  | 0);
+  if (!SWIG_IsOK(res3)) {
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "VectorDiffusionIntegrator_AssemblePA" "', argument " "3"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  if (!argp3) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "VectorDiffusionIntegrator_AssemblePA" "', argument " "3"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  arg3 = reinterpret_cast< mfem::FiniteElementSpace * >(argp3);
+  {
+    try {
+      (arg1)->AssemblePA((mfem::FiniteElementSpace const &)*arg2,(mfem::FiniteElementSpace const &)*arg3); 
+    }
+    catch (Swig::DirectorException &e) {
+      SWIG_fail; 
+    }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -24257,6 +27565,11 @@ SWIGINTERN PyObject *_wrap_VectorDiffusionIntegrator_AssemblePA__SWIG_1(PyObject
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -24267,12 +27580,25 @@ fail:
 
 SWIGINTERN PyObject *_wrap_VectorDiffusionIntegrator_AssemblePA(PyObject *self, PyObject *args) {
   Py_ssize_t argc;
-  PyObject *argv[3] = {
+  PyObject *argv[4] = {
     0
   };
   
-  if (!(argc = SWIG_Python_UnpackTuple(args, "VectorDiffusionIntegrator_AssemblePA", 0, 2, argv))) SWIG_fail;
+  if (!(argc = SWIG_Python_UnpackTuple(args, "VectorDiffusionIntegrator_AssemblePA", 0, 3, argv))) SWIG_fail;
   --argc;
+  if (argc == 2) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_mfem__VectorDiffusionIntegrator, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      int res = SWIG_ConvertPtr(argv[1], 0, SWIGTYPE_p_mfem__FiniteElementSpace, SWIG_POINTER_NO_NULL | 0);
+      _v = SWIG_CheckState(res);
+      if (_v) {
+        return _wrap_VectorDiffusionIntegrator_AssemblePA__SWIG_0_0(self, argc, argv);
+      }
+    }
+  }
   if (argc == 2) {
     int _v;
     void *vptr = 0;
@@ -24286,11 +27612,29 @@ SWIGINTERN PyObject *_wrap_VectorDiffusionIntegrator_AssemblePA(PyObject *self, 
       }
     }
   }
+  if (argc == 3) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_mfem__VectorDiffusionIntegrator, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      int res = SWIG_ConvertPtr(argv[1], 0, SWIGTYPE_p_mfem__FiniteElementSpace, SWIG_POINTER_NO_NULL | 0);
+      _v = SWIG_CheckState(res);
+      if (_v) {
+        int res = SWIG_ConvertPtr(argv[2], 0, SWIGTYPE_p_mfem__FiniteElementSpace, SWIG_POINTER_NO_NULL | 0);
+        _v = SWIG_CheckState(res);
+        if (_v) {
+          return _wrap_VectorDiffusionIntegrator_AssemblePA__SWIG_0_1(self, argc, argv);
+        }
+      }
+    }
+  }
   
 fail:
   SWIG_Python_RaiseOrModifyTypeError("Wrong number or type of arguments for overloaded function 'VectorDiffusionIntegrator_AssemblePA'.\n"
     "  Possible C/C++ prototypes are:\n"
-    "    mfem::VectorDiffusionIntegrator::AssemblePA()\n"
+    "    AssemblePA(mfem::FiniteElementSpace const &)\n"
+    "    AssemblePA(mfem::FiniteElementSpace const &,mfem::FiniteElementSpace const &)\n"
     "    mfem::VectorDiffusionIntegrator::AssemblePA(mfem::FiniteElementSpace const &)\n");
   return 0;
 }
@@ -24331,6 +27675,11 @@ SWIGINTERN PyObject *_wrap_VectorDiffusionIntegrator_AssembleMF(PyObject *SWIGUN
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -24374,6 +27723,11 @@ SWIGINTERN PyObject *_wrap_VectorDiffusionIntegrator_AssembleDiagonalPA(PyObject
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -24417,6 +27771,11 @@ SWIGINTERN PyObject *_wrap_VectorDiffusionIntegrator_AssembleDiagonalMF(PyObject
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -24472,6 +27831,11 @@ SWIGINTERN PyObject *_wrap_VectorDiffusionIntegrator_AddMultPA(PyObject *SWIGUNU
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -24527,6 +27891,11 @@ SWIGINTERN PyObject *_wrap_VectorDiffusionIntegrator_AddMultMF(PyObject *SWIGUNU
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -24580,6 +27949,11 @@ SWIGINTERN PyObject *_wrap_new_ElasticityIntegrator__SWIG_0(PyObject *SWIGUNUSED
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__ElasticityIntegrator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -24627,6 +28001,11 @@ SWIGINTERN PyObject *_wrap_new_ElasticityIntegrator__SWIG_1(PyObject *SWIGUNUSED
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__ElasticityIntegrator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -24747,6 +28126,11 @@ SWIGINTERN PyObject *_wrap_ElasticityIntegrator_AssembleElementMatrix(PyObject *
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -24849,6 +28233,11 @@ SWIGINTERN PyObject *_wrap_ElasticityIntegrator_ComputeElementFlux(PyObject *SWI
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -24928,6 +28317,11 @@ SWIGINTERN PyObject *_wrap_ElasticityIntegrator_ComputeFluxEnergy(PyObject *SWIG
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_From_double(static_cast< double >(result));
   return resultobj;
@@ -24957,6 +28351,11 @@ SWIGINTERN PyObject *_wrap_delete_ElasticityIntegrator(PyObject *SWIGUNUSEDPARM(
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -25015,6 +28414,11 @@ SWIGINTERN PyObject *_wrap_new_DGTraceIntegrator__SWIG_0(PyObject *SWIGUNUSEDPAR
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__DGTraceIntegrator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -25073,6 +28477,11 @@ SWIGINTERN PyObject *_wrap_new_DGTraceIntegrator__SWIG_1(PyObject *SWIGUNUSEDPAR
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__DGTraceIntegrator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -25209,6 +28618,11 @@ SWIGINTERN PyObject *_wrap_DGTraceIntegrator_AssembleFaceMatrix__SWIG_0_0(PyObje
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -25291,6 +28705,11 @@ SWIGINTERN PyObject *_wrap_DGTraceIntegrator_AssembleFaceMatrix__SWIG_0_1(PyObje
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -25362,6 +28781,11 @@ SWIGINTERN PyObject *_wrap_DGTraceIntegrator_AssembleFaceMatrix__SWIG_1(PyObject
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -25474,6 +28898,151 @@ fail:
 }
 
 
+SWIGINTERN PyObject *_wrap_DGTraceIntegrator_AssemblePA_SWIG_0_0(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
+  PyObject *resultobj = 0;
+  mfem::DGTraceIntegrator *arg1 = (mfem::DGTraceIntegrator *) 0 ;
+  mfem::FiniteElementSpace *arg2 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  
+  if ((nobjs < 2) || (nobjs > 2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_mfem__DGTraceIntegrator, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "DGTraceIntegrator_AssemblePA" "', argument " "1"" of type '" "mfem::DGTraceIntegrator *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::DGTraceIntegrator * >(argp1);
+  res2 = SWIG_ConvertPtr(swig_obj[1], &argp2, SWIGTYPE_p_mfem__FiniteElementSpace,  0  | 0);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "DGTraceIntegrator_AssemblePA" "', argument " "2"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  if (!argp2) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "DGTraceIntegrator_AssemblePA" "', argument " "2"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  arg2 = reinterpret_cast< mfem::FiniteElementSpace * >(argp2);
+  {
+    try {
+      (arg1)->AssemblePA((mfem::FiniteElementSpace const &)*arg2); 
+    }
+    catch (Swig::DirectorException &e) {
+      SWIG_fail; 
+    }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_DGTraceIntegrator_AssemblePA_SWIG_0_1(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
+  PyObject *resultobj = 0;
+  mfem::DGTraceIntegrator *arg1 = (mfem::DGTraceIntegrator *) 0 ;
+  mfem::FiniteElementSpace *arg2 = 0 ;
+  mfem::FiniteElementSpace *arg3 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  void *argp3 = 0 ;
+  int res3 = 0 ;
+  
+  if ((nobjs < 3) || (nobjs > 3)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_mfem__DGTraceIntegrator, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "DGTraceIntegrator_AssemblePA" "', argument " "1"" of type '" "mfem::DGTraceIntegrator *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::DGTraceIntegrator * >(argp1);
+  res2 = SWIG_ConvertPtr(swig_obj[1], &argp2, SWIGTYPE_p_mfem__FiniteElementSpace,  0  | 0);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "DGTraceIntegrator_AssemblePA" "', argument " "2"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  if (!argp2) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "DGTraceIntegrator_AssemblePA" "', argument " "2"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  arg2 = reinterpret_cast< mfem::FiniteElementSpace * >(argp2);
+  res3 = SWIG_ConvertPtr(swig_obj[2], &argp3, SWIGTYPE_p_mfem__FiniteElementSpace,  0  | 0);
+  if (!SWIG_IsOK(res3)) {
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "DGTraceIntegrator_AssemblePA" "', argument " "3"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  if (!argp3) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "DGTraceIntegrator_AssemblePA" "', argument " "3"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  arg3 = reinterpret_cast< mfem::FiniteElementSpace * >(argp3);
+  {
+    try {
+      (arg1)->AssemblePA((mfem::FiniteElementSpace const &)*arg2,(mfem::FiniteElementSpace const &)*arg3); 
+    }
+    catch (Swig::DirectorException &e) {
+      SWIG_fail; 
+    }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_DGTraceIntegrator_AssemblePA(PyObject *self, PyObject *args) {
+  Py_ssize_t argc;
+  PyObject *argv[4] = {
+    0
+  };
+  
+  if (!(argc = SWIG_Python_UnpackTuple(args, "DGTraceIntegrator_AssemblePA", 0, 3, argv))) SWIG_fail;
+  --argc;
+  if (argc == 2) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_mfem__DGTraceIntegrator, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      int res = SWIG_ConvertPtr(argv[1], 0, SWIGTYPE_p_mfem__FiniteElementSpace, SWIG_POINTER_NO_NULL | 0);
+      _v = SWIG_CheckState(res);
+      if (_v) {
+        return _wrap_DGTraceIntegrator_AssemblePA_SWIG_0_0(self, argc, argv);
+      }
+    }
+  }
+  if (argc == 3) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_mfem__DGTraceIntegrator, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      int res = SWIG_ConvertPtr(argv[1], 0, SWIGTYPE_p_mfem__FiniteElementSpace, SWIG_POINTER_NO_NULL | 0);
+      _v = SWIG_CheckState(res);
+      if (_v) {
+        int res = SWIG_ConvertPtr(argv[2], 0, SWIGTYPE_p_mfem__FiniteElementSpace, SWIG_POINTER_NO_NULL | 0);
+        _v = SWIG_CheckState(res);
+        if (_v) {
+          return _wrap_DGTraceIntegrator_AssemblePA_SWIG_0_1(self, argc, argv);
+        }
+      }
+    }
+  }
+  
+fail:
+  SWIG_Python_RaiseOrModifyTypeError("Wrong number or type of arguments for overloaded function 'DGTraceIntegrator_AssemblePA'.\n"
+    "  Possible C/C++ prototypes are:\n"
+    "    AssemblePA(mfem::FiniteElementSpace const &)\n"
+    "    AssemblePA(mfem::FiniteElementSpace const &,mfem::FiniteElementSpace const &)\n");
+  return 0;
+}
+
+
 SWIGINTERN PyObject *_wrap_DGTraceIntegrator_AssemblePAInteriorFaces(PyObject *SWIGUNUSEDPARM(self), PyObject *args, PyObject *kwargs) {
   PyObject *resultobj = 0;
   mfem::DGTraceIntegrator *arg1 = (mfem::DGTraceIntegrator *) 0 ;
@@ -25509,6 +29078,11 @@ SWIGINTERN PyObject *_wrap_DGTraceIntegrator_AssemblePAInteriorFaces(PyObject *S
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -25552,6 +29126,11 @@ SWIGINTERN PyObject *_wrap_DGTraceIntegrator_AssemblePABoundaryFaces(PyObject *S
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -25607,6 +29186,11 @@ SWIGINTERN PyObject *_wrap_DGTraceIntegrator_AddMultTransposePA(PyObject *SWIGUN
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -25662,6 +29246,11 @@ SWIGINTERN PyObject *_wrap_DGTraceIntegrator_AddMultPA(PyObject *SWIGUNUSEDPARM(
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -25738,6 +29327,11 @@ SWIGINTERN PyObject *_wrap_DGTraceIntegrator_AssembleEAInteriorFaces(PyObject *S
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -25802,6 +29396,11 @@ SWIGINTERN PyObject *_wrap_DGTraceIntegrator_AssembleEABoundaryFaces(PyObject *S
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -25854,6 +29453,11 @@ SWIGINTERN PyObject *_wrap_DGTraceIntegrator_GetRule(PyObject *SWIGUNUSEDPARM(se
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__IntegrationRule, 0 |  0 );
   return resultobj;
@@ -25883,6 +29487,11 @@ SWIGINTERN PyObject *_wrap_delete_DGTraceIntegrator(PyObject *SWIGUNUSEDPARM(sel
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -25930,6 +29539,11 @@ SWIGINTERN PyObject *_wrap_new_DGDiffusionIntegrator__SWIG_0(PyObject *SWIGUNUSE
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__DGDiffusionIntegrator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -25977,6 +29591,11 @@ SWIGINTERN PyObject *_wrap_new_DGDiffusionIntegrator__SWIG_1(PyObject *SWIGUNUSE
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__DGDiffusionIntegrator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -26024,6 +29643,11 @@ SWIGINTERN PyObject *_wrap_new_DGDiffusionIntegrator__SWIG_2(PyObject *SWIGUNUSE
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__DGDiffusionIntegrator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -26172,6 +29796,11 @@ SWIGINTERN PyObject *_wrap_DGDiffusionIntegrator_AssembleFaceMatrix__SWIG_0_0(Py
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -26254,6 +29883,11 @@ SWIGINTERN PyObject *_wrap_DGDiffusionIntegrator_AssembleFaceMatrix__SWIG_0_1(Py
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -26325,6 +29959,11 @@ SWIGINTERN PyObject *_wrap_DGDiffusionIntegrator_AssembleFaceMatrix__SWIG_1(PyOb
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -26458,6 +30097,11 @@ SWIGINTERN PyObject *_wrap_delete_DGDiffusionIntegrator(PyObject *SWIGUNUSEDPARM
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -26505,6 +30149,11 @@ SWIGINTERN PyObject *_wrap_new_DGElasticityIntegrator__SWIG_0(PyObject *SWIGUNUS
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__DGElasticityIntegrator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -26563,6 +30212,11 @@ SWIGINTERN PyObject *_wrap_new_DGElasticityIntegrator__SWIG_1(PyObject *SWIGUNUS
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__DGElasticityIntegrator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -26694,6 +30348,11 @@ SWIGINTERN PyObject *_wrap_DGElasticityIntegrator_AssembleFaceMatrix__SWIG_0_0(P
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -26776,6 +30435,11 @@ SWIGINTERN PyObject *_wrap_DGElasticityIntegrator_AssembleFaceMatrix__SWIG_0_1(P
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -26847,6 +30511,11 @@ SWIGINTERN PyObject *_wrap_DGElasticityIntegrator_AssembleFaceMatrix__SWIG_1(PyO
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -26980,6 +30649,11 @@ SWIGINTERN PyObject *_wrap_delete_DGElasticityIntegrator(PyObject *SWIGUNUSEDPAR
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -27011,6 +30685,11 @@ SWIGINTERN PyObject *_wrap_new_TraceJumpIntegrator(PyObject *SWIGUNUSEDPARM(self
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__TraceJumpIntegrator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -27082,6 +30761,11 @@ SWIGINTERN PyObject *_wrap_TraceJumpIntegrator_AssembleFaceMatrix__SWIG_0_0(PyOb
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -27164,6 +30848,11 @@ SWIGINTERN PyObject *_wrap_TraceJumpIntegrator_AssembleFaceMatrix__SWIG_0_1(PyOb
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -27246,6 +30935,11 @@ SWIGINTERN PyObject *_wrap_TraceJumpIntegrator_AssembleFaceMatrix__SWIG_1(PyObje
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -27383,6 +31077,11 @@ SWIGINTERN PyObject *_wrap_delete_TraceJumpIntegrator(PyObject *SWIGUNUSEDPARM(s
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -27414,6 +31113,11 @@ SWIGINTERN PyObject *_wrap_new_NormalTraceJumpIntegrator(PyObject *SWIGUNUSEDPAR
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__NormalTraceJumpIntegrator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -27485,6 +31189,11 @@ SWIGINTERN PyObject *_wrap_NormalTraceJumpIntegrator_AssembleFaceMatrix__SWIG_0_
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -27567,6 +31276,11 @@ SWIGINTERN PyObject *_wrap_NormalTraceJumpIntegrator_AssembleFaceMatrix__SWIG_0_
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -27649,6 +31363,11 @@ SWIGINTERN PyObject *_wrap_NormalTraceJumpIntegrator_AssembleFaceMatrix__SWIG_1(
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -27786,6 +31505,11 @@ SWIGINTERN PyObject *_wrap_delete_NormalTraceJumpIntegrator(PyObject *SWIGUNUSED
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -27817,6 +31541,11 @@ SWIGINTERN PyObject *_wrap_new_DiscreteInterpolator(PyObject *SWIGUNUSEDPARM(sel
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__DiscreteInterpolator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -27846,6 +31575,11 @@ SWIGINTERN PyObject *_wrap_delete_DiscreteInterpolator(PyObject *SWIGUNUSEDPARM(
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -27936,6 +31670,11 @@ SWIGINTERN PyObject *_wrap_GradientInterpolator_AssembleElementMatrix2(PyObject 
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -27956,6 +31695,11 @@ SWIGINTERN PyObject *_wrap_new_GradientInterpolator(PyObject *SWIGUNUSEDPARM(sel
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__GradientInterpolator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -27985,6 +31729,11 @@ SWIGINTERN PyObject *_wrap_delete_GradientInterpolator(PyObject *SWIGUNUSEDPARM(
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -28075,6 +31824,11 @@ SWIGINTERN PyObject *_wrap_IdentityInterpolator_AssembleElementMatrix2(PyObject 
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -28095,6 +31849,11 @@ SWIGINTERN PyObject *_wrap_new_IdentityInterpolator(PyObject *SWIGUNUSEDPARM(sel
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__IdentityInterpolator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -28124,6 +31883,11 @@ SWIGINTERN PyObject *_wrap_delete_IdentityInterpolator(PyObject *SWIGUNUSEDPARM(
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -28214,6 +31978,11 @@ SWIGINTERN PyObject *_wrap_CurlInterpolator_AssembleElementMatrix2(PyObject *SWI
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -28234,6 +32003,11 @@ SWIGINTERN PyObject *_wrap_new_CurlInterpolator(PyObject *SWIGUNUSEDPARM(self), 
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__CurlInterpolator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -28263,6 +32037,11 @@ SWIGINTERN PyObject *_wrap_delete_CurlInterpolator(PyObject *SWIGUNUSEDPARM(self
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -28353,6 +32132,11 @@ SWIGINTERN PyObject *_wrap_DivergenceInterpolator_AssembleElementMatrix2(PyObjec
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -28373,6 +32157,11 @@ SWIGINTERN PyObject *_wrap_new_DivergenceInterpolator(PyObject *SWIGUNUSEDPARM(s
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__DivergenceInterpolator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -28402,6 +32191,11 @@ SWIGINTERN PyObject *_wrap_delete_DivergenceInterpolator(PyObject *SWIGUNUSEDPAR
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -28492,6 +32286,11 @@ SWIGINTERN PyObject *_wrap_NormalInterpolator_AssembleElementMatrix2(PyObject *S
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -28512,6 +32311,11 @@ SWIGINTERN PyObject *_wrap_new_NormalInterpolator(PyObject *SWIGUNUSEDPARM(self)
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__NormalInterpolator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -28541,6 +32345,11 @@ SWIGINTERN PyObject *_wrap_delete_NormalInterpolator(PyObject *SWIGUNUSEDPARM(se
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -28587,6 +32396,11 @@ SWIGINTERN PyObject *_wrap_new_ScalarProductInterpolator(PyObject *SWIGUNUSEDPAR
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__ScalarProductInterpolator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -28666,6 +32480,11 @@ SWIGINTERN PyObject *_wrap_ScalarProductInterpolator_AssembleElementMatrix2(PyOb
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -28695,6 +32514,11 @@ SWIGINTERN PyObject *_wrap_delete_ScalarProductInterpolator(PyObject *SWIGUNUSED
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -28741,6 +32565,11 @@ SWIGINTERN PyObject *_wrap_new_ScalarVectorProductInterpolator(PyObject *SWIGUNU
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__ScalarVectorProductInterpolator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -28820,6 +32649,11 @@ SWIGINTERN PyObject *_wrap_ScalarVectorProductInterpolator_AssembleElementMatrix
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -28849,6 +32683,11 @@ SWIGINTERN PyObject *_wrap_delete_ScalarVectorProductInterpolator(PyObject *SWIG
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -28895,6 +32734,11 @@ SWIGINTERN PyObject *_wrap_new_VectorScalarProductInterpolator(PyObject *SWIGUNU
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__VectorScalarProductInterpolator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -28974,6 +32818,11 @@ SWIGINTERN PyObject *_wrap_VectorScalarProductInterpolator_AssembleElementMatrix
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -29003,6 +32852,11 @@ SWIGINTERN PyObject *_wrap_delete_VectorScalarProductInterpolator(PyObject *SWIG
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -29049,6 +32903,11 @@ SWIGINTERN PyObject *_wrap_new_VectorCrossProductInterpolator(PyObject *SWIGUNUS
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__VectorCrossProductInterpolator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -29128,6 +32987,11 @@ SWIGINTERN PyObject *_wrap_VectorCrossProductInterpolator_AssembleElementMatrix2
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -29157,6 +33021,11 @@ SWIGINTERN PyObject *_wrap_delete_VectorCrossProductInterpolator(PyObject *SWIGU
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -29203,6 +33072,11 @@ SWIGINTERN PyObject *_wrap_new_VectorInnerProductInterpolator(PyObject *SWIGUNUS
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__VectorInnerProductInterpolator, SWIG_POINTER_NEW |  0 );
   return resultobj;
@@ -29282,6 +33156,11 @@ SWIGINTERN PyObject *_wrap_VectorInnerProductInterpolator_AssembleElementMatrix2
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -29311,6 +33190,11 @@ SWIGINTERN PyObject *_wrap_delete_VectorInnerProductInterpolator(PyObject *SWIGU
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
     }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -29335,7 +33219,8 @@ static PyMethodDef SwigMethods[] = {
 	 { "SWIG_PyStaticMethod_New", SWIG_PyStaticMethod_New, METH_O, NULL},
 	 { "new_BilinearFormIntegrator", (PyCFunction)(void(*)(void))_wrap_new_BilinearFormIntegrator, METH_VARARGS|METH_KEYWORDS, "new_BilinearFormIntegrator(PyObject * _self, IntegrationRule ir=None) -> BilinearFormIntegrator"},
 	 { "BilinearFormIntegrator_AssemblePA", _wrap_BilinearFormIntegrator_AssemblePA, METH_VARARGS, "\n"
-		"AssemblePA(BilinearFormIntegrator self)\n"
+		"BilinearFormIntegrator_AssemblePA(BilinearFormIntegrator self, FiniteElementSpace fes)\n"
+		"BilinearFormIntegrator_AssemblePA(BilinearFormIntegrator self, FiniteElementSpace trial_fes, FiniteElementSpace test_fes)\n"
 		"BilinearFormIntegrator_AssemblePA(BilinearFormIntegrator self, FiniteElementSpace fes)\n"
 		"BilinearFormIntegrator_AssemblePA(BilinearFormIntegrator self, FiniteElementSpace trial_fes, FiniteElementSpace test_fes)\n"
 		""},
@@ -29377,8 +33262,9 @@ static PyMethodDef SwigMethods[] = {
 		"TransposeIntegrator_AssembleFaceMatrix(TransposeIntegrator self, FiniteElement el1, FiniteElement el2, FaceElementTransformations Trans, DenseMatrix elmat)\n"
 		""},
 	 { "TransposeIntegrator_AssemblePA", _wrap_TransposeIntegrator_AssemblePA, METH_VARARGS, "\n"
-		"AssemblePA()\n"
-		"TransposeIntegrator_AssemblePA(FiniteElementSpace fes)\n"
+		"TransposeIntegrator_AssemblePA(TransposeIntegrator self, FiniteElementSpace fes)\n"
+		"TransposeIntegrator_AssemblePA(TransposeIntegrator self, FiniteElementSpace trial_fes, FiniteElementSpace test_fes)\n"
+		"TransposeIntegrator_AssemblePA(TransposeIntegrator self, FiniteElementSpace fes)\n"
 		""},
 	 { "TransposeIntegrator_AssemblePAInteriorFaces", (PyCFunction)(void(*)(void))_wrap_TransposeIntegrator_AssemblePAInteriorFaces, METH_VARARGS|METH_KEYWORDS, "TransposeIntegrator_AssemblePAInteriorFaces(TransposeIntegrator self, FiniteElementSpace fes)"},
 	 { "TransposeIntegrator_AssemblePABoundaryFaces", (PyCFunction)(void(*)(void))_wrap_TransposeIntegrator_AssemblePABoundaryFaces, METH_VARARGS|METH_KEYWORDS, "TransposeIntegrator_AssemblePABoundaryFaces(TransposeIntegrator self, FiniteElementSpace fes)"},
@@ -29697,8 +33583,9 @@ static PyMethodDef SwigMethods[] = {
 		""},
 	 { "GradientIntegrator_AssembleElementMatrix2", (PyCFunction)(void(*)(void))_wrap_GradientIntegrator_AssembleElementMatrix2, METH_VARARGS|METH_KEYWORDS, "GradientIntegrator_AssembleElementMatrix2(GradientIntegrator self, FiniteElement trial_fe, FiniteElement test_fe, ElementTransformation Trans, DenseMatrix elmat)"},
 	 { "GradientIntegrator_AssemblePA", _wrap_GradientIntegrator_AssemblePA, METH_VARARGS, "\n"
-		"AssemblePA()\n"
-		"GradientIntegrator_AssemblePA(FiniteElementSpace trial_fes, FiniteElementSpace test_fes)\n"
+		"GradientIntegrator_AssemblePA(GradientIntegrator self, FiniteElementSpace fes)\n"
+		"GradientIntegrator_AssemblePA(GradientIntegrator self, FiniteElementSpace trial_fes, FiniteElementSpace test_fes)\n"
+		"GradientIntegrator_AssemblePA(GradientIntegrator self, FiniteElementSpace trial_fes, FiniteElementSpace test_fes)\n"
 		""},
 	 { "GradientIntegrator_AddMultPA", (PyCFunction)(void(*)(void))_wrap_GradientIntegrator_AddMultPA, METH_VARARGS|METH_KEYWORDS, "GradientIntegrator_AddMultPA(GradientIntegrator self, Vector x, Vector y)"},
 	 { "GradientIntegrator_AddMultTransposePA", (PyCFunction)(void(*)(void))_wrap_GradientIntegrator_AddMultTransposePA, METH_VARARGS|METH_KEYWORDS, "GradientIntegrator_AddMultTransposePA(GradientIntegrator self, Vector x, Vector y)"},
@@ -29720,8 +33607,9 @@ static PyMethodDef SwigMethods[] = {
 	 { "DiffusionIntegrator_ComputeFluxEnergy", (PyCFunction)(void(*)(void))_wrap_DiffusionIntegrator_ComputeFluxEnergy, METH_VARARGS|METH_KEYWORDS, "DiffusionIntegrator_ComputeFluxEnergy(DiffusionIntegrator self, FiniteElement fluxelem, ElementTransformation Trans, Vector flux, Vector d_energy=None) -> double"},
 	 { "DiffusionIntegrator_AssembleMF", (PyCFunction)(void(*)(void))_wrap_DiffusionIntegrator_AssembleMF, METH_VARARGS|METH_KEYWORDS, "DiffusionIntegrator_AssembleMF(DiffusionIntegrator self, FiniteElementSpace fes)"},
 	 { "DiffusionIntegrator_AssemblePA", _wrap_DiffusionIntegrator_AssemblePA, METH_VARARGS, "\n"
-		"AssemblePA()\n"
-		"DiffusionIntegrator_AssemblePA(FiniteElementSpace fes)\n"
+		"DiffusionIntegrator_AssemblePA(DiffusionIntegrator self, FiniteElementSpace fes)\n"
+		"DiffusionIntegrator_AssemblePA(DiffusionIntegrator self, FiniteElementSpace trial_fes, FiniteElementSpace test_fes)\n"
+		"DiffusionIntegrator_AssemblePA(DiffusionIntegrator self, FiniteElementSpace fes)\n"
 		""},
 	 { "DiffusionIntegrator_AssembleEA", (PyCFunction)(void(*)(void))_wrap_DiffusionIntegrator_AssembleEA, METH_VARARGS|METH_KEYWORDS, "DiffusionIntegrator_AssembleEA(DiffusionIntegrator self, FiniteElementSpace fes, Vector emat, bool const add)"},
 	 { "DiffusionIntegrator_AssembleDiagonalPA", (PyCFunction)(void(*)(void))_wrap_DiffusionIntegrator_AssembleDiagonalPA, METH_VARARGS|METH_KEYWORDS, "DiffusionIntegrator_AssembleDiagonalPA(DiffusionIntegrator self, Vector diag)"},
@@ -29740,8 +33628,9 @@ static PyMethodDef SwigMethods[] = {
 	 { "MassIntegrator_AssembleElementMatrix2", (PyCFunction)(void(*)(void))_wrap_MassIntegrator_AssembleElementMatrix2, METH_VARARGS|METH_KEYWORDS, "MassIntegrator_AssembleElementMatrix2(MassIntegrator self, FiniteElement trial_fe, FiniteElement test_fe, ElementTransformation Trans, DenseMatrix elmat)"},
 	 { "MassIntegrator_AssembleMF", (PyCFunction)(void(*)(void))_wrap_MassIntegrator_AssembleMF, METH_VARARGS|METH_KEYWORDS, "MassIntegrator_AssembleMF(MassIntegrator self, FiniteElementSpace fes)"},
 	 { "MassIntegrator_AssemblePA", _wrap_MassIntegrator_AssemblePA, METH_VARARGS, "\n"
-		"AssemblePA()\n"
-		"MassIntegrator_AssemblePA(FiniteElementSpace fes)\n"
+		"MassIntegrator_AssemblePA(MassIntegrator self, FiniteElementSpace fes)\n"
+		"MassIntegrator_AssemblePA(MassIntegrator self, FiniteElementSpace trial_fes, FiniteElementSpace test_fes)\n"
+		"MassIntegrator_AssemblePA(MassIntegrator self, FiniteElementSpace fes)\n"
 		""},
 	 { "MassIntegrator_AssembleEA", (PyCFunction)(void(*)(void))_wrap_MassIntegrator_AssembleEA, METH_VARARGS|METH_KEYWORDS, "MassIntegrator_AssembleEA(MassIntegrator self, FiniteElementSpace fes, Vector emat, bool const add)"},
 	 { "MassIntegrator_AssembleDiagonalPA", (PyCFunction)(void(*)(void))_wrap_MassIntegrator_AssembleDiagonalPA, METH_VARARGS|METH_KEYWORDS, "MassIntegrator_AssembleDiagonalPA(MassIntegrator self, Vector diag)"},
@@ -29763,8 +33652,9 @@ static PyMethodDef SwigMethods[] = {
 	 { "new_ConvectionIntegrator", (PyCFunction)(void(*)(void))_wrap_new_ConvectionIntegrator, METH_VARARGS|METH_KEYWORDS, "new_ConvectionIntegrator(VectorCoefficient q, double a=1.0) -> ConvectionIntegrator"},
 	 { "ConvectionIntegrator_AssembleElementMatrix", (PyCFunction)(void(*)(void))_wrap_ConvectionIntegrator_AssembleElementMatrix, METH_VARARGS|METH_KEYWORDS, "ConvectionIntegrator_AssembleElementMatrix(ConvectionIntegrator self, FiniteElement arg2, ElementTransformation arg3, DenseMatrix arg4)"},
 	 { "ConvectionIntegrator_AssemblePA", _wrap_ConvectionIntegrator_AssemblePA, METH_VARARGS, "\n"
-		"AssemblePA()\n"
-		"ConvectionIntegrator_AssemblePA(FiniteElementSpace arg1)\n"
+		"ConvectionIntegrator_AssemblePA(ConvectionIntegrator self, FiniteElementSpace fes)\n"
+		"ConvectionIntegrator_AssemblePA(ConvectionIntegrator self, FiniteElementSpace trial_fes, FiniteElementSpace test_fes)\n"
+		"ConvectionIntegrator_AssemblePA(ConvectionIntegrator self, FiniteElementSpace arg2)\n"
 		""},
 	 { "ConvectionIntegrator_AssembleEA", (PyCFunction)(void(*)(void))_wrap_ConvectionIntegrator_AssembleEA, METH_VARARGS|METH_KEYWORDS, "ConvectionIntegrator_AssembleEA(ConvectionIntegrator self, FiniteElementSpace fes, Vector emat, bool const add)"},
 	 { "ConvectionIntegrator_AddMultPA", (PyCFunction)(void(*)(void))_wrap_ConvectionIntegrator_AddMultPA, METH_VARARGS|METH_KEYWORDS, "ConvectionIntegrator_AddMultPA(ConvectionIntegrator self, Vector arg2, Vector arg3)"},
@@ -29793,8 +33683,9 @@ static PyMethodDef SwigMethods[] = {
 	 { "VectorMassIntegrator_AssembleElementMatrix", (PyCFunction)(void(*)(void))_wrap_VectorMassIntegrator_AssembleElementMatrix, METH_VARARGS|METH_KEYWORDS, "VectorMassIntegrator_AssembleElementMatrix(VectorMassIntegrator self, FiniteElement el, ElementTransformation Trans, DenseMatrix elmat)"},
 	 { "VectorMassIntegrator_AssembleElementMatrix2", (PyCFunction)(void(*)(void))_wrap_VectorMassIntegrator_AssembleElementMatrix2, METH_VARARGS|METH_KEYWORDS, "VectorMassIntegrator_AssembleElementMatrix2(VectorMassIntegrator self, FiniteElement trial_fe, FiniteElement test_fe, ElementTransformation Trans, DenseMatrix elmat)"},
 	 { "VectorMassIntegrator_AssemblePA", _wrap_VectorMassIntegrator_AssemblePA, METH_VARARGS, "\n"
-		"AssemblePA()\n"
-		"VectorMassIntegrator_AssemblePA(FiniteElementSpace fes)\n"
+		"VectorMassIntegrator_AssemblePA(VectorMassIntegrator self, FiniteElementSpace fes)\n"
+		"VectorMassIntegrator_AssemblePA(VectorMassIntegrator self, FiniteElementSpace trial_fes, FiniteElementSpace test_fes)\n"
+		"VectorMassIntegrator_AssemblePA(VectorMassIntegrator self, FiniteElementSpace fes)\n"
 		""},
 	 { "VectorMassIntegrator_AssembleMF", (PyCFunction)(void(*)(void))_wrap_VectorMassIntegrator_AssembleMF, METH_VARARGS|METH_KEYWORDS, "VectorMassIntegrator_AssembleMF(VectorMassIntegrator self, FiniteElementSpace fes)"},
 	 { "VectorMassIntegrator_AssembleDiagonalPA", (PyCFunction)(void(*)(void))_wrap_VectorMassIntegrator_AssembleDiagonalPA, METH_VARARGS|METH_KEYWORDS, "VectorMassIntegrator_AssembleDiagonalPA(VectorMassIntegrator self, Vector diag)"},
@@ -29847,8 +33738,9 @@ static PyMethodDef SwigMethods[] = {
 	 { "CurlCurlIntegrator_ComputeElementFlux", (PyCFunction)(void(*)(void))_wrap_CurlCurlIntegrator_ComputeElementFlux, METH_VARARGS|METH_KEYWORDS, "CurlCurlIntegrator_ComputeElementFlux(CurlCurlIntegrator self, FiniteElement el, ElementTransformation Trans, Vector u, FiniteElement fluxelem, Vector flux, bool with_coef)"},
 	 { "CurlCurlIntegrator_ComputeFluxEnergy", (PyCFunction)(void(*)(void))_wrap_CurlCurlIntegrator_ComputeFluxEnergy, METH_VARARGS|METH_KEYWORDS, "CurlCurlIntegrator_ComputeFluxEnergy(CurlCurlIntegrator self, FiniteElement fluxelem, ElementTransformation Trans, Vector flux, Vector d_energy=None) -> double"},
 	 { "CurlCurlIntegrator_AssemblePA", _wrap_CurlCurlIntegrator_AssemblePA, METH_VARARGS, "\n"
-		"AssemblePA()\n"
-		"CurlCurlIntegrator_AssemblePA(FiniteElementSpace fes)\n"
+		"CurlCurlIntegrator_AssemblePA(CurlCurlIntegrator self, FiniteElementSpace fes)\n"
+		"CurlCurlIntegrator_AssemblePA(CurlCurlIntegrator self, FiniteElementSpace trial_fes, FiniteElementSpace test_fes)\n"
+		"CurlCurlIntegrator_AssemblePA(CurlCurlIntegrator self, FiniteElementSpace fes)\n"
 		""},
 	 { "CurlCurlIntegrator_AddMultPA", (PyCFunction)(void(*)(void))_wrap_CurlCurlIntegrator_AddMultPA, METH_VARARGS|METH_KEYWORDS, "CurlCurlIntegrator_AddMultPA(CurlCurlIntegrator self, Vector x, Vector y)"},
 	 { "CurlCurlIntegrator_AssembleDiagonalPA", (PyCFunction)(void(*)(void))_wrap_CurlCurlIntegrator_AssembleDiagonalPA, METH_VARARGS|METH_KEYWORDS, "CurlCurlIntegrator_AssembleDiagonalPA(CurlCurlIntegrator self, Vector diag)"},
@@ -29876,7 +33768,8 @@ static PyMethodDef SwigMethods[] = {
 	 { "VectorFEMassIntegrator_AssembleElementMatrix", (PyCFunction)(void(*)(void))_wrap_VectorFEMassIntegrator_AssembleElementMatrix, METH_VARARGS|METH_KEYWORDS, "VectorFEMassIntegrator_AssembleElementMatrix(VectorFEMassIntegrator self, FiniteElement el, ElementTransformation Trans, DenseMatrix elmat)"},
 	 { "VectorFEMassIntegrator_AssembleElementMatrix2", (PyCFunction)(void(*)(void))_wrap_VectorFEMassIntegrator_AssembleElementMatrix2, METH_VARARGS|METH_KEYWORDS, "VectorFEMassIntegrator_AssembleElementMatrix2(VectorFEMassIntegrator self, FiniteElement trial_fe, FiniteElement test_fe, ElementTransformation Trans, DenseMatrix elmat)"},
 	 { "VectorFEMassIntegrator_AssemblePA", _wrap_VectorFEMassIntegrator_AssemblePA, METH_VARARGS, "\n"
-		"AssemblePA(VectorFEMassIntegrator self)\n"
+		"VectorFEMassIntegrator_AssemblePA(VectorFEMassIntegrator self, FiniteElementSpace fes)\n"
+		"VectorFEMassIntegrator_AssemblePA(VectorFEMassIntegrator self, FiniteElementSpace trial_fes, FiniteElementSpace test_fes)\n"
 		"VectorFEMassIntegrator_AssemblePA(VectorFEMassIntegrator self, FiniteElementSpace fes)\n"
 		"VectorFEMassIntegrator_AssemblePA(VectorFEMassIntegrator self, FiniteElementSpace trial_fes, FiniteElementSpace test_fes)\n"
 		""},
@@ -29892,8 +33785,9 @@ static PyMethodDef SwigMethods[] = {
 		""},
 	 { "VectorDivergenceIntegrator_AssembleElementMatrix2", (PyCFunction)(void(*)(void))_wrap_VectorDivergenceIntegrator_AssembleElementMatrix2, METH_VARARGS|METH_KEYWORDS, "VectorDivergenceIntegrator_AssembleElementMatrix2(VectorDivergenceIntegrator self, FiniteElement trial_fe, FiniteElement test_fe, ElementTransformation Trans, DenseMatrix elmat)"},
 	 { "VectorDivergenceIntegrator_AssemblePA", _wrap_VectorDivergenceIntegrator_AssemblePA, METH_VARARGS, "\n"
-		"AssemblePA()\n"
-		"VectorDivergenceIntegrator_AssemblePA(FiniteElementSpace trial_fes, FiniteElementSpace test_fes)\n"
+		"VectorDivergenceIntegrator_AssemblePA(VectorDivergenceIntegrator self, FiniteElementSpace fes)\n"
+		"VectorDivergenceIntegrator_AssemblePA(VectorDivergenceIntegrator self, FiniteElementSpace trial_fes, FiniteElementSpace test_fes)\n"
+		"VectorDivergenceIntegrator_AssemblePA(VectorDivergenceIntegrator self, FiniteElementSpace trial_fes, FiniteElementSpace test_fes)\n"
 		""},
 	 { "VectorDivergenceIntegrator_AddMultPA", (PyCFunction)(void(*)(void))_wrap_VectorDivergenceIntegrator_AddMultPA, METH_VARARGS|METH_KEYWORDS, "VectorDivergenceIntegrator_AddMultPA(VectorDivergenceIntegrator self, Vector x, Vector y)"},
 	 { "VectorDivergenceIntegrator_AddMultTransposePA", (PyCFunction)(void(*)(void))_wrap_VectorDivergenceIntegrator_AddMultTransposePA, METH_VARARGS|METH_KEYWORDS, "VectorDivergenceIntegrator_AddMultTransposePA(VectorDivergenceIntegrator self, Vector x, Vector y)"},
@@ -29917,8 +33811,9 @@ static PyMethodDef SwigMethods[] = {
 	 { "VectorDiffusionIntegrator_AssembleElementMatrix", (PyCFunction)(void(*)(void))_wrap_VectorDiffusionIntegrator_AssembleElementMatrix, METH_VARARGS|METH_KEYWORDS, "VectorDiffusionIntegrator_AssembleElementMatrix(VectorDiffusionIntegrator self, FiniteElement el, ElementTransformation Trans, DenseMatrix elmat)"},
 	 { "VectorDiffusionIntegrator_AssembleElementVector", (PyCFunction)(void(*)(void))_wrap_VectorDiffusionIntegrator_AssembleElementVector, METH_VARARGS|METH_KEYWORDS, "VectorDiffusionIntegrator_AssembleElementVector(VectorDiffusionIntegrator self, FiniteElement el, ElementTransformation Tr, Vector elfun, Vector elvect)"},
 	 { "VectorDiffusionIntegrator_AssemblePA", _wrap_VectorDiffusionIntegrator_AssemblePA, METH_VARARGS, "\n"
-		"AssemblePA()\n"
-		"VectorDiffusionIntegrator_AssemblePA(FiniteElementSpace fes)\n"
+		"VectorDiffusionIntegrator_AssemblePA(VectorDiffusionIntegrator self, FiniteElementSpace fes)\n"
+		"VectorDiffusionIntegrator_AssemblePA(VectorDiffusionIntegrator self, FiniteElementSpace trial_fes, FiniteElementSpace test_fes)\n"
+		"VectorDiffusionIntegrator_AssemblePA(VectorDiffusionIntegrator self, FiniteElementSpace fes)\n"
 		""},
 	 { "VectorDiffusionIntegrator_AssembleMF", (PyCFunction)(void(*)(void))_wrap_VectorDiffusionIntegrator_AssembleMF, METH_VARARGS|METH_KEYWORDS, "VectorDiffusionIntegrator_AssembleMF(VectorDiffusionIntegrator self, FiniteElementSpace fes)"},
 	 { "VectorDiffusionIntegrator_AssembleDiagonalPA", (PyCFunction)(void(*)(void))_wrap_VectorDiffusionIntegrator_AssembleDiagonalPA, METH_VARARGS|METH_KEYWORDS, "VectorDiffusionIntegrator_AssembleDiagonalPA(VectorDiffusionIntegrator self, Vector diag)"},
@@ -29945,6 +33840,10 @@ static PyMethodDef SwigMethods[] = {
 		"DGTraceIntegrator_AssembleFaceMatrix(DGTraceIntegrator self, FiniteElement el1, FiniteElement el2, FaceElementTransformations Trans, DenseMatrix elmat)\n"
 		"DGTraceIntegrator_AssembleFaceMatrix(DGTraceIntegrator self, FiniteElement trial_face_fe, FiniteElement test_fe1, FiniteElement test_fe2, FaceElementTransformations Trans, DenseMatrix elmat)\n"
 		"DGTraceIntegrator_AssembleFaceMatrix(DGTraceIntegrator self, FiniteElement el1, FiniteElement el2, FaceElementTransformations Trans, DenseMatrix elmat)\n"
+		""},
+	 { "DGTraceIntegrator_AssemblePA", _wrap_DGTraceIntegrator_AssemblePA, METH_VARARGS, "\n"
+		"DGTraceIntegrator_AssemblePA(DGTraceIntegrator self, FiniteElementSpace fes)\n"
+		"DGTraceIntegrator_AssemblePA(DGTraceIntegrator self, FiniteElementSpace trial_fes, FiniteElementSpace test_fes)\n"
 		""},
 	 { "DGTraceIntegrator_AssemblePAInteriorFaces", (PyCFunction)(void(*)(void))_wrap_DGTraceIntegrator_AssemblePAInteriorFaces, METH_VARARGS|METH_KEYWORDS, "DGTraceIntegrator_AssemblePAInteriorFaces(DGTraceIntegrator self, FiniteElementSpace fes)"},
 	 { "DGTraceIntegrator_AssemblePABoundaryFaces", (PyCFunction)(void(*)(void))_wrap_DGTraceIntegrator_AssemblePABoundaryFaces, METH_VARARGS|METH_KEYWORDS, "DGTraceIntegrator_AssemblePABoundaryFaces(DGTraceIntegrator self, FiniteElementSpace fes)"},
@@ -30061,7 +33960,8 @@ static PyMethodDef SwigMethods_proxydocs[] = {
 	 { "SWIG_PyStaticMethod_New", SWIG_PyStaticMethod_New, METH_O, NULL},
 	 { "new_BilinearFormIntegrator", (PyCFunction)(void(*)(void))_wrap_new_BilinearFormIntegrator, METH_VARARGS|METH_KEYWORDS, "new_BilinearFormIntegrator(PyObject * _self, IntegrationRule ir=None) -> BilinearFormIntegrator"},
 	 { "BilinearFormIntegrator_AssemblePA", _wrap_BilinearFormIntegrator_AssemblePA, METH_VARARGS, "\n"
-		"AssemblePA(BilinearFormIntegrator self)\n"
+		"AssemblePA(BilinearFormIntegrator self, FiniteElementSpace fes)\n"
+		"AssemblePA(BilinearFormIntegrator self, FiniteElementSpace trial_fes, FiniteElementSpace test_fes)\n"
 		"AssemblePA(BilinearFormIntegrator self, FiniteElementSpace fes)\n"
 		"AssemblePA(BilinearFormIntegrator self, FiniteElementSpace trial_fes, FiniteElementSpace test_fes)\n"
 		""},
@@ -30103,8 +34003,9 @@ static PyMethodDef SwigMethods_proxydocs[] = {
 		"AssembleFaceMatrix(TransposeIntegrator self, FiniteElement el1, FiniteElement el2, FaceElementTransformations Trans, DenseMatrix elmat)\n"
 		""},
 	 { "TransposeIntegrator_AssemblePA", _wrap_TransposeIntegrator_AssemblePA, METH_VARARGS, "\n"
-		"AssemblePA()\n"
-		"AssemblePA(FiniteElementSpace fes)\n"
+		"AssemblePA(TransposeIntegrator self, FiniteElementSpace fes)\n"
+		"AssemblePA(TransposeIntegrator self, FiniteElementSpace trial_fes, FiniteElementSpace test_fes)\n"
+		"AssemblePA(TransposeIntegrator self, FiniteElementSpace fes)\n"
 		""},
 	 { "TransposeIntegrator_AssemblePAInteriorFaces", (PyCFunction)(void(*)(void))_wrap_TransposeIntegrator_AssemblePAInteriorFaces, METH_VARARGS|METH_KEYWORDS, "AssemblePAInteriorFaces(TransposeIntegrator self, FiniteElementSpace fes)"},
 	 { "TransposeIntegrator_AssemblePABoundaryFaces", (PyCFunction)(void(*)(void))_wrap_TransposeIntegrator_AssemblePABoundaryFaces, METH_VARARGS|METH_KEYWORDS, "AssemblePABoundaryFaces(TransposeIntegrator self, FiniteElementSpace fes)"},
@@ -30423,8 +34324,9 @@ static PyMethodDef SwigMethods_proxydocs[] = {
 		""},
 	 { "GradientIntegrator_AssembleElementMatrix2", (PyCFunction)(void(*)(void))_wrap_GradientIntegrator_AssembleElementMatrix2, METH_VARARGS|METH_KEYWORDS, "AssembleElementMatrix2(GradientIntegrator self, FiniteElement trial_fe, FiniteElement test_fe, ElementTransformation Trans, DenseMatrix elmat)"},
 	 { "GradientIntegrator_AssemblePA", _wrap_GradientIntegrator_AssemblePA, METH_VARARGS, "\n"
-		"AssemblePA()\n"
-		"AssemblePA(FiniteElementSpace trial_fes, FiniteElementSpace test_fes)\n"
+		"AssemblePA(GradientIntegrator self, FiniteElementSpace fes)\n"
+		"AssemblePA(GradientIntegrator self, FiniteElementSpace trial_fes, FiniteElementSpace test_fes)\n"
+		"AssemblePA(GradientIntegrator self, FiniteElementSpace trial_fes, FiniteElementSpace test_fes)\n"
 		""},
 	 { "GradientIntegrator_AddMultPA", (PyCFunction)(void(*)(void))_wrap_GradientIntegrator_AddMultPA, METH_VARARGS|METH_KEYWORDS, "AddMultPA(GradientIntegrator self, Vector x, Vector y)"},
 	 { "GradientIntegrator_AddMultTransposePA", (PyCFunction)(void(*)(void))_wrap_GradientIntegrator_AddMultTransposePA, METH_VARARGS|METH_KEYWORDS, "AddMultTransposePA(GradientIntegrator self, Vector x, Vector y)"},
@@ -30446,8 +34348,9 @@ static PyMethodDef SwigMethods_proxydocs[] = {
 	 { "DiffusionIntegrator_ComputeFluxEnergy", (PyCFunction)(void(*)(void))_wrap_DiffusionIntegrator_ComputeFluxEnergy, METH_VARARGS|METH_KEYWORDS, "ComputeFluxEnergy(DiffusionIntegrator self, FiniteElement fluxelem, ElementTransformation Trans, Vector flux, Vector d_energy=None) -> double"},
 	 { "DiffusionIntegrator_AssembleMF", (PyCFunction)(void(*)(void))_wrap_DiffusionIntegrator_AssembleMF, METH_VARARGS|METH_KEYWORDS, "AssembleMF(DiffusionIntegrator self, FiniteElementSpace fes)"},
 	 { "DiffusionIntegrator_AssemblePA", _wrap_DiffusionIntegrator_AssemblePA, METH_VARARGS, "\n"
-		"AssemblePA()\n"
-		"AssemblePA(FiniteElementSpace fes)\n"
+		"AssemblePA(DiffusionIntegrator self, FiniteElementSpace fes)\n"
+		"AssemblePA(DiffusionIntegrator self, FiniteElementSpace trial_fes, FiniteElementSpace test_fes)\n"
+		"AssemblePA(DiffusionIntegrator self, FiniteElementSpace fes)\n"
 		""},
 	 { "DiffusionIntegrator_AssembleEA", (PyCFunction)(void(*)(void))_wrap_DiffusionIntegrator_AssembleEA, METH_VARARGS|METH_KEYWORDS, "AssembleEA(DiffusionIntegrator self, FiniteElementSpace fes, Vector emat, bool const add)"},
 	 { "DiffusionIntegrator_AssembleDiagonalPA", (PyCFunction)(void(*)(void))_wrap_DiffusionIntegrator_AssembleDiagonalPA, METH_VARARGS|METH_KEYWORDS, "AssembleDiagonalPA(DiffusionIntegrator self, Vector diag)"},
@@ -30466,8 +34369,9 @@ static PyMethodDef SwigMethods_proxydocs[] = {
 	 { "MassIntegrator_AssembleElementMatrix2", (PyCFunction)(void(*)(void))_wrap_MassIntegrator_AssembleElementMatrix2, METH_VARARGS|METH_KEYWORDS, "AssembleElementMatrix2(MassIntegrator self, FiniteElement trial_fe, FiniteElement test_fe, ElementTransformation Trans, DenseMatrix elmat)"},
 	 { "MassIntegrator_AssembleMF", (PyCFunction)(void(*)(void))_wrap_MassIntegrator_AssembleMF, METH_VARARGS|METH_KEYWORDS, "AssembleMF(MassIntegrator self, FiniteElementSpace fes)"},
 	 { "MassIntegrator_AssemblePA", _wrap_MassIntegrator_AssemblePA, METH_VARARGS, "\n"
-		"AssemblePA()\n"
-		"AssemblePA(FiniteElementSpace fes)\n"
+		"AssemblePA(MassIntegrator self, FiniteElementSpace fes)\n"
+		"AssemblePA(MassIntegrator self, FiniteElementSpace trial_fes, FiniteElementSpace test_fes)\n"
+		"AssemblePA(MassIntegrator self, FiniteElementSpace fes)\n"
 		""},
 	 { "MassIntegrator_AssembleEA", (PyCFunction)(void(*)(void))_wrap_MassIntegrator_AssembleEA, METH_VARARGS|METH_KEYWORDS, "AssembleEA(MassIntegrator self, FiniteElementSpace fes, Vector emat, bool const add)"},
 	 { "MassIntegrator_AssembleDiagonalPA", (PyCFunction)(void(*)(void))_wrap_MassIntegrator_AssembleDiagonalPA, METH_VARARGS|METH_KEYWORDS, "AssembleDiagonalPA(MassIntegrator self, Vector diag)"},
@@ -30489,8 +34393,9 @@ static PyMethodDef SwigMethods_proxydocs[] = {
 	 { "new_ConvectionIntegrator", (PyCFunction)(void(*)(void))_wrap_new_ConvectionIntegrator, METH_VARARGS|METH_KEYWORDS, "new_ConvectionIntegrator(VectorCoefficient q, double a=1.0) -> ConvectionIntegrator"},
 	 { "ConvectionIntegrator_AssembleElementMatrix", (PyCFunction)(void(*)(void))_wrap_ConvectionIntegrator_AssembleElementMatrix, METH_VARARGS|METH_KEYWORDS, "AssembleElementMatrix(ConvectionIntegrator self, FiniteElement arg2, ElementTransformation arg3, DenseMatrix arg4)"},
 	 { "ConvectionIntegrator_AssemblePA", _wrap_ConvectionIntegrator_AssemblePA, METH_VARARGS, "\n"
-		"AssemblePA()\n"
-		"AssemblePA(FiniteElementSpace arg1)\n"
+		"AssemblePA(ConvectionIntegrator self, FiniteElementSpace fes)\n"
+		"AssemblePA(ConvectionIntegrator self, FiniteElementSpace trial_fes, FiniteElementSpace test_fes)\n"
+		"AssemblePA(ConvectionIntegrator self, FiniteElementSpace arg2)\n"
 		""},
 	 { "ConvectionIntegrator_AssembleEA", (PyCFunction)(void(*)(void))_wrap_ConvectionIntegrator_AssembleEA, METH_VARARGS|METH_KEYWORDS, "AssembleEA(ConvectionIntegrator self, FiniteElementSpace fes, Vector emat, bool const add)"},
 	 { "ConvectionIntegrator_AddMultPA", (PyCFunction)(void(*)(void))_wrap_ConvectionIntegrator_AddMultPA, METH_VARARGS|METH_KEYWORDS, "AddMultPA(ConvectionIntegrator self, Vector arg2, Vector arg3)"},
@@ -30519,8 +34424,9 @@ static PyMethodDef SwigMethods_proxydocs[] = {
 	 { "VectorMassIntegrator_AssembleElementMatrix", (PyCFunction)(void(*)(void))_wrap_VectorMassIntegrator_AssembleElementMatrix, METH_VARARGS|METH_KEYWORDS, "AssembleElementMatrix(VectorMassIntegrator self, FiniteElement el, ElementTransformation Trans, DenseMatrix elmat)"},
 	 { "VectorMassIntegrator_AssembleElementMatrix2", (PyCFunction)(void(*)(void))_wrap_VectorMassIntegrator_AssembleElementMatrix2, METH_VARARGS|METH_KEYWORDS, "AssembleElementMatrix2(VectorMassIntegrator self, FiniteElement trial_fe, FiniteElement test_fe, ElementTransformation Trans, DenseMatrix elmat)"},
 	 { "VectorMassIntegrator_AssemblePA", _wrap_VectorMassIntegrator_AssemblePA, METH_VARARGS, "\n"
-		"AssemblePA()\n"
-		"AssemblePA(FiniteElementSpace fes)\n"
+		"AssemblePA(VectorMassIntegrator self, FiniteElementSpace fes)\n"
+		"AssemblePA(VectorMassIntegrator self, FiniteElementSpace trial_fes, FiniteElementSpace test_fes)\n"
+		"AssemblePA(VectorMassIntegrator self, FiniteElementSpace fes)\n"
 		""},
 	 { "VectorMassIntegrator_AssembleMF", (PyCFunction)(void(*)(void))_wrap_VectorMassIntegrator_AssembleMF, METH_VARARGS|METH_KEYWORDS, "AssembleMF(VectorMassIntegrator self, FiniteElementSpace fes)"},
 	 { "VectorMassIntegrator_AssembleDiagonalPA", (PyCFunction)(void(*)(void))_wrap_VectorMassIntegrator_AssembleDiagonalPA, METH_VARARGS|METH_KEYWORDS, "AssembleDiagonalPA(VectorMassIntegrator self, Vector diag)"},
@@ -30573,8 +34479,9 @@ static PyMethodDef SwigMethods_proxydocs[] = {
 	 { "CurlCurlIntegrator_ComputeElementFlux", (PyCFunction)(void(*)(void))_wrap_CurlCurlIntegrator_ComputeElementFlux, METH_VARARGS|METH_KEYWORDS, "ComputeElementFlux(CurlCurlIntegrator self, FiniteElement el, ElementTransformation Trans, Vector u, FiniteElement fluxelem, Vector flux, bool with_coef)"},
 	 { "CurlCurlIntegrator_ComputeFluxEnergy", (PyCFunction)(void(*)(void))_wrap_CurlCurlIntegrator_ComputeFluxEnergy, METH_VARARGS|METH_KEYWORDS, "ComputeFluxEnergy(CurlCurlIntegrator self, FiniteElement fluxelem, ElementTransformation Trans, Vector flux, Vector d_energy=None) -> double"},
 	 { "CurlCurlIntegrator_AssemblePA", _wrap_CurlCurlIntegrator_AssemblePA, METH_VARARGS, "\n"
-		"AssemblePA()\n"
-		"AssemblePA(FiniteElementSpace fes)\n"
+		"AssemblePA(CurlCurlIntegrator self, FiniteElementSpace fes)\n"
+		"AssemblePA(CurlCurlIntegrator self, FiniteElementSpace trial_fes, FiniteElementSpace test_fes)\n"
+		"AssemblePA(CurlCurlIntegrator self, FiniteElementSpace fes)\n"
 		""},
 	 { "CurlCurlIntegrator_AddMultPA", (PyCFunction)(void(*)(void))_wrap_CurlCurlIntegrator_AddMultPA, METH_VARARGS|METH_KEYWORDS, "AddMultPA(CurlCurlIntegrator self, Vector x, Vector y)"},
 	 { "CurlCurlIntegrator_AssembleDiagonalPA", (PyCFunction)(void(*)(void))_wrap_CurlCurlIntegrator_AssembleDiagonalPA, METH_VARARGS|METH_KEYWORDS, "AssembleDiagonalPA(CurlCurlIntegrator self, Vector diag)"},
@@ -30602,7 +34509,8 @@ static PyMethodDef SwigMethods_proxydocs[] = {
 	 { "VectorFEMassIntegrator_AssembleElementMatrix", (PyCFunction)(void(*)(void))_wrap_VectorFEMassIntegrator_AssembleElementMatrix, METH_VARARGS|METH_KEYWORDS, "AssembleElementMatrix(VectorFEMassIntegrator self, FiniteElement el, ElementTransformation Trans, DenseMatrix elmat)"},
 	 { "VectorFEMassIntegrator_AssembleElementMatrix2", (PyCFunction)(void(*)(void))_wrap_VectorFEMassIntegrator_AssembleElementMatrix2, METH_VARARGS|METH_KEYWORDS, "AssembleElementMatrix2(VectorFEMassIntegrator self, FiniteElement trial_fe, FiniteElement test_fe, ElementTransformation Trans, DenseMatrix elmat)"},
 	 { "VectorFEMassIntegrator_AssemblePA", _wrap_VectorFEMassIntegrator_AssemblePA, METH_VARARGS, "\n"
-		"AssemblePA(VectorFEMassIntegrator self)\n"
+		"AssemblePA(VectorFEMassIntegrator self, FiniteElementSpace fes)\n"
+		"AssemblePA(VectorFEMassIntegrator self, FiniteElementSpace trial_fes, FiniteElementSpace test_fes)\n"
 		"AssemblePA(VectorFEMassIntegrator self, FiniteElementSpace fes)\n"
 		"AssemblePA(VectorFEMassIntegrator self, FiniteElementSpace trial_fes, FiniteElementSpace test_fes)\n"
 		""},
@@ -30618,8 +34526,9 @@ static PyMethodDef SwigMethods_proxydocs[] = {
 		""},
 	 { "VectorDivergenceIntegrator_AssembleElementMatrix2", (PyCFunction)(void(*)(void))_wrap_VectorDivergenceIntegrator_AssembleElementMatrix2, METH_VARARGS|METH_KEYWORDS, "AssembleElementMatrix2(VectorDivergenceIntegrator self, FiniteElement trial_fe, FiniteElement test_fe, ElementTransformation Trans, DenseMatrix elmat)"},
 	 { "VectorDivergenceIntegrator_AssemblePA", _wrap_VectorDivergenceIntegrator_AssemblePA, METH_VARARGS, "\n"
-		"AssemblePA()\n"
-		"AssemblePA(FiniteElementSpace trial_fes, FiniteElementSpace test_fes)\n"
+		"AssemblePA(VectorDivergenceIntegrator self, FiniteElementSpace fes)\n"
+		"AssemblePA(VectorDivergenceIntegrator self, FiniteElementSpace trial_fes, FiniteElementSpace test_fes)\n"
+		"AssemblePA(VectorDivergenceIntegrator self, FiniteElementSpace trial_fes, FiniteElementSpace test_fes)\n"
 		""},
 	 { "VectorDivergenceIntegrator_AddMultPA", (PyCFunction)(void(*)(void))_wrap_VectorDivergenceIntegrator_AddMultPA, METH_VARARGS|METH_KEYWORDS, "AddMultPA(VectorDivergenceIntegrator self, Vector x, Vector y)"},
 	 { "VectorDivergenceIntegrator_AddMultTransposePA", (PyCFunction)(void(*)(void))_wrap_VectorDivergenceIntegrator_AddMultTransposePA, METH_VARARGS|METH_KEYWORDS, "AddMultTransposePA(VectorDivergenceIntegrator self, Vector x, Vector y)"},
@@ -30643,8 +34552,9 @@ static PyMethodDef SwigMethods_proxydocs[] = {
 	 { "VectorDiffusionIntegrator_AssembleElementMatrix", (PyCFunction)(void(*)(void))_wrap_VectorDiffusionIntegrator_AssembleElementMatrix, METH_VARARGS|METH_KEYWORDS, "AssembleElementMatrix(VectorDiffusionIntegrator self, FiniteElement el, ElementTransformation Trans, DenseMatrix elmat)"},
 	 { "VectorDiffusionIntegrator_AssembleElementVector", (PyCFunction)(void(*)(void))_wrap_VectorDiffusionIntegrator_AssembleElementVector, METH_VARARGS|METH_KEYWORDS, "AssembleElementVector(VectorDiffusionIntegrator self, FiniteElement el, ElementTransformation Tr, Vector elfun, Vector elvect)"},
 	 { "VectorDiffusionIntegrator_AssemblePA", _wrap_VectorDiffusionIntegrator_AssemblePA, METH_VARARGS, "\n"
-		"AssemblePA()\n"
-		"AssemblePA(FiniteElementSpace fes)\n"
+		"AssemblePA(VectorDiffusionIntegrator self, FiniteElementSpace fes)\n"
+		"AssemblePA(VectorDiffusionIntegrator self, FiniteElementSpace trial_fes, FiniteElementSpace test_fes)\n"
+		"AssemblePA(VectorDiffusionIntegrator self, FiniteElementSpace fes)\n"
 		""},
 	 { "VectorDiffusionIntegrator_AssembleMF", (PyCFunction)(void(*)(void))_wrap_VectorDiffusionIntegrator_AssembleMF, METH_VARARGS|METH_KEYWORDS, "AssembleMF(VectorDiffusionIntegrator self, FiniteElementSpace fes)"},
 	 { "VectorDiffusionIntegrator_AssembleDiagonalPA", (PyCFunction)(void(*)(void))_wrap_VectorDiffusionIntegrator_AssembleDiagonalPA, METH_VARARGS|METH_KEYWORDS, "AssembleDiagonalPA(VectorDiffusionIntegrator self, Vector diag)"},
@@ -30671,6 +34581,10 @@ static PyMethodDef SwigMethods_proxydocs[] = {
 		"AssembleFaceMatrix(DGTraceIntegrator self, FiniteElement el1, FiniteElement el2, FaceElementTransformations Trans, DenseMatrix elmat)\n"
 		"AssembleFaceMatrix(DGTraceIntegrator self, FiniteElement trial_face_fe, FiniteElement test_fe1, FiniteElement test_fe2, FaceElementTransformations Trans, DenseMatrix elmat)\n"
 		"AssembleFaceMatrix(DGTraceIntegrator self, FiniteElement el1, FiniteElement el2, FaceElementTransformations Trans, DenseMatrix elmat)\n"
+		""},
+	 { "DGTraceIntegrator_AssemblePA", _wrap_DGTraceIntegrator_AssemblePA, METH_VARARGS, "\n"
+		"AssemblePA(DGTraceIntegrator self, FiniteElementSpace fes)\n"
+		"AssemblePA(DGTraceIntegrator self, FiniteElementSpace trial_fes, FiniteElementSpace test_fes)\n"
 		""},
 	 { "DGTraceIntegrator_AssemblePAInteriorFaces", (PyCFunction)(void(*)(void))_wrap_DGTraceIntegrator_AssemblePAInteriorFaces, METH_VARARGS|METH_KEYWORDS, "AssemblePAInteriorFaces(DGTraceIntegrator self, FiniteElementSpace fes)"},
 	 { "DGTraceIntegrator_AssemblePABoundaryFaces", (PyCFunction)(void(*)(void))_wrap_DGTraceIntegrator_AssemblePABoundaryFaces, METH_VARARGS|METH_KEYWORDS, "AssemblePABoundaryFaces(DGTraceIntegrator self, FiniteElementSpace fes)"},
@@ -31283,6 +35197,246 @@ static void *_p_mfem__VectorCrossProductInterpolatorTo_p_mfem__BilinearFormInteg
 static void *_p_mfem__VectorInnerProductInterpolatorTo_p_mfem__BilinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
     return (void *)((mfem::BilinearFormIntegrator *) (mfem::DiscreteInterpolator *) ((mfem::VectorInnerProductInterpolator *) x));
 }
+static void *_p_mfem__NormalTraceJumpIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *) ((mfem::NormalTraceJumpIntegrator *) x));
+}
+static void *_p_mfem__TraceJumpIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *) ((mfem::TraceJumpIntegrator *) x));
+}
+static void *_p_mfem__DGElasticityIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *) ((mfem::DGElasticityIntegrator *) x));
+}
+static void *_p_mfem__DGDiffusionIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *) ((mfem::DGDiffusionIntegrator *) x));
+}
+static void *_p_mfem__DGTraceIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *) ((mfem::DGTraceIntegrator *) x));
+}
+static void *_p_mfem__ElasticityIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *) ((mfem::ElasticityIntegrator *) x));
+}
+static void *_p_mfem__VectorDiffusionIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *) ((mfem::VectorDiffusionIntegrator *) x));
+}
+static void *_p_mfem__DivDivIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *) ((mfem::DivDivIntegrator *) x));
+}
+static void *_p_mfem__VectorDivergenceIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *) ((mfem::VectorDivergenceIntegrator *) x));
+}
+static void *_p_mfem__VectorFEMassIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *) ((mfem::VectorFEMassIntegrator *) x));
+}
+static void *_p_mfem__VectorCurlCurlIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *) ((mfem::VectorCurlCurlIntegrator *) x));
+}
+static void *_p_mfem__CurlCurlIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *) ((mfem::CurlCurlIntegrator *) x));
+}
+static void *_p_mfem__DerivativeIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *) ((mfem::DerivativeIntegrator *) x));
+}
+static void *_p_mfem__VectorFECurlIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *) ((mfem::VectorFECurlIntegrator *) x));
+}
+static void *_p_mfem__VectorFEWeakDivergenceIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *) ((mfem::VectorFEWeakDivergenceIntegrator *) x));
+}
+static void *_p_mfem__VectorFEDivergenceIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *) ((mfem::VectorFEDivergenceIntegrator *) x));
+}
+static void *_p_mfem__VectorMassIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *) ((mfem::VectorMassIntegrator *) x));
+}
+static void *_p_mfem__GroupConvectionIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *) ((mfem::GroupConvectionIntegrator *) x));
+}
+static void *_p_mfem__ConvectionIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *) ((mfem::ConvectionIntegrator *) x));
+}
+static void *_p_mfem__BoundaryMassIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *)(mfem::MassIntegrator *) ((mfem::BoundaryMassIntegrator *) x));
+}
+static void *_p_mfem__MassIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *) ((mfem::MassIntegrator *) x));
+}
+static void *_p_mfem__DiffusionIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *) ((mfem::DiffusionIntegrator *) x));
+}
+static void *_p_mfem__GradientIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *) ((mfem::GradientIntegrator *) x));
+}
+static void *_p_mfem__MixedVectorWeakDivergenceIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *)(mfem::MixedVectorIntegrator *) ((mfem::MixedVectorWeakDivergenceIntegrator *) x));
+}
+static void *_p_mfem__MixedVectorWeakCurlIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *)(mfem::MixedVectorIntegrator *) ((mfem::MixedVectorWeakCurlIntegrator *) x));
+}
+static void *_p_mfem__MixedVectorCurlIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *)(mfem::MixedVectorIntegrator *) ((mfem::MixedVectorCurlIntegrator *) x));
+}
+static void *_p_mfem__MixedVectorGradientIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *)(mfem::MixedVectorIntegrator *) ((mfem::MixedVectorGradientIntegrator *) x));
+}
+static void *_p_mfem__MixedScalarWeakDivergenceIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *)(mfem::MixedScalarVectorIntegrator *) ((mfem::MixedScalarWeakDivergenceIntegrator *) x));
+}
+static void *_p_mfem__MixedDivGradIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *)(mfem::MixedScalarVectorIntegrator *) ((mfem::MixedDivGradIntegrator *) x));
+}
+static void *_p_mfem__MixedGradDivIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *)(mfem::MixedScalarVectorIntegrator *) ((mfem::MixedGradDivIntegrator *) x));
+}
+static void *_p_mfem__MixedDirectionalDerivativeIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *)(mfem::MixedScalarVectorIntegrator *) ((mfem::MixedDirectionalDerivativeIntegrator *) x));
+}
+static void *_p_mfem__MixedScalarWeakCrossProductIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *)(mfem::MixedScalarVectorIntegrator *) ((mfem::MixedScalarWeakCrossProductIntegrator *) x));
+}
+static void *_p_mfem__MixedScalarCrossProductIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *)(mfem::MixedScalarVectorIntegrator *) ((mfem::MixedScalarCrossProductIntegrator *) x));
+}
+static void *_p_mfem__MixedScalarCrossGradIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *)(mfem::MixedScalarVectorIntegrator *) ((mfem::MixedScalarCrossGradIntegrator *) x));
+}
+static void *_p_mfem__MixedScalarCrossCurlIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *)(mfem::MixedScalarVectorIntegrator *) ((mfem::MixedScalarCrossCurlIntegrator *) x));
+}
+static void *_p_mfem__MixedScalarWeakDerivativeIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *)(mfem::MixedScalarIntegrator *) ((mfem::MixedScalarWeakDerivativeIntegrator *) x));
+}
+static void *_p_mfem__MixedScalarDerivativeIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *)(mfem::MixedScalarIntegrator *) ((mfem::MixedScalarDerivativeIntegrator *) x));
+}
+static void *_p_mfem__MixedVectorProductIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *)(mfem::MixedScalarVectorIntegrator *) ((mfem::MixedVectorProductIntegrator *) x));
+}
+static void *_p_mfem__MixedScalarMassIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *)(mfem::MixedScalarIntegrator *) ((mfem::MixedScalarMassIntegrator *) x));
+}
+static void *_p_mfem__MixedScalarVectorIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *) ((mfem::MixedScalarVectorIntegrator *) x));
+}
+static void *_p_mfem__MixedVectorIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *) ((mfem::MixedVectorIntegrator *) x));
+}
+static void *_p_mfem__MixedScalarIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *) ((mfem::MixedScalarIntegrator *) x));
+}
+static void *_p_mfem__SumIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *) ((mfem::SumIntegrator *) x));
+}
+static void *_p_mfem__InverseIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *) ((mfem::InverseIntegrator *) x));
+}
+static void *_p_mfem__LumpedIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *) ((mfem::LumpedIntegrator *) x));
+}
+static void *_p_mfem__TransposeIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *) ((mfem::TransposeIntegrator *) x));
+}
+static void *_p_mfem__BilinearFormIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *)  ((mfem::BilinearFormIntegrator *) x));
+}
+static void *_p_mfem__VectorConvectionNLFIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *)  ((mfem::VectorConvectionNLFIntegrator *) x));
+}
+static void *_p_mfem__HyperelasticNLFIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *)  ((mfem::HyperelasticNLFIntegrator *) x));
+}
+static void *_p_mfem__MixedScalarDivergenceIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *)(mfem::MixedScalarIntegrator *) ((mfem::MixedScalarDivergenceIntegrator *) x));
+}
+static void *_p_mfem__MixedVectorDivergenceIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *)(mfem::MixedScalarVectorIntegrator *) ((mfem::MixedVectorDivergenceIntegrator *) x));
+}
+static void *_p_mfem__MixedScalarWeakGradientIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *)(mfem::MixedScalarIntegrator *) ((mfem::MixedScalarWeakGradientIntegrator *) x));
+}
+static void *_p_mfem__MixedScalarCurlIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *)(mfem::MixedScalarIntegrator *) ((mfem::MixedScalarCurlIntegrator *) x));
+}
+static void *_p_mfem__MixedScalarWeakCurlIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *)(mfem::MixedScalarIntegrator *) ((mfem::MixedScalarWeakCurlIntegrator *) x));
+}
+static void *_p_mfem__MixedVectorMassIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *)(mfem::MixedVectorIntegrator *) ((mfem::MixedVectorMassIntegrator *) x));
+}
+static void *_p_mfem__MixedCrossProductIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *)(mfem::MixedVectorIntegrator *) ((mfem::MixedCrossProductIntegrator *) x));
+}
+static void *_p_mfem__MixedDotProductIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *)(mfem::MixedScalarVectorIntegrator *) ((mfem::MixedDotProductIntegrator *) x));
+}
+static void *_p_mfem__MixedWeakGradDotIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *)(mfem::MixedScalarVectorIntegrator *) ((mfem::MixedWeakGradDotIntegrator *) x));
+}
+static void *_p_mfem__MixedWeakDivCrossIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *)(mfem::MixedVectorIntegrator *) ((mfem::MixedWeakDivCrossIntegrator *) x));
+}
+static void *_p_mfem__MixedGradGradIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *)(mfem::MixedVectorIntegrator *) ((mfem::MixedGradGradIntegrator *) x));
+}
+static void *_p_mfem__MixedCrossGradGradIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *)(mfem::MixedVectorIntegrator *) ((mfem::MixedCrossGradGradIntegrator *) x));
+}
+static void *_p_mfem__MixedCurlCurlIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *)(mfem::MixedVectorIntegrator *) ((mfem::MixedCurlCurlIntegrator *) x));
+}
+static void *_p_mfem__MixedCrossCurlCurlIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *)(mfem::MixedVectorIntegrator *) ((mfem::MixedCrossCurlCurlIntegrator *) x));
+}
+static void *_p_mfem__MixedCrossCurlGradIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *)(mfem::MixedVectorIntegrator *) ((mfem::MixedCrossCurlGradIntegrator *) x));
+}
+static void *_p_mfem__MixedCrossGradCurlIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *)(mfem::MixedVectorIntegrator *) ((mfem::MixedCrossGradCurlIntegrator *) x));
+}
+static void *_p_mfem__MixedWeakCurlCrossIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *)(mfem::MixedVectorIntegrator *) ((mfem::MixedWeakCurlCrossIntegrator *) x));
+}
+static void *_p_mfem__MixedScalarWeakCurlCrossIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *)(mfem::MixedScalarVectorIntegrator *) ((mfem::MixedScalarWeakCurlCrossIntegrator *) x));
+}
+static void *_p_mfem__MixedCrossGradIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *)(mfem::MixedVectorIntegrator *) ((mfem::MixedCrossGradIntegrator *) x));
+}
+static void *_p_mfem__MixedCrossCurlIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *)(mfem::MixedVectorIntegrator *) ((mfem::MixedCrossCurlIntegrator *) x));
+}
+static void *_p_mfem__DivergenceInterpolatorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *)(mfem::DiscreteInterpolator *) ((mfem::DivergenceInterpolator *) x));
+}
+static void *_p_mfem__CurlInterpolatorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *)(mfem::DiscreteInterpolator *) ((mfem::CurlInterpolator *) x));
+}
+static void *_p_mfem__IdentityInterpolatorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *)(mfem::DiscreteInterpolator *) ((mfem::IdentityInterpolator *) x));
+}
+static void *_p_mfem__GradientInterpolatorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *)(mfem::DiscreteInterpolator *) ((mfem::GradientInterpolator *) x));
+}
+static void *_p_mfem__DiscreteInterpolatorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *) ((mfem::DiscreteInterpolator *) x));
+}
+static void *_p_mfem__NormalInterpolatorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *)(mfem::DiscreteInterpolator *) ((mfem::NormalInterpolator *) x));
+}
+static void *_p_mfem__ScalarProductInterpolatorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *)(mfem::DiscreteInterpolator *) ((mfem::ScalarProductInterpolator *) x));
+}
+static void *_p_mfem__ScalarVectorProductInterpolatorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *)(mfem::DiscreteInterpolator *) ((mfem::ScalarVectorProductInterpolator *) x));
+}
+static void *_p_mfem__VectorScalarProductInterpolatorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *)(mfem::DiscreteInterpolator *) ((mfem::VectorScalarProductInterpolator *) x));
+}
+static void *_p_mfem__VectorCrossProductInterpolatorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *)(mfem::DiscreteInterpolator *) ((mfem::VectorCrossProductInterpolator *) x));
+}
+static void *_p_mfem__VectorInnerProductInterpolatorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *)(mfem::DiscreteInterpolator *) ((mfem::VectorInnerProductInterpolator *) x));
+}
 static void *_p_mfem__GradientInterpolatorTo_p_mfem__DiscreteInterpolator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
     return (void *)((mfem::DiscreteInterpolator *)  ((mfem::GradientInterpolator *) x));
 }
@@ -31817,6 +35971,9 @@ static swig_type_info _swigt__p_mfem__MixedVectorWeakDivergenceIntegrator = {"_p
 static swig_type_info _swigt__p_mfem__MixedWeakCurlCrossIntegrator = {"_p_mfem__MixedWeakCurlCrossIntegrator", "mfem::MixedWeakCurlCrossIntegrator *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_mfem__MixedWeakDivCrossIntegrator = {"_p_mfem__MixedWeakDivCrossIntegrator", "mfem::MixedWeakDivCrossIntegrator *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_mfem__MixedWeakGradDotIntegrator = {"_p_mfem__MixedWeakGradDotIntegrator", "mfem::MixedWeakGradDotIntegrator *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_mfem__NonlinearFormIntegrator = {"_p_mfem__NonlinearFormIntegrator", "mfem::NonlinearFormIntegrator *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_mfem__HyperelasticNLFIntegrator = {"_p_mfem__HyperelasticNLFIntegrator", 0, 0, 0, 0, 0};
+static swig_type_info _swigt__p_mfem__VectorConvectionNLFIntegrator = {"_p_mfem__VectorConvectionNLFIntegrator", 0, 0, 0, 0, 0};
 static swig_type_info _swigt__p_mfem__NormalInterpolator = {"_p_mfem__NormalInterpolator", "mfem::NormalInterpolator *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_mfem__NormalTraceJumpIntegrator = {"_p_mfem__NormalTraceJumpIntegrator", "mfem::NormalTraceJumpIntegrator *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_mfem__OperatorHandle = {"_p_mfem__OperatorHandle", "mfem::OperatorPtr *|mfem::OperatorHandle *", 0, 0, (void*)0, 0};
@@ -31932,6 +36089,7 @@ static swig_type_info *swig_type_initial[] = {
   &_swigt__p_mfem__H1_TetrahedronElement,
   &_swigt__p_mfem__H1_TriangleElement,
   &_swigt__p_mfem__H1_WedgeElement,
+  &_swigt__p_mfem__HyperelasticNLFIntegrator,
   &_swigt__p_mfem__HypreParVector,
   &_swigt__p_mfem__IdentityInterpolator,
   &_swigt__p_mfem__IdentityMatrixCoefficient,
@@ -32022,6 +36180,7 @@ static swig_type_info *swig_type_initial[] = {
   &_swigt__p_mfem__NodalFiniteElement,
   &_swigt__p_mfem__NodalTensorFiniteElement,
   &_swigt__p_mfem__NodeExtrudeCoefficient,
+  &_swigt__p_mfem__NonlinearFormIntegrator,
   &_swigt__p_mfem__NormalInterpolator,
   &_swigt__p_mfem__NormalTraceJumpIntegrator,
   &_swigt__p_mfem__NormalizedVectorCoefficient,
@@ -32087,6 +36246,7 @@ static swig_type_info *swig_type_initial[] = {
   &_swigt__p_mfem__VectorArrayCoefficient,
   &_swigt__p_mfem__VectorCoefficient,
   &_swigt__p_mfem__VectorConstantCoefficient,
+  &_swigt__p_mfem__VectorConvectionNLFIntegrator,
   &_swigt__p_mfem__VectorCrossProductCoefficient,
   &_swigt__p_mfem__VectorCrossProductInterpolator,
   &_swigt__p_mfem__VectorCurlCurlIntegrator,
@@ -32323,6 +36483,9 @@ static swig_cast_info _swigc__p_mfem__MixedVectorWeakDivergenceIntegrator[] = { 
 static swig_cast_info _swigc__p_mfem__MixedWeakCurlCrossIntegrator[] = {  {&_swigt__p_mfem__MixedWeakCurlCrossIntegrator, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_mfem__MixedWeakDivCrossIntegrator[] = {  {&_swigt__p_mfem__MixedWeakDivCrossIntegrator, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_mfem__MixedWeakGradDotIntegrator[] = {  {&_swigt__p_mfem__MixedWeakGradDotIntegrator, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_mfem__HyperelasticNLFIntegrator[] = {{&_swigt__p_mfem__HyperelasticNLFIntegrator, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_mfem__VectorConvectionNLFIntegrator[] = {{&_swigt__p_mfem__VectorConvectionNLFIntegrator, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_mfem__NonlinearFormIntegrator[] = {  {&_swigt__p_mfem__GradientIntegrator, _p_mfem__GradientIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__DiffusionIntegrator, _p_mfem__DiffusionIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__MassIntegrator, _p_mfem__MassIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__BoundaryMassIntegrator, _p_mfem__BoundaryMassIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__ConvectionIntegrator, _p_mfem__ConvectionIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__GroupConvectionIntegrator, _p_mfem__GroupConvectionIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__VectorMassIntegrator, _p_mfem__VectorMassIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__VectorFEDivergenceIntegrator, _p_mfem__VectorFEDivergenceIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__VectorFEWeakDivergenceIntegrator, _p_mfem__VectorFEWeakDivergenceIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__VectorFECurlIntegrator, _p_mfem__VectorFECurlIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__NormalTraceJumpIntegrator, _p_mfem__NormalTraceJumpIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__TraceJumpIntegrator, _p_mfem__TraceJumpIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__DGElasticityIntegrator, _p_mfem__DGElasticityIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__DGDiffusionIntegrator, _p_mfem__DGDiffusionIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__DGTraceIntegrator, _p_mfem__DGTraceIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__ElasticityIntegrator, _p_mfem__ElasticityIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__VectorDiffusionIntegrator, _p_mfem__VectorDiffusionIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__DivDivIntegrator, _p_mfem__DivDivIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__VectorDivergenceIntegrator, _p_mfem__VectorDivergenceIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__VectorFEMassIntegrator, _p_mfem__VectorFEMassIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__VectorCurlCurlIntegrator, _p_mfem__VectorCurlCurlIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__CurlCurlIntegrator, _p_mfem__CurlCurlIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__DerivativeIntegrator, _p_mfem__DerivativeIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__MixedVectorProductIntegrator, _p_mfem__MixedVectorProductIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__MixedScalarWeakCrossProductIntegrator, _p_mfem__MixedScalarWeakCrossProductIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__MixedDirectionalDerivativeIntegrator, _p_mfem__MixedDirectionalDerivativeIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__MixedGradDivIntegrator, _p_mfem__MixedGradDivIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__MixedDivGradIntegrator, _p_mfem__MixedDivGradIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__MixedScalarWeakDivergenceIntegrator, _p_mfem__MixedScalarWeakDivergenceIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__MixedScalarVectorIntegrator, _p_mfem__MixedScalarVectorIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__MixedVectorWeakDivergenceIntegrator, _p_mfem__MixedVectorWeakDivergenceIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__MixedVectorWeakCurlIntegrator, _p_mfem__MixedVectorWeakCurlIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__MixedVectorCurlIntegrator, _p_mfem__MixedVectorCurlIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__MixedVectorGradientIntegrator, _p_mfem__MixedVectorGradientIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__MixedVectorIntegrator, _p_mfem__MixedVectorIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__MixedScalarWeakDerivativeIntegrator, _p_mfem__MixedScalarWeakDerivativeIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__MixedDotProductIntegrator, _p_mfem__MixedDotProductIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__MixedWeakGradDotIntegrator, _p_mfem__MixedWeakGradDotIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__MixedWeakDivCrossIntegrator, _p_mfem__MixedWeakDivCrossIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__MixedGradGradIntegrator, _p_mfem__MixedGradGradIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__MixedCrossGradGradIntegrator, _p_mfem__MixedCrossGradGradIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__MixedCurlCurlIntegrator, _p_mfem__MixedCurlCurlIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__MixedCrossCurlCurlIntegrator, _p_mfem__MixedCrossCurlCurlIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__MixedCrossCurlGradIntegrator, _p_mfem__MixedCrossCurlGradIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__MixedCrossGradCurlIntegrator, _p_mfem__MixedCrossGradCurlIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__MixedWeakCurlCrossIntegrator, _p_mfem__MixedWeakCurlCrossIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__MixedScalarWeakCurlCrossIntegrator, _p_mfem__MixedScalarWeakCurlCrossIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__MixedCrossGradIntegrator, _p_mfem__MixedCrossGradIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__MixedCrossCurlIntegrator, _p_mfem__MixedCrossCurlIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__NonlinearFormIntegrator, 0, 0, 0},  {&_swigt__p_mfem__MixedCrossProductIntegrator, _p_mfem__MixedCrossProductIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__MixedVectorMassIntegrator, _p_mfem__MixedVectorMassIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__MixedScalarWeakCurlIntegrator, _p_mfem__MixedScalarWeakCurlIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__MixedScalarCurlIntegrator, _p_mfem__MixedScalarCurlIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__MixedScalarWeakGradientIntegrator, _p_mfem__MixedScalarWeakGradientIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__MixedVectorDivergenceIntegrator, _p_mfem__MixedVectorDivergenceIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__MixedScalarDivergenceIntegrator, _p_mfem__MixedScalarDivergenceIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__HyperelasticNLFIntegrator, _p_mfem__HyperelasticNLFIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__VectorConvectionNLFIntegrator, _p_mfem__VectorConvectionNLFIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__BilinearFormIntegrator, _p_mfem__BilinearFormIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__MixedScalarCrossProductIntegrator, _p_mfem__MixedScalarCrossProductIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__MixedScalarCrossGradIntegrator, _p_mfem__MixedScalarCrossGradIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__MixedScalarCrossCurlIntegrator, _p_mfem__MixedScalarCrossCurlIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__TransposeIntegrator, _p_mfem__TransposeIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__LumpedIntegrator, _p_mfem__LumpedIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__InverseIntegrator, _p_mfem__InverseIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__SumIntegrator, _p_mfem__SumIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__MixedScalarIntegrator, _p_mfem__MixedScalarIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__MixedScalarMassIntegrator, _p_mfem__MixedScalarMassIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__MixedScalarDerivativeIntegrator, _p_mfem__MixedScalarDerivativeIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__DivergenceInterpolator, _p_mfem__DivergenceInterpolatorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__CurlInterpolator, _p_mfem__CurlInterpolatorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__IdentityInterpolator, _p_mfem__IdentityInterpolatorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__GradientInterpolator, _p_mfem__GradientInterpolatorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__NormalInterpolator, _p_mfem__NormalInterpolatorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__ScalarProductInterpolator, _p_mfem__ScalarProductInterpolatorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__ScalarVectorProductInterpolator, _p_mfem__ScalarVectorProductInterpolatorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__DiscreteInterpolator, _p_mfem__DiscreteInterpolatorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__VectorScalarProductInterpolator, _p_mfem__VectorScalarProductInterpolatorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__VectorCrossProductInterpolator, _p_mfem__VectorCrossProductInterpolatorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__VectorInnerProductInterpolator, _p_mfem__VectorInnerProductInterpolatorTo_p_mfem__NonlinearFormIntegrator, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_mfem__NormalInterpolator[] = {  {&_swigt__p_mfem__NormalInterpolator, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_mfem__NormalTraceJumpIntegrator[] = {  {&_swigt__p_mfem__NormalTraceJumpIntegrator, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_mfem__OperatorHandle[] = {  {&_swigt__p_mfem__OperatorHandle, 0, 0, 0},{0, 0, 0, 0}};
@@ -32438,6 +36601,7 @@ static swig_cast_info *swig_cast_initial[] = {
   _swigc__p_mfem__H1_TetrahedronElement,
   _swigc__p_mfem__H1_TriangleElement,
   _swigc__p_mfem__H1_WedgeElement,
+  _swigc__p_mfem__HyperelasticNLFIntegrator,
   _swigc__p_mfem__HypreParVector,
   _swigc__p_mfem__IdentityInterpolator,
   _swigc__p_mfem__IdentityMatrixCoefficient,
@@ -32528,6 +36692,7 @@ static swig_cast_info *swig_cast_initial[] = {
   _swigc__p_mfem__NodalFiniteElement,
   _swigc__p_mfem__NodalTensorFiniteElement,
   _swigc__p_mfem__NodeExtrudeCoefficient,
+  _swigc__p_mfem__NonlinearFormIntegrator,
   _swigc__p_mfem__NormalInterpolator,
   _swigc__p_mfem__NormalTraceJumpIntegrator,
   _swigc__p_mfem__NormalizedVectorCoefficient,
@@ -32593,6 +36758,7 @@ static swig_cast_info *swig_cast_initial[] = {
   _swigc__p_mfem__VectorArrayCoefficient,
   _swigc__p_mfem__VectorCoefficient,
   _swigc__p_mfem__VectorConstantCoefficient,
+  _swigc__p_mfem__VectorConvectionNLFIntegrator,
   _swigc__p_mfem__VectorCrossProductCoefficient,
   _swigc__p_mfem__VectorCrossProductInterpolator,
   _swigc__p_mfem__VectorCurlCurlIntegrator,

--- a/mfem/_par/bilininteg_wrap.h
+++ b/mfem/_par/bilininteg_wrap.h
@@ -19,13 +19,19 @@ class SwigDirector_BilinearFormIntegrator : public mfem::BilinearFormIntegrator,
 
 public:
     SwigDirector_BilinearFormIntegrator(PyObject *self, mfem::IntegrationRule const *ir = NULL);
+    virtual void AssembleElementVector(mfem::FiniteElement const &el, mfem::ElementTransformation &Tr, mfem::Vector const &elfun, mfem::Vector &elvect);
+    virtual void AssembleFaceVector(mfem::FiniteElement const &el1, mfem::FiniteElement const &el2, mfem::FaceElementTransformations &Tr, mfem::Vector const &elfun, mfem::Vector &elvect);
+    virtual void AssembleElementGrad(mfem::FiniteElement const &el, mfem::ElementTransformation &Tr, mfem::Vector const &elfun, mfem::DenseMatrix &elmat);
+    virtual void AssembleFaceGrad(mfem::FiniteElement const &el1, mfem::FiniteElement const &el2, mfem::FaceElementTransformations &Tr, mfem::Vector const &elfun, mfem::DenseMatrix &elmat);
+    virtual double GetElementEnergy(mfem::FiniteElement const &el, mfem::ElementTransformation &Tr, mfem::Vector const &elfun);
     virtual void AssemblePA(mfem::FiniteElementSpace const &fes);
     virtual void AssemblePA(mfem::FiniteElementSpace const &trial_fes, mfem::FiniteElementSpace const &test_fes);
+    virtual void AddMultPA(mfem::Vector const &x, mfem::Vector &y) const;
+    virtual ~SwigDirector_BilinearFormIntegrator();
     virtual void AssemblePAInteriorFaces(mfem::FiniteElementSpace const &fes);
     virtual void AssemblePABoundaryFaces(mfem::FiniteElementSpace const &fes);
     virtual void AssembleDiagonalPA(mfem::Vector &diag);
     virtual void AssembleDiagonalPA_ADAt(mfem::Vector const &D, mfem::Vector &diag);
-    virtual void AddMultPA(mfem::Vector const &x, mfem::Vector &y) const;
     virtual void AddMultTransposePA(mfem::Vector const &x, mfem::Vector &y) const;
     virtual void AssembleEA(mfem::FiniteElementSpace const &fes, mfem::Vector &emat, bool const add = true);
     virtual void AssembleMF(mfem::FiniteElementSpace const &fes);
@@ -38,13 +44,8 @@ public:
     virtual void AssembleElementMatrix2(mfem::FiniteElement const &trial_fe, mfem::FiniteElement const &test_fe, mfem::ElementTransformation &Trans, mfem::DenseMatrix &elmat);
     virtual void AssembleFaceMatrix(mfem::FiniteElement const &el1, mfem::FiniteElement const &el2, mfem::FaceElementTransformations &Trans, mfem::DenseMatrix &elmat);
     virtual void AssembleFaceMatrix(mfem::FiniteElement const &trial_face_fe, mfem::FiniteElement const &test_fe1, mfem::FiniteElement const &test_fe2, mfem::FaceElementTransformations &Trans, mfem::DenseMatrix &elmat);
-    virtual void AssembleElementVector(mfem::FiniteElement const &el, mfem::ElementTransformation &Tr, mfem::Vector const &elfun, mfem::Vector &elvect);
-    virtual void AssembleFaceVector(mfem::FiniteElement const &el1, mfem::FiniteElement const &el2, mfem::FaceElementTransformations &Tr, mfem::Vector const &elfun, mfem::Vector &elvect);
-    virtual void AssembleElementGrad(mfem::FiniteElement const &el, mfem::ElementTransformation &Tr, mfem::Vector const &elfun, mfem::DenseMatrix &elmat);
-    virtual void AssembleFaceGrad(mfem::FiniteElement const &el1, mfem::FiniteElement const &el2, mfem::FaceElementTransformations &Tr, mfem::Vector const &elfun, mfem::DenseMatrix &elmat);
     virtual void ComputeElementFlux(mfem::FiniteElement const &el, mfem::ElementTransformation &Trans, mfem::Vector &u, mfem::FiniteElement const &fluxelem, mfem::Vector &flux, bool with_coef = true);
     virtual double ComputeFluxEnergy(mfem::FiniteElement const &fluxelem, mfem::ElementTransformation &Trans, mfem::Vector &flux, mfem::Vector *d_energy = NULL);
-    virtual ~SwigDirector_BilinearFormIntegrator();
 
 /* Internal director utilities */
 public:
@@ -75,7 +76,7 @@ private:
       return method;
     }
 private:
-    mutable swig::SwigVar_PyObject vtable[25];
+    mutable swig::SwigVar_PyObject vtable[26];
 #endif
 
 };

--- a/mfem/_par/setup.py
+++ b/mfem/_par/setup.py
@@ -20,8 +20,6 @@ from  setup_local import *
 if cc_par != '': os.environ['CC'] = cc_par
 if cxx_par != '': os.environ['CXX'] = cxx_par
 
-
-
 from distutils.core import setup, Extension
 from distutils.core import *
 from distutils      import sysconfig

--- a/mfem/_ser/bilininteg.i
+++ b/mfem/_ser/bilininteg.i
@@ -39,6 +39,7 @@ import_array();
 %import "eltrans.i"
 %import "linearform.i"
 %import "fe.i"
+%import "nonlininteg.i"
 %include "../common/exception_director.i"
  //%template(IntegrationPointArray) mfem::Array<mfem::IntegrationPoint>;
 

--- a/mfem/_ser/bilininteg.py
+++ b/mfem/_ser/bilininteg.py
@@ -94,7 +94,8 @@ import mfem._ser.lininteg
 import mfem._ser.handle
 import mfem._ser.restriction
 import mfem._ser.linearform
-class BilinearFormIntegrator(object):
+import mfem._ser.nonlininteg
+class BilinearFormIntegrator(mfem._ser.nonlininteg.NonlinearFormIntegrator):
     r"""Proxy of C++ mfem::BilinearFormIntegrator class."""
 
     thisown = property(lambda x: x.this.own(), lambda x, v: x.this.own(v), doc="The membership flag")
@@ -110,7 +111,8 @@ class BilinearFormIntegrator(object):
 
     def AssemblePA(self, *args):
         r"""
-        AssemblePA(BilinearFormIntegrator self)
+        AssemblePA(BilinearFormIntegrator self, FiniteElementSpace fes)
+        AssemblePA(BilinearFormIntegrator self, FiniteElementSpace trial_fes, FiniteElementSpace test_fes)
         AssemblePA(BilinearFormIntegrator self, FiniteElementSpace fes)
         AssemblePA(BilinearFormIntegrator self, FiniteElementSpace trial_fes, FiniteElementSpace test_fes)
         """
@@ -278,7 +280,8 @@ class TransposeIntegrator(BilinearFormIntegrator):
 
     def AssemblePA(self, *args):
         r"""
-        AssemblePA(TransposeIntegrator self)
+        AssemblePA(TransposeIntegrator self, FiniteElementSpace fes)
+        AssemblePA(TransposeIntegrator self, FiniteElementSpace trial_fes, FiniteElementSpace test_fes)
         AssemblePA(TransposeIntegrator self, FiniteElementSpace fes)
         """
         return _bilininteg.TransposeIntegrator_AssemblePA(self, *args)
@@ -1423,7 +1426,8 @@ class GradientIntegrator(BilinearFormIntegrator):
 
     def AssemblePA(self, *args):
         r"""
-        AssemblePA(GradientIntegrator self)
+        AssemblePA(GradientIntegrator self, FiniteElementSpace fes)
+        AssemblePA(GradientIntegrator self, FiniteElementSpace trial_fes, FiniteElementSpace test_fes)
         AssemblePA(GradientIntegrator self, FiniteElementSpace trial_fes, FiniteElementSpace test_fes)
         """
         return _bilininteg.GradientIntegrator_AssemblePA(self, *args)
@@ -1507,7 +1511,8 @@ class DiffusionIntegrator(BilinearFormIntegrator):
 
     def AssemblePA(self, *args):
         r"""
-        AssemblePA(DiffusionIntegrator self)
+        AssemblePA(DiffusionIntegrator self, FiniteElementSpace fes)
+        AssemblePA(DiffusionIntegrator self, FiniteElementSpace trial_fes, FiniteElementSpace test_fes)
         AssemblePA(DiffusionIntegrator self, FiniteElementSpace fes)
         """
         return _bilininteg.DiffusionIntegrator_AssemblePA(self, *args)
@@ -1588,7 +1593,8 @@ class MassIntegrator(BilinearFormIntegrator):
 
     def AssemblePA(self, *args):
         r"""
-        AssemblePA(MassIntegrator self)
+        AssemblePA(MassIntegrator self, FiniteElementSpace fes)
+        AssemblePA(MassIntegrator self, FiniteElementSpace trial_fes, FiniteElementSpace test_fes)
         AssemblePA(MassIntegrator self, FiniteElementSpace fes)
         """
         return _bilininteg.MassIntegrator_AssemblePA(self, *args)
@@ -1673,7 +1679,8 @@ class ConvectionIntegrator(BilinearFormIntegrator):
 
     def AssemblePA(self, *args):
         r"""
-        AssemblePA(ConvectionIntegrator self)
+        AssemblePA(ConvectionIntegrator self, FiniteElementSpace fes)
+        AssemblePA(ConvectionIntegrator self, FiniteElementSpace trial_fes, FiniteElementSpace test_fes)
         AssemblePA(ConvectionIntegrator self, FiniteElementSpace arg2)
         """
         return _bilininteg.ConvectionIntegrator_AssemblePA(self, *args)
@@ -1768,7 +1775,8 @@ class VectorMassIntegrator(BilinearFormIntegrator):
 
     def AssemblePA(self, *args):
         r"""
-        AssemblePA(VectorMassIntegrator self)
+        AssemblePA(VectorMassIntegrator self, FiniteElementSpace fes)
+        AssemblePA(VectorMassIntegrator self, FiniteElementSpace trial_fes, FiniteElementSpace test_fes)
         AssemblePA(VectorMassIntegrator self, FiniteElementSpace fes)
         """
         return _bilininteg.VectorMassIntegrator_AssemblePA(self, *args)
@@ -1949,7 +1957,8 @@ class CurlCurlIntegrator(BilinearFormIntegrator):
 
     def AssemblePA(self, *args):
         r"""
-        AssemblePA(CurlCurlIntegrator self)
+        AssemblePA(CurlCurlIntegrator self, FiniteElementSpace fes)
+        AssemblePA(CurlCurlIntegrator self, FiniteElementSpace trial_fes, FiniteElementSpace test_fes)
         AssemblePA(CurlCurlIntegrator self, FiniteElementSpace fes)
         """
         return _bilininteg.CurlCurlIntegrator_AssemblePA(self, *args)
@@ -2031,7 +2040,8 @@ class VectorFEMassIntegrator(BilinearFormIntegrator):
 
     def AssemblePA(self, *args):
         r"""
-        AssemblePA(VectorFEMassIntegrator self)
+        AssemblePA(VectorFEMassIntegrator self, FiniteElementSpace fes)
+        AssemblePA(VectorFEMassIntegrator self, FiniteElementSpace trial_fes, FiniteElementSpace test_fes)
         AssemblePA(VectorFEMassIntegrator self, FiniteElementSpace fes)
         AssemblePA(VectorFEMassIntegrator self, FiniteElementSpace trial_fes, FiniteElementSpace test_fes)
         """
@@ -2073,7 +2083,8 @@ class VectorDivergenceIntegrator(BilinearFormIntegrator):
 
     def AssemblePA(self, *args):
         r"""
-        AssemblePA(VectorDivergenceIntegrator self)
+        AssemblePA(VectorDivergenceIntegrator self, FiniteElementSpace fes)
+        AssemblePA(VectorDivergenceIntegrator self, FiniteElementSpace trial_fes, FiniteElementSpace test_fes)
         AssemblePA(VectorDivergenceIntegrator self, FiniteElementSpace trial_fes, FiniteElementSpace test_fes)
         """
         return _bilininteg.VectorDivergenceIntegrator_AssemblePA(self, *args)
@@ -2152,7 +2163,8 @@ class VectorDiffusionIntegrator(BilinearFormIntegrator):
 
     def AssemblePA(self, *args):
         r"""
-        AssemblePA(VectorDiffusionIntegrator self)
+        AssemblePA(VectorDiffusionIntegrator self, FiniteElementSpace fes)
+        AssemblePA(VectorDiffusionIntegrator self, FiniteElementSpace trial_fes, FiniteElementSpace test_fes)
         AssemblePA(VectorDiffusionIntegrator self, FiniteElementSpace fes)
         """
         return _bilininteg.VectorDiffusionIntegrator_AssemblePA(self, *args)
@@ -2239,6 +2251,14 @@ class DGTraceIntegrator(BilinearFormIntegrator):
         """
         return _bilininteg.DGTraceIntegrator_AssembleFaceMatrix(self, *args)
     AssembleFaceMatrix = _swig_new_instance_method(_bilininteg.DGTraceIntegrator_AssembleFaceMatrix)
+
+    def AssemblePA(self, *args):
+        r"""
+        AssemblePA(DGTraceIntegrator self, FiniteElementSpace fes)
+        AssemblePA(DGTraceIntegrator self, FiniteElementSpace trial_fes, FiniteElementSpace test_fes)
+        """
+        return _bilininteg.DGTraceIntegrator_AssemblePA(self, *args)
+    AssemblePA = _swig_new_instance_method(_bilininteg.DGTraceIntegrator_AssemblePA)
 
     def AssemblePAInteriorFaces(self, fes):
         r"""AssemblePAInteriorFaces(DGTraceIntegrator self, FiniteElementSpace fes)"""

--- a/mfem/_ser/bilininteg_wrap.cxx
+++ b/mfem/_ser/bilininteg_wrap.cxx
@@ -3166,189 +3166,192 @@ namespace Swig {
 #define SWIGTYPE_p_mfem__H1_TetrahedronElement swig_types[66]
 #define SWIGTYPE_p_mfem__H1_TriangleElement swig_types[67]
 #define SWIGTYPE_p_mfem__H1_WedgeElement swig_types[68]
-#define SWIGTYPE_p_mfem__IdentityInterpolator swig_types[69]
-#define SWIGTYPE_p_mfem__IdentityMatrixCoefficient swig_types[70]
-#define SWIGTYPE_p_mfem__InnerProductCoefficient swig_types[71]
-#define SWIGTYPE_p_mfem__IntegrationRule swig_types[72]
-#define SWIGTYPE_p_mfem__InverseIntegrator swig_types[73]
-#define SWIGTYPE_p_mfem__InverseMatrixCoefficient swig_types[74]
-#define SWIGTYPE_p_mfem__IsoparametricTransformation swig_types[75]
-#define SWIGTYPE_p_mfem__L2Pos_HexahedronElement swig_types[76]
-#define SWIGTYPE_p_mfem__L2Pos_QuadrilateralElement swig_types[77]
-#define SWIGTYPE_p_mfem__L2Pos_SegmentElement swig_types[78]
-#define SWIGTYPE_p_mfem__L2Pos_TetrahedronElement swig_types[79]
-#define SWIGTYPE_p_mfem__L2Pos_TriangleElement swig_types[80]
-#define SWIGTYPE_p_mfem__L2Pos_WedgeElement swig_types[81]
-#define SWIGTYPE_p_mfem__L2_FECollection swig_types[82]
-#define SWIGTYPE_p_mfem__L2_HexahedronElement swig_types[83]
-#define SWIGTYPE_p_mfem__L2_QuadrilateralElement swig_types[84]
-#define SWIGTYPE_p_mfem__L2_SegmentElement swig_types[85]
-#define SWIGTYPE_p_mfem__L2_TetrahedronElement swig_types[86]
-#define SWIGTYPE_p_mfem__L2_TriangleElement swig_types[87]
-#define SWIGTYPE_p_mfem__L2_WedgeElement swig_types[88]
-#define SWIGTYPE_p_mfem__Lagrange1DFiniteElement swig_types[89]
-#define SWIGTYPE_p_mfem__LagrangeHexFiniteElement swig_types[90]
-#define SWIGTYPE_p_mfem__Linear1DFiniteElement swig_types[91]
-#define SWIGTYPE_p_mfem__Linear2DFiniteElement swig_types[92]
-#define SWIGTYPE_p_mfem__Linear3DFiniteElement swig_types[93]
-#define SWIGTYPE_p_mfem__LinearForm swig_types[94]
-#define SWIGTYPE_p_mfem__LumpedIntegrator swig_types[95]
-#define SWIGTYPE_p_mfem__MassIntegrator swig_types[96]
-#define SWIGTYPE_p_mfem__MatrixArrayCoefficient swig_types[97]
-#define SWIGTYPE_p_mfem__MatrixCoefficient swig_types[98]
-#define SWIGTYPE_p_mfem__MatrixConstantCoefficient swig_types[99]
-#define SWIGTYPE_p_mfem__MatrixFunctionCoefficient swig_types[100]
-#define SWIGTYPE_p_mfem__MatrixPyCoefficientBase swig_types[101]
-#define SWIGTYPE_p_mfem__MatrixRestrictedCoefficient swig_types[102]
-#define SWIGTYPE_p_mfem__MatrixSumCoefficient swig_types[103]
-#define SWIGTYPE_p_mfem__MatrixVectorProductCoefficient swig_types[104]
-#define SWIGTYPE_p_mfem__MixedCrossCurlCurlIntegrator swig_types[105]
-#define SWIGTYPE_p_mfem__MixedCrossCurlGradIntegrator swig_types[106]
-#define SWIGTYPE_p_mfem__MixedCrossCurlIntegrator swig_types[107]
-#define SWIGTYPE_p_mfem__MixedCrossGradCurlIntegrator swig_types[108]
-#define SWIGTYPE_p_mfem__MixedCrossGradGradIntegrator swig_types[109]
-#define SWIGTYPE_p_mfem__MixedCrossGradIntegrator swig_types[110]
-#define SWIGTYPE_p_mfem__MixedCrossProductIntegrator swig_types[111]
-#define SWIGTYPE_p_mfem__MixedCurlCurlIntegrator swig_types[112]
-#define SWIGTYPE_p_mfem__MixedDirectionalDerivativeIntegrator swig_types[113]
-#define SWIGTYPE_p_mfem__MixedDivGradIntegrator swig_types[114]
-#define SWIGTYPE_p_mfem__MixedDotProductIntegrator swig_types[115]
-#define SWIGTYPE_p_mfem__MixedGradDivIntegrator swig_types[116]
-#define SWIGTYPE_p_mfem__MixedGradGradIntegrator swig_types[117]
-#define SWIGTYPE_p_mfem__MixedScalarCrossCurlIntegrator swig_types[118]
-#define SWIGTYPE_p_mfem__MixedScalarCrossGradIntegrator swig_types[119]
-#define SWIGTYPE_p_mfem__MixedScalarCrossProductIntegrator swig_types[120]
-#define SWIGTYPE_p_mfem__MixedScalarCurlIntegrator swig_types[121]
-#define SWIGTYPE_p_mfem__MixedScalarDerivativeIntegrator swig_types[122]
-#define SWIGTYPE_p_mfem__MixedScalarDivergenceIntegrator swig_types[123]
-#define SWIGTYPE_p_mfem__MixedScalarIntegrator swig_types[124]
-#define SWIGTYPE_p_mfem__MixedScalarMassIntegrator swig_types[125]
-#define SWIGTYPE_p_mfem__MixedScalarVectorIntegrator swig_types[126]
-#define SWIGTYPE_p_mfem__MixedScalarWeakCrossProductIntegrator swig_types[127]
-#define SWIGTYPE_p_mfem__MixedScalarWeakCurlCrossIntegrator swig_types[128]
-#define SWIGTYPE_p_mfem__MixedScalarWeakCurlIntegrator swig_types[129]
-#define SWIGTYPE_p_mfem__MixedScalarWeakDerivativeIntegrator swig_types[130]
-#define SWIGTYPE_p_mfem__MixedScalarWeakDivergenceIntegrator swig_types[131]
-#define SWIGTYPE_p_mfem__MixedScalarWeakGradientIntegrator swig_types[132]
-#define SWIGTYPE_p_mfem__MixedVectorCurlIntegrator swig_types[133]
-#define SWIGTYPE_p_mfem__MixedVectorDivergenceIntegrator swig_types[134]
-#define SWIGTYPE_p_mfem__MixedVectorGradientIntegrator swig_types[135]
-#define SWIGTYPE_p_mfem__MixedVectorIntegrator swig_types[136]
-#define SWIGTYPE_p_mfem__MixedVectorMassIntegrator swig_types[137]
-#define SWIGTYPE_p_mfem__MixedVectorProductIntegrator swig_types[138]
-#define SWIGTYPE_p_mfem__MixedVectorWeakCurlIntegrator swig_types[139]
-#define SWIGTYPE_p_mfem__MixedVectorWeakDivergenceIntegrator swig_types[140]
-#define SWIGTYPE_p_mfem__MixedWeakCurlCrossIntegrator swig_types[141]
-#define SWIGTYPE_p_mfem__MixedWeakDivCrossIntegrator swig_types[142]
-#define SWIGTYPE_p_mfem__MixedWeakGradDotIntegrator swig_types[143]
-#define SWIGTYPE_p_mfem__ND_HexahedronElement swig_types[144]
-#define SWIGTYPE_p_mfem__ND_QuadrilateralElement swig_types[145]
-#define SWIGTYPE_p_mfem__ND_SegmentElement swig_types[146]
-#define SWIGTYPE_p_mfem__ND_TetrahedronElement swig_types[147]
-#define SWIGTYPE_p_mfem__ND_TriangleElement swig_types[148]
-#define SWIGTYPE_p_mfem__NURBS1DFiniteElement swig_types[149]
-#define SWIGTYPE_p_mfem__NURBS2DFiniteElement swig_types[150]
-#define SWIGTYPE_p_mfem__NURBS3DFiniteElement swig_types[151]
-#define SWIGTYPE_p_mfem__NURBSFiniteElement swig_types[152]
-#define SWIGTYPE_p_mfem__Nedelec1HexFiniteElement swig_types[153]
-#define SWIGTYPE_p_mfem__Nedelec1TetFiniteElement swig_types[154]
-#define SWIGTYPE_p_mfem__NodalFiniteElement swig_types[155]
-#define SWIGTYPE_p_mfem__NodalTensorFiniteElement swig_types[156]
-#define SWIGTYPE_p_mfem__NodeExtrudeCoefficient swig_types[157]
-#define SWIGTYPE_p_mfem__NormalInterpolator swig_types[158]
-#define SWIGTYPE_p_mfem__NormalTraceJumpIntegrator swig_types[159]
-#define SWIGTYPE_p_mfem__NormalizedVectorCoefficient swig_types[160]
-#define SWIGTYPE_p_mfem__OperatorHandle swig_types[161]
-#define SWIGTYPE_p_mfem__OuterProductCoefficient swig_types[162]
-#define SWIGTYPE_p_mfem__P0HexFiniteElement swig_types[163]
-#define SWIGTYPE_p_mfem__P0QuadFiniteElement swig_types[164]
-#define SWIGTYPE_p_mfem__P0SegmentFiniteElement swig_types[165]
-#define SWIGTYPE_p_mfem__P0TetFiniteElement swig_types[166]
-#define SWIGTYPE_p_mfem__P0TriangleFiniteElement swig_types[167]
-#define SWIGTYPE_p_mfem__P0WedgeFiniteElement swig_types[168]
-#define SWIGTYPE_p_mfem__P1OnQuadFiniteElement swig_types[169]
-#define SWIGTYPE_p_mfem__P1SegmentFiniteElement swig_types[170]
-#define SWIGTYPE_p_mfem__P1TetNonConfFiniteElement swig_types[171]
-#define SWIGTYPE_p_mfem__P2SegmentFiniteElement swig_types[172]
-#define SWIGTYPE_p_mfem__PWConstCoefficient swig_types[173]
-#define SWIGTYPE_p_mfem__PointFiniteElement swig_types[174]
-#define SWIGTYPE_p_mfem__PositiveFiniteElement swig_types[175]
-#define SWIGTYPE_p_mfem__PositiveTensorFiniteElement swig_types[176]
-#define SWIGTYPE_p_mfem__PowerCoefficient swig_types[177]
-#define SWIGTYPE_p_mfem__ProductCoefficient swig_types[178]
-#define SWIGTYPE_p_mfem__PyCoefficientBase swig_types[179]
-#define SWIGTYPE_p_mfem__Quad1DFiniteElement swig_types[180]
-#define SWIGTYPE_p_mfem__Quad2DFiniteElement swig_types[181]
-#define SWIGTYPE_p_mfem__QuadPos1DFiniteElement swig_types[182]
-#define SWIGTYPE_p_mfem__Quadratic3DFiniteElement swig_types[183]
-#define SWIGTYPE_p_mfem__QuadratureFunction swig_types[184]
-#define SWIGTYPE_p_mfem__QuadratureFunctionCoefficient swig_types[185]
-#define SWIGTYPE_p_mfem__RT0HexFiniteElement swig_types[186]
-#define SWIGTYPE_p_mfem__RT0QuadFiniteElement swig_types[187]
-#define SWIGTYPE_p_mfem__RT0TetFiniteElement swig_types[188]
-#define SWIGTYPE_p_mfem__RT0TriangleFiniteElement swig_types[189]
-#define SWIGTYPE_p_mfem__RT1HexFiniteElement swig_types[190]
-#define SWIGTYPE_p_mfem__RT1QuadFiniteElement swig_types[191]
-#define SWIGTYPE_p_mfem__RT1TriangleFiniteElement swig_types[192]
-#define SWIGTYPE_p_mfem__RT2QuadFiniteElement swig_types[193]
-#define SWIGTYPE_p_mfem__RT2TriangleFiniteElement swig_types[194]
-#define SWIGTYPE_p_mfem__RT_HexahedronElement swig_types[195]
-#define SWIGTYPE_p_mfem__RT_QuadrilateralElement swig_types[196]
-#define SWIGTYPE_p_mfem__RT_TetrahedronElement swig_types[197]
-#define SWIGTYPE_p_mfem__RT_TriangleElement swig_types[198]
-#define SWIGTYPE_p_mfem__RatioCoefficient swig_types[199]
-#define SWIGTYPE_p_mfem__RefinedBiLinear2DFiniteElement swig_types[200]
-#define SWIGTYPE_p_mfem__RefinedLinear1DFiniteElement swig_types[201]
-#define SWIGTYPE_p_mfem__RefinedLinear2DFiniteElement swig_types[202]
-#define SWIGTYPE_p_mfem__RefinedLinear3DFiniteElement swig_types[203]
-#define SWIGTYPE_p_mfem__RefinedTriLinear3DFiniteElement swig_types[204]
-#define SWIGTYPE_p_mfem__RestrictedCoefficient swig_types[205]
-#define SWIGTYPE_p_mfem__RotTriLinearHexFiniteElement swig_types[206]
-#define SWIGTYPE_p_mfem__ScalarFiniteElement swig_types[207]
-#define SWIGTYPE_p_mfem__ScalarMatrixProductCoefficient swig_types[208]
-#define SWIGTYPE_p_mfem__ScalarProductInterpolator swig_types[209]
-#define SWIGTYPE_p_mfem__ScalarVectorProductCoefficient swig_types[210]
-#define SWIGTYPE_p_mfem__ScalarVectorProductInterpolator swig_types[211]
-#define SWIGTYPE_p_mfem__SumCoefficient swig_types[212]
-#define SWIGTYPE_p_mfem__SumIntegrator swig_types[213]
-#define SWIGTYPE_p_mfem__TraceJumpIntegrator swig_types[214]
-#define SWIGTYPE_p_mfem__TransformedCoefficient swig_types[215]
-#define SWIGTYPE_p_mfem__TransposeIntegrator swig_types[216]
-#define SWIGTYPE_p_mfem__TransposeMatrixCoefficient swig_types[217]
-#define SWIGTYPE_p_mfem__TriLinear3DFiniteElement swig_types[218]
-#define SWIGTYPE_p_mfem__Vector swig_types[219]
-#define SWIGTYPE_p_mfem__VectorArrayCoefficient swig_types[220]
-#define SWIGTYPE_p_mfem__VectorCoefficient swig_types[221]
-#define SWIGTYPE_p_mfem__VectorConstantCoefficient swig_types[222]
-#define SWIGTYPE_p_mfem__VectorCrossProductCoefficient swig_types[223]
-#define SWIGTYPE_p_mfem__VectorCrossProductInterpolator swig_types[224]
-#define SWIGTYPE_p_mfem__VectorCurlCurlIntegrator swig_types[225]
-#define SWIGTYPE_p_mfem__VectorDeltaCoefficient swig_types[226]
-#define SWIGTYPE_p_mfem__VectorDiffusionIntegrator swig_types[227]
-#define SWIGTYPE_p_mfem__VectorDivergenceIntegrator swig_types[228]
-#define SWIGTYPE_p_mfem__VectorFECurlIntegrator swig_types[229]
-#define SWIGTYPE_p_mfem__VectorFEDivergenceIntegrator swig_types[230]
-#define SWIGTYPE_p_mfem__VectorFEMassIntegrator swig_types[231]
-#define SWIGTYPE_p_mfem__VectorFEWeakDivergenceIntegrator swig_types[232]
-#define SWIGTYPE_p_mfem__VectorFiniteElement swig_types[233]
-#define SWIGTYPE_p_mfem__VectorFunctionCoefficient swig_types[234]
-#define SWIGTYPE_p_mfem__VectorGridFunctionCoefficient swig_types[235]
-#define SWIGTYPE_p_mfem__VectorInnerProductInterpolator swig_types[236]
-#define SWIGTYPE_p_mfem__VectorMassIntegrator swig_types[237]
-#define SWIGTYPE_p_mfem__VectorPyCoefficientBase swig_types[238]
-#define SWIGTYPE_p_mfem__VectorQuadratureFunctionCoefficient swig_types[239]
-#define SWIGTYPE_p_mfem__VectorRestrictedCoefficient swig_types[240]
-#define SWIGTYPE_p_mfem__VectorRotProductCoefficient swig_types[241]
-#define SWIGTYPE_p_mfem__VectorScalarProductInterpolator swig_types[242]
-#define SWIGTYPE_p_mfem__VectorSumCoefficient swig_types[243]
-#define SWIGTYPE_p_mfem__VectorTensorFiniteElement swig_types[244]
-#define SWIGTYPE_p_pri_t swig_types[245]
-#define SWIGTYPE_p_quad_t swig_types[246]
-#define SWIGTYPE_p_seg_t swig_types[247]
-#define SWIGTYPE_p_tet_t swig_types[248]
-#define SWIGTYPE_p_tri_t swig_types[249]
-static swig_type_info *swig_types[251];
-static swig_module_info swig_module = {swig_types, 250, 0, 0, 0, 0};
+#define SWIGTYPE_p_mfem__HyperelasticNLFIntegrator swig_types[69]
+#define SWIGTYPE_p_mfem__IdentityInterpolator swig_types[70]
+#define SWIGTYPE_p_mfem__IdentityMatrixCoefficient swig_types[71]
+#define SWIGTYPE_p_mfem__InnerProductCoefficient swig_types[72]
+#define SWIGTYPE_p_mfem__IntegrationRule swig_types[73]
+#define SWIGTYPE_p_mfem__InverseIntegrator swig_types[74]
+#define SWIGTYPE_p_mfem__InverseMatrixCoefficient swig_types[75]
+#define SWIGTYPE_p_mfem__IsoparametricTransformation swig_types[76]
+#define SWIGTYPE_p_mfem__L2Pos_HexahedronElement swig_types[77]
+#define SWIGTYPE_p_mfem__L2Pos_QuadrilateralElement swig_types[78]
+#define SWIGTYPE_p_mfem__L2Pos_SegmentElement swig_types[79]
+#define SWIGTYPE_p_mfem__L2Pos_TetrahedronElement swig_types[80]
+#define SWIGTYPE_p_mfem__L2Pos_TriangleElement swig_types[81]
+#define SWIGTYPE_p_mfem__L2Pos_WedgeElement swig_types[82]
+#define SWIGTYPE_p_mfem__L2_FECollection swig_types[83]
+#define SWIGTYPE_p_mfem__L2_HexahedronElement swig_types[84]
+#define SWIGTYPE_p_mfem__L2_QuadrilateralElement swig_types[85]
+#define SWIGTYPE_p_mfem__L2_SegmentElement swig_types[86]
+#define SWIGTYPE_p_mfem__L2_TetrahedronElement swig_types[87]
+#define SWIGTYPE_p_mfem__L2_TriangleElement swig_types[88]
+#define SWIGTYPE_p_mfem__L2_WedgeElement swig_types[89]
+#define SWIGTYPE_p_mfem__Lagrange1DFiniteElement swig_types[90]
+#define SWIGTYPE_p_mfem__LagrangeHexFiniteElement swig_types[91]
+#define SWIGTYPE_p_mfem__Linear1DFiniteElement swig_types[92]
+#define SWIGTYPE_p_mfem__Linear2DFiniteElement swig_types[93]
+#define SWIGTYPE_p_mfem__Linear3DFiniteElement swig_types[94]
+#define SWIGTYPE_p_mfem__LinearForm swig_types[95]
+#define SWIGTYPE_p_mfem__LumpedIntegrator swig_types[96]
+#define SWIGTYPE_p_mfem__MassIntegrator swig_types[97]
+#define SWIGTYPE_p_mfem__MatrixArrayCoefficient swig_types[98]
+#define SWIGTYPE_p_mfem__MatrixCoefficient swig_types[99]
+#define SWIGTYPE_p_mfem__MatrixConstantCoefficient swig_types[100]
+#define SWIGTYPE_p_mfem__MatrixFunctionCoefficient swig_types[101]
+#define SWIGTYPE_p_mfem__MatrixPyCoefficientBase swig_types[102]
+#define SWIGTYPE_p_mfem__MatrixRestrictedCoefficient swig_types[103]
+#define SWIGTYPE_p_mfem__MatrixSumCoefficient swig_types[104]
+#define SWIGTYPE_p_mfem__MatrixVectorProductCoefficient swig_types[105]
+#define SWIGTYPE_p_mfem__MixedCrossCurlCurlIntegrator swig_types[106]
+#define SWIGTYPE_p_mfem__MixedCrossCurlGradIntegrator swig_types[107]
+#define SWIGTYPE_p_mfem__MixedCrossCurlIntegrator swig_types[108]
+#define SWIGTYPE_p_mfem__MixedCrossGradCurlIntegrator swig_types[109]
+#define SWIGTYPE_p_mfem__MixedCrossGradGradIntegrator swig_types[110]
+#define SWIGTYPE_p_mfem__MixedCrossGradIntegrator swig_types[111]
+#define SWIGTYPE_p_mfem__MixedCrossProductIntegrator swig_types[112]
+#define SWIGTYPE_p_mfem__MixedCurlCurlIntegrator swig_types[113]
+#define SWIGTYPE_p_mfem__MixedDirectionalDerivativeIntegrator swig_types[114]
+#define SWIGTYPE_p_mfem__MixedDivGradIntegrator swig_types[115]
+#define SWIGTYPE_p_mfem__MixedDotProductIntegrator swig_types[116]
+#define SWIGTYPE_p_mfem__MixedGradDivIntegrator swig_types[117]
+#define SWIGTYPE_p_mfem__MixedGradGradIntegrator swig_types[118]
+#define SWIGTYPE_p_mfem__MixedScalarCrossCurlIntegrator swig_types[119]
+#define SWIGTYPE_p_mfem__MixedScalarCrossGradIntegrator swig_types[120]
+#define SWIGTYPE_p_mfem__MixedScalarCrossProductIntegrator swig_types[121]
+#define SWIGTYPE_p_mfem__MixedScalarCurlIntegrator swig_types[122]
+#define SWIGTYPE_p_mfem__MixedScalarDerivativeIntegrator swig_types[123]
+#define SWIGTYPE_p_mfem__MixedScalarDivergenceIntegrator swig_types[124]
+#define SWIGTYPE_p_mfem__MixedScalarIntegrator swig_types[125]
+#define SWIGTYPE_p_mfem__MixedScalarMassIntegrator swig_types[126]
+#define SWIGTYPE_p_mfem__MixedScalarVectorIntegrator swig_types[127]
+#define SWIGTYPE_p_mfem__MixedScalarWeakCrossProductIntegrator swig_types[128]
+#define SWIGTYPE_p_mfem__MixedScalarWeakCurlCrossIntegrator swig_types[129]
+#define SWIGTYPE_p_mfem__MixedScalarWeakCurlIntegrator swig_types[130]
+#define SWIGTYPE_p_mfem__MixedScalarWeakDerivativeIntegrator swig_types[131]
+#define SWIGTYPE_p_mfem__MixedScalarWeakDivergenceIntegrator swig_types[132]
+#define SWIGTYPE_p_mfem__MixedScalarWeakGradientIntegrator swig_types[133]
+#define SWIGTYPE_p_mfem__MixedVectorCurlIntegrator swig_types[134]
+#define SWIGTYPE_p_mfem__MixedVectorDivergenceIntegrator swig_types[135]
+#define SWIGTYPE_p_mfem__MixedVectorGradientIntegrator swig_types[136]
+#define SWIGTYPE_p_mfem__MixedVectorIntegrator swig_types[137]
+#define SWIGTYPE_p_mfem__MixedVectorMassIntegrator swig_types[138]
+#define SWIGTYPE_p_mfem__MixedVectorProductIntegrator swig_types[139]
+#define SWIGTYPE_p_mfem__MixedVectorWeakCurlIntegrator swig_types[140]
+#define SWIGTYPE_p_mfem__MixedVectorWeakDivergenceIntegrator swig_types[141]
+#define SWIGTYPE_p_mfem__MixedWeakCurlCrossIntegrator swig_types[142]
+#define SWIGTYPE_p_mfem__MixedWeakDivCrossIntegrator swig_types[143]
+#define SWIGTYPE_p_mfem__MixedWeakGradDotIntegrator swig_types[144]
+#define SWIGTYPE_p_mfem__ND_HexahedronElement swig_types[145]
+#define SWIGTYPE_p_mfem__ND_QuadrilateralElement swig_types[146]
+#define SWIGTYPE_p_mfem__ND_SegmentElement swig_types[147]
+#define SWIGTYPE_p_mfem__ND_TetrahedronElement swig_types[148]
+#define SWIGTYPE_p_mfem__ND_TriangleElement swig_types[149]
+#define SWIGTYPE_p_mfem__NURBS1DFiniteElement swig_types[150]
+#define SWIGTYPE_p_mfem__NURBS2DFiniteElement swig_types[151]
+#define SWIGTYPE_p_mfem__NURBS3DFiniteElement swig_types[152]
+#define SWIGTYPE_p_mfem__NURBSFiniteElement swig_types[153]
+#define SWIGTYPE_p_mfem__Nedelec1HexFiniteElement swig_types[154]
+#define SWIGTYPE_p_mfem__Nedelec1TetFiniteElement swig_types[155]
+#define SWIGTYPE_p_mfem__NodalFiniteElement swig_types[156]
+#define SWIGTYPE_p_mfem__NodalTensorFiniteElement swig_types[157]
+#define SWIGTYPE_p_mfem__NodeExtrudeCoefficient swig_types[158]
+#define SWIGTYPE_p_mfem__NonlinearFormIntegrator swig_types[159]
+#define SWIGTYPE_p_mfem__NormalInterpolator swig_types[160]
+#define SWIGTYPE_p_mfem__NormalTraceJumpIntegrator swig_types[161]
+#define SWIGTYPE_p_mfem__NormalizedVectorCoefficient swig_types[162]
+#define SWIGTYPE_p_mfem__OperatorHandle swig_types[163]
+#define SWIGTYPE_p_mfem__OuterProductCoefficient swig_types[164]
+#define SWIGTYPE_p_mfem__P0HexFiniteElement swig_types[165]
+#define SWIGTYPE_p_mfem__P0QuadFiniteElement swig_types[166]
+#define SWIGTYPE_p_mfem__P0SegmentFiniteElement swig_types[167]
+#define SWIGTYPE_p_mfem__P0TetFiniteElement swig_types[168]
+#define SWIGTYPE_p_mfem__P0TriangleFiniteElement swig_types[169]
+#define SWIGTYPE_p_mfem__P0WedgeFiniteElement swig_types[170]
+#define SWIGTYPE_p_mfem__P1OnQuadFiniteElement swig_types[171]
+#define SWIGTYPE_p_mfem__P1SegmentFiniteElement swig_types[172]
+#define SWIGTYPE_p_mfem__P1TetNonConfFiniteElement swig_types[173]
+#define SWIGTYPE_p_mfem__P2SegmentFiniteElement swig_types[174]
+#define SWIGTYPE_p_mfem__PWConstCoefficient swig_types[175]
+#define SWIGTYPE_p_mfem__PointFiniteElement swig_types[176]
+#define SWIGTYPE_p_mfem__PositiveFiniteElement swig_types[177]
+#define SWIGTYPE_p_mfem__PositiveTensorFiniteElement swig_types[178]
+#define SWIGTYPE_p_mfem__PowerCoefficient swig_types[179]
+#define SWIGTYPE_p_mfem__ProductCoefficient swig_types[180]
+#define SWIGTYPE_p_mfem__PyCoefficientBase swig_types[181]
+#define SWIGTYPE_p_mfem__Quad1DFiniteElement swig_types[182]
+#define SWIGTYPE_p_mfem__Quad2DFiniteElement swig_types[183]
+#define SWIGTYPE_p_mfem__QuadPos1DFiniteElement swig_types[184]
+#define SWIGTYPE_p_mfem__Quadratic3DFiniteElement swig_types[185]
+#define SWIGTYPE_p_mfem__QuadratureFunction swig_types[186]
+#define SWIGTYPE_p_mfem__QuadratureFunctionCoefficient swig_types[187]
+#define SWIGTYPE_p_mfem__RT0HexFiniteElement swig_types[188]
+#define SWIGTYPE_p_mfem__RT0QuadFiniteElement swig_types[189]
+#define SWIGTYPE_p_mfem__RT0TetFiniteElement swig_types[190]
+#define SWIGTYPE_p_mfem__RT0TriangleFiniteElement swig_types[191]
+#define SWIGTYPE_p_mfem__RT1HexFiniteElement swig_types[192]
+#define SWIGTYPE_p_mfem__RT1QuadFiniteElement swig_types[193]
+#define SWIGTYPE_p_mfem__RT1TriangleFiniteElement swig_types[194]
+#define SWIGTYPE_p_mfem__RT2QuadFiniteElement swig_types[195]
+#define SWIGTYPE_p_mfem__RT2TriangleFiniteElement swig_types[196]
+#define SWIGTYPE_p_mfem__RT_HexahedronElement swig_types[197]
+#define SWIGTYPE_p_mfem__RT_QuadrilateralElement swig_types[198]
+#define SWIGTYPE_p_mfem__RT_TetrahedronElement swig_types[199]
+#define SWIGTYPE_p_mfem__RT_TriangleElement swig_types[200]
+#define SWIGTYPE_p_mfem__RatioCoefficient swig_types[201]
+#define SWIGTYPE_p_mfem__RefinedBiLinear2DFiniteElement swig_types[202]
+#define SWIGTYPE_p_mfem__RefinedLinear1DFiniteElement swig_types[203]
+#define SWIGTYPE_p_mfem__RefinedLinear2DFiniteElement swig_types[204]
+#define SWIGTYPE_p_mfem__RefinedLinear3DFiniteElement swig_types[205]
+#define SWIGTYPE_p_mfem__RefinedTriLinear3DFiniteElement swig_types[206]
+#define SWIGTYPE_p_mfem__RestrictedCoefficient swig_types[207]
+#define SWIGTYPE_p_mfem__RotTriLinearHexFiniteElement swig_types[208]
+#define SWIGTYPE_p_mfem__ScalarFiniteElement swig_types[209]
+#define SWIGTYPE_p_mfem__ScalarMatrixProductCoefficient swig_types[210]
+#define SWIGTYPE_p_mfem__ScalarProductInterpolator swig_types[211]
+#define SWIGTYPE_p_mfem__ScalarVectorProductCoefficient swig_types[212]
+#define SWIGTYPE_p_mfem__ScalarVectorProductInterpolator swig_types[213]
+#define SWIGTYPE_p_mfem__SumCoefficient swig_types[214]
+#define SWIGTYPE_p_mfem__SumIntegrator swig_types[215]
+#define SWIGTYPE_p_mfem__TraceJumpIntegrator swig_types[216]
+#define SWIGTYPE_p_mfem__TransformedCoefficient swig_types[217]
+#define SWIGTYPE_p_mfem__TransposeIntegrator swig_types[218]
+#define SWIGTYPE_p_mfem__TransposeMatrixCoefficient swig_types[219]
+#define SWIGTYPE_p_mfem__TriLinear3DFiniteElement swig_types[220]
+#define SWIGTYPE_p_mfem__Vector swig_types[221]
+#define SWIGTYPE_p_mfem__VectorArrayCoefficient swig_types[222]
+#define SWIGTYPE_p_mfem__VectorCoefficient swig_types[223]
+#define SWIGTYPE_p_mfem__VectorConstantCoefficient swig_types[224]
+#define SWIGTYPE_p_mfem__VectorConvectionNLFIntegrator swig_types[225]
+#define SWIGTYPE_p_mfem__VectorCrossProductCoefficient swig_types[226]
+#define SWIGTYPE_p_mfem__VectorCrossProductInterpolator swig_types[227]
+#define SWIGTYPE_p_mfem__VectorCurlCurlIntegrator swig_types[228]
+#define SWIGTYPE_p_mfem__VectorDeltaCoefficient swig_types[229]
+#define SWIGTYPE_p_mfem__VectorDiffusionIntegrator swig_types[230]
+#define SWIGTYPE_p_mfem__VectorDivergenceIntegrator swig_types[231]
+#define SWIGTYPE_p_mfem__VectorFECurlIntegrator swig_types[232]
+#define SWIGTYPE_p_mfem__VectorFEDivergenceIntegrator swig_types[233]
+#define SWIGTYPE_p_mfem__VectorFEMassIntegrator swig_types[234]
+#define SWIGTYPE_p_mfem__VectorFEWeakDivergenceIntegrator swig_types[235]
+#define SWIGTYPE_p_mfem__VectorFiniteElement swig_types[236]
+#define SWIGTYPE_p_mfem__VectorFunctionCoefficient swig_types[237]
+#define SWIGTYPE_p_mfem__VectorGridFunctionCoefficient swig_types[238]
+#define SWIGTYPE_p_mfem__VectorInnerProductInterpolator swig_types[239]
+#define SWIGTYPE_p_mfem__VectorMassIntegrator swig_types[240]
+#define SWIGTYPE_p_mfem__VectorPyCoefficientBase swig_types[241]
+#define SWIGTYPE_p_mfem__VectorQuadratureFunctionCoefficient swig_types[242]
+#define SWIGTYPE_p_mfem__VectorRestrictedCoefficient swig_types[243]
+#define SWIGTYPE_p_mfem__VectorRotProductCoefficient swig_types[244]
+#define SWIGTYPE_p_mfem__VectorScalarProductInterpolator swig_types[245]
+#define SWIGTYPE_p_mfem__VectorSumCoefficient swig_types[246]
+#define SWIGTYPE_p_mfem__VectorTensorFiniteElement swig_types[247]
+#define SWIGTYPE_p_pri_t swig_types[248]
+#define SWIGTYPE_p_quad_t swig_types[249]
+#define SWIGTYPE_p_seg_t swig_types[250]
+#define SWIGTYPE_p_tet_t swig_types[251]
+#define SWIGTYPE_p_tri_t swig_types[252]
+static swig_type_info *swig_types[254];
+static swig_module_info swig_module = {swig_types, 253, 0, 0, 0, 0};
 #define SWIG_TypeQuery(name) SWIG_TypeQueryModule(&swig_module, &swig_module, name)
 #define SWIG_MangledTypeQuery(name) SWIG_MangledTypeQueryModule(&swig_module, &swig_module, name)
 
@@ -3700,550 +3703,6 @@ SwigDirector_BilinearFormIntegrator::SwigDirector_BilinearFormIntegrator(PyObjec
 
 
 
-void SwigDirector_BilinearFormIntegrator::AssemblePA(mfem::FiniteElementSpace const &fes) {
-  swig::SwigVar_PyObject obj0;
-  obj0 = SWIG_NewPointerObj(SWIG_as_voidptr(&fes), SWIGTYPE_p_mfem__FiniteElementSpace,  0 );
-  if (!swig_get_self()) {
-    Swig::DirectorException::raise("'self' uninitialized, maybe you forgot to call BilinearFormIntegrator.__init__.");
-  }
-#if defined(SWIG_PYTHON_DIRECTOR_VTABLE)
-  const size_t swig_method_index = 0;
-  const char *const swig_method_name = "AssemblePA";
-  PyObject *method = swig_get_method(swig_method_index, swig_method_name);
-  swig::SwigVar_PyObject result = PyObject_CallFunctionObjArgs(method ,(PyObject *)obj0, NULL);
-#else
-  swig::SwigVar_PyObject swig_method_name = SWIG_Python_str_FromChar("AssemblePA");
-  swig::SwigVar_PyObject result = PyObject_CallMethodObjArgs(swig_get_self(), (PyObject *) swig_method_name ,(PyObject *)obj0, NULL);
-#endif
-  if (!result) {
-    PyObject *error = PyErr_Occurred();
-    {
-      if (error != NULL) {
-        throw Swig::DirectorMethodException();
-      }
-    }
-  }
-}
-
-
-void SwigDirector_BilinearFormIntegrator::AssemblePA(mfem::FiniteElementSpace const &trial_fes, mfem::FiniteElementSpace const &test_fes) {
-  swig::SwigVar_PyObject obj0;
-  obj0 = SWIG_NewPointerObj(SWIG_as_voidptr(&trial_fes), SWIGTYPE_p_mfem__FiniteElementSpace,  0 );
-  swig::SwigVar_PyObject obj1;
-  obj1 = SWIG_NewPointerObj(SWIG_as_voidptr(&test_fes), SWIGTYPE_p_mfem__FiniteElementSpace,  0 );
-  if (!swig_get_self()) {
-    Swig::DirectorException::raise("'self' uninitialized, maybe you forgot to call BilinearFormIntegrator.__init__.");
-  }
-#if defined(SWIG_PYTHON_DIRECTOR_VTABLE)
-  const size_t swig_method_index = 1;
-  const char *const swig_method_name = "AssemblePA";
-  PyObject *method = swig_get_method(swig_method_index, swig_method_name);
-  swig::SwigVar_PyObject result = PyObject_CallFunctionObjArgs(method ,(PyObject *)obj0,(PyObject *)obj1, NULL);
-#else
-  swig::SwigVar_PyObject swig_method_name = SWIG_Python_str_FromChar("AssemblePA");
-  swig::SwigVar_PyObject result = PyObject_CallMethodObjArgs(swig_get_self(), (PyObject *) swig_method_name ,(PyObject *)obj0,(PyObject *)obj1, NULL);
-#endif
-  if (!result) {
-    PyObject *error = PyErr_Occurred();
-    {
-      if (error != NULL) {
-        throw Swig::DirectorMethodException();
-      }
-    }
-  }
-}
-
-
-void SwigDirector_BilinearFormIntegrator::AssemblePAInteriorFaces(mfem::FiniteElementSpace const &fes) {
-  swig::SwigVar_PyObject obj0;
-  obj0 = SWIG_NewPointerObj(SWIG_as_voidptr(&fes), SWIGTYPE_p_mfem__FiniteElementSpace,  0 );
-  if (!swig_get_self()) {
-    Swig::DirectorException::raise("'self' uninitialized, maybe you forgot to call BilinearFormIntegrator.__init__.");
-  }
-#if defined(SWIG_PYTHON_DIRECTOR_VTABLE)
-  const size_t swig_method_index = 2;
-  const char *const swig_method_name = "AssemblePAInteriorFaces";
-  PyObject *method = swig_get_method(swig_method_index, swig_method_name);
-  swig::SwigVar_PyObject result = PyObject_CallFunctionObjArgs(method ,(PyObject *)obj0, NULL);
-#else
-  swig::SwigVar_PyObject swig_method_name = SWIG_Python_str_FromChar("AssemblePAInteriorFaces");
-  swig::SwigVar_PyObject result = PyObject_CallMethodObjArgs(swig_get_self(), (PyObject *) swig_method_name ,(PyObject *)obj0, NULL);
-#endif
-  if (!result) {
-    PyObject *error = PyErr_Occurred();
-    {
-      if (error != NULL) {
-        throw Swig::DirectorMethodException();
-      }
-    }
-  }
-}
-
-
-void SwigDirector_BilinearFormIntegrator::AssemblePABoundaryFaces(mfem::FiniteElementSpace const &fes) {
-  swig::SwigVar_PyObject obj0;
-  obj0 = SWIG_NewPointerObj(SWIG_as_voidptr(&fes), SWIGTYPE_p_mfem__FiniteElementSpace,  0 );
-  if (!swig_get_self()) {
-    Swig::DirectorException::raise("'self' uninitialized, maybe you forgot to call BilinearFormIntegrator.__init__.");
-  }
-#if defined(SWIG_PYTHON_DIRECTOR_VTABLE)
-  const size_t swig_method_index = 3;
-  const char *const swig_method_name = "AssemblePABoundaryFaces";
-  PyObject *method = swig_get_method(swig_method_index, swig_method_name);
-  swig::SwigVar_PyObject result = PyObject_CallFunctionObjArgs(method ,(PyObject *)obj0, NULL);
-#else
-  swig::SwigVar_PyObject swig_method_name = SWIG_Python_str_FromChar("AssemblePABoundaryFaces");
-  swig::SwigVar_PyObject result = PyObject_CallMethodObjArgs(swig_get_self(), (PyObject *) swig_method_name ,(PyObject *)obj0, NULL);
-#endif
-  if (!result) {
-    PyObject *error = PyErr_Occurred();
-    {
-      if (error != NULL) {
-        throw Swig::DirectorMethodException();
-      }
-    }
-  }
-}
-
-
-void SwigDirector_BilinearFormIntegrator::AssembleDiagonalPA(mfem::Vector &diag) {
-  swig::SwigVar_PyObject obj0;
-  obj0 = SWIG_NewPointerObj(SWIG_as_voidptr(&diag), SWIGTYPE_p_mfem__Vector,  0 );
-  if (!swig_get_self()) {
-    Swig::DirectorException::raise("'self' uninitialized, maybe you forgot to call BilinearFormIntegrator.__init__.");
-  }
-#if defined(SWIG_PYTHON_DIRECTOR_VTABLE)
-  const size_t swig_method_index = 4;
-  const char *const swig_method_name = "AssembleDiagonalPA";
-  PyObject *method = swig_get_method(swig_method_index, swig_method_name);
-  swig::SwigVar_PyObject result = PyObject_CallFunctionObjArgs(method ,(PyObject *)obj0, NULL);
-#else
-  swig::SwigVar_PyObject swig_method_name = SWIG_Python_str_FromChar("AssembleDiagonalPA");
-  swig::SwigVar_PyObject result = PyObject_CallMethodObjArgs(swig_get_self(), (PyObject *) swig_method_name ,(PyObject *)obj0, NULL);
-#endif
-  if (!result) {
-    PyObject *error = PyErr_Occurred();
-    {
-      if (error != NULL) {
-        throw Swig::DirectorMethodException();
-      }
-    }
-  }
-}
-
-
-void SwigDirector_BilinearFormIntegrator::AssembleDiagonalPA_ADAt(mfem::Vector const &D, mfem::Vector &diag) {
-  swig::SwigVar_PyObject obj0;
-  obj0 = SWIG_NewPointerObj(SWIG_as_voidptr(&D), SWIGTYPE_p_mfem__Vector,  0 );
-  swig::SwigVar_PyObject obj1;
-  obj1 = SWIG_NewPointerObj(SWIG_as_voidptr(&diag), SWIGTYPE_p_mfem__Vector,  0 );
-  if (!swig_get_self()) {
-    Swig::DirectorException::raise("'self' uninitialized, maybe you forgot to call BilinearFormIntegrator.__init__.");
-  }
-#if defined(SWIG_PYTHON_DIRECTOR_VTABLE)
-  const size_t swig_method_index = 5;
-  const char *const swig_method_name = "AssembleDiagonalPA_ADAt";
-  PyObject *method = swig_get_method(swig_method_index, swig_method_name);
-  swig::SwigVar_PyObject result = PyObject_CallFunctionObjArgs(method ,(PyObject *)obj0,(PyObject *)obj1, NULL);
-#else
-  swig::SwigVar_PyObject swig_method_name = SWIG_Python_str_FromChar("AssembleDiagonalPA_ADAt");
-  swig::SwigVar_PyObject result = PyObject_CallMethodObjArgs(swig_get_self(), (PyObject *) swig_method_name ,(PyObject *)obj0,(PyObject *)obj1, NULL);
-#endif
-  if (!result) {
-    PyObject *error = PyErr_Occurred();
-    {
-      if (error != NULL) {
-        throw Swig::DirectorMethodException();
-      }
-    }
-  }
-}
-
-
-void SwigDirector_BilinearFormIntegrator::AddMultPA(mfem::Vector const &x, mfem::Vector &y) const {
-  swig::SwigVar_PyObject obj0;
-  obj0 = SWIG_NewPointerObj(SWIG_as_voidptr(&x), SWIGTYPE_p_mfem__Vector,  0 );
-  swig::SwigVar_PyObject obj1;
-  obj1 = SWIG_NewPointerObj(SWIG_as_voidptr(&y), SWIGTYPE_p_mfem__Vector,  0 );
-  if (!swig_get_self()) {
-    Swig::DirectorException::raise("'self' uninitialized, maybe you forgot to call BilinearFormIntegrator.__init__.");
-  }
-#if defined(SWIG_PYTHON_DIRECTOR_VTABLE)
-  const size_t swig_method_index = 6;
-  const char *const swig_method_name = "AddMultPA";
-  PyObject *method = swig_get_method(swig_method_index, swig_method_name);
-  swig::SwigVar_PyObject result = PyObject_CallFunctionObjArgs(method ,(PyObject *)obj0,(PyObject *)obj1, NULL);
-#else
-  swig::SwigVar_PyObject swig_method_name = SWIG_Python_str_FromChar("AddMultPA");
-  swig::SwigVar_PyObject result = PyObject_CallMethodObjArgs(swig_get_self(), (PyObject *) swig_method_name ,(PyObject *)obj0,(PyObject *)obj1, NULL);
-#endif
-  if (!result) {
-    PyObject *error = PyErr_Occurred();
-    {
-      if (error != NULL) {
-        throw Swig::DirectorMethodException();
-      }
-    }
-  }
-}
-
-
-void SwigDirector_BilinearFormIntegrator::AddMultTransposePA(mfem::Vector const &x, mfem::Vector &y) const {
-  swig::SwigVar_PyObject obj0;
-  obj0 = SWIG_NewPointerObj(SWIG_as_voidptr(&x), SWIGTYPE_p_mfem__Vector,  0 );
-  swig::SwigVar_PyObject obj1;
-  obj1 = SWIG_NewPointerObj(SWIG_as_voidptr(&y), SWIGTYPE_p_mfem__Vector,  0 );
-  if (!swig_get_self()) {
-    Swig::DirectorException::raise("'self' uninitialized, maybe you forgot to call BilinearFormIntegrator.__init__.");
-  }
-#if defined(SWIG_PYTHON_DIRECTOR_VTABLE)
-  const size_t swig_method_index = 7;
-  const char *const swig_method_name = "AddMultTransposePA";
-  PyObject *method = swig_get_method(swig_method_index, swig_method_name);
-  swig::SwigVar_PyObject result = PyObject_CallFunctionObjArgs(method ,(PyObject *)obj0,(PyObject *)obj1, NULL);
-#else
-  swig::SwigVar_PyObject swig_method_name = SWIG_Python_str_FromChar("AddMultTransposePA");
-  swig::SwigVar_PyObject result = PyObject_CallMethodObjArgs(swig_get_self(), (PyObject *) swig_method_name ,(PyObject *)obj0,(PyObject *)obj1, NULL);
-#endif
-  if (!result) {
-    PyObject *error = PyErr_Occurred();
-    {
-      if (error != NULL) {
-        throw Swig::DirectorMethodException();
-      }
-    }
-  }
-}
-
-
-void SwigDirector_BilinearFormIntegrator::AssembleEA(mfem::FiniteElementSpace const &fes, mfem::Vector &emat, bool const add) {
-  swig::SwigVar_PyObject obj0;
-  obj0 = SWIG_NewPointerObj(SWIG_as_voidptr(&fes), SWIGTYPE_p_mfem__FiniteElementSpace,  0 );
-  swig::SwigVar_PyObject obj1;
-  obj1 = SWIG_NewPointerObj(SWIG_as_voidptr(&emat), SWIGTYPE_p_mfem__Vector,  0 );
-  swig::SwigVar_PyObject obj2;
-  obj2 = SWIG_From_bool(static_cast< bool >(add));
-  if (!swig_get_self()) {
-    Swig::DirectorException::raise("'self' uninitialized, maybe you forgot to call BilinearFormIntegrator.__init__.");
-  }
-#if defined(SWIG_PYTHON_DIRECTOR_VTABLE)
-  const size_t swig_method_index = 8;
-  const char *const swig_method_name = "AssembleEA";
-  PyObject *method = swig_get_method(swig_method_index, swig_method_name);
-  swig::SwigVar_PyObject result = PyObject_CallFunctionObjArgs(method ,(PyObject *)obj0,(PyObject *)obj1,(PyObject *)obj2, NULL);
-#else
-  swig::SwigVar_PyObject swig_method_name = SWIG_Python_str_FromChar("AssembleEA");
-  swig::SwigVar_PyObject result = PyObject_CallMethodObjArgs(swig_get_self(), (PyObject *) swig_method_name ,(PyObject *)obj0,(PyObject *)obj1,(PyObject *)obj2, NULL);
-#endif
-  if (!result) {
-    PyObject *error = PyErr_Occurred();
-    {
-      if (error != NULL) {
-        throw Swig::DirectorMethodException();
-      }
-    }
-  }
-}
-
-
-void SwigDirector_BilinearFormIntegrator::AssembleMF(mfem::FiniteElementSpace const &fes) {
-  swig::SwigVar_PyObject obj0;
-  obj0 = SWIG_NewPointerObj(SWIG_as_voidptr(&fes), SWIGTYPE_p_mfem__FiniteElementSpace,  0 );
-  if (!swig_get_self()) {
-    Swig::DirectorException::raise("'self' uninitialized, maybe you forgot to call BilinearFormIntegrator.__init__.");
-  }
-#if defined(SWIG_PYTHON_DIRECTOR_VTABLE)
-  const size_t swig_method_index = 9;
-  const char *const swig_method_name = "AssembleMF";
-  PyObject *method = swig_get_method(swig_method_index, swig_method_name);
-  swig::SwigVar_PyObject result = PyObject_CallFunctionObjArgs(method ,(PyObject *)obj0, NULL);
-#else
-  swig::SwigVar_PyObject swig_method_name = SWIG_Python_str_FromChar("AssembleMF");
-  swig::SwigVar_PyObject result = PyObject_CallMethodObjArgs(swig_get_self(), (PyObject *) swig_method_name ,(PyObject *)obj0, NULL);
-#endif
-  if (!result) {
-    PyObject *error = PyErr_Occurred();
-    {
-      if (error != NULL) {
-        throw Swig::DirectorMethodException();
-      }
-    }
-  }
-}
-
-
-void SwigDirector_BilinearFormIntegrator::AddMultMF(mfem::Vector const &x, mfem::Vector &y) const {
-  swig::SwigVar_PyObject obj0;
-  obj0 = SWIG_NewPointerObj(SWIG_as_voidptr(&x), SWIGTYPE_p_mfem__Vector,  0 );
-  swig::SwigVar_PyObject obj1;
-  obj1 = SWIG_NewPointerObj(SWIG_as_voidptr(&y), SWIGTYPE_p_mfem__Vector,  0 );
-  if (!swig_get_self()) {
-    Swig::DirectorException::raise("'self' uninitialized, maybe you forgot to call BilinearFormIntegrator.__init__.");
-  }
-#if defined(SWIG_PYTHON_DIRECTOR_VTABLE)
-  const size_t swig_method_index = 10;
-  const char *const swig_method_name = "AddMultMF";
-  PyObject *method = swig_get_method(swig_method_index, swig_method_name);
-  swig::SwigVar_PyObject result = PyObject_CallFunctionObjArgs(method ,(PyObject *)obj0,(PyObject *)obj1, NULL);
-#else
-  swig::SwigVar_PyObject swig_method_name = SWIG_Python_str_FromChar("AddMultMF");
-  swig::SwigVar_PyObject result = PyObject_CallMethodObjArgs(swig_get_self(), (PyObject *) swig_method_name ,(PyObject *)obj0,(PyObject *)obj1, NULL);
-#endif
-  if (!result) {
-    PyObject *error = PyErr_Occurred();
-    {
-      if (error != NULL) {
-        throw Swig::DirectorMethodException();
-      }
-    }
-  }
-}
-
-
-void SwigDirector_BilinearFormIntegrator::AddMultTransposeMF(mfem::Vector const &x, mfem::Vector &y) const {
-  swig::SwigVar_PyObject obj0;
-  obj0 = SWIG_NewPointerObj(SWIG_as_voidptr(&x), SWIGTYPE_p_mfem__Vector,  0 );
-  swig::SwigVar_PyObject obj1;
-  obj1 = SWIG_NewPointerObj(SWIG_as_voidptr(&y), SWIGTYPE_p_mfem__Vector,  0 );
-  if (!swig_get_self()) {
-    Swig::DirectorException::raise("'self' uninitialized, maybe you forgot to call BilinearFormIntegrator.__init__.");
-  }
-#if defined(SWIG_PYTHON_DIRECTOR_VTABLE)
-  const size_t swig_method_index = 11;
-  const char *const swig_method_name = "AddMultTransposeMF";
-  PyObject *method = swig_get_method(swig_method_index, swig_method_name);
-  swig::SwigVar_PyObject result = PyObject_CallFunctionObjArgs(method ,(PyObject *)obj0,(PyObject *)obj1, NULL);
-#else
-  swig::SwigVar_PyObject swig_method_name = SWIG_Python_str_FromChar("AddMultTransposeMF");
-  swig::SwigVar_PyObject result = PyObject_CallMethodObjArgs(swig_get_self(), (PyObject *) swig_method_name ,(PyObject *)obj0,(PyObject *)obj1, NULL);
-#endif
-  if (!result) {
-    PyObject *error = PyErr_Occurred();
-    {
-      if (error != NULL) {
-        throw Swig::DirectorMethodException();
-      }
-    }
-  }
-}
-
-
-void SwigDirector_BilinearFormIntegrator::AssembleDiagonalMF(mfem::Vector &diag) {
-  swig::SwigVar_PyObject obj0;
-  obj0 = SWIG_NewPointerObj(SWIG_as_voidptr(&diag), SWIGTYPE_p_mfem__Vector,  0 );
-  if (!swig_get_self()) {
-    Swig::DirectorException::raise("'self' uninitialized, maybe you forgot to call BilinearFormIntegrator.__init__.");
-  }
-#if defined(SWIG_PYTHON_DIRECTOR_VTABLE)
-  const size_t swig_method_index = 12;
-  const char *const swig_method_name = "AssembleDiagonalMF";
-  PyObject *method = swig_get_method(swig_method_index, swig_method_name);
-  swig::SwigVar_PyObject result = PyObject_CallFunctionObjArgs(method ,(PyObject *)obj0, NULL);
-#else
-  swig::SwigVar_PyObject swig_method_name = SWIG_Python_str_FromChar("AssembleDiagonalMF");
-  swig::SwigVar_PyObject result = PyObject_CallMethodObjArgs(swig_get_self(), (PyObject *) swig_method_name ,(PyObject *)obj0, NULL);
-#endif
-  if (!result) {
-    PyObject *error = PyErr_Occurred();
-    {
-      if (error != NULL) {
-        throw Swig::DirectorMethodException();
-      }
-    }
-  }
-}
-
-
-void SwigDirector_BilinearFormIntegrator::AssembleEAInteriorFaces(mfem::FiniteElementSpace const &fes, mfem::Vector &ea_data_int, mfem::Vector &ea_data_ext, bool const add) {
-  swig::SwigVar_PyObject obj0;
-  obj0 = SWIG_NewPointerObj(SWIG_as_voidptr(&fes), SWIGTYPE_p_mfem__FiniteElementSpace,  0 );
-  swig::SwigVar_PyObject obj1;
-  obj1 = SWIG_NewPointerObj(SWIG_as_voidptr(&ea_data_int), SWIGTYPE_p_mfem__Vector,  0 );
-  swig::SwigVar_PyObject obj2;
-  obj2 = SWIG_NewPointerObj(SWIG_as_voidptr(&ea_data_ext), SWIGTYPE_p_mfem__Vector,  0 );
-  swig::SwigVar_PyObject obj3;
-  obj3 = SWIG_From_bool(static_cast< bool >(add));
-  if (!swig_get_self()) {
-    Swig::DirectorException::raise("'self' uninitialized, maybe you forgot to call BilinearFormIntegrator.__init__.");
-  }
-#if defined(SWIG_PYTHON_DIRECTOR_VTABLE)
-  const size_t swig_method_index = 13;
-  const char *const swig_method_name = "AssembleEAInteriorFaces";
-  PyObject *method = swig_get_method(swig_method_index, swig_method_name);
-  swig::SwigVar_PyObject result = PyObject_CallFunctionObjArgs(method ,(PyObject *)obj0,(PyObject *)obj1,(PyObject *)obj2,(PyObject *)obj3, NULL);
-#else
-  swig::SwigVar_PyObject swig_method_name = SWIG_Python_str_FromChar("AssembleEAInteriorFaces");
-  swig::SwigVar_PyObject result = PyObject_CallMethodObjArgs(swig_get_self(), (PyObject *) swig_method_name ,(PyObject *)obj0,(PyObject *)obj1,(PyObject *)obj2,(PyObject *)obj3, NULL);
-#endif
-  if (!result) {
-    PyObject *error = PyErr_Occurred();
-    {
-      if (error != NULL) {
-        throw Swig::DirectorMethodException();
-      }
-    }
-  }
-}
-
-
-void SwigDirector_BilinearFormIntegrator::AssembleEABoundaryFaces(mfem::FiniteElementSpace const &fes, mfem::Vector &ea_data_bdr, bool const add) {
-  swig::SwigVar_PyObject obj0;
-  obj0 = SWIG_NewPointerObj(SWIG_as_voidptr(&fes), SWIGTYPE_p_mfem__FiniteElementSpace,  0 );
-  swig::SwigVar_PyObject obj1;
-  obj1 = SWIG_NewPointerObj(SWIG_as_voidptr(&ea_data_bdr), SWIGTYPE_p_mfem__Vector,  0 );
-  swig::SwigVar_PyObject obj2;
-  obj2 = SWIG_From_bool(static_cast< bool >(add));
-  if (!swig_get_self()) {
-    Swig::DirectorException::raise("'self' uninitialized, maybe you forgot to call BilinearFormIntegrator.__init__.");
-  }
-#if defined(SWIG_PYTHON_DIRECTOR_VTABLE)
-  const size_t swig_method_index = 14;
-  const char *const swig_method_name = "AssembleEABoundaryFaces";
-  PyObject *method = swig_get_method(swig_method_index, swig_method_name);
-  swig::SwigVar_PyObject result = PyObject_CallFunctionObjArgs(method ,(PyObject *)obj0,(PyObject *)obj1,(PyObject *)obj2, NULL);
-#else
-  swig::SwigVar_PyObject swig_method_name = SWIG_Python_str_FromChar("AssembleEABoundaryFaces");
-  swig::SwigVar_PyObject result = PyObject_CallMethodObjArgs(swig_get_self(), (PyObject *) swig_method_name ,(PyObject *)obj0,(PyObject *)obj1,(PyObject *)obj2, NULL);
-#endif
-  if (!result) {
-    PyObject *error = PyErr_Occurred();
-    {
-      if (error != NULL) {
-        throw Swig::DirectorMethodException();
-      }
-    }
-  }
-}
-
-
-void SwigDirector_BilinearFormIntegrator::AssembleElementMatrix(mfem::FiniteElement const &el, mfem::ElementTransformation &Trans, mfem::DenseMatrix &elmat) {
-  swig::SwigVar_PyObject obj0;
-  obj0 = SWIG_NewPointerObj(SWIG_as_voidptr(&el), SWIGTYPE_p_mfem__FiniteElement,  0 );
-  swig::SwigVar_PyObject obj1;
-  obj1 = SWIG_NewPointerObj(SWIG_as_voidptr(&Trans), SWIGTYPE_p_mfem__ElementTransformation,  0 );
-  swig::SwigVar_PyObject obj2;
-  obj2 = SWIG_NewPointerObj(SWIG_as_voidptr(&elmat), SWIGTYPE_p_mfem__DenseMatrix,  0 );
-  if (!swig_get_self()) {
-    Swig::DirectorException::raise("'self' uninitialized, maybe you forgot to call BilinearFormIntegrator.__init__.");
-  }
-#if defined(SWIG_PYTHON_DIRECTOR_VTABLE)
-  const size_t swig_method_index = 15;
-  const char *const swig_method_name = "AssembleElementMatrix";
-  PyObject *method = swig_get_method(swig_method_index, swig_method_name);
-  swig::SwigVar_PyObject result = PyObject_CallFunctionObjArgs(method ,(PyObject *)obj0,(PyObject *)obj1,(PyObject *)obj2, NULL);
-#else
-  swig::SwigVar_PyObject swig_method_name = SWIG_Python_str_FromChar("AssembleElementMatrix");
-  swig::SwigVar_PyObject result = PyObject_CallMethodObjArgs(swig_get_self(), (PyObject *) swig_method_name ,(PyObject *)obj0,(PyObject *)obj1,(PyObject *)obj2, NULL);
-#endif
-  if (!result) {
-    PyObject *error = PyErr_Occurred();
-    {
-      if (error != NULL) {
-        throw Swig::DirectorMethodException();
-      }
-    }
-  }
-}
-
-
-void SwigDirector_BilinearFormIntegrator::AssembleElementMatrix2(mfem::FiniteElement const &trial_fe, mfem::FiniteElement const &test_fe, mfem::ElementTransformation &Trans, mfem::DenseMatrix &elmat) {
-  swig::SwigVar_PyObject obj0;
-  obj0 = SWIG_NewPointerObj(SWIG_as_voidptr(&trial_fe), SWIGTYPE_p_mfem__FiniteElement,  0 );
-  swig::SwigVar_PyObject obj1;
-  obj1 = SWIG_NewPointerObj(SWIG_as_voidptr(&test_fe), SWIGTYPE_p_mfem__FiniteElement,  0 );
-  swig::SwigVar_PyObject obj2;
-  obj2 = SWIG_NewPointerObj(SWIG_as_voidptr(&Trans), SWIGTYPE_p_mfem__ElementTransformation,  0 );
-  swig::SwigVar_PyObject obj3;
-  obj3 = SWIG_NewPointerObj(SWIG_as_voidptr(&elmat), SWIGTYPE_p_mfem__DenseMatrix,  0 );
-  if (!swig_get_self()) {
-    Swig::DirectorException::raise("'self' uninitialized, maybe you forgot to call BilinearFormIntegrator.__init__.");
-  }
-#if defined(SWIG_PYTHON_DIRECTOR_VTABLE)
-  const size_t swig_method_index = 16;
-  const char *const swig_method_name = "AssembleElementMatrix2";
-  PyObject *method = swig_get_method(swig_method_index, swig_method_name);
-  swig::SwigVar_PyObject result = PyObject_CallFunctionObjArgs(method ,(PyObject *)obj0,(PyObject *)obj1,(PyObject *)obj2,(PyObject *)obj3, NULL);
-#else
-  swig::SwigVar_PyObject swig_method_name = SWIG_Python_str_FromChar("AssembleElementMatrix2");
-  swig::SwigVar_PyObject result = PyObject_CallMethodObjArgs(swig_get_self(), (PyObject *) swig_method_name ,(PyObject *)obj0,(PyObject *)obj1,(PyObject *)obj2,(PyObject *)obj3, NULL);
-#endif
-  if (!result) {
-    PyObject *error = PyErr_Occurred();
-    {
-      if (error != NULL) {
-        throw Swig::DirectorMethodException();
-      }
-    }
-  }
-}
-
-
-void SwigDirector_BilinearFormIntegrator::AssembleFaceMatrix(mfem::FiniteElement const &el1, mfem::FiniteElement const &el2, mfem::FaceElementTransformations &Trans, mfem::DenseMatrix &elmat) {
-  swig::SwigVar_PyObject obj0;
-  obj0 = SWIG_NewPointerObj(SWIG_as_voidptr(&el1), SWIGTYPE_p_mfem__FiniteElement,  0 );
-  swig::SwigVar_PyObject obj1;
-  obj1 = SWIG_NewPointerObj(SWIG_as_voidptr(&el2), SWIGTYPE_p_mfem__FiniteElement,  0 );
-  swig::SwigVar_PyObject obj2;
-  obj2 = SWIG_NewPointerObj(SWIG_as_voidptr(&Trans), SWIGTYPE_p_mfem__FaceElementTransformations,  0 );
-  swig::SwigVar_PyObject obj3;
-  obj3 = SWIG_NewPointerObj(SWIG_as_voidptr(&elmat), SWIGTYPE_p_mfem__DenseMatrix,  0 );
-  if (!swig_get_self()) {
-    Swig::DirectorException::raise("'self' uninitialized, maybe you forgot to call BilinearFormIntegrator.__init__.");
-  }
-#if defined(SWIG_PYTHON_DIRECTOR_VTABLE)
-  const size_t swig_method_index = 17;
-  const char *const swig_method_name = "AssembleFaceMatrix";
-  PyObject *method = swig_get_method(swig_method_index, swig_method_name);
-  swig::SwigVar_PyObject result = PyObject_CallFunctionObjArgs(method ,(PyObject *)obj0,(PyObject *)obj1,(PyObject *)obj2,(PyObject *)obj3, NULL);
-#else
-  swig::SwigVar_PyObject swig_method_name = SWIG_Python_str_FromChar("AssembleFaceMatrix");
-  swig::SwigVar_PyObject result = PyObject_CallMethodObjArgs(swig_get_self(), (PyObject *) swig_method_name ,(PyObject *)obj0,(PyObject *)obj1,(PyObject *)obj2,(PyObject *)obj3, NULL);
-#endif
-  if (!result) {
-    PyObject *error = PyErr_Occurred();
-    {
-      if (error != NULL) {
-        throw Swig::DirectorMethodException();
-      }
-    }
-  }
-}
-
-
-void SwigDirector_BilinearFormIntegrator::AssembleFaceMatrix(mfem::FiniteElement const &trial_face_fe, mfem::FiniteElement const &test_fe1, mfem::FiniteElement const &test_fe2, mfem::FaceElementTransformations &Trans, mfem::DenseMatrix &elmat) {
-  swig::SwigVar_PyObject obj0;
-  obj0 = SWIG_NewPointerObj(SWIG_as_voidptr(&trial_face_fe), SWIGTYPE_p_mfem__FiniteElement,  0 );
-  swig::SwigVar_PyObject obj1;
-  obj1 = SWIG_NewPointerObj(SWIG_as_voidptr(&test_fe1), SWIGTYPE_p_mfem__FiniteElement,  0 );
-  swig::SwigVar_PyObject obj2;
-  obj2 = SWIG_NewPointerObj(SWIG_as_voidptr(&test_fe2), SWIGTYPE_p_mfem__FiniteElement,  0 );
-  swig::SwigVar_PyObject obj3;
-  obj3 = SWIG_NewPointerObj(SWIG_as_voidptr(&Trans), SWIGTYPE_p_mfem__FaceElementTransformations,  0 );
-  swig::SwigVar_PyObject obj4;
-  obj4 = SWIG_NewPointerObj(SWIG_as_voidptr(&elmat), SWIGTYPE_p_mfem__DenseMatrix,  0 );
-  if (!swig_get_self()) {
-    Swig::DirectorException::raise("'self' uninitialized, maybe you forgot to call BilinearFormIntegrator.__init__.");
-  }
-#if defined(SWIG_PYTHON_DIRECTOR_VTABLE)
-  const size_t swig_method_index = 18;
-  const char *const swig_method_name = "AssembleFaceMatrix";
-  PyObject *method = swig_get_method(swig_method_index, swig_method_name);
-  swig::SwigVar_PyObject result = PyObject_CallFunctionObjArgs(method ,(PyObject *)obj0,(PyObject *)obj1,(PyObject *)obj2,(PyObject *)obj3,(PyObject *)obj4, NULL);
-#else
-  swig::SwigVar_PyObject swig_method_name = SWIG_Python_str_FromChar("AssembleFaceMatrix");
-  swig::SwigVar_PyObject result = PyObject_CallMethodObjArgs(swig_get_self(), (PyObject *) swig_method_name ,(PyObject *)obj0,(PyObject *)obj1,(PyObject *)obj2,(PyObject *)obj3,(PyObject *)obj4, NULL);
-#endif
-  if (!result) {
-    PyObject *error = PyErr_Occurred();
-    {
-      if (error != NULL) {
-        throw Swig::DirectorMethodException();
-      }
-    }
-  }
-}
-
-
 void SwigDirector_BilinearFormIntegrator::AssembleElementVector(mfem::FiniteElement const &el, mfem::ElementTransformation &Tr, mfem::Vector const &elfun, mfem::Vector &elvect) {
   swig::SwigVar_PyObject obj0;
   obj0 = SWIG_NewPointerObj(SWIG_as_voidptr(&el), SWIGTYPE_p_mfem__FiniteElement,  0 );
@@ -4257,7 +3716,7 @@ void SwigDirector_BilinearFormIntegrator::AssembleElementVector(mfem::FiniteElem
     Swig::DirectorException::raise("'self' uninitialized, maybe you forgot to call BilinearFormIntegrator.__init__.");
   }
 #if defined(SWIG_PYTHON_DIRECTOR_VTABLE)
-  const size_t swig_method_index = 19;
+  const size_t swig_method_index = 0;
   const char *const swig_method_name = "AssembleElementVector";
   PyObject *method = swig_get_method(swig_method_index, swig_method_name);
   swig::SwigVar_PyObject result = PyObject_CallFunctionObjArgs(method ,(PyObject *)obj0,(PyObject *)obj1,(PyObject *)obj2,(PyObject *)obj3, NULL);
@@ -4291,7 +3750,7 @@ void SwigDirector_BilinearFormIntegrator::AssembleFaceVector(mfem::FiniteElement
     Swig::DirectorException::raise("'self' uninitialized, maybe you forgot to call BilinearFormIntegrator.__init__.");
   }
 #if defined(SWIG_PYTHON_DIRECTOR_VTABLE)
-  const size_t swig_method_index = 20;
+  const size_t swig_method_index = 1;
   const char *const swig_method_name = "AssembleFaceVector";
   PyObject *method = swig_get_method(swig_method_index, swig_method_name);
   swig::SwigVar_PyObject result = PyObject_CallFunctionObjArgs(method ,(PyObject *)obj0,(PyObject *)obj1,(PyObject *)obj2,(PyObject *)obj3,(PyObject *)obj4, NULL);
@@ -4323,7 +3782,7 @@ void SwigDirector_BilinearFormIntegrator::AssembleElementGrad(mfem::FiniteElemen
     Swig::DirectorException::raise("'self' uninitialized, maybe you forgot to call BilinearFormIntegrator.__init__.");
   }
 #if defined(SWIG_PYTHON_DIRECTOR_VTABLE)
-  const size_t swig_method_index = 21;
+  const size_t swig_method_index = 2;
   const char *const swig_method_name = "AssembleElementGrad";
   PyObject *method = swig_get_method(swig_method_index, swig_method_name);
   swig::SwigVar_PyObject result = PyObject_CallFunctionObjArgs(method ,(PyObject *)obj0,(PyObject *)obj1,(PyObject *)obj2,(PyObject *)obj3, NULL);
@@ -4357,12 +3816,598 @@ void SwigDirector_BilinearFormIntegrator::AssembleFaceGrad(mfem::FiniteElement c
     Swig::DirectorException::raise("'self' uninitialized, maybe you forgot to call BilinearFormIntegrator.__init__.");
   }
 #if defined(SWIG_PYTHON_DIRECTOR_VTABLE)
-  const size_t swig_method_index = 22;
+  const size_t swig_method_index = 3;
   const char *const swig_method_name = "AssembleFaceGrad";
   PyObject *method = swig_get_method(swig_method_index, swig_method_name);
   swig::SwigVar_PyObject result = PyObject_CallFunctionObjArgs(method ,(PyObject *)obj0,(PyObject *)obj1,(PyObject *)obj2,(PyObject *)obj3,(PyObject *)obj4, NULL);
 #else
   swig::SwigVar_PyObject swig_method_name = SWIG_Python_str_FromChar("AssembleFaceGrad");
+  swig::SwigVar_PyObject result = PyObject_CallMethodObjArgs(swig_get_self(), (PyObject *) swig_method_name ,(PyObject *)obj0,(PyObject *)obj1,(PyObject *)obj2,(PyObject *)obj3,(PyObject *)obj4, NULL);
+#endif
+  if (!result) {
+    PyObject *error = PyErr_Occurred();
+    {
+      if (error != NULL) {
+        throw Swig::DirectorMethodException();
+      }
+    }
+  }
+}
+
+
+double SwigDirector_BilinearFormIntegrator::GetElementEnergy(mfem::FiniteElement const &el, mfem::ElementTransformation &Tr, mfem::Vector const &elfun) {
+  double c_result = SwigValueInit< double >() ;
+  
+  swig::SwigVar_PyObject obj0;
+  obj0 = SWIG_NewPointerObj(SWIG_as_voidptr(&el), SWIGTYPE_p_mfem__FiniteElement,  0 );
+  swig::SwigVar_PyObject obj1;
+  obj1 = SWIG_NewPointerObj(SWIG_as_voidptr(&Tr), SWIGTYPE_p_mfem__ElementTransformation,  0 );
+  swig::SwigVar_PyObject obj2;
+  obj2 = SWIG_NewPointerObj(SWIG_as_voidptr(&elfun), SWIGTYPE_p_mfem__Vector,  0 );
+  if (!swig_get_self()) {
+    Swig::DirectorException::raise("'self' uninitialized, maybe you forgot to call BilinearFormIntegrator.__init__.");
+  }
+#if defined(SWIG_PYTHON_DIRECTOR_VTABLE)
+  const size_t swig_method_index = 4;
+  const char *const swig_method_name = "GetElementEnergy";
+  PyObject *method = swig_get_method(swig_method_index, swig_method_name);
+  swig::SwigVar_PyObject result = PyObject_CallFunctionObjArgs(method ,(PyObject *)obj0,(PyObject *)obj1,(PyObject *)obj2, NULL);
+#else
+  swig::SwigVar_PyObject swig_method_name = SWIG_Python_str_FromChar("GetElementEnergy");
+  swig::SwigVar_PyObject result = PyObject_CallMethodObjArgs(swig_get_self(), (PyObject *) swig_method_name ,(PyObject *)obj0,(PyObject *)obj1,(PyObject *)obj2, NULL);
+#endif
+  if (!result) {
+    PyObject *error = PyErr_Occurred();
+    {
+      if (error != NULL) {
+        throw Swig::DirectorMethodException();
+      }
+    }
+  }
+  double swig_val;
+  int swig_res = SWIG_AsVal_double(result, &swig_val);
+  if (!SWIG_IsOK(swig_res)) {
+    Swig::DirectorTypeMismatchException::raise(SWIG_ErrorType(SWIG_ArgError(swig_res)), "in output value of type '""double""'");
+  }
+  c_result = static_cast< double >(swig_val);
+  return (double) c_result;
+}
+
+
+void SwigDirector_BilinearFormIntegrator::AssemblePA(mfem::FiniteElementSpace const &fes) {
+  swig::SwigVar_PyObject obj0;
+  obj0 = SWIG_NewPointerObj(SWIG_as_voidptr(&fes), SWIGTYPE_p_mfem__FiniteElementSpace,  0 );
+  if (!swig_get_self()) {
+    Swig::DirectorException::raise("'self' uninitialized, maybe you forgot to call BilinearFormIntegrator.__init__.");
+  }
+#if defined(SWIG_PYTHON_DIRECTOR_VTABLE)
+  const size_t swig_method_index = 5;
+  const char *const swig_method_name = "AssemblePA";
+  PyObject *method = swig_get_method(swig_method_index, swig_method_name);
+  swig::SwigVar_PyObject result = PyObject_CallFunctionObjArgs(method ,(PyObject *)obj0, NULL);
+#else
+  swig::SwigVar_PyObject swig_method_name = SWIG_Python_str_FromChar("AssemblePA");
+  swig::SwigVar_PyObject result = PyObject_CallMethodObjArgs(swig_get_self(), (PyObject *) swig_method_name ,(PyObject *)obj0, NULL);
+#endif
+  if (!result) {
+    PyObject *error = PyErr_Occurred();
+    {
+      if (error != NULL) {
+        throw Swig::DirectorMethodException();
+      }
+    }
+  }
+}
+
+
+void SwigDirector_BilinearFormIntegrator::AssemblePA(mfem::FiniteElementSpace const &trial_fes, mfem::FiniteElementSpace const &test_fes) {
+  swig::SwigVar_PyObject obj0;
+  obj0 = SWIG_NewPointerObj(SWIG_as_voidptr(&trial_fes), SWIGTYPE_p_mfem__FiniteElementSpace,  0 );
+  swig::SwigVar_PyObject obj1;
+  obj1 = SWIG_NewPointerObj(SWIG_as_voidptr(&test_fes), SWIGTYPE_p_mfem__FiniteElementSpace,  0 );
+  if (!swig_get_self()) {
+    Swig::DirectorException::raise("'self' uninitialized, maybe you forgot to call BilinearFormIntegrator.__init__.");
+  }
+#if defined(SWIG_PYTHON_DIRECTOR_VTABLE)
+  const size_t swig_method_index = 6;
+  const char *const swig_method_name = "AssemblePA";
+  PyObject *method = swig_get_method(swig_method_index, swig_method_name);
+  swig::SwigVar_PyObject result = PyObject_CallFunctionObjArgs(method ,(PyObject *)obj0,(PyObject *)obj1, NULL);
+#else
+  swig::SwigVar_PyObject swig_method_name = SWIG_Python_str_FromChar("AssemblePA");
+  swig::SwigVar_PyObject result = PyObject_CallMethodObjArgs(swig_get_self(), (PyObject *) swig_method_name ,(PyObject *)obj0,(PyObject *)obj1, NULL);
+#endif
+  if (!result) {
+    PyObject *error = PyErr_Occurred();
+    {
+      if (error != NULL) {
+        throw Swig::DirectorMethodException();
+      }
+    }
+  }
+}
+
+
+void SwigDirector_BilinearFormIntegrator::AddMultPA(mfem::Vector const &x, mfem::Vector &y) const {
+  swig::SwigVar_PyObject obj0;
+  obj0 = SWIG_NewPointerObj(SWIG_as_voidptr(&x), SWIGTYPE_p_mfem__Vector,  0 );
+  swig::SwigVar_PyObject obj1;
+  obj1 = SWIG_NewPointerObj(SWIG_as_voidptr(&y), SWIGTYPE_p_mfem__Vector,  0 );
+  if (!swig_get_self()) {
+    Swig::DirectorException::raise("'self' uninitialized, maybe you forgot to call BilinearFormIntegrator.__init__.");
+  }
+#if defined(SWIG_PYTHON_DIRECTOR_VTABLE)
+  const size_t swig_method_index = 7;
+  const char *const swig_method_name = "AddMultPA";
+  PyObject *method = swig_get_method(swig_method_index, swig_method_name);
+  swig::SwigVar_PyObject result = PyObject_CallFunctionObjArgs(method ,(PyObject *)obj0,(PyObject *)obj1, NULL);
+#else
+  swig::SwigVar_PyObject swig_method_name = SWIG_Python_str_FromChar("AddMultPA");
+  swig::SwigVar_PyObject result = PyObject_CallMethodObjArgs(swig_get_self(), (PyObject *) swig_method_name ,(PyObject *)obj0,(PyObject *)obj1, NULL);
+#endif
+  if (!result) {
+    PyObject *error = PyErr_Occurred();
+    {
+      if (error != NULL) {
+        throw Swig::DirectorMethodException();
+      }
+    }
+  }
+}
+
+
+SwigDirector_BilinearFormIntegrator::~SwigDirector_BilinearFormIntegrator() {
+}
+
+void SwigDirector_BilinearFormIntegrator::AssemblePAInteriorFaces(mfem::FiniteElementSpace const &fes) {
+  swig::SwigVar_PyObject obj0;
+  obj0 = SWIG_NewPointerObj(SWIG_as_voidptr(&fes), SWIGTYPE_p_mfem__FiniteElementSpace,  0 );
+  if (!swig_get_self()) {
+    Swig::DirectorException::raise("'self' uninitialized, maybe you forgot to call BilinearFormIntegrator.__init__.");
+  }
+#if defined(SWIG_PYTHON_DIRECTOR_VTABLE)
+  const size_t swig_method_index = 8;
+  const char *const swig_method_name = "AssemblePAInteriorFaces";
+  PyObject *method = swig_get_method(swig_method_index, swig_method_name);
+  swig::SwigVar_PyObject result = PyObject_CallFunctionObjArgs(method ,(PyObject *)obj0, NULL);
+#else
+  swig::SwigVar_PyObject swig_method_name = SWIG_Python_str_FromChar("AssemblePAInteriorFaces");
+  swig::SwigVar_PyObject result = PyObject_CallMethodObjArgs(swig_get_self(), (PyObject *) swig_method_name ,(PyObject *)obj0, NULL);
+#endif
+  if (!result) {
+    PyObject *error = PyErr_Occurred();
+    {
+      if (error != NULL) {
+        throw Swig::DirectorMethodException();
+      }
+    }
+  }
+}
+
+
+void SwigDirector_BilinearFormIntegrator::AssemblePABoundaryFaces(mfem::FiniteElementSpace const &fes) {
+  swig::SwigVar_PyObject obj0;
+  obj0 = SWIG_NewPointerObj(SWIG_as_voidptr(&fes), SWIGTYPE_p_mfem__FiniteElementSpace,  0 );
+  if (!swig_get_self()) {
+    Swig::DirectorException::raise("'self' uninitialized, maybe you forgot to call BilinearFormIntegrator.__init__.");
+  }
+#if defined(SWIG_PYTHON_DIRECTOR_VTABLE)
+  const size_t swig_method_index = 9;
+  const char *const swig_method_name = "AssemblePABoundaryFaces";
+  PyObject *method = swig_get_method(swig_method_index, swig_method_name);
+  swig::SwigVar_PyObject result = PyObject_CallFunctionObjArgs(method ,(PyObject *)obj0, NULL);
+#else
+  swig::SwigVar_PyObject swig_method_name = SWIG_Python_str_FromChar("AssemblePABoundaryFaces");
+  swig::SwigVar_PyObject result = PyObject_CallMethodObjArgs(swig_get_self(), (PyObject *) swig_method_name ,(PyObject *)obj0, NULL);
+#endif
+  if (!result) {
+    PyObject *error = PyErr_Occurred();
+    {
+      if (error != NULL) {
+        throw Swig::DirectorMethodException();
+      }
+    }
+  }
+}
+
+
+void SwigDirector_BilinearFormIntegrator::AssembleDiagonalPA(mfem::Vector &diag) {
+  swig::SwigVar_PyObject obj0;
+  obj0 = SWIG_NewPointerObj(SWIG_as_voidptr(&diag), SWIGTYPE_p_mfem__Vector,  0 );
+  if (!swig_get_self()) {
+    Swig::DirectorException::raise("'self' uninitialized, maybe you forgot to call BilinearFormIntegrator.__init__.");
+  }
+#if defined(SWIG_PYTHON_DIRECTOR_VTABLE)
+  const size_t swig_method_index = 10;
+  const char *const swig_method_name = "AssembleDiagonalPA";
+  PyObject *method = swig_get_method(swig_method_index, swig_method_name);
+  swig::SwigVar_PyObject result = PyObject_CallFunctionObjArgs(method ,(PyObject *)obj0, NULL);
+#else
+  swig::SwigVar_PyObject swig_method_name = SWIG_Python_str_FromChar("AssembleDiagonalPA");
+  swig::SwigVar_PyObject result = PyObject_CallMethodObjArgs(swig_get_self(), (PyObject *) swig_method_name ,(PyObject *)obj0, NULL);
+#endif
+  if (!result) {
+    PyObject *error = PyErr_Occurred();
+    {
+      if (error != NULL) {
+        throw Swig::DirectorMethodException();
+      }
+    }
+  }
+}
+
+
+void SwigDirector_BilinearFormIntegrator::AssembleDiagonalPA_ADAt(mfem::Vector const &D, mfem::Vector &diag) {
+  swig::SwigVar_PyObject obj0;
+  obj0 = SWIG_NewPointerObj(SWIG_as_voidptr(&D), SWIGTYPE_p_mfem__Vector,  0 );
+  swig::SwigVar_PyObject obj1;
+  obj1 = SWIG_NewPointerObj(SWIG_as_voidptr(&diag), SWIGTYPE_p_mfem__Vector,  0 );
+  if (!swig_get_self()) {
+    Swig::DirectorException::raise("'self' uninitialized, maybe you forgot to call BilinearFormIntegrator.__init__.");
+  }
+#if defined(SWIG_PYTHON_DIRECTOR_VTABLE)
+  const size_t swig_method_index = 11;
+  const char *const swig_method_name = "AssembleDiagonalPA_ADAt";
+  PyObject *method = swig_get_method(swig_method_index, swig_method_name);
+  swig::SwigVar_PyObject result = PyObject_CallFunctionObjArgs(method ,(PyObject *)obj0,(PyObject *)obj1, NULL);
+#else
+  swig::SwigVar_PyObject swig_method_name = SWIG_Python_str_FromChar("AssembleDiagonalPA_ADAt");
+  swig::SwigVar_PyObject result = PyObject_CallMethodObjArgs(swig_get_self(), (PyObject *) swig_method_name ,(PyObject *)obj0,(PyObject *)obj1, NULL);
+#endif
+  if (!result) {
+    PyObject *error = PyErr_Occurred();
+    {
+      if (error != NULL) {
+        throw Swig::DirectorMethodException();
+      }
+    }
+  }
+}
+
+
+void SwigDirector_BilinearFormIntegrator::AddMultTransposePA(mfem::Vector const &x, mfem::Vector &y) const {
+  swig::SwigVar_PyObject obj0;
+  obj0 = SWIG_NewPointerObj(SWIG_as_voidptr(&x), SWIGTYPE_p_mfem__Vector,  0 );
+  swig::SwigVar_PyObject obj1;
+  obj1 = SWIG_NewPointerObj(SWIG_as_voidptr(&y), SWIGTYPE_p_mfem__Vector,  0 );
+  if (!swig_get_self()) {
+    Swig::DirectorException::raise("'self' uninitialized, maybe you forgot to call BilinearFormIntegrator.__init__.");
+  }
+#if defined(SWIG_PYTHON_DIRECTOR_VTABLE)
+  const size_t swig_method_index = 12;
+  const char *const swig_method_name = "AddMultTransposePA";
+  PyObject *method = swig_get_method(swig_method_index, swig_method_name);
+  swig::SwigVar_PyObject result = PyObject_CallFunctionObjArgs(method ,(PyObject *)obj0,(PyObject *)obj1, NULL);
+#else
+  swig::SwigVar_PyObject swig_method_name = SWIG_Python_str_FromChar("AddMultTransposePA");
+  swig::SwigVar_PyObject result = PyObject_CallMethodObjArgs(swig_get_self(), (PyObject *) swig_method_name ,(PyObject *)obj0,(PyObject *)obj1, NULL);
+#endif
+  if (!result) {
+    PyObject *error = PyErr_Occurred();
+    {
+      if (error != NULL) {
+        throw Swig::DirectorMethodException();
+      }
+    }
+  }
+}
+
+
+void SwigDirector_BilinearFormIntegrator::AssembleEA(mfem::FiniteElementSpace const &fes, mfem::Vector &emat, bool const add) {
+  swig::SwigVar_PyObject obj0;
+  obj0 = SWIG_NewPointerObj(SWIG_as_voidptr(&fes), SWIGTYPE_p_mfem__FiniteElementSpace,  0 );
+  swig::SwigVar_PyObject obj1;
+  obj1 = SWIG_NewPointerObj(SWIG_as_voidptr(&emat), SWIGTYPE_p_mfem__Vector,  0 );
+  swig::SwigVar_PyObject obj2;
+  obj2 = SWIG_From_bool(static_cast< bool >(add));
+  if (!swig_get_self()) {
+    Swig::DirectorException::raise("'self' uninitialized, maybe you forgot to call BilinearFormIntegrator.__init__.");
+  }
+#if defined(SWIG_PYTHON_DIRECTOR_VTABLE)
+  const size_t swig_method_index = 13;
+  const char *const swig_method_name = "AssembleEA";
+  PyObject *method = swig_get_method(swig_method_index, swig_method_name);
+  swig::SwigVar_PyObject result = PyObject_CallFunctionObjArgs(method ,(PyObject *)obj0,(PyObject *)obj1,(PyObject *)obj2, NULL);
+#else
+  swig::SwigVar_PyObject swig_method_name = SWIG_Python_str_FromChar("AssembleEA");
+  swig::SwigVar_PyObject result = PyObject_CallMethodObjArgs(swig_get_self(), (PyObject *) swig_method_name ,(PyObject *)obj0,(PyObject *)obj1,(PyObject *)obj2, NULL);
+#endif
+  if (!result) {
+    PyObject *error = PyErr_Occurred();
+    {
+      if (error != NULL) {
+        throw Swig::DirectorMethodException();
+      }
+    }
+  }
+}
+
+
+void SwigDirector_BilinearFormIntegrator::AssembleMF(mfem::FiniteElementSpace const &fes) {
+  swig::SwigVar_PyObject obj0;
+  obj0 = SWIG_NewPointerObj(SWIG_as_voidptr(&fes), SWIGTYPE_p_mfem__FiniteElementSpace,  0 );
+  if (!swig_get_self()) {
+    Swig::DirectorException::raise("'self' uninitialized, maybe you forgot to call BilinearFormIntegrator.__init__.");
+  }
+#if defined(SWIG_PYTHON_DIRECTOR_VTABLE)
+  const size_t swig_method_index = 14;
+  const char *const swig_method_name = "AssembleMF";
+  PyObject *method = swig_get_method(swig_method_index, swig_method_name);
+  swig::SwigVar_PyObject result = PyObject_CallFunctionObjArgs(method ,(PyObject *)obj0, NULL);
+#else
+  swig::SwigVar_PyObject swig_method_name = SWIG_Python_str_FromChar("AssembleMF");
+  swig::SwigVar_PyObject result = PyObject_CallMethodObjArgs(swig_get_self(), (PyObject *) swig_method_name ,(PyObject *)obj0, NULL);
+#endif
+  if (!result) {
+    PyObject *error = PyErr_Occurred();
+    {
+      if (error != NULL) {
+        throw Swig::DirectorMethodException();
+      }
+    }
+  }
+}
+
+
+void SwigDirector_BilinearFormIntegrator::AddMultMF(mfem::Vector const &x, mfem::Vector &y) const {
+  swig::SwigVar_PyObject obj0;
+  obj0 = SWIG_NewPointerObj(SWIG_as_voidptr(&x), SWIGTYPE_p_mfem__Vector,  0 );
+  swig::SwigVar_PyObject obj1;
+  obj1 = SWIG_NewPointerObj(SWIG_as_voidptr(&y), SWIGTYPE_p_mfem__Vector,  0 );
+  if (!swig_get_self()) {
+    Swig::DirectorException::raise("'self' uninitialized, maybe you forgot to call BilinearFormIntegrator.__init__.");
+  }
+#if defined(SWIG_PYTHON_DIRECTOR_VTABLE)
+  const size_t swig_method_index = 15;
+  const char *const swig_method_name = "AddMultMF";
+  PyObject *method = swig_get_method(swig_method_index, swig_method_name);
+  swig::SwigVar_PyObject result = PyObject_CallFunctionObjArgs(method ,(PyObject *)obj0,(PyObject *)obj1, NULL);
+#else
+  swig::SwigVar_PyObject swig_method_name = SWIG_Python_str_FromChar("AddMultMF");
+  swig::SwigVar_PyObject result = PyObject_CallMethodObjArgs(swig_get_self(), (PyObject *) swig_method_name ,(PyObject *)obj0,(PyObject *)obj1, NULL);
+#endif
+  if (!result) {
+    PyObject *error = PyErr_Occurred();
+    {
+      if (error != NULL) {
+        throw Swig::DirectorMethodException();
+      }
+    }
+  }
+}
+
+
+void SwigDirector_BilinearFormIntegrator::AddMultTransposeMF(mfem::Vector const &x, mfem::Vector &y) const {
+  swig::SwigVar_PyObject obj0;
+  obj0 = SWIG_NewPointerObj(SWIG_as_voidptr(&x), SWIGTYPE_p_mfem__Vector,  0 );
+  swig::SwigVar_PyObject obj1;
+  obj1 = SWIG_NewPointerObj(SWIG_as_voidptr(&y), SWIGTYPE_p_mfem__Vector,  0 );
+  if (!swig_get_self()) {
+    Swig::DirectorException::raise("'self' uninitialized, maybe you forgot to call BilinearFormIntegrator.__init__.");
+  }
+#if defined(SWIG_PYTHON_DIRECTOR_VTABLE)
+  const size_t swig_method_index = 16;
+  const char *const swig_method_name = "AddMultTransposeMF";
+  PyObject *method = swig_get_method(swig_method_index, swig_method_name);
+  swig::SwigVar_PyObject result = PyObject_CallFunctionObjArgs(method ,(PyObject *)obj0,(PyObject *)obj1, NULL);
+#else
+  swig::SwigVar_PyObject swig_method_name = SWIG_Python_str_FromChar("AddMultTransposeMF");
+  swig::SwigVar_PyObject result = PyObject_CallMethodObjArgs(swig_get_self(), (PyObject *) swig_method_name ,(PyObject *)obj0,(PyObject *)obj1, NULL);
+#endif
+  if (!result) {
+    PyObject *error = PyErr_Occurred();
+    {
+      if (error != NULL) {
+        throw Swig::DirectorMethodException();
+      }
+    }
+  }
+}
+
+
+void SwigDirector_BilinearFormIntegrator::AssembleDiagonalMF(mfem::Vector &diag) {
+  swig::SwigVar_PyObject obj0;
+  obj0 = SWIG_NewPointerObj(SWIG_as_voidptr(&diag), SWIGTYPE_p_mfem__Vector,  0 );
+  if (!swig_get_self()) {
+    Swig::DirectorException::raise("'self' uninitialized, maybe you forgot to call BilinearFormIntegrator.__init__.");
+  }
+#if defined(SWIG_PYTHON_DIRECTOR_VTABLE)
+  const size_t swig_method_index = 17;
+  const char *const swig_method_name = "AssembleDiagonalMF";
+  PyObject *method = swig_get_method(swig_method_index, swig_method_name);
+  swig::SwigVar_PyObject result = PyObject_CallFunctionObjArgs(method ,(PyObject *)obj0, NULL);
+#else
+  swig::SwigVar_PyObject swig_method_name = SWIG_Python_str_FromChar("AssembleDiagonalMF");
+  swig::SwigVar_PyObject result = PyObject_CallMethodObjArgs(swig_get_self(), (PyObject *) swig_method_name ,(PyObject *)obj0, NULL);
+#endif
+  if (!result) {
+    PyObject *error = PyErr_Occurred();
+    {
+      if (error != NULL) {
+        throw Swig::DirectorMethodException();
+      }
+    }
+  }
+}
+
+
+void SwigDirector_BilinearFormIntegrator::AssembleEAInteriorFaces(mfem::FiniteElementSpace const &fes, mfem::Vector &ea_data_int, mfem::Vector &ea_data_ext, bool const add) {
+  swig::SwigVar_PyObject obj0;
+  obj0 = SWIG_NewPointerObj(SWIG_as_voidptr(&fes), SWIGTYPE_p_mfem__FiniteElementSpace,  0 );
+  swig::SwigVar_PyObject obj1;
+  obj1 = SWIG_NewPointerObj(SWIG_as_voidptr(&ea_data_int), SWIGTYPE_p_mfem__Vector,  0 );
+  swig::SwigVar_PyObject obj2;
+  obj2 = SWIG_NewPointerObj(SWIG_as_voidptr(&ea_data_ext), SWIGTYPE_p_mfem__Vector,  0 );
+  swig::SwigVar_PyObject obj3;
+  obj3 = SWIG_From_bool(static_cast< bool >(add));
+  if (!swig_get_self()) {
+    Swig::DirectorException::raise("'self' uninitialized, maybe you forgot to call BilinearFormIntegrator.__init__.");
+  }
+#if defined(SWIG_PYTHON_DIRECTOR_VTABLE)
+  const size_t swig_method_index = 18;
+  const char *const swig_method_name = "AssembleEAInteriorFaces";
+  PyObject *method = swig_get_method(swig_method_index, swig_method_name);
+  swig::SwigVar_PyObject result = PyObject_CallFunctionObjArgs(method ,(PyObject *)obj0,(PyObject *)obj1,(PyObject *)obj2,(PyObject *)obj3, NULL);
+#else
+  swig::SwigVar_PyObject swig_method_name = SWIG_Python_str_FromChar("AssembleEAInteriorFaces");
+  swig::SwigVar_PyObject result = PyObject_CallMethodObjArgs(swig_get_self(), (PyObject *) swig_method_name ,(PyObject *)obj0,(PyObject *)obj1,(PyObject *)obj2,(PyObject *)obj3, NULL);
+#endif
+  if (!result) {
+    PyObject *error = PyErr_Occurred();
+    {
+      if (error != NULL) {
+        throw Swig::DirectorMethodException();
+      }
+    }
+  }
+}
+
+
+void SwigDirector_BilinearFormIntegrator::AssembleEABoundaryFaces(mfem::FiniteElementSpace const &fes, mfem::Vector &ea_data_bdr, bool const add) {
+  swig::SwigVar_PyObject obj0;
+  obj0 = SWIG_NewPointerObj(SWIG_as_voidptr(&fes), SWIGTYPE_p_mfem__FiniteElementSpace,  0 );
+  swig::SwigVar_PyObject obj1;
+  obj1 = SWIG_NewPointerObj(SWIG_as_voidptr(&ea_data_bdr), SWIGTYPE_p_mfem__Vector,  0 );
+  swig::SwigVar_PyObject obj2;
+  obj2 = SWIG_From_bool(static_cast< bool >(add));
+  if (!swig_get_self()) {
+    Swig::DirectorException::raise("'self' uninitialized, maybe you forgot to call BilinearFormIntegrator.__init__.");
+  }
+#if defined(SWIG_PYTHON_DIRECTOR_VTABLE)
+  const size_t swig_method_index = 19;
+  const char *const swig_method_name = "AssembleEABoundaryFaces";
+  PyObject *method = swig_get_method(swig_method_index, swig_method_name);
+  swig::SwigVar_PyObject result = PyObject_CallFunctionObjArgs(method ,(PyObject *)obj0,(PyObject *)obj1,(PyObject *)obj2, NULL);
+#else
+  swig::SwigVar_PyObject swig_method_name = SWIG_Python_str_FromChar("AssembleEABoundaryFaces");
+  swig::SwigVar_PyObject result = PyObject_CallMethodObjArgs(swig_get_self(), (PyObject *) swig_method_name ,(PyObject *)obj0,(PyObject *)obj1,(PyObject *)obj2, NULL);
+#endif
+  if (!result) {
+    PyObject *error = PyErr_Occurred();
+    {
+      if (error != NULL) {
+        throw Swig::DirectorMethodException();
+      }
+    }
+  }
+}
+
+
+void SwigDirector_BilinearFormIntegrator::AssembleElementMatrix(mfem::FiniteElement const &el, mfem::ElementTransformation &Trans, mfem::DenseMatrix &elmat) {
+  swig::SwigVar_PyObject obj0;
+  obj0 = SWIG_NewPointerObj(SWIG_as_voidptr(&el), SWIGTYPE_p_mfem__FiniteElement,  0 );
+  swig::SwigVar_PyObject obj1;
+  obj1 = SWIG_NewPointerObj(SWIG_as_voidptr(&Trans), SWIGTYPE_p_mfem__ElementTransformation,  0 );
+  swig::SwigVar_PyObject obj2;
+  obj2 = SWIG_NewPointerObj(SWIG_as_voidptr(&elmat), SWIGTYPE_p_mfem__DenseMatrix,  0 );
+  if (!swig_get_self()) {
+    Swig::DirectorException::raise("'self' uninitialized, maybe you forgot to call BilinearFormIntegrator.__init__.");
+  }
+#if defined(SWIG_PYTHON_DIRECTOR_VTABLE)
+  const size_t swig_method_index = 20;
+  const char *const swig_method_name = "AssembleElementMatrix";
+  PyObject *method = swig_get_method(swig_method_index, swig_method_name);
+  swig::SwigVar_PyObject result = PyObject_CallFunctionObjArgs(method ,(PyObject *)obj0,(PyObject *)obj1,(PyObject *)obj2, NULL);
+#else
+  swig::SwigVar_PyObject swig_method_name = SWIG_Python_str_FromChar("AssembleElementMatrix");
+  swig::SwigVar_PyObject result = PyObject_CallMethodObjArgs(swig_get_self(), (PyObject *) swig_method_name ,(PyObject *)obj0,(PyObject *)obj1,(PyObject *)obj2, NULL);
+#endif
+  if (!result) {
+    PyObject *error = PyErr_Occurred();
+    {
+      if (error != NULL) {
+        throw Swig::DirectorMethodException();
+      }
+    }
+  }
+}
+
+
+void SwigDirector_BilinearFormIntegrator::AssembleElementMatrix2(mfem::FiniteElement const &trial_fe, mfem::FiniteElement const &test_fe, mfem::ElementTransformation &Trans, mfem::DenseMatrix &elmat) {
+  swig::SwigVar_PyObject obj0;
+  obj0 = SWIG_NewPointerObj(SWIG_as_voidptr(&trial_fe), SWIGTYPE_p_mfem__FiniteElement,  0 );
+  swig::SwigVar_PyObject obj1;
+  obj1 = SWIG_NewPointerObj(SWIG_as_voidptr(&test_fe), SWIGTYPE_p_mfem__FiniteElement,  0 );
+  swig::SwigVar_PyObject obj2;
+  obj2 = SWIG_NewPointerObj(SWIG_as_voidptr(&Trans), SWIGTYPE_p_mfem__ElementTransformation,  0 );
+  swig::SwigVar_PyObject obj3;
+  obj3 = SWIG_NewPointerObj(SWIG_as_voidptr(&elmat), SWIGTYPE_p_mfem__DenseMatrix,  0 );
+  if (!swig_get_self()) {
+    Swig::DirectorException::raise("'self' uninitialized, maybe you forgot to call BilinearFormIntegrator.__init__.");
+  }
+#if defined(SWIG_PYTHON_DIRECTOR_VTABLE)
+  const size_t swig_method_index = 21;
+  const char *const swig_method_name = "AssembleElementMatrix2";
+  PyObject *method = swig_get_method(swig_method_index, swig_method_name);
+  swig::SwigVar_PyObject result = PyObject_CallFunctionObjArgs(method ,(PyObject *)obj0,(PyObject *)obj1,(PyObject *)obj2,(PyObject *)obj3, NULL);
+#else
+  swig::SwigVar_PyObject swig_method_name = SWIG_Python_str_FromChar("AssembleElementMatrix2");
+  swig::SwigVar_PyObject result = PyObject_CallMethodObjArgs(swig_get_self(), (PyObject *) swig_method_name ,(PyObject *)obj0,(PyObject *)obj1,(PyObject *)obj2,(PyObject *)obj3, NULL);
+#endif
+  if (!result) {
+    PyObject *error = PyErr_Occurred();
+    {
+      if (error != NULL) {
+        throw Swig::DirectorMethodException();
+      }
+    }
+  }
+}
+
+
+void SwigDirector_BilinearFormIntegrator::AssembleFaceMatrix(mfem::FiniteElement const &el1, mfem::FiniteElement const &el2, mfem::FaceElementTransformations &Trans, mfem::DenseMatrix &elmat) {
+  swig::SwigVar_PyObject obj0;
+  obj0 = SWIG_NewPointerObj(SWIG_as_voidptr(&el1), SWIGTYPE_p_mfem__FiniteElement,  0 );
+  swig::SwigVar_PyObject obj1;
+  obj1 = SWIG_NewPointerObj(SWIG_as_voidptr(&el2), SWIGTYPE_p_mfem__FiniteElement,  0 );
+  swig::SwigVar_PyObject obj2;
+  obj2 = SWIG_NewPointerObj(SWIG_as_voidptr(&Trans), SWIGTYPE_p_mfem__FaceElementTransformations,  0 );
+  swig::SwigVar_PyObject obj3;
+  obj3 = SWIG_NewPointerObj(SWIG_as_voidptr(&elmat), SWIGTYPE_p_mfem__DenseMatrix,  0 );
+  if (!swig_get_self()) {
+    Swig::DirectorException::raise("'self' uninitialized, maybe you forgot to call BilinearFormIntegrator.__init__.");
+  }
+#if defined(SWIG_PYTHON_DIRECTOR_VTABLE)
+  const size_t swig_method_index = 22;
+  const char *const swig_method_name = "AssembleFaceMatrix";
+  PyObject *method = swig_get_method(swig_method_index, swig_method_name);
+  swig::SwigVar_PyObject result = PyObject_CallFunctionObjArgs(method ,(PyObject *)obj0,(PyObject *)obj1,(PyObject *)obj2,(PyObject *)obj3, NULL);
+#else
+  swig::SwigVar_PyObject swig_method_name = SWIG_Python_str_FromChar("AssembleFaceMatrix");
+  swig::SwigVar_PyObject result = PyObject_CallMethodObjArgs(swig_get_self(), (PyObject *) swig_method_name ,(PyObject *)obj0,(PyObject *)obj1,(PyObject *)obj2,(PyObject *)obj3, NULL);
+#endif
+  if (!result) {
+    PyObject *error = PyErr_Occurred();
+    {
+      if (error != NULL) {
+        throw Swig::DirectorMethodException();
+      }
+    }
+  }
+}
+
+
+void SwigDirector_BilinearFormIntegrator::AssembleFaceMatrix(mfem::FiniteElement const &trial_face_fe, mfem::FiniteElement const &test_fe1, mfem::FiniteElement const &test_fe2, mfem::FaceElementTransformations &Trans, mfem::DenseMatrix &elmat) {
+  swig::SwigVar_PyObject obj0;
+  obj0 = SWIG_NewPointerObj(SWIG_as_voidptr(&trial_face_fe), SWIGTYPE_p_mfem__FiniteElement,  0 );
+  swig::SwigVar_PyObject obj1;
+  obj1 = SWIG_NewPointerObj(SWIG_as_voidptr(&test_fe1), SWIGTYPE_p_mfem__FiniteElement,  0 );
+  swig::SwigVar_PyObject obj2;
+  obj2 = SWIG_NewPointerObj(SWIG_as_voidptr(&test_fe2), SWIGTYPE_p_mfem__FiniteElement,  0 );
+  swig::SwigVar_PyObject obj3;
+  obj3 = SWIG_NewPointerObj(SWIG_as_voidptr(&Trans), SWIGTYPE_p_mfem__FaceElementTransformations,  0 );
+  swig::SwigVar_PyObject obj4;
+  obj4 = SWIG_NewPointerObj(SWIG_as_voidptr(&elmat), SWIGTYPE_p_mfem__DenseMatrix,  0 );
+  if (!swig_get_self()) {
+    Swig::DirectorException::raise("'self' uninitialized, maybe you forgot to call BilinearFormIntegrator.__init__.");
+  }
+#if defined(SWIG_PYTHON_DIRECTOR_VTABLE)
+  const size_t swig_method_index = 23;
+  const char *const swig_method_name = "AssembleFaceMatrix";
+  PyObject *method = swig_get_method(swig_method_index, swig_method_name);
+  swig::SwigVar_PyObject result = PyObject_CallFunctionObjArgs(method ,(PyObject *)obj0,(PyObject *)obj1,(PyObject *)obj2,(PyObject *)obj3,(PyObject *)obj4, NULL);
+#else
+  swig::SwigVar_PyObject swig_method_name = SWIG_Python_str_FromChar("AssembleFaceMatrix");
   swig::SwigVar_PyObject result = PyObject_CallMethodObjArgs(swig_get_self(), (PyObject *) swig_method_name ,(PyObject *)obj0,(PyObject *)obj1,(PyObject *)obj2,(PyObject *)obj3,(PyObject *)obj4, NULL);
 #endif
   if (!result) {
@@ -4393,7 +4438,7 @@ void SwigDirector_BilinearFormIntegrator::ComputeElementFlux(mfem::FiniteElement
     Swig::DirectorException::raise("'self' uninitialized, maybe you forgot to call BilinearFormIntegrator.__init__.");
   }
 #if defined(SWIG_PYTHON_DIRECTOR_VTABLE)
-  const size_t swig_method_index = 23;
+  const size_t swig_method_index = 24;
   const char *const swig_method_name = "ComputeElementFlux";
   PyObject *method = swig_get_method(swig_method_index, swig_method_name);
   swig::SwigVar_PyObject result = PyObject_CallFunctionObjArgs(method ,(PyObject *)obj0,(PyObject *)obj1,(PyObject *)obj2,(PyObject *)obj3,(PyObject *)obj4,(PyObject *)obj5, NULL);
@@ -4427,7 +4472,7 @@ double SwigDirector_BilinearFormIntegrator::ComputeFluxEnergy(mfem::FiniteElemen
     Swig::DirectorException::raise("'self' uninitialized, maybe you forgot to call BilinearFormIntegrator.__init__.");
   }
 #if defined(SWIG_PYTHON_DIRECTOR_VTABLE)
-  const size_t swig_method_index = 24;
+  const size_t swig_method_index = 25;
   const char *const swig_method_name = "ComputeFluxEnergy";
   PyObject *method = swig_get_method(swig_method_index, swig_method_name);
   swig::SwigVar_PyObject result = PyObject_CallFunctionObjArgs(method ,(PyObject *)obj0,(PyObject *)obj1,(PyObject *)obj2,(PyObject *)obj3, NULL);
@@ -4452,9 +4497,6 @@ double SwigDirector_BilinearFormIntegrator::ComputeFluxEnergy(mfem::FiniteElemen
   return (double) c_result;
 }
 
-
-SwigDirector_BilinearFormIntegrator::~SwigDirector_BilinearFormIntegrator() {
-}
 
 #ifdef __cplusplus
 extern "C" {
@@ -4564,6 +4606,139 @@ SWIGINTERN PyObject *_wrap_new_BilinearFormIntegrator(PyObject *SWIGUNUSEDPARM(s
     }	 
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__BilinearFormIntegrator, SWIG_POINTER_NEW |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_BilinearFormIntegrator_AssemblePA__SWIG_0_0(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
+  PyObject *resultobj = 0;
+  mfem::BilinearFormIntegrator *arg1 = (mfem::BilinearFormIntegrator *) 0 ;
+  mfem::FiniteElementSpace *arg2 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  Swig::Director *director = 0;
+  bool upcall = false;
+  
+  if ((nobjs < 2) || (nobjs > 2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_mfem__BilinearFormIntegrator, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "BilinearFormIntegrator_AssemblePA" "', argument " "1"" of type '" "mfem::BilinearFormIntegrator *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::BilinearFormIntegrator * >(argp1);
+  res2 = SWIG_ConvertPtr(swig_obj[1], &argp2, SWIGTYPE_p_mfem__FiniteElementSpace,  0  | 0);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "BilinearFormIntegrator_AssemblePA" "', argument " "2"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  if (!argp2) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "BilinearFormIntegrator_AssemblePA" "', argument " "2"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  arg2 = reinterpret_cast< mfem::FiniteElementSpace * >(argp2);
+  director = SWIG_DIRECTOR_CAST(arg1);
+  upcall = (director && (director->swig_get_self()==swig_obj[0]));
+  try {
+    {
+      try {
+        if (upcall) {
+          (arg1)->mfem::BilinearFormIntegrator::AssemblePA((mfem::FiniteElementSpace const &)*arg2);
+        } else {
+          (arg1)->AssemblePA((mfem::FiniteElementSpace const &)*arg2);
+        }
+      }
+#ifdef  MFEM_USE_EXCEPTIONS
+      catch (mfem::ErrorException &_e) {
+        std::string s("PyMFEM error (mfem::ErrorException): "), s2(_e.what());
+        s = s + s2;    
+        SWIG_exception(SWIG_RuntimeError, s.c_str());
+      }
+#endif
+      
+      catch (Swig::DirectorException &e){
+        SWIG_fail;
+      }    
+      catch (...) {
+        SWIG_exception(SWIG_RuntimeError, "unknown exception");
+      }	 
+    }
+  } catch (Swig::DirectorException&) {
+    SWIG_fail;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_BilinearFormIntegrator_AssemblePA__SWIG_0_1(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
+  PyObject *resultobj = 0;
+  mfem::BilinearFormIntegrator *arg1 = (mfem::BilinearFormIntegrator *) 0 ;
+  mfem::FiniteElementSpace *arg2 = 0 ;
+  mfem::FiniteElementSpace *arg3 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  void *argp3 = 0 ;
+  int res3 = 0 ;
+  Swig::Director *director = 0;
+  bool upcall = false;
+  
+  if ((nobjs < 3) || (nobjs > 3)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_mfem__BilinearFormIntegrator, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "BilinearFormIntegrator_AssemblePA" "', argument " "1"" of type '" "mfem::BilinearFormIntegrator *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::BilinearFormIntegrator * >(argp1);
+  res2 = SWIG_ConvertPtr(swig_obj[1], &argp2, SWIGTYPE_p_mfem__FiniteElementSpace,  0  | 0);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "BilinearFormIntegrator_AssemblePA" "', argument " "2"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  if (!argp2) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "BilinearFormIntegrator_AssemblePA" "', argument " "2"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  arg2 = reinterpret_cast< mfem::FiniteElementSpace * >(argp2);
+  res3 = SWIG_ConvertPtr(swig_obj[2], &argp3, SWIGTYPE_p_mfem__FiniteElementSpace,  0  | 0);
+  if (!SWIG_IsOK(res3)) {
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "BilinearFormIntegrator_AssemblePA" "', argument " "3"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  if (!argp3) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "BilinearFormIntegrator_AssemblePA" "', argument " "3"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  arg3 = reinterpret_cast< mfem::FiniteElementSpace * >(argp3);
+  director = SWIG_DIRECTOR_CAST(arg1);
+  upcall = (director && (director->swig_get_self()==swig_obj[0]));
+  try {
+    {
+      try {
+        if (upcall) {
+          (arg1)->mfem::BilinearFormIntegrator::AssemblePA((mfem::FiniteElementSpace const &)*arg2,(mfem::FiniteElementSpace const &)*arg3);
+        } else {
+          (arg1)->AssemblePA((mfem::FiniteElementSpace const &)*arg2,(mfem::FiniteElementSpace const &)*arg3);
+        }
+      }
+#ifdef  MFEM_USE_EXCEPTIONS
+      catch (mfem::ErrorException &_e) {
+        std::string s("PyMFEM error (mfem::ErrorException): "), s2(_e.what());
+        s = s + s2;    
+        SWIG_exception(SWIG_RuntimeError, s.c_str());
+      }
+#endif
+      
+      catch (Swig::DirectorException &e){
+        SWIG_fail;
+      }    
+      catch (...) {
+        SWIG_exception(SWIG_RuntimeError, "unknown exception");
+      }	 
+    }
+  } catch (Swig::DirectorException&) {
+    SWIG_fail;
+  }
+  resultobj = SWIG_Py_Void();
   return resultobj;
 fail:
   return NULL;
@@ -4720,7 +4895,37 @@ SWIGINTERN PyObject *_wrap_BilinearFormIntegrator_AssemblePA(PyObject *self, PyO
       int res = SWIG_ConvertPtr(argv[1], 0, SWIGTYPE_p_mfem__FiniteElementSpace, SWIG_POINTER_NO_NULL | 0);
       _v = SWIG_CheckState(res);
       if (_v) {
+        return _wrap_BilinearFormIntegrator_AssemblePA__SWIG_0_0(self, argc, argv);
+      }
+    }
+  }
+  if (argc == 2) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_mfem__BilinearFormIntegrator, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      int res = SWIG_ConvertPtr(argv[1], 0, SWIGTYPE_p_mfem__FiniteElementSpace, SWIG_POINTER_NO_NULL | 0);
+      _v = SWIG_CheckState(res);
+      if (_v) {
         return _wrap_BilinearFormIntegrator_AssemblePA__SWIG_1(self, argc, argv);
+      }
+    }
+  }
+  if (argc == 3) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_mfem__BilinearFormIntegrator, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      int res = SWIG_ConvertPtr(argv[1], 0, SWIGTYPE_p_mfem__FiniteElementSpace, SWIG_POINTER_NO_NULL | 0);
+      _v = SWIG_CheckState(res);
+      if (_v) {
+        int res = SWIG_ConvertPtr(argv[2], 0, SWIGTYPE_p_mfem__FiniteElementSpace, SWIG_POINTER_NO_NULL | 0);
+        _v = SWIG_CheckState(res);
+        if (_v) {
+          return _wrap_BilinearFormIntegrator_AssemblePA__SWIG_0_1(self, argc, argv);
+        }
       }
     }
   }
@@ -4745,7 +4950,8 @@ SWIGINTERN PyObject *_wrap_BilinearFormIntegrator_AssemblePA(PyObject *self, PyO
 fail:
   SWIG_Python_RaiseOrModifyTypeError("Wrong number or type of arguments for overloaded function 'BilinearFormIntegrator_AssemblePA'.\n"
     "  Possible C/C++ prototypes are:\n"
-    "    mfem::BilinearFormIntegrator::AssemblePA()\n"
+    "    AssemblePA(mfem::FiniteElementSpace const &)\n"
+    "    AssemblePA(mfem::FiniteElementSpace const &,mfem::FiniteElementSpace const &)\n"
     "    mfem::BilinearFormIntegrator::AssemblePA(mfem::FiniteElementSpace const &)\n"
     "    mfem::BilinearFormIntegrator::AssemblePA(mfem::FiniteElementSpace const &,mfem::FiniteElementSpace const &)\n");
   return 0;
@@ -7538,6 +7744,115 @@ fail:
 }
 
 
+SWIGINTERN PyObject *_wrap_TransposeIntegrator_AssemblePA__SWIG_0_0(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
+  PyObject *resultobj = 0;
+  mfem::TransposeIntegrator *arg1 = (mfem::TransposeIntegrator *) 0 ;
+  mfem::FiniteElementSpace *arg2 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  
+  if ((nobjs < 2) || (nobjs > 2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_mfem__TransposeIntegrator, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "TransposeIntegrator_AssemblePA" "', argument " "1"" of type '" "mfem::TransposeIntegrator *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::TransposeIntegrator * >(argp1);
+  res2 = SWIG_ConvertPtr(swig_obj[1], &argp2, SWIGTYPE_p_mfem__FiniteElementSpace,  0  | 0);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "TransposeIntegrator_AssemblePA" "', argument " "2"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  if (!argp2) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "TransposeIntegrator_AssemblePA" "', argument " "2"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  arg2 = reinterpret_cast< mfem::FiniteElementSpace * >(argp2);
+  {
+    try {
+      (arg1)->AssemblePA((mfem::FiniteElementSpace const &)*arg2);
+    }
+#ifdef  MFEM_USE_EXCEPTIONS
+    catch (mfem::ErrorException &_e) {
+      std::string s("PyMFEM error (mfem::ErrorException): "), s2(_e.what());
+      s = s + s2;    
+      SWIG_exception(SWIG_RuntimeError, s.c_str());
+    }
+#endif
+    
+    catch (Swig::DirectorException &e){
+      SWIG_fail;
+    }    
+    catch (...) {
+      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+    }	 
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_TransposeIntegrator_AssemblePA__SWIG_0_1(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
+  PyObject *resultobj = 0;
+  mfem::TransposeIntegrator *arg1 = (mfem::TransposeIntegrator *) 0 ;
+  mfem::FiniteElementSpace *arg2 = 0 ;
+  mfem::FiniteElementSpace *arg3 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  void *argp3 = 0 ;
+  int res3 = 0 ;
+  
+  if ((nobjs < 3) || (nobjs > 3)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_mfem__TransposeIntegrator, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "TransposeIntegrator_AssemblePA" "', argument " "1"" of type '" "mfem::TransposeIntegrator *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::TransposeIntegrator * >(argp1);
+  res2 = SWIG_ConvertPtr(swig_obj[1], &argp2, SWIGTYPE_p_mfem__FiniteElementSpace,  0  | 0);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "TransposeIntegrator_AssemblePA" "', argument " "2"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  if (!argp2) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "TransposeIntegrator_AssemblePA" "', argument " "2"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  arg2 = reinterpret_cast< mfem::FiniteElementSpace * >(argp2);
+  res3 = SWIG_ConvertPtr(swig_obj[2], &argp3, SWIGTYPE_p_mfem__FiniteElementSpace,  0  | 0);
+  if (!SWIG_IsOK(res3)) {
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "TransposeIntegrator_AssemblePA" "', argument " "3"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  if (!argp3) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "TransposeIntegrator_AssemblePA" "', argument " "3"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  arg3 = reinterpret_cast< mfem::FiniteElementSpace * >(argp3);
+  {
+    try {
+      (arg1)->AssemblePA((mfem::FiniteElementSpace const &)*arg2,(mfem::FiniteElementSpace const &)*arg3);
+    }
+#ifdef  MFEM_USE_EXCEPTIONS
+    catch (mfem::ErrorException &_e) {
+      std::string s("PyMFEM error (mfem::ErrorException): "), s2(_e.what());
+      s = s + s2;    
+      SWIG_exception(SWIG_RuntimeError, s.c_str());
+    }
+#endif
+    
+    catch (Swig::DirectorException &e){
+      SWIG_fail;
+    }    
+    catch (...) {
+      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+    }	 
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
 SWIGINTERN PyObject *_wrap_TransposeIntegrator_AssemblePA__SWIG_1(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
   PyObject *resultobj = 0;
   mfem::TransposeIntegrator *arg1 = (mfem::TransposeIntegrator *) 0 ;
@@ -7589,12 +7904,25 @@ fail:
 
 SWIGINTERN PyObject *_wrap_TransposeIntegrator_AssemblePA(PyObject *self, PyObject *args) {
   Py_ssize_t argc;
-  PyObject *argv[3] = {
+  PyObject *argv[4] = {
     0
   };
   
-  if (!(argc = SWIG_Python_UnpackTuple(args, "TransposeIntegrator_AssemblePA", 0, 2, argv))) SWIG_fail;
+  if (!(argc = SWIG_Python_UnpackTuple(args, "TransposeIntegrator_AssemblePA", 0, 3, argv))) SWIG_fail;
   --argc;
+  if (argc == 2) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_mfem__TransposeIntegrator, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      int res = SWIG_ConvertPtr(argv[1], 0, SWIGTYPE_p_mfem__FiniteElementSpace, SWIG_POINTER_NO_NULL | 0);
+      _v = SWIG_CheckState(res);
+      if (_v) {
+        return _wrap_TransposeIntegrator_AssemblePA__SWIG_0_0(self, argc, argv);
+      }
+    }
+  }
   if (argc == 2) {
     int _v;
     void *vptr = 0;
@@ -7608,11 +7936,29 @@ SWIGINTERN PyObject *_wrap_TransposeIntegrator_AssemblePA(PyObject *self, PyObje
       }
     }
   }
+  if (argc == 3) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_mfem__TransposeIntegrator, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      int res = SWIG_ConvertPtr(argv[1], 0, SWIGTYPE_p_mfem__FiniteElementSpace, SWIG_POINTER_NO_NULL | 0);
+      _v = SWIG_CheckState(res);
+      if (_v) {
+        int res = SWIG_ConvertPtr(argv[2], 0, SWIGTYPE_p_mfem__FiniteElementSpace, SWIG_POINTER_NO_NULL | 0);
+        _v = SWIG_CheckState(res);
+        if (_v) {
+          return _wrap_TransposeIntegrator_AssemblePA__SWIG_0_1(self, argc, argv);
+        }
+      }
+    }
+  }
   
 fail:
   SWIG_Python_RaiseOrModifyTypeError("Wrong number or type of arguments for overloaded function 'TransposeIntegrator_AssemblePA'.\n"
     "  Possible C/C++ prototypes are:\n"
-    "    mfem::TransposeIntegrator::AssemblePA()\n"
+    "    AssemblePA(mfem::FiniteElementSpace const &)\n"
+    "    AssemblePA(mfem::FiniteElementSpace const &,mfem::FiniteElementSpace const &)\n"
     "    mfem::TransposeIntegrator::AssemblePA(mfem::FiniteElementSpace const &)\n");
   return 0;
 }
@@ -19249,6 +19595,115 @@ fail:
 }
 
 
+SWIGINTERN PyObject *_wrap_GradientIntegrator_AssemblePA__SWIG_0_0(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
+  PyObject *resultobj = 0;
+  mfem::GradientIntegrator *arg1 = (mfem::GradientIntegrator *) 0 ;
+  mfem::FiniteElementSpace *arg2 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  
+  if ((nobjs < 2) || (nobjs > 2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_mfem__GradientIntegrator, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "GradientIntegrator_AssemblePA" "', argument " "1"" of type '" "mfem::GradientIntegrator *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::GradientIntegrator * >(argp1);
+  res2 = SWIG_ConvertPtr(swig_obj[1], &argp2, SWIGTYPE_p_mfem__FiniteElementSpace,  0  | 0);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "GradientIntegrator_AssemblePA" "', argument " "2"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  if (!argp2) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "GradientIntegrator_AssemblePA" "', argument " "2"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  arg2 = reinterpret_cast< mfem::FiniteElementSpace * >(argp2);
+  {
+    try {
+      (arg1)->AssemblePA((mfem::FiniteElementSpace const &)*arg2);
+    }
+#ifdef  MFEM_USE_EXCEPTIONS
+    catch (mfem::ErrorException &_e) {
+      std::string s("PyMFEM error (mfem::ErrorException): "), s2(_e.what());
+      s = s + s2;    
+      SWIG_exception(SWIG_RuntimeError, s.c_str());
+    }
+#endif
+    
+    catch (Swig::DirectorException &e){
+      SWIG_fail;
+    }    
+    catch (...) {
+      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+    }	 
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_GradientIntegrator_AssemblePA__SWIG_0_1(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
+  PyObject *resultobj = 0;
+  mfem::GradientIntegrator *arg1 = (mfem::GradientIntegrator *) 0 ;
+  mfem::FiniteElementSpace *arg2 = 0 ;
+  mfem::FiniteElementSpace *arg3 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  void *argp3 = 0 ;
+  int res3 = 0 ;
+  
+  if ((nobjs < 3) || (nobjs > 3)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_mfem__GradientIntegrator, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "GradientIntegrator_AssemblePA" "', argument " "1"" of type '" "mfem::GradientIntegrator *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::GradientIntegrator * >(argp1);
+  res2 = SWIG_ConvertPtr(swig_obj[1], &argp2, SWIGTYPE_p_mfem__FiniteElementSpace,  0  | 0);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "GradientIntegrator_AssemblePA" "', argument " "2"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  if (!argp2) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "GradientIntegrator_AssemblePA" "', argument " "2"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  arg2 = reinterpret_cast< mfem::FiniteElementSpace * >(argp2);
+  res3 = SWIG_ConvertPtr(swig_obj[2], &argp3, SWIGTYPE_p_mfem__FiniteElementSpace,  0  | 0);
+  if (!SWIG_IsOK(res3)) {
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "GradientIntegrator_AssemblePA" "', argument " "3"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  if (!argp3) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "GradientIntegrator_AssemblePA" "', argument " "3"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  arg3 = reinterpret_cast< mfem::FiniteElementSpace * >(argp3);
+  {
+    try {
+      (arg1)->AssemblePA((mfem::FiniteElementSpace const &)*arg2,(mfem::FiniteElementSpace const &)*arg3);
+    }
+#ifdef  MFEM_USE_EXCEPTIONS
+    catch (mfem::ErrorException &_e) {
+      std::string s("PyMFEM error (mfem::ErrorException): "), s2(_e.what());
+      s = s + s2;    
+      SWIG_exception(SWIG_RuntimeError, s.c_str());
+    }
+#endif
+    
+    catch (Swig::DirectorException &e){
+      SWIG_fail;
+    }    
+    catch (...) {
+      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+    }	 
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
 SWIGINTERN PyObject *_wrap_GradientIntegrator_AssemblePA__SWIG_1(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
   PyObject *resultobj = 0;
   mfem::GradientIntegrator *arg1 = (mfem::GradientIntegrator *) 0 ;
@@ -19317,6 +19772,36 @@ SWIGINTERN PyObject *_wrap_GradientIntegrator_AssemblePA(PyObject *self, PyObjec
   
   if (!(argc = SWIG_Python_UnpackTuple(args, "GradientIntegrator_AssemblePA", 0, 3, argv))) SWIG_fail;
   --argc;
+  if (argc == 2) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_mfem__GradientIntegrator, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      int res = SWIG_ConvertPtr(argv[1], 0, SWIGTYPE_p_mfem__FiniteElementSpace, SWIG_POINTER_NO_NULL | 0);
+      _v = SWIG_CheckState(res);
+      if (_v) {
+        return _wrap_GradientIntegrator_AssemblePA__SWIG_0_0(self, argc, argv);
+      }
+    }
+  }
+  if (argc == 3) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_mfem__GradientIntegrator, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      int res = SWIG_ConvertPtr(argv[1], 0, SWIGTYPE_p_mfem__FiniteElementSpace, SWIG_POINTER_NO_NULL | 0);
+      _v = SWIG_CheckState(res);
+      if (_v) {
+        int res = SWIG_ConvertPtr(argv[2], 0, SWIGTYPE_p_mfem__FiniteElementSpace, SWIG_POINTER_NO_NULL | 0);
+        _v = SWIG_CheckState(res);
+        if (_v) {
+          return _wrap_GradientIntegrator_AssemblePA__SWIG_0_1(self, argc, argv);
+        }
+      }
+    }
+  }
   if (argc == 3) {
     int _v;
     void *vptr = 0;
@@ -19338,7 +19823,8 @@ SWIGINTERN PyObject *_wrap_GradientIntegrator_AssemblePA(PyObject *self, PyObjec
 fail:
   SWIG_Python_RaiseOrModifyTypeError("Wrong number or type of arguments for overloaded function 'GradientIntegrator_AssemblePA'.\n"
     "  Possible C/C++ prototypes are:\n"
-    "    mfem::GradientIntegrator::AssemblePA()\n"
+    "    AssemblePA(mfem::FiniteElementSpace const &)\n"
+    "    AssemblePA(mfem::FiniteElementSpace const &,mfem::FiniteElementSpace const &)\n"
     "    mfem::GradientIntegrator::AssemblePA(mfem::FiniteElementSpace const &,mfem::FiniteElementSpace const &)\n");
   return 0;
 }
@@ -20305,6 +20791,115 @@ fail:
 }
 
 
+SWIGINTERN PyObject *_wrap_DiffusionIntegrator_AssemblePA__SWIG_0_0(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
+  PyObject *resultobj = 0;
+  mfem::DiffusionIntegrator *arg1 = (mfem::DiffusionIntegrator *) 0 ;
+  mfem::FiniteElementSpace *arg2 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  
+  if ((nobjs < 2) || (nobjs > 2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_mfem__DiffusionIntegrator, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "DiffusionIntegrator_AssemblePA" "', argument " "1"" of type '" "mfem::DiffusionIntegrator *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::DiffusionIntegrator * >(argp1);
+  res2 = SWIG_ConvertPtr(swig_obj[1], &argp2, SWIGTYPE_p_mfem__FiniteElementSpace,  0  | 0);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "DiffusionIntegrator_AssemblePA" "', argument " "2"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  if (!argp2) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "DiffusionIntegrator_AssemblePA" "', argument " "2"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  arg2 = reinterpret_cast< mfem::FiniteElementSpace * >(argp2);
+  {
+    try {
+      (arg1)->AssemblePA((mfem::FiniteElementSpace const &)*arg2);
+    }
+#ifdef  MFEM_USE_EXCEPTIONS
+    catch (mfem::ErrorException &_e) {
+      std::string s("PyMFEM error (mfem::ErrorException): "), s2(_e.what());
+      s = s + s2;    
+      SWIG_exception(SWIG_RuntimeError, s.c_str());
+    }
+#endif
+    
+    catch (Swig::DirectorException &e){
+      SWIG_fail;
+    }    
+    catch (...) {
+      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+    }	 
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_DiffusionIntegrator_AssemblePA__SWIG_0_1(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
+  PyObject *resultobj = 0;
+  mfem::DiffusionIntegrator *arg1 = (mfem::DiffusionIntegrator *) 0 ;
+  mfem::FiniteElementSpace *arg2 = 0 ;
+  mfem::FiniteElementSpace *arg3 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  void *argp3 = 0 ;
+  int res3 = 0 ;
+  
+  if ((nobjs < 3) || (nobjs > 3)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_mfem__DiffusionIntegrator, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "DiffusionIntegrator_AssemblePA" "', argument " "1"" of type '" "mfem::DiffusionIntegrator *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::DiffusionIntegrator * >(argp1);
+  res2 = SWIG_ConvertPtr(swig_obj[1], &argp2, SWIGTYPE_p_mfem__FiniteElementSpace,  0  | 0);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "DiffusionIntegrator_AssemblePA" "', argument " "2"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  if (!argp2) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "DiffusionIntegrator_AssemblePA" "', argument " "2"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  arg2 = reinterpret_cast< mfem::FiniteElementSpace * >(argp2);
+  res3 = SWIG_ConvertPtr(swig_obj[2], &argp3, SWIGTYPE_p_mfem__FiniteElementSpace,  0  | 0);
+  if (!SWIG_IsOK(res3)) {
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "DiffusionIntegrator_AssemblePA" "', argument " "3"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  if (!argp3) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "DiffusionIntegrator_AssemblePA" "', argument " "3"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  arg3 = reinterpret_cast< mfem::FiniteElementSpace * >(argp3);
+  {
+    try {
+      (arg1)->AssemblePA((mfem::FiniteElementSpace const &)*arg2,(mfem::FiniteElementSpace const &)*arg3);
+    }
+#ifdef  MFEM_USE_EXCEPTIONS
+    catch (mfem::ErrorException &_e) {
+      std::string s("PyMFEM error (mfem::ErrorException): "), s2(_e.what());
+      s = s + s2;    
+      SWIG_exception(SWIG_RuntimeError, s.c_str());
+    }
+#endif
+    
+    catch (Swig::DirectorException &e){
+      SWIG_fail;
+    }    
+    catch (...) {
+      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+    }	 
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
 SWIGINTERN PyObject *_wrap_DiffusionIntegrator_AssembleMF(PyObject *SWIGUNUSEDPARM(self), PyObject *args, PyObject *kwargs) {
   PyObject *resultobj = 0;
   mfem::DiffusionIntegrator *arg1 = (mfem::DiffusionIntegrator *) 0 ;
@@ -20410,12 +21005,25 @@ fail:
 
 SWIGINTERN PyObject *_wrap_DiffusionIntegrator_AssemblePA(PyObject *self, PyObject *args) {
   Py_ssize_t argc;
-  PyObject *argv[3] = {
+  PyObject *argv[4] = {
     0
   };
   
-  if (!(argc = SWIG_Python_UnpackTuple(args, "DiffusionIntegrator_AssemblePA", 0, 2, argv))) SWIG_fail;
+  if (!(argc = SWIG_Python_UnpackTuple(args, "DiffusionIntegrator_AssemblePA", 0, 3, argv))) SWIG_fail;
   --argc;
+  if (argc == 2) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_mfem__DiffusionIntegrator, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      int res = SWIG_ConvertPtr(argv[1], 0, SWIGTYPE_p_mfem__FiniteElementSpace, SWIG_POINTER_NO_NULL | 0);
+      _v = SWIG_CheckState(res);
+      if (_v) {
+        return _wrap_DiffusionIntegrator_AssemblePA__SWIG_0_0(self, argc, argv);
+      }
+    }
+  }
   if (argc == 2) {
     int _v;
     void *vptr = 0;
@@ -20429,11 +21037,29 @@ SWIGINTERN PyObject *_wrap_DiffusionIntegrator_AssemblePA(PyObject *self, PyObje
       }
     }
   }
+  if (argc == 3) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_mfem__DiffusionIntegrator, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      int res = SWIG_ConvertPtr(argv[1], 0, SWIGTYPE_p_mfem__FiniteElementSpace, SWIG_POINTER_NO_NULL | 0);
+      _v = SWIG_CheckState(res);
+      if (_v) {
+        int res = SWIG_ConvertPtr(argv[2], 0, SWIGTYPE_p_mfem__FiniteElementSpace, SWIG_POINTER_NO_NULL | 0);
+        _v = SWIG_CheckState(res);
+        if (_v) {
+          return _wrap_DiffusionIntegrator_AssemblePA__SWIG_0_1(self, argc, argv);
+        }
+      }
+    }
+  }
   
 fail:
   SWIG_Python_RaiseOrModifyTypeError("Wrong number or type of arguments for overloaded function 'DiffusionIntegrator_AssemblePA'.\n"
     "  Possible C/C++ prototypes are:\n"
-    "    mfem::DiffusionIntegrator::AssemblePA()\n"
+    "    AssemblePA(mfem::FiniteElementSpace const &)\n"
+    "    AssemblePA(mfem::FiniteElementSpace const &,mfem::FiniteElementSpace const &)\n"
     "    mfem::DiffusionIntegrator::AssemblePA(mfem::FiniteElementSpace const &)\n");
   return 0;
 }
@@ -21171,6 +21797,115 @@ fail:
 }
 
 
+SWIGINTERN PyObject *_wrap_MassIntegrator_AssemblePA__SWIG_0_0(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
+  PyObject *resultobj = 0;
+  mfem::MassIntegrator *arg1 = (mfem::MassIntegrator *) 0 ;
+  mfem::FiniteElementSpace *arg2 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  
+  if ((nobjs < 2) || (nobjs > 2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_mfem__MassIntegrator, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "MassIntegrator_AssemblePA" "', argument " "1"" of type '" "mfem::MassIntegrator *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::MassIntegrator * >(argp1);
+  res2 = SWIG_ConvertPtr(swig_obj[1], &argp2, SWIGTYPE_p_mfem__FiniteElementSpace,  0  | 0);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "MassIntegrator_AssemblePA" "', argument " "2"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  if (!argp2) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "MassIntegrator_AssemblePA" "', argument " "2"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  arg2 = reinterpret_cast< mfem::FiniteElementSpace * >(argp2);
+  {
+    try {
+      (arg1)->AssemblePA((mfem::FiniteElementSpace const &)*arg2);
+    }
+#ifdef  MFEM_USE_EXCEPTIONS
+    catch (mfem::ErrorException &_e) {
+      std::string s("PyMFEM error (mfem::ErrorException): "), s2(_e.what());
+      s = s + s2;    
+      SWIG_exception(SWIG_RuntimeError, s.c_str());
+    }
+#endif
+    
+    catch (Swig::DirectorException &e){
+      SWIG_fail;
+    }    
+    catch (...) {
+      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+    }	 
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_MassIntegrator_AssemblePA__SWIG_0_1(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
+  PyObject *resultobj = 0;
+  mfem::MassIntegrator *arg1 = (mfem::MassIntegrator *) 0 ;
+  mfem::FiniteElementSpace *arg2 = 0 ;
+  mfem::FiniteElementSpace *arg3 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  void *argp3 = 0 ;
+  int res3 = 0 ;
+  
+  if ((nobjs < 3) || (nobjs > 3)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_mfem__MassIntegrator, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "MassIntegrator_AssemblePA" "', argument " "1"" of type '" "mfem::MassIntegrator *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::MassIntegrator * >(argp1);
+  res2 = SWIG_ConvertPtr(swig_obj[1], &argp2, SWIGTYPE_p_mfem__FiniteElementSpace,  0  | 0);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "MassIntegrator_AssemblePA" "', argument " "2"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  if (!argp2) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "MassIntegrator_AssemblePA" "', argument " "2"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  arg2 = reinterpret_cast< mfem::FiniteElementSpace * >(argp2);
+  res3 = SWIG_ConvertPtr(swig_obj[2], &argp3, SWIGTYPE_p_mfem__FiniteElementSpace,  0  | 0);
+  if (!SWIG_IsOK(res3)) {
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "MassIntegrator_AssemblePA" "', argument " "3"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  if (!argp3) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "MassIntegrator_AssemblePA" "', argument " "3"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  arg3 = reinterpret_cast< mfem::FiniteElementSpace * >(argp3);
+  {
+    try {
+      (arg1)->AssemblePA((mfem::FiniteElementSpace const &)*arg2,(mfem::FiniteElementSpace const &)*arg3);
+    }
+#ifdef  MFEM_USE_EXCEPTIONS
+    catch (mfem::ErrorException &_e) {
+      std::string s("PyMFEM error (mfem::ErrorException): "), s2(_e.what());
+      s = s + s2;    
+      SWIG_exception(SWIG_RuntimeError, s.c_str());
+    }
+#endif
+    
+    catch (Swig::DirectorException &e){
+      SWIG_fail;
+    }    
+    catch (...) {
+      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+    }	 
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
 SWIGINTERN PyObject *_wrap_MassIntegrator_AssembleMF(PyObject *SWIGUNUSEDPARM(self), PyObject *args, PyObject *kwargs) {
   PyObject *resultobj = 0;
   mfem::MassIntegrator *arg1 = (mfem::MassIntegrator *) 0 ;
@@ -21276,12 +22011,25 @@ fail:
 
 SWIGINTERN PyObject *_wrap_MassIntegrator_AssemblePA(PyObject *self, PyObject *args) {
   Py_ssize_t argc;
-  PyObject *argv[3] = {
+  PyObject *argv[4] = {
     0
   };
   
-  if (!(argc = SWIG_Python_UnpackTuple(args, "MassIntegrator_AssemblePA", 0, 2, argv))) SWIG_fail;
+  if (!(argc = SWIG_Python_UnpackTuple(args, "MassIntegrator_AssemblePA", 0, 3, argv))) SWIG_fail;
   --argc;
+  if (argc == 2) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_mfem__MassIntegrator, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      int res = SWIG_ConvertPtr(argv[1], 0, SWIGTYPE_p_mfem__FiniteElementSpace, SWIG_POINTER_NO_NULL | 0);
+      _v = SWIG_CheckState(res);
+      if (_v) {
+        return _wrap_MassIntegrator_AssemblePA__SWIG_0_0(self, argc, argv);
+      }
+    }
+  }
   if (argc == 2) {
     int _v;
     void *vptr = 0;
@@ -21295,11 +22043,29 @@ SWIGINTERN PyObject *_wrap_MassIntegrator_AssemblePA(PyObject *self, PyObject *a
       }
     }
   }
+  if (argc == 3) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_mfem__MassIntegrator, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      int res = SWIG_ConvertPtr(argv[1], 0, SWIGTYPE_p_mfem__FiniteElementSpace, SWIG_POINTER_NO_NULL | 0);
+      _v = SWIG_CheckState(res);
+      if (_v) {
+        int res = SWIG_ConvertPtr(argv[2], 0, SWIGTYPE_p_mfem__FiniteElementSpace, SWIG_POINTER_NO_NULL | 0);
+        _v = SWIG_CheckState(res);
+        if (_v) {
+          return _wrap_MassIntegrator_AssemblePA__SWIG_0_1(self, argc, argv);
+        }
+      }
+    }
+  }
   
 fail:
   SWIG_Python_RaiseOrModifyTypeError("Wrong number or type of arguments for overloaded function 'MassIntegrator_AssemblePA'.\n"
     "  Possible C/C++ prototypes are:\n"
-    "    mfem::MassIntegrator::AssemblePA()\n"
+    "    AssemblePA(mfem::FiniteElementSpace const &)\n"
+    "    AssemblePA(mfem::FiniteElementSpace const &,mfem::FiniteElementSpace const &)\n"
     "    mfem::MassIntegrator::AssemblePA(mfem::FiniteElementSpace const &)\n");
   return 0;
 }
@@ -22294,6 +23060,115 @@ fail:
 }
 
 
+SWIGINTERN PyObject *_wrap_ConvectionIntegrator_AssemblePA__SWIG_0_0(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
+  PyObject *resultobj = 0;
+  mfem::ConvectionIntegrator *arg1 = (mfem::ConvectionIntegrator *) 0 ;
+  mfem::FiniteElementSpace *arg2 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  
+  if ((nobjs < 2) || (nobjs > 2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_mfem__ConvectionIntegrator, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "ConvectionIntegrator_AssemblePA" "', argument " "1"" of type '" "mfem::ConvectionIntegrator *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::ConvectionIntegrator * >(argp1);
+  res2 = SWIG_ConvertPtr(swig_obj[1], &argp2, SWIGTYPE_p_mfem__FiniteElementSpace,  0  | 0);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "ConvectionIntegrator_AssemblePA" "', argument " "2"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  if (!argp2) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "ConvectionIntegrator_AssemblePA" "', argument " "2"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  arg2 = reinterpret_cast< mfem::FiniteElementSpace * >(argp2);
+  {
+    try {
+      (arg1)->AssemblePA((mfem::FiniteElementSpace const &)*arg2);
+    }
+#ifdef  MFEM_USE_EXCEPTIONS
+    catch (mfem::ErrorException &_e) {
+      std::string s("PyMFEM error (mfem::ErrorException): "), s2(_e.what());
+      s = s + s2;    
+      SWIG_exception(SWIG_RuntimeError, s.c_str());
+    }
+#endif
+    
+    catch (Swig::DirectorException &e){
+      SWIG_fail;
+    }    
+    catch (...) {
+      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+    }	 
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_ConvectionIntegrator_AssemblePA__SWIG_0_1(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
+  PyObject *resultobj = 0;
+  mfem::ConvectionIntegrator *arg1 = (mfem::ConvectionIntegrator *) 0 ;
+  mfem::FiniteElementSpace *arg2 = 0 ;
+  mfem::FiniteElementSpace *arg3 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  void *argp3 = 0 ;
+  int res3 = 0 ;
+  
+  if ((nobjs < 3) || (nobjs > 3)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_mfem__ConvectionIntegrator, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "ConvectionIntegrator_AssemblePA" "', argument " "1"" of type '" "mfem::ConvectionIntegrator *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::ConvectionIntegrator * >(argp1);
+  res2 = SWIG_ConvertPtr(swig_obj[1], &argp2, SWIGTYPE_p_mfem__FiniteElementSpace,  0  | 0);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "ConvectionIntegrator_AssemblePA" "', argument " "2"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  if (!argp2) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "ConvectionIntegrator_AssemblePA" "', argument " "2"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  arg2 = reinterpret_cast< mfem::FiniteElementSpace * >(argp2);
+  res3 = SWIG_ConvertPtr(swig_obj[2], &argp3, SWIGTYPE_p_mfem__FiniteElementSpace,  0  | 0);
+  if (!SWIG_IsOK(res3)) {
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "ConvectionIntegrator_AssemblePA" "', argument " "3"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  if (!argp3) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "ConvectionIntegrator_AssemblePA" "', argument " "3"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  arg3 = reinterpret_cast< mfem::FiniteElementSpace * >(argp3);
+  {
+    try {
+      (arg1)->AssemblePA((mfem::FiniteElementSpace const &)*arg2,(mfem::FiniteElementSpace const &)*arg3);
+    }
+#ifdef  MFEM_USE_EXCEPTIONS
+    catch (mfem::ErrorException &_e) {
+      std::string s("PyMFEM error (mfem::ErrorException): "), s2(_e.what());
+      s = s + s2;    
+      SWIG_exception(SWIG_RuntimeError, s.c_str());
+    }
+#endif
+    
+    catch (Swig::DirectorException &e){
+      SWIG_fail;
+    }    
+    catch (...) {
+      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+    }	 
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
 SWIGINTERN PyObject *_wrap_ConvectionIntegrator_AssemblePA__SWIG_1(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
   PyObject *resultobj = 0;
   mfem::ConvectionIntegrator *arg1 = (mfem::ConvectionIntegrator *) 0 ;
@@ -22345,12 +23220,25 @@ fail:
 
 SWIGINTERN PyObject *_wrap_ConvectionIntegrator_AssemblePA(PyObject *self, PyObject *args) {
   Py_ssize_t argc;
-  PyObject *argv[3] = {
+  PyObject *argv[4] = {
     0
   };
   
-  if (!(argc = SWIG_Python_UnpackTuple(args, "ConvectionIntegrator_AssemblePA", 0, 2, argv))) SWIG_fail;
+  if (!(argc = SWIG_Python_UnpackTuple(args, "ConvectionIntegrator_AssemblePA", 0, 3, argv))) SWIG_fail;
   --argc;
+  if (argc == 2) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_mfem__ConvectionIntegrator, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      int res = SWIG_ConvertPtr(argv[1], 0, SWIGTYPE_p_mfem__FiniteElementSpace, SWIG_POINTER_NO_NULL | 0);
+      _v = SWIG_CheckState(res);
+      if (_v) {
+        return _wrap_ConvectionIntegrator_AssemblePA__SWIG_0_0(self, argc, argv);
+      }
+    }
+  }
   if (argc == 2) {
     int _v;
     void *vptr = 0;
@@ -22364,11 +23252,29 @@ SWIGINTERN PyObject *_wrap_ConvectionIntegrator_AssemblePA(PyObject *self, PyObj
       }
     }
   }
+  if (argc == 3) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_mfem__ConvectionIntegrator, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      int res = SWIG_ConvertPtr(argv[1], 0, SWIGTYPE_p_mfem__FiniteElementSpace, SWIG_POINTER_NO_NULL | 0);
+      _v = SWIG_CheckState(res);
+      if (_v) {
+        int res = SWIG_ConvertPtr(argv[2], 0, SWIGTYPE_p_mfem__FiniteElementSpace, SWIG_POINTER_NO_NULL | 0);
+        _v = SWIG_CheckState(res);
+        if (_v) {
+          return _wrap_ConvectionIntegrator_AssemblePA__SWIG_0_1(self, argc, argv);
+        }
+      }
+    }
+  }
   
 fail:
   SWIG_Python_RaiseOrModifyTypeError("Wrong number or type of arguments for overloaded function 'ConvectionIntegrator_AssemblePA'.\n"
     "  Possible C/C++ prototypes are:\n"
-    "    mfem::ConvectionIntegrator::AssemblePA()\n"
+    "    AssemblePA(mfem::FiniteElementSpace const &)\n"
+    "    AssemblePA(mfem::FiniteElementSpace const &,mfem::FiniteElementSpace const &)\n"
     "    mfem::ConvectionIntegrator::AssemblePA(mfem::FiniteElementSpace const &)\n");
   return 0;
 }
@@ -23554,6 +24460,115 @@ fail:
 }
 
 
+SWIGINTERN PyObject *_wrap_VectorMassIntegrator_AssemblePA__SWIG_0_0(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
+  PyObject *resultobj = 0;
+  mfem::VectorMassIntegrator *arg1 = (mfem::VectorMassIntegrator *) 0 ;
+  mfem::FiniteElementSpace *arg2 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  
+  if ((nobjs < 2) || (nobjs > 2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_mfem__VectorMassIntegrator, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "VectorMassIntegrator_AssemblePA" "', argument " "1"" of type '" "mfem::VectorMassIntegrator *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::VectorMassIntegrator * >(argp1);
+  res2 = SWIG_ConvertPtr(swig_obj[1], &argp2, SWIGTYPE_p_mfem__FiniteElementSpace,  0  | 0);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "VectorMassIntegrator_AssemblePA" "', argument " "2"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  if (!argp2) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "VectorMassIntegrator_AssemblePA" "', argument " "2"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  arg2 = reinterpret_cast< mfem::FiniteElementSpace * >(argp2);
+  {
+    try {
+      (arg1)->AssemblePA((mfem::FiniteElementSpace const &)*arg2);
+    }
+#ifdef  MFEM_USE_EXCEPTIONS
+    catch (mfem::ErrorException &_e) {
+      std::string s("PyMFEM error (mfem::ErrorException): "), s2(_e.what());
+      s = s + s2;    
+      SWIG_exception(SWIG_RuntimeError, s.c_str());
+    }
+#endif
+    
+    catch (Swig::DirectorException &e){
+      SWIG_fail;
+    }    
+    catch (...) {
+      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+    }	 
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_VectorMassIntegrator_AssemblePA__SWIG_0_1(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
+  PyObject *resultobj = 0;
+  mfem::VectorMassIntegrator *arg1 = (mfem::VectorMassIntegrator *) 0 ;
+  mfem::FiniteElementSpace *arg2 = 0 ;
+  mfem::FiniteElementSpace *arg3 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  void *argp3 = 0 ;
+  int res3 = 0 ;
+  
+  if ((nobjs < 3) || (nobjs > 3)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_mfem__VectorMassIntegrator, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "VectorMassIntegrator_AssemblePA" "', argument " "1"" of type '" "mfem::VectorMassIntegrator *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::VectorMassIntegrator * >(argp1);
+  res2 = SWIG_ConvertPtr(swig_obj[1], &argp2, SWIGTYPE_p_mfem__FiniteElementSpace,  0  | 0);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "VectorMassIntegrator_AssemblePA" "', argument " "2"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  if (!argp2) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "VectorMassIntegrator_AssemblePA" "', argument " "2"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  arg2 = reinterpret_cast< mfem::FiniteElementSpace * >(argp2);
+  res3 = SWIG_ConvertPtr(swig_obj[2], &argp3, SWIGTYPE_p_mfem__FiniteElementSpace,  0  | 0);
+  if (!SWIG_IsOK(res3)) {
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "VectorMassIntegrator_AssemblePA" "', argument " "3"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  if (!argp3) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "VectorMassIntegrator_AssemblePA" "', argument " "3"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  arg3 = reinterpret_cast< mfem::FiniteElementSpace * >(argp3);
+  {
+    try {
+      (arg1)->AssemblePA((mfem::FiniteElementSpace const &)*arg2,(mfem::FiniteElementSpace const &)*arg3);
+    }
+#ifdef  MFEM_USE_EXCEPTIONS
+    catch (mfem::ErrorException &_e) {
+      std::string s("PyMFEM error (mfem::ErrorException): "), s2(_e.what());
+      s = s + s2;    
+      SWIG_exception(SWIG_RuntimeError, s.c_str());
+    }
+#endif
+    
+    catch (Swig::DirectorException &e){
+      SWIG_fail;
+    }    
+    catch (...) {
+      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+    }	 
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
 SWIGINTERN PyObject *_wrap_VectorMassIntegrator_AssemblePA__SWIG_1(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
   PyObject *resultobj = 0;
   mfem::VectorMassIntegrator *arg1 = (mfem::VectorMassIntegrator *) 0 ;
@@ -23605,12 +24620,25 @@ fail:
 
 SWIGINTERN PyObject *_wrap_VectorMassIntegrator_AssemblePA(PyObject *self, PyObject *args) {
   Py_ssize_t argc;
-  PyObject *argv[3] = {
+  PyObject *argv[4] = {
     0
   };
   
-  if (!(argc = SWIG_Python_UnpackTuple(args, "VectorMassIntegrator_AssemblePA", 0, 2, argv))) SWIG_fail;
+  if (!(argc = SWIG_Python_UnpackTuple(args, "VectorMassIntegrator_AssemblePA", 0, 3, argv))) SWIG_fail;
   --argc;
+  if (argc == 2) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_mfem__VectorMassIntegrator, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      int res = SWIG_ConvertPtr(argv[1], 0, SWIGTYPE_p_mfem__FiniteElementSpace, SWIG_POINTER_NO_NULL | 0);
+      _v = SWIG_CheckState(res);
+      if (_v) {
+        return _wrap_VectorMassIntegrator_AssemblePA__SWIG_0_0(self, argc, argv);
+      }
+    }
+  }
   if (argc == 2) {
     int _v;
     void *vptr = 0;
@@ -23624,11 +24652,29 @@ SWIGINTERN PyObject *_wrap_VectorMassIntegrator_AssemblePA(PyObject *self, PyObj
       }
     }
   }
+  if (argc == 3) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_mfem__VectorMassIntegrator, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      int res = SWIG_ConvertPtr(argv[1], 0, SWIGTYPE_p_mfem__FiniteElementSpace, SWIG_POINTER_NO_NULL | 0);
+      _v = SWIG_CheckState(res);
+      if (_v) {
+        int res = SWIG_ConvertPtr(argv[2], 0, SWIGTYPE_p_mfem__FiniteElementSpace, SWIG_POINTER_NO_NULL | 0);
+        _v = SWIG_CheckState(res);
+        if (_v) {
+          return _wrap_VectorMassIntegrator_AssemblePA__SWIG_0_1(self, argc, argv);
+        }
+      }
+    }
+  }
   
 fail:
   SWIG_Python_RaiseOrModifyTypeError("Wrong number or type of arguments for overloaded function 'VectorMassIntegrator_AssemblePA'.\n"
     "  Possible C/C++ prototypes are:\n"
-    "    mfem::VectorMassIntegrator::AssemblePA()\n"
+    "    AssemblePA(mfem::FiniteElementSpace const &)\n"
+    "    AssemblePA(mfem::FiniteElementSpace const &,mfem::FiniteElementSpace const &)\n"
     "    mfem::VectorMassIntegrator::AssemblePA(mfem::FiniteElementSpace const &)\n");
   return 0;
 }
@@ -25784,6 +26830,115 @@ fail:
 }
 
 
+SWIGINTERN PyObject *_wrap_CurlCurlIntegrator_AssemblePA__SWIG_0_0(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
+  PyObject *resultobj = 0;
+  mfem::CurlCurlIntegrator *arg1 = (mfem::CurlCurlIntegrator *) 0 ;
+  mfem::FiniteElementSpace *arg2 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  
+  if ((nobjs < 2) || (nobjs > 2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_mfem__CurlCurlIntegrator, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "CurlCurlIntegrator_AssemblePA" "', argument " "1"" of type '" "mfem::CurlCurlIntegrator *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::CurlCurlIntegrator * >(argp1);
+  res2 = SWIG_ConvertPtr(swig_obj[1], &argp2, SWIGTYPE_p_mfem__FiniteElementSpace,  0  | 0);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "CurlCurlIntegrator_AssemblePA" "', argument " "2"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  if (!argp2) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "CurlCurlIntegrator_AssemblePA" "', argument " "2"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  arg2 = reinterpret_cast< mfem::FiniteElementSpace * >(argp2);
+  {
+    try {
+      (arg1)->AssemblePA((mfem::FiniteElementSpace const &)*arg2);
+    }
+#ifdef  MFEM_USE_EXCEPTIONS
+    catch (mfem::ErrorException &_e) {
+      std::string s("PyMFEM error (mfem::ErrorException): "), s2(_e.what());
+      s = s + s2;    
+      SWIG_exception(SWIG_RuntimeError, s.c_str());
+    }
+#endif
+    
+    catch (Swig::DirectorException &e){
+      SWIG_fail;
+    }    
+    catch (...) {
+      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+    }	 
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_CurlCurlIntegrator_AssemblePA__SWIG_0_1(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
+  PyObject *resultobj = 0;
+  mfem::CurlCurlIntegrator *arg1 = (mfem::CurlCurlIntegrator *) 0 ;
+  mfem::FiniteElementSpace *arg2 = 0 ;
+  mfem::FiniteElementSpace *arg3 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  void *argp3 = 0 ;
+  int res3 = 0 ;
+  
+  if ((nobjs < 3) || (nobjs > 3)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_mfem__CurlCurlIntegrator, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "CurlCurlIntegrator_AssemblePA" "', argument " "1"" of type '" "mfem::CurlCurlIntegrator *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::CurlCurlIntegrator * >(argp1);
+  res2 = SWIG_ConvertPtr(swig_obj[1], &argp2, SWIGTYPE_p_mfem__FiniteElementSpace,  0  | 0);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "CurlCurlIntegrator_AssemblePA" "', argument " "2"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  if (!argp2) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "CurlCurlIntegrator_AssemblePA" "', argument " "2"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  arg2 = reinterpret_cast< mfem::FiniteElementSpace * >(argp2);
+  res3 = SWIG_ConvertPtr(swig_obj[2], &argp3, SWIGTYPE_p_mfem__FiniteElementSpace,  0  | 0);
+  if (!SWIG_IsOK(res3)) {
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "CurlCurlIntegrator_AssemblePA" "', argument " "3"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  if (!argp3) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "CurlCurlIntegrator_AssemblePA" "', argument " "3"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  arg3 = reinterpret_cast< mfem::FiniteElementSpace * >(argp3);
+  {
+    try {
+      (arg1)->AssemblePA((mfem::FiniteElementSpace const &)*arg2,(mfem::FiniteElementSpace const &)*arg3);
+    }
+#ifdef  MFEM_USE_EXCEPTIONS
+    catch (mfem::ErrorException &_e) {
+      std::string s("PyMFEM error (mfem::ErrorException): "), s2(_e.what());
+      s = s + s2;    
+      SWIG_exception(SWIG_RuntimeError, s.c_str());
+    }
+#endif
+    
+    catch (Swig::DirectorException &e){
+      SWIG_fail;
+    }    
+    catch (...) {
+      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+    }	 
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
 SWIGINTERN PyObject *_wrap_CurlCurlIntegrator_AssemblePA__SWIG_1(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
   PyObject *resultobj = 0;
   mfem::CurlCurlIntegrator *arg1 = (mfem::CurlCurlIntegrator *) 0 ;
@@ -25835,12 +26990,25 @@ fail:
 
 SWIGINTERN PyObject *_wrap_CurlCurlIntegrator_AssemblePA(PyObject *self, PyObject *args) {
   Py_ssize_t argc;
-  PyObject *argv[3] = {
+  PyObject *argv[4] = {
     0
   };
   
-  if (!(argc = SWIG_Python_UnpackTuple(args, "CurlCurlIntegrator_AssemblePA", 0, 2, argv))) SWIG_fail;
+  if (!(argc = SWIG_Python_UnpackTuple(args, "CurlCurlIntegrator_AssemblePA", 0, 3, argv))) SWIG_fail;
   --argc;
+  if (argc == 2) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_mfem__CurlCurlIntegrator, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      int res = SWIG_ConvertPtr(argv[1], 0, SWIGTYPE_p_mfem__FiniteElementSpace, SWIG_POINTER_NO_NULL | 0);
+      _v = SWIG_CheckState(res);
+      if (_v) {
+        return _wrap_CurlCurlIntegrator_AssemblePA__SWIG_0_0(self, argc, argv);
+      }
+    }
+  }
   if (argc == 2) {
     int _v;
     void *vptr = 0;
@@ -25854,11 +27022,29 @@ SWIGINTERN PyObject *_wrap_CurlCurlIntegrator_AssemblePA(PyObject *self, PyObjec
       }
     }
   }
+  if (argc == 3) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_mfem__CurlCurlIntegrator, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      int res = SWIG_ConvertPtr(argv[1], 0, SWIGTYPE_p_mfem__FiniteElementSpace, SWIG_POINTER_NO_NULL | 0);
+      _v = SWIG_CheckState(res);
+      if (_v) {
+        int res = SWIG_ConvertPtr(argv[2], 0, SWIGTYPE_p_mfem__FiniteElementSpace, SWIG_POINTER_NO_NULL | 0);
+        _v = SWIG_CheckState(res);
+        if (_v) {
+          return _wrap_CurlCurlIntegrator_AssemblePA__SWIG_0_1(self, argc, argv);
+        }
+      }
+    }
+  }
   
 fail:
   SWIG_Python_RaiseOrModifyTypeError("Wrong number or type of arguments for overloaded function 'CurlCurlIntegrator_AssemblePA'.\n"
     "  Possible C/C++ prototypes are:\n"
-    "    mfem::CurlCurlIntegrator::AssemblePA()\n"
+    "    AssemblePA(mfem::FiniteElementSpace const &)\n"
+    "    AssemblePA(mfem::FiniteElementSpace const &,mfem::FiniteElementSpace const &)\n"
     "    mfem::CurlCurlIntegrator::AssemblePA(mfem::FiniteElementSpace const &)\n");
   return 0;
 }
@@ -26868,6 +28054,115 @@ fail:
 }
 
 
+SWIGINTERN PyObject *_wrap_VectorFEMassIntegrator_AssemblePA__SWIG_0_0(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
+  PyObject *resultobj = 0;
+  mfem::VectorFEMassIntegrator *arg1 = (mfem::VectorFEMassIntegrator *) 0 ;
+  mfem::FiniteElementSpace *arg2 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  
+  if ((nobjs < 2) || (nobjs > 2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_mfem__VectorFEMassIntegrator, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "VectorFEMassIntegrator_AssemblePA" "', argument " "1"" of type '" "mfem::VectorFEMassIntegrator *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::VectorFEMassIntegrator * >(argp1);
+  res2 = SWIG_ConvertPtr(swig_obj[1], &argp2, SWIGTYPE_p_mfem__FiniteElementSpace,  0  | 0);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "VectorFEMassIntegrator_AssemblePA" "', argument " "2"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  if (!argp2) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "VectorFEMassIntegrator_AssemblePA" "', argument " "2"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  arg2 = reinterpret_cast< mfem::FiniteElementSpace * >(argp2);
+  {
+    try {
+      (arg1)->AssemblePA((mfem::FiniteElementSpace const &)*arg2);
+    }
+#ifdef  MFEM_USE_EXCEPTIONS
+    catch (mfem::ErrorException &_e) {
+      std::string s("PyMFEM error (mfem::ErrorException): "), s2(_e.what());
+      s = s + s2;    
+      SWIG_exception(SWIG_RuntimeError, s.c_str());
+    }
+#endif
+    
+    catch (Swig::DirectorException &e){
+      SWIG_fail;
+    }    
+    catch (...) {
+      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+    }	 
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_VectorFEMassIntegrator_AssemblePA__SWIG_0_1(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
+  PyObject *resultobj = 0;
+  mfem::VectorFEMassIntegrator *arg1 = (mfem::VectorFEMassIntegrator *) 0 ;
+  mfem::FiniteElementSpace *arg2 = 0 ;
+  mfem::FiniteElementSpace *arg3 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  void *argp3 = 0 ;
+  int res3 = 0 ;
+  
+  if ((nobjs < 3) || (nobjs > 3)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_mfem__VectorFEMassIntegrator, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "VectorFEMassIntegrator_AssemblePA" "', argument " "1"" of type '" "mfem::VectorFEMassIntegrator *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::VectorFEMassIntegrator * >(argp1);
+  res2 = SWIG_ConvertPtr(swig_obj[1], &argp2, SWIGTYPE_p_mfem__FiniteElementSpace,  0  | 0);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "VectorFEMassIntegrator_AssemblePA" "', argument " "2"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  if (!argp2) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "VectorFEMassIntegrator_AssemblePA" "', argument " "2"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  arg2 = reinterpret_cast< mfem::FiniteElementSpace * >(argp2);
+  res3 = SWIG_ConvertPtr(swig_obj[2], &argp3, SWIGTYPE_p_mfem__FiniteElementSpace,  0  | 0);
+  if (!SWIG_IsOK(res3)) {
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "VectorFEMassIntegrator_AssemblePA" "', argument " "3"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  if (!argp3) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "VectorFEMassIntegrator_AssemblePA" "', argument " "3"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  arg3 = reinterpret_cast< mfem::FiniteElementSpace * >(argp3);
+  {
+    try {
+      (arg1)->AssemblePA((mfem::FiniteElementSpace const &)*arg2,(mfem::FiniteElementSpace const &)*arg3);
+    }
+#ifdef  MFEM_USE_EXCEPTIONS
+    catch (mfem::ErrorException &_e) {
+      std::string s("PyMFEM error (mfem::ErrorException): "), s2(_e.what());
+      s = s + s2;    
+      SWIG_exception(SWIG_RuntimeError, s.c_str());
+    }
+#endif
+    
+    catch (Swig::DirectorException &e){
+      SWIG_fail;
+    }    
+    catch (...) {
+      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+    }	 
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
 SWIGINTERN PyObject *_wrap_VectorFEMassIntegrator_AssemblePA__SWIG_1(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
   PyObject *resultobj = 0;
   mfem::VectorFEMassIntegrator *arg1 = (mfem::VectorFEMassIntegrator *) 0 ;
@@ -26994,7 +28289,37 @@ SWIGINTERN PyObject *_wrap_VectorFEMassIntegrator_AssemblePA(PyObject *self, PyO
       int res = SWIG_ConvertPtr(argv[1], 0, SWIGTYPE_p_mfem__FiniteElementSpace, SWIG_POINTER_NO_NULL | 0);
       _v = SWIG_CheckState(res);
       if (_v) {
+        return _wrap_VectorFEMassIntegrator_AssemblePA__SWIG_0_0(self, argc, argv);
+      }
+    }
+  }
+  if (argc == 2) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_mfem__VectorFEMassIntegrator, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      int res = SWIG_ConvertPtr(argv[1], 0, SWIGTYPE_p_mfem__FiniteElementSpace, SWIG_POINTER_NO_NULL | 0);
+      _v = SWIG_CheckState(res);
+      if (_v) {
         return _wrap_VectorFEMassIntegrator_AssemblePA__SWIG_1(self, argc, argv);
+      }
+    }
+  }
+  if (argc == 3) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_mfem__VectorFEMassIntegrator, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      int res = SWIG_ConvertPtr(argv[1], 0, SWIGTYPE_p_mfem__FiniteElementSpace, SWIG_POINTER_NO_NULL | 0);
+      _v = SWIG_CheckState(res);
+      if (_v) {
+        int res = SWIG_ConvertPtr(argv[2], 0, SWIGTYPE_p_mfem__FiniteElementSpace, SWIG_POINTER_NO_NULL | 0);
+        _v = SWIG_CheckState(res);
+        if (_v) {
+          return _wrap_VectorFEMassIntegrator_AssemblePA__SWIG_0_1(self, argc, argv);
+        }
       }
     }
   }
@@ -27019,7 +28344,8 @@ SWIGINTERN PyObject *_wrap_VectorFEMassIntegrator_AssemblePA(PyObject *self, PyO
 fail:
   SWIG_Python_RaiseOrModifyTypeError("Wrong number or type of arguments for overloaded function 'VectorFEMassIntegrator_AssemblePA'.\n"
     "  Possible C/C++ prototypes are:\n"
-    "    mfem::VectorFEMassIntegrator::AssemblePA()\n"
+    "    AssemblePA(mfem::FiniteElementSpace const &)\n"
+    "    AssemblePA(mfem::FiniteElementSpace const &,mfem::FiniteElementSpace const &)\n"
     "    mfem::VectorFEMassIntegrator::AssemblePA(mfem::FiniteElementSpace const &)\n"
     "    mfem::VectorFEMassIntegrator::AssemblePA(mfem::FiniteElementSpace const &,mfem::FiniteElementSpace const &)\n");
   return 0;
@@ -27439,6 +28765,115 @@ fail:
 }
 
 
+SWIGINTERN PyObject *_wrap_VectorDivergenceIntegrator_AssemblePA__SWIG_0_0(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
+  PyObject *resultobj = 0;
+  mfem::VectorDivergenceIntegrator *arg1 = (mfem::VectorDivergenceIntegrator *) 0 ;
+  mfem::FiniteElementSpace *arg2 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  
+  if ((nobjs < 2) || (nobjs > 2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_mfem__VectorDivergenceIntegrator, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "VectorDivergenceIntegrator_AssemblePA" "', argument " "1"" of type '" "mfem::VectorDivergenceIntegrator *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::VectorDivergenceIntegrator * >(argp1);
+  res2 = SWIG_ConvertPtr(swig_obj[1], &argp2, SWIGTYPE_p_mfem__FiniteElementSpace,  0  | 0);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "VectorDivergenceIntegrator_AssemblePA" "', argument " "2"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  if (!argp2) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "VectorDivergenceIntegrator_AssemblePA" "', argument " "2"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  arg2 = reinterpret_cast< mfem::FiniteElementSpace * >(argp2);
+  {
+    try {
+      (arg1)->AssemblePA((mfem::FiniteElementSpace const &)*arg2);
+    }
+#ifdef  MFEM_USE_EXCEPTIONS
+    catch (mfem::ErrorException &_e) {
+      std::string s("PyMFEM error (mfem::ErrorException): "), s2(_e.what());
+      s = s + s2;    
+      SWIG_exception(SWIG_RuntimeError, s.c_str());
+    }
+#endif
+    
+    catch (Swig::DirectorException &e){
+      SWIG_fail;
+    }    
+    catch (...) {
+      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+    }	 
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_VectorDivergenceIntegrator_AssemblePA__SWIG_0_1(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
+  PyObject *resultobj = 0;
+  mfem::VectorDivergenceIntegrator *arg1 = (mfem::VectorDivergenceIntegrator *) 0 ;
+  mfem::FiniteElementSpace *arg2 = 0 ;
+  mfem::FiniteElementSpace *arg3 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  void *argp3 = 0 ;
+  int res3 = 0 ;
+  
+  if ((nobjs < 3) || (nobjs > 3)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_mfem__VectorDivergenceIntegrator, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "VectorDivergenceIntegrator_AssemblePA" "', argument " "1"" of type '" "mfem::VectorDivergenceIntegrator *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::VectorDivergenceIntegrator * >(argp1);
+  res2 = SWIG_ConvertPtr(swig_obj[1], &argp2, SWIGTYPE_p_mfem__FiniteElementSpace,  0  | 0);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "VectorDivergenceIntegrator_AssemblePA" "', argument " "2"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  if (!argp2) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "VectorDivergenceIntegrator_AssemblePA" "', argument " "2"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  arg2 = reinterpret_cast< mfem::FiniteElementSpace * >(argp2);
+  res3 = SWIG_ConvertPtr(swig_obj[2], &argp3, SWIGTYPE_p_mfem__FiniteElementSpace,  0  | 0);
+  if (!SWIG_IsOK(res3)) {
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "VectorDivergenceIntegrator_AssemblePA" "', argument " "3"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  if (!argp3) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "VectorDivergenceIntegrator_AssemblePA" "', argument " "3"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  arg3 = reinterpret_cast< mfem::FiniteElementSpace * >(argp3);
+  {
+    try {
+      (arg1)->AssemblePA((mfem::FiniteElementSpace const &)*arg2,(mfem::FiniteElementSpace const &)*arg3);
+    }
+#ifdef  MFEM_USE_EXCEPTIONS
+    catch (mfem::ErrorException &_e) {
+      std::string s("PyMFEM error (mfem::ErrorException): "), s2(_e.what());
+      s = s + s2;    
+      SWIG_exception(SWIG_RuntimeError, s.c_str());
+    }
+#endif
+    
+    catch (Swig::DirectorException &e){
+      SWIG_fail;
+    }    
+    catch (...) {
+      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+    }	 
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
 SWIGINTERN PyObject *_wrap_VectorDivergenceIntegrator_AssemblePA__SWIG_1(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
   PyObject *resultobj = 0;
   mfem::VectorDivergenceIntegrator *arg1 = (mfem::VectorDivergenceIntegrator *) 0 ;
@@ -27507,6 +28942,36 @@ SWIGINTERN PyObject *_wrap_VectorDivergenceIntegrator_AssemblePA(PyObject *self,
   
   if (!(argc = SWIG_Python_UnpackTuple(args, "VectorDivergenceIntegrator_AssemblePA", 0, 3, argv))) SWIG_fail;
   --argc;
+  if (argc == 2) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_mfem__VectorDivergenceIntegrator, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      int res = SWIG_ConvertPtr(argv[1], 0, SWIGTYPE_p_mfem__FiniteElementSpace, SWIG_POINTER_NO_NULL | 0);
+      _v = SWIG_CheckState(res);
+      if (_v) {
+        return _wrap_VectorDivergenceIntegrator_AssemblePA__SWIG_0_0(self, argc, argv);
+      }
+    }
+  }
+  if (argc == 3) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_mfem__VectorDivergenceIntegrator, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      int res = SWIG_ConvertPtr(argv[1], 0, SWIGTYPE_p_mfem__FiniteElementSpace, SWIG_POINTER_NO_NULL | 0);
+      _v = SWIG_CheckState(res);
+      if (_v) {
+        int res = SWIG_ConvertPtr(argv[2], 0, SWIGTYPE_p_mfem__FiniteElementSpace, SWIG_POINTER_NO_NULL | 0);
+        _v = SWIG_CheckState(res);
+        if (_v) {
+          return _wrap_VectorDivergenceIntegrator_AssemblePA__SWIG_0_1(self, argc, argv);
+        }
+      }
+    }
+  }
   if (argc == 3) {
     int _v;
     void *vptr = 0;
@@ -27528,7 +28993,8 @@ SWIGINTERN PyObject *_wrap_VectorDivergenceIntegrator_AssemblePA(PyObject *self,
 fail:
   SWIG_Python_RaiseOrModifyTypeError("Wrong number or type of arguments for overloaded function 'VectorDivergenceIntegrator_AssemblePA'.\n"
     "  Possible C/C++ prototypes are:\n"
-    "    mfem::VectorDivergenceIntegrator::AssemblePA()\n"
+    "    AssemblePA(mfem::FiniteElementSpace const &)\n"
+    "    AssemblePA(mfem::FiniteElementSpace const &,mfem::FiniteElementSpace const &)\n"
     "    mfem::VectorDivergenceIntegrator::AssemblePA(mfem::FiniteElementSpace const &,mfem::FiniteElementSpace const &)\n");
   return 0;
 }
@@ -28330,6 +29796,115 @@ fail:
 }
 
 
+SWIGINTERN PyObject *_wrap_VectorDiffusionIntegrator_AssemblePA__SWIG_0_0(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
+  PyObject *resultobj = 0;
+  mfem::VectorDiffusionIntegrator *arg1 = (mfem::VectorDiffusionIntegrator *) 0 ;
+  mfem::FiniteElementSpace *arg2 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  
+  if ((nobjs < 2) || (nobjs > 2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_mfem__VectorDiffusionIntegrator, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "VectorDiffusionIntegrator_AssemblePA" "', argument " "1"" of type '" "mfem::VectorDiffusionIntegrator *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::VectorDiffusionIntegrator * >(argp1);
+  res2 = SWIG_ConvertPtr(swig_obj[1], &argp2, SWIGTYPE_p_mfem__FiniteElementSpace,  0  | 0);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "VectorDiffusionIntegrator_AssemblePA" "', argument " "2"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  if (!argp2) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "VectorDiffusionIntegrator_AssemblePA" "', argument " "2"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  arg2 = reinterpret_cast< mfem::FiniteElementSpace * >(argp2);
+  {
+    try {
+      (arg1)->AssemblePA((mfem::FiniteElementSpace const &)*arg2);
+    }
+#ifdef  MFEM_USE_EXCEPTIONS
+    catch (mfem::ErrorException &_e) {
+      std::string s("PyMFEM error (mfem::ErrorException): "), s2(_e.what());
+      s = s + s2;    
+      SWIG_exception(SWIG_RuntimeError, s.c_str());
+    }
+#endif
+    
+    catch (Swig::DirectorException &e){
+      SWIG_fail;
+    }    
+    catch (...) {
+      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+    }	 
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_VectorDiffusionIntegrator_AssemblePA__SWIG_0_1(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
+  PyObject *resultobj = 0;
+  mfem::VectorDiffusionIntegrator *arg1 = (mfem::VectorDiffusionIntegrator *) 0 ;
+  mfem::FiniteElementSpace *arg2 = 0 ;
+  mfem::FiniteElementSpace *arg3 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  void *argp3 = 0 ;
+  int res3 = 0 ;
+  
+  if ((nobjs < 3) || (nobjs > 3)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_mfem__VectorDiffusionIntegrator, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "VectorDiffusionIntegrator_AssemblePA" "', argument " "1"" of type '" "mfem::VectorDiffusionIntegrator *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::VectorDiffusionIntegrator * >(argp1);
+  res2 = SWIG_ConvertPtr(swig_obj[1], &argp2, SWIGTYPE_p_mfem__FiniteElementSpace,  0  | 0);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "VectorDiffusionIntegrator_AssemblePA" "', argument " "2"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  if (!argp2) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "VectorDiffusionIntegrator_AssemblePA" "', argument " "2"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  arg2 = reinterpret_cast< mfem::FiniteElementSpace * >(argp2);
+  res3 = SWIG_ConvertPtr(swig_obj[2], &argp3, SWIGTYPE_p_mfem__FiniteElementSpace,  0  | 0);
+  if (!SWIG_IsOK(res3)) {
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "VectorDiffusionIntegrator_AssemblePA" "', argument " "3"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  if (!argp3) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "VectorDiffusionIntegrator_AssemblePA" "', argument " "3"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  arg3 = reinterpret_cast< mfem::FiniteElementSpace * >(argp3);
+  {
+    try {
+      (arg1)->AssemblePA((mfem::FiniteElementSpace const &)*arg2,(mfem::FiniteElementSpace const &)*arg3);
+    }
+#ifdef  MFEM_USE_EXCEPTIONS
+    catch (mfem::ErrorException &_e) {
+      std::string s("PyMFEM error (mfem::ErrorException): "), s2(_e.what());
+      s = s + s2;    
+      SWIG_exception(SWIG_RuntimeError, s.c_str());
+    }
+#endif
+    
+    catch (Swig::DirectorException &e){
+      SWIG_fail;
+    }    
+    catch (...) {
+      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+    }	 
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
 SWIGINTERN PyObject *_wrap_VectorDiffusionIntegrator_AssemblePA__SWIG_1(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
   PyObject *resultobj = 0;
   mfem::VectorDiffusionIntegrator *arg1 = (mfem::VectorDiffusionIntegrator *) 0 ;
@@ -28381,12 +29956,25 @@ fail:
 
 SWIGINTERN PyObject *_wrap_VectorDiffusionIntegrator_AssemblePA(PyObject *self, PyObject *args) {
   Py_ssize_t argc;
-  PyObject *argv[3] = {
+  PyObject *argv[4] = {
     0
   };
   
-  if (!(argc = SWIG_Python_UnpackTuple(args, "VectorDiffusionIntegrator_AssemblePA", 0, 2, argv))) SWIG_fail;
+  if (!(argc = SWIG_Python_UnpackTuple(args, "VectorDiffusionIntegrator_AssemblePA", 0, 3, argv))) SWIG_fail;
   --argc;
+  if (argc == 2) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_mfem__VectorDiffusionIntegrator, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      int res = SWIG_ConvertPtr(argv[1], 0, SWIGTYPE_p_mfem__FiniteElementSpace, SWIG_POINTER_NO_NULL | 0);
+      _v = SWIG_CheckState(res);
+      if (_v) {
+        return _wrap_VectorDiffusionIntegrator_AssemblePA__SWIG_0_0(self, argc, argv);
+      }
+    }
+  }
   if (argc == 2) {
     int _v;
     void *vptr = 0;
@@ -28400,11 +29988,29 @@ SWIGINTERN PyObject *_wrap_VectorDiffusionIntegrator_AssemblePA(PyObject *self, 
       }
     }
   }
+  if (argc == 3) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_mfem__VectorDiffusionIntegrator, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      int res = SWIG_ConvertPtr(argv[1], 0, SWIGTYPE_p_mfem__FiniteElementSpace, SWIG_POINTER_NO_NULL | 0);
+      _v = SWIG_CheckState(res);
+      if (_v) {
+        int res = SWIG_ConvertPtr(argv[2], 0, SWIGTYPE_p_mfem__FiniteElementSpace, SWIG_POINTER_NO_NULL | 0);
+        _v = SWIG_CheckState(res);
+        if (_v) {
+          return _wrap_VectorDiffusionIntegrator_AssemblePA__SWIG_0_1(self, argc, argv);
+        }
+      }
+    }
+  }
   
 fail:
   SWIG_Python_RaiseOrModifyTypeError("Wrong number or type of arguments for overloaded function 'VectorDiffusionIntegrator_AssemblePA'.\n"
     "  Possible C/C++ prototypes are:\n"
-    "    mfem::VectorDiffusionIntegrator::AssemblePA()\n"
+    "    AssemblePA(mfem::FiniteElementSpace const &)\n"
+    "    AssemblePA(mfem::FiniteElementSpace const &,mfem::FiniteElementSpace const &)\n"
     "    mfem::VectorDiffusionIntegrator::AssemblePA(mfem::FiniteElementSpace const &)\n");
   return 0;
 }
@@ -29778,6 +31384,163 @@ fail:
     "    AssembleFaceMatrix(mfem::FiniteElement const &,mfem::FiniteElement const &,mfem::FaceElementTransformations &,mfem::DenseMatrix &)\n"
     "    AssembleFaceMatrix(mfem::FiniteElement const &,mfem::FiniteElement const &,mfem::FiniteElement const &,mfem::FaceElementTransformations &,mfem::DenseMatrix &)\n"
     "    mfem::DGTraceIntegrator::AssembleFaceMatrix(mfem::FiniteElement const &,mfem::FiniteElement const &,mfem::FaceElementTransformations &,mfem::DenseMatrix &)\n");
+  return 0;
+}
+
+
+SWIGINTERN PyObject *_wrap_DGTraceIntegrator_AssemblePA_SWIG_0_0(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
+  PyObject *resultobj = 0;
+  mfem::DGTraceIntegrator *arg1 = (mfem::DGTraceIntegrator *) 0 ;
+  mfem::FiniteElementSpace *arg2 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  
+  if ((nobjs < 2) || (nobjs > 2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_mfem__DGTraceIntegrator, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "DGTraceIntegrator_AssemblePA" "', argument " "1"" of type '" "mfem::DGTraceIntegrator *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::DGTraceIntegrator * >(argp1);
+  res2 = SWIG_ConvertPtr(swig_obj[1], &argp2, SWIGTYPE_p_mfem__FiniteElementSpace,  0  | 0);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "DGTraceIntegrator_AssemblePA" "', argument " "2"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  if (!argp2) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "DGTraceIntegrator_AssemblePA" "', argument " "2"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  arg2 = reinterpret_cast< mfem::FiniteElementSpace * >(argp2);
+  {
+    try {
+      (arg1)->AssemblePA((mfem::FiniteElementSpace const &)*arg2);
+    }
+#ifdef  MFEM_USE_EXCEPTIONS
+    catch (mfem::ErrorException &_e) {
+      std::string s("PyMFEM error (mfem::ErrorException): "), s2(_e.what());
+      s = s + s2;    
+      SWIG_exception(SWIG_RuntimeError, s.c_str());
+    }
+#endif
+    
+    catch (Swig::DirectorException &e){
+      SWIG_fail;
+    }    
+    catch (...) {
+      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+    }	 
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_DGTraceIntegrator_AssemblePA_SWIG_0_1(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
+  PyObject *resultobj = 0;
+  mfem::DGTraceIntegrator *arg1 = (mfem::DGTraceIntegrator *) 0 ;
+  mfem::FiniteElementSpace *arg2 = 0 ;
+  mfem::FiniteElementSpace *arg3 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  void *argp3 = 0 ;
+  int res3 = 0 ;
+  
+  if ((nobjs < 3) || (nobjs > 3)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_mfem__DGTraceIntegrator, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "DGTraceIntegrator_AssemblePA" "', argument " "1"" of type '" "mfem::DGTraceIntegrator *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::DGTraceIntegrator * >(argp1);
+  res2 = SWIG_ConvertPtr(swig_obj[1], &argp2, SWIGTYPE_p_mfem__FiniteElementSpace,  0  | 0);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "DGTraceIntegrator_AssemblePA" "', argument " "2"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  if (!argp2) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "DGTraceIntegrator_AssemblePA" "', argument " "2"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  arg2 = reinterpret_cast< mfem::FiniteElementSpace * >(argp2);
+  res3 = SWIG_ConvertPtr(swig_obj[2], &argp3, SWIGTYPE_p_mfem__FiniteElementSpace,  0  | 0);
+  if (!SWIG_IsOK(res3)) {
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "DGTraceIntegrator_AssemblePA" "', argument " "3"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  if (!argp3) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "DGTraceIntegrator_AssemblePA" "', argument " "3"" of type '" "mfem::FiniteElementSpace const &""'"); 
+  }
+  arg3 = reinterpret_cast< mfem::FiniteElementSpace * >(argp3);
+  {
+    try {
+      (arg1)->AssemblePA((mfem::FiniteElementSpace const &)*arg2,(mfem::FiniteElementSpace const &)*arg3);
+    }
+#ifdef  MFEM_USE_EXCEPTIONS
+    catch (mfem::ErrorException &_e) {
+      std::string s("PyMFEM error (mfem::ErrorException): "), s2(_e.what());
+      s = s + s2;    
+      SWIG_exception(SWIG_RuntimeError, s.c_str());
+    }
+#endif
+    
+    catch (Swig::DirectorException &e){
+      SWIG_fail;
+    }    
+    catch (...) {
+      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+    }	 
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_DGTraceIntegrator_AssemblePA(PyObject *self, PyObject *args) {
+  Py_ssize_t argc;
+  PyObject *argv[4] = {
+    0
+  };
+  
+  if (!(argc = SWIG_Python_UnpackTuple(args, "DGTraceIntegrator_AssemblePA", 0, 3, argv))) SWIG_fail;
+  --argc;
+  if (argc == 2) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_mfem__DGTraceIntegrator, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      int res = SWIG_ConvertPtr(argv[1], 0, SWIGTYPE_p_mfem__FiniteElementSpace, SWIG_POINTER_NO_NULL | 0);
+      _v = SWIG_CheckState(res);
+      if (_v) {
+        return _wrap_DGTraceIntegrator_AssemblePA_SWIG_0_0(self, argc, argv);
+      }
+    }
+  }
+  if (argc == 3) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_mfem__DGTraceIntegrator, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      int res = SWIG_ConvertPtr(argv[1], 0, SWIGTYPE_p_mfem__FiniteElementSpace, SWIG_POINTER_NO_NULL | 0);
+      _v = SWIG_CheckState(res);
+      if (_v) {
+        int res = SWIG_ConvertPtr(argv[2], 0, SWIGTYPE_p_mfem__FiniteElementSpace, SWIG_POINTER_NO_NULL | 0);
+        _v = SWIG_CheckState(res);
+        if (_v) {
+          return _wrap_DGTraceIntegrator_AssemblePA_SWIG_0_1(self, argc, argv);
+        }
+      }
+    }
+  }
+  
+fail:
+  SWIG_Python_RaiseOrModifyTypeError("Wrong number or type of arguments for overloaded function 'DGTraceIntegrator_AssemblePA'.\n"
+    "  Possible C/C++ prototypes are:\n"
+    "    AssemblePA(mfem::FiniteElementSpace const &)\n"
+    "    AssemblePA(mfem::FiniteElementSpace const &,mfem::FiniteElementSpace const &)\n");
   return 0;
 }
 
@@ -34366,7 +36129,8 @@ static PyMethodDef SwigMethods[] = {
 	 { "SWIG_PyStaticMethod_New", SWIG_PyStaticMethod_New, METH_O, NULL},
 	 { "new_BilinearFormIntegrator", (PyCFunction)(void(*)(void))_wrap_new_BilinearFormIntegrator, METH_VARARGS|METH_KEYWORDS, "new_BilinearFormIntegrator(PyObject * _self, IntegrationRule ir=None) -> BilinearFormIntegrator"},
 	 { "BilinearFormIntegrator_AssemblePA", _wrap_BilinearFormIntegrator_AssemblePA, METH_VARARGS, "\n"
-		"AssemblePA(BilinearFormIntegrator self)\n"
+		"BilinearFormIntegrator_AssemblePA(BilinearFormIntegrator self, FiniteElementSpace fes)\n"
+		"BilinearFormIntegrator_AssemblePA(BilinearFormIntegrator self, FiniteElementSpace trial_fes, FiniteElementSpace test_fes)\n"
 		"BilinearFormIntegrator_AssemblePA(BilinearFormIntegrator self, FiniteElementSpace fes)\n"
 		"BilinearFormIntegrator_AssemblePA(BilinearFormIntegrator self, FiniteElementSpace trial_fes, FiniteElementSpace test_fes)\n"
 		""},
@@ -34408,8 +36172,9 @@ static PyMethodDef SwigMethods[] = {
 		"TransposeIntegrator_AssembleFaceMatrix(TransposeIntegrator self, FiniteElement el1, FiniteElement el2, FaceElementTransformations Trans, DenseMatrix elmat)\n"
 		""},
 	 { "TransposeIntegrator_AssemblePA", _wrap_TransposeIntegrator_AssemblePA, METH_VARARGS, "\n"
-		"AssemblePA()\n"
-		"TransposeIntegrator_AssemblePA(FiniteElementSpace fes)\n"
+		"TransposeIntegrator_AssemblePA(TransposeIntegrator self, FiniteElementSpace fes)\n"
+		"TransposeIntegrator_AssemblePA(TransposeIntegrator self, FiniteElementSpace trial_fes, FiniteElementSpace test_fes)\n"
+		"TransposeIntegrator_AssemblePA(TransposeIntegrator self, FiniteElementSpace fes)\n"
 		""},
 	 { "TransposeIntegrator_AssemblePAInteriorFaces", (PyCFunction)(void(*)(void))_wrap_TransposeIntegrator_AssemblePAInteriorFaces, METH_VARARGS|METH_KEYWORDS, "TransposeIntegrator_AssemblePAInteriorFaces(TransposeIntegrator self, FiniteElementSpace fes)"},
 	 { "TransposeIntegrator_AssemblePABoundaryFaces", (PyCFunction)(void(*)(void))_wrap_TransposeIntegrator_AssemblePABoundaryFaces, METH_VARARGS|METH_KEYWORDS, "TransposeIntegrator_AssemblePABoundaryFaces(TransposeIntegrator self, FiniteElementSpace fes)"},
@@ -34728,8 +36493,9 @@ static PyMethodDef SwigMethods[] = {
 		""},
 	 { "GradientIntegrator_AssembleElementMatrix2", (PyCFunction)(void(*)(void))_wrap_GradientIntegrator_AssembleElementMatrix2, METH_VARARGS|METH_KEYWORDS, "GradientIntegrator_AssembleElementMatrix2(GradientIntegrator self, FiniteElement trial_fe, FiniteElement test_fe, ElementTransformation Trans, DenseMatrix elmat)"},
 	 { "GradientIntegrator_AssemblePA", _wrap_GradientIntegrator_AssemblePA, METH_VARARGS, "\n"
-		"AssemblePA()\n"
-		"GradientIntegrator_AssemblePA(FiniteElementSpace trial_fes, FiniteElementSpace test_fes)\n"
+		"GradientIntegrator_AssemblePA(GradientIntegrator self, FiniteElementSpace fes)\n"
+		"GradientIntegrator_AssemblePA(GradientIntegrator self, FiniteElementSpace trial_fes, FiniteElementSpace test_fes)\n"
+		"GradientIntegrator_AssemblePA(GradientIntegrator self, FiniteElementSpace trial_fes, FiniteElementSpace test_fes)\n"
 		""},
 	 { "GradientIntegrator_AddMultPA", (PyCFunction)(void(*)(void))_wrap_GradientIntegrator_AddMultPA, METH_VARARGS|METH_KEYWORDS, "GradientIntegrator_AddMultPA(GradientIntegrator self, Vector x, Vector y)"},
 	 { "GradientIntegrator_AddMultTransposePA", (PyCFunction)(void(*)(void))_wrap_GradientIntegrator_AddMultTransposePA, METH_VARARGS|METH_KEYWORDS, "GradientIntegrator_AddMultTransposePA(GradientIntegrator self, Vector x, Vector y)"},
@@ -34751,8 +36517,9 @@ static PyMethodDef SwigMethods[] = {
 	 { "DiffusionIntegrator_ComputeFluxEnergy", (PyCFunction)(void(*)(void))_wrap_DiffusionIntegrator_ComputeFluxEnergy, METH_VARARGS|METH_KEYWORDS, "DiffusionIntegrator_ComputeFluxEnergy(DiffusionIntegrator self, FiniteElement fluxelem, ElementTransformation Trans, Vector flux, Vector d_energy=None) -> double"},
 	 { "DiffusionIntegrator_AssembleMF", (PyCFunction)(void(*)(void))_wrap_DiffusionIntegrator_AssembleMF, METH_VARARGS|METH_KEYWORDS, "DiffusionIntegrator_AssembleMF(DiffusionIntegrator self, FiniteElementSpace fes)"},
 	 { "DiffusionIntegrator_AssemblePA", _wrap_DiffusionIntegrator_AssemblePA, METH_VARARGS, "\n"
-		"AssemblePA()\n"
-		"DiffusionIntegrator_AssemblePA(FiniteElementSpace fes)\n"
+		"DiffusionIntegrator_AssemblePA(DiffusionIntegrator self, FiniteElementSpace fes)\n"
+		"DiffusionIntegrator_AssemblePA(DiffusionIntegrator self, FiniteElementSpace trial_fes, FiniteElementSpace test_fes)\n"
+		"DiffusionIntegrator_AssemblePA(DiffusionIntegrator self, FiniteElementSpace fes)\n"
 		""},
 	 { "DiffusionIntegrator_AssembleEA", (PyCFunction)(void(*)(void))_wrap_DiffusionIntegrator_AssembleEA, METH_VARARGS|METH_KEYWORDS, "DiffusionIntegrator_AssembleEA(DiffusionIntegrator self, FiniteElementSpace fes, Vector emat, bool const add)"},
 	 { "DiffusionIntegrator_AssembleDiagonalPA", (PyCFunction)(void(*)(void))_wrap_DiffusionIntegrator_AssembleDiagonalPA, METH_VARARGS|METH_KEYWORDS, "DiffusionIntegrator_AssembleDiagonalPA(DiffusionIntegrator self, Vector diag)"},
@@ -34771,8 +36538,9 @@ static PyMethodDef SwigMethods[] = {
 	 { "MassIntegrator_AssembleElementMatrix2", (PyCFunction)(void(*)(void))_wrap_MassIntegrator_AssembleElementMatrix2, METH_VARARGS|METH_KEYWORDS, "MassIntegrator_AssembleElementMatrix2(MassIntegrator self, FiniteElement trial_fe, FiniteElement test_fe, ElementTransformation Trans, DenseMatrix elmat)"},
 	 { "MassIntegrator_AssembleMF", (PyCFunction)(void(*)(void))_wrap_MassIntegrator_AssembleMF, METH_VARARGS|METH_KEYWORDS, "MassIntegrator_AssembleMF(MassIntegrator self, FiniteElementSpace fes)"},
 	 { "MassIntegrator_AssemblePA", _wrap_MassIntegrator_AssemblePA, METH_VARARGS, "\n"
-		"AssemblePA()\n"
-		"MassIntegrator_AssemblePA(FiniteElementSpace fes)\n"
+		"MassIntegrator_AssemblePA(MassIntegrator self, FiniteElementSpace fes)\n"
+		"MassIntegrator_AssemblePA(MassIntegrator self, FiniteElementSpace trial_fes, FiniteElementSpace test_fes)\n"
+		"MassIntegrator_AssemblePA(MassIntegrator self, FiniteElementSpace fes)\n"
 		""},
 	 { "MassIntegrator_AssembleEA", (PyCFunction)(void(*)(void))_wrap_MassIntegrator_AssembleEA, METH_VARARGS|METH_KEYWORDS, "MassIntegrator_AssembleEA(MassIntegrator self, FiniteElementSpace fes, Vector emat, bool const add)"},
 	 { "MassIntegrator_AssembleDiagonalPA", (PyCFunction)(void(*)(void))_wrap_MassIntegrator_AssembleDiagonalPA, METH_VARARGS|METH_KEYWORDS, "MassIntegrator_AssembleDiagonalPA(MassIntegrator self, Vector diag)"},
@@ -34794,8 +36562,9 @@ static PyMethodDef SwigMethods[] = {
 	 { "new_ConvectionIntegrator", (PyCFunction)(void(*)(void))_wrap_new_ConvectionIntegrator, METH_VARARGS|METH_KEYWORDS, "new_ConvectionIntegrator(VectorCoefficient q, double a=1.0) -> ConvectionIntegrator"},
 	 { "ConvectionIntegrator_AssembleElementMatrix", (PyCFunction)(void(*)(void))_wrap_ConvectionIntegrator_AssembleElementMatrix, METH_VARARGS|METH_KEYWORDS, "ConvectionIntegrator_AssembleElementMatrix(ConvectionIntegrator self, FiniteElement arg2, ElementTransformation arg3, DenseMatrix arg4)"},
 	 { "ConvectionIntegrator_AssemblePA", _wrap_ConvectionIntegrator_AssemblePA, METH_VARARGS, "\n"
-		"AssemblePA()\n"
-		"ConvectionIntegrator_AssemblePA(FiniteElementSpace arg1)\n"
+		"ConvectionIntegrator_AssemblePA(ConvectionIntegrator self, FiniteElementSpace fes)\n"
+		"ConvectionIntegrator_AssemblePA(ConvectionIntegrator self, FiniteElementSpace trial_fes, FiniteElementSpace test_fes)\n"
+		"ConvectionIntegrator_AssemblePA(ConvectionIntegrator self, FiniteElementSpace arg2)\n"
 		""},
 	 { "ConvectionIntegrator_AssembleEA", (PyCFunction)(void(*)(void))_wrap_ConvectionIntegrator_AssembleEA, METH_VARARGS|METH_KEYWORDS, "ConvectionIntegrator_AssembleEA(ConvectionIntegrator self, FiniteElementSpace fes, Vector emat, bool const add)"},
 	 { "ConvectionIntegrator_AddMultPA", (PyCFunction)(void(*)(void))_wrap_ConvectionIntegrator_AddMultPA, METH_VARARGS|METH_KEYWORDS, "ConvectionIntegrator_AddMultPA(ConvectionIntegrator self, Vector arg2, Vector arg3)"},
@@ -34824,8 +36593,9 @@ static PyMethodDef SwigMethods[] = {
 	 { "VectorMassIntegrator_AssembleElementMatrix", (PyCFunction)(void(*)(void))_wrap_VectorMassIntegrator_AssembleElementMatrix, METH_VARARGS|METH_KEYWORDS, "VectorMassIntegrator_AssembleElementMatrix(VectorMassIntegrator self, FiniteElement el, ElementTransformation Trans, DenseMatrix elmat)"},
 	 { "VectorMassIntegrator_AssembleElementMatrix2", (PyCFunction)(void(*)(void))_wrap_VectorMassIntegrator_AssembleElementMatrix2, METH_VARARGS|METH_KEYWORDS, "VectorMassIntegrator_AssembleElementMatrix2(VectorMassIntegrator self, FiniteElement trial_fe, FiniteElement test_fe, ElementTransformation Trans, DenseMatrix elmat)"},
 	 { "VectorMassIntegrator_AssemblePA", _wrap_VectorMassIntegrator_AssemblePA, METH_VARARGS, "\n"
-		"AssemblePA()\n"
-		"VectorMassIntegrator_AssemblePA(FiniteElementSpace fes)\n"
+		"VectorMassIntegrator_AssemblePA(VectorMassIntegrator self, FiniteElementSpace fes)\n"
+		"VectorMassIntegrator_AssemblePA(VectorMassIntegrator self, FiniteElementSpace trial_fes, FiniteElementSpace test_fes)\n"
+		"VectorMassIntegrator_AssemblePA(VectorMassIntegrator self, FiniteElementSpace fes)\n"
 		""},
 	 { "VectorMassIntegrator_AssembleMF", (PyCFunction)(void(*)(void))_wrap_VectorMassIntegrator_AssembleMF, METH_VARARGS|METH_KEYWORDS, "VectorMassIntegrator_AssembleMF(VectorMassIntegrator self, FiniteElementSpace fes)"},
 	 { "VectorMassIntegrator_AssembleDiagonalPA", (PyCFunction)(void(*)(void))_wrap_VectorMassIntegrator_AssembleDiagonalPA, METH_VARARGS|METH_KEYWORDS, "VectorMassIntegrator_AssembleDiagonalPA(VectorMassIntegrator self, Vector diag)"},
@@ -34878,8 +36648,9 @@ static PyMethodDef SwigMethods[] = {
 	 { "CurlCurlIntegrator_ComputeElementFlux", (PyCFunction)(void(*)(void))_wrap_CurlCurlIntegrator_ComputeElementFlux, METH_VARARGS|METH_KEYWORDS, "CurlCurlIntegrator_ComputeElementFlux(CurlCurlIntegrator self, FiniteElement el, ElementTransformation Trans, Vector u, FiniteElement fluxelem, Vector flux, bool with_coef)"},
 	 { "CurlCurlIntegrator_ComputeFluxEnergy", (PyCFunction)(void(*)(void))_wrap_CurlCurlIntegrator_ComputeFluxEnergy, METH_VARARGS|METH_KEYWORDS, "CurlCurlIntegrator_ComputeFluxEnergy(CurlCurlIntegrator self, FiniteElement fluxelem, ElementTransformation Trans, Vector flux, Vector d_energy=None) -> double"},
 	 { "CurlCurlIntegrator_AssemblePA", _wrap_CurlCurlIntegrator_AssemblePA, METH_VARARGS, "\n"
-		"AssemblePA()\n"
-		"CurlCurlIntegrator_AssemblePA(FiniteElementSpace fes)\n"
+		"CurlCurlIntegrator_AssemblePA(CurlCurlIntegrator self, FiniteElementSpace fes)\n"
+		"CurlCurlIntegrator_AssemblePA(CurlCurlIntegrator self, FiniteElementSpace trial_fes, FiniteElementSpace test_fes)\n"
+		"CurlCurlIntegrator_AssemblePA(CurlCurlIntegrator self, FiniteElementSpace fes)\n"
 		""},
 	 { "CurlCurlIntegrator_AddMultPA", (PyCFunction)(void(*)(void))_wrap_CurlCurlIntegrator_AddMultPA, METH_VARARGS|METH_KEYWORDS, "CurlCurlIntegrator_AddMultPA(CurlCurlIntegrator self, Vector x, Vector y)"},
 	 { "CurlCurlIntegrator_AssembleDiagonalPA", (PyCFunction)(void(*)(void))_wrap_CurlCurlIntegrator_AssembleDiagonalPA, METH_VARARGS|METH_KEYWORDS, "CurlCurlIntegrator_AssembleDiagonalPA(CurlCurlIntegrator self, Vector diag)"},
@@ -34907,7 +36678,8 @@ static PyMethodDef SwigMethods[] = {
 	 { "VectorFEMassIntegrator_AssembleElementMatrix", (PyCFunction)(void(*)(void))_wrap_VectorFEMassIntegrator_AssembleElementMatrix, METH_VARARGS|METH_KEYWORDS, "VectorFEMassIntegrator_AssembleElementMatrix(VectorFEMassIntegrator self, FiniteElement el, ElementTransformation Trans, DenseMatrix elmat)"},
 	 { "VectorFEMassIntegrator_AssembleElementMatrix2", (PyCFunction)(void(*)(void))_wrap_VectorFEMassIntegrator_AssembleElementMatrix2, METH_VARARGS|METH_KEYWORDS, "VectorFEMassIntegrator_AssembleElementMatrix2(VectorFEMassIntegrator self, FiniteElement trial_fe, FiniteElement test_fe, ElementTransformation Trans, DenseMatrix elmat)"},
 	 { "VectorFEMassIntegrator_AssemblePA", _wrap_VectorFEMassIntegrator_AssemblePA, METH_VARARGS, "\n"
-		"AssemblePA(VectorFEMassIntegrator self)\n"
+		"VectorFEMassIntegrator_AssemblePA(VectorFEMassIntegrator self, FiniteElementSpace fes)\n"
+		"VectorFEMassIntegrator_AssemblePA(VectorFEMassIntegrator self, FiniteElementSpace trial_fes, FiniteElementSpace test_fes)\n"
 		"VectorFEMassIntegrator_AssemblePA(VectorFEMassIntegrator self, FiniteElementSpace fes)\n"
 		"VectorFEMassIntegrator_AssemblePA(VectorFEMassIntegrator self, FiniteElementSpace trial_fes, FiniteElementSpace test_fes)\n"
 		""},
@@ -34923,8 +36695,9 @@ static PyMethodDef SwigMethods[] = {
 		""},
 	 { "VectorDivergenceIntegrator_AssembleElementMatrix2", (PyCFunction)(void(*)(void))_wrap_VectorDivergenceIntegrator_AssembleElementMatrix2, METH_VARARGS|METH_KEYWORDS, "VectorDivergenceIntegrator_AssembleElementMatrix2(VectorDivergenceIntegrator self, FiniteElement trial_fe, FiniteElement test_fe, ElementTransformation Trans, DenseMatrix elmat)"},
 	 { "VectorDivergenceIntegrator_AssemblePA", _wrap_VectorDivergenceIntegrator_AssemblePA, METH_VARARGS, "\n"
-		"AssemblePA()\n"
-		"VectorDivergenceIntegrator_AssemblePA(FiniteElementSpace trial_fes, FiniteElementSpace test_fes)\n"
+		"VectorDivergenceIntegrator_AssemblePA(VectorDivergenceIntegrator self, FiniteElementSpace fes)\n"
+		"VectorDivergenceIntegrator_AssemblePA(VectorDivergenceIntegrator self, FiniteElementSpace trial_fes, FiniteElementSpace test_fes)\n"
+		"VectorDivergenceIntegrator_AssemblePA(VectorDivergenceIntegrator self, FiniteElementSpace trial_fes, FiniteElementSpace test_fes)\n"
 		""},
 	 { "VectorDivergenceIntegrator_AddMultPA", (PyCFunction)(void(*)(void))_wrap_VectorDivergenceIntegrator_AddMultPA, METH_VARARGS|METH_KEYWORDS, "VectorDivergenceIntegrator_AddMultPA(VectorDivergenceIntegrator self, Vector x, Vector y)"},
 	 { "VectorDivergenceIntegrator_AddMultTransposePA", (PyCFunction)(void(*)(void))_wrap_VectorDivergenceIntegrator_AddMultTransposePA, METH_VARARGS|METH_KEYWORDS, "VectorDivergenceIntegrator_AddMultTransposePA(VectorDivergenceIntegrator self, Vector x, Vector y)"},
@@ -34948,8 +36721,9 @@ static PyMethodDef SwigMethods[] = {
 	 { "VectorDiffusionIntegrator_AssembleElementMatrix", (PyCFunction)(void(*)(void))_wrap_VectorDiffusionIntegrator_AssembleElementMatrix, METH_VARARGS|METH_KEYWORDS, "VectorDiffusionIntegrator_AssembleElementMatrix(VectorDiffusionIntegrator self, FiniteElement el, ElementTransformation Trans, DenseMatrix elmat)"},
 	 { "VectorDiffusionIntegrator_AssembleElementVector", (PyCFunction)(void(*)(void))_wrap_VectorDiffusionIntegrator_AssembleElementVector, METH_VARARGS|METH_KEYWORDS, "VectorDiffusionIntegrator_AssembleElementVector(VectorDiffusionIntegrator self, FiniteElement el, ElementTransformation Tr, Vector elfun, Vector elvect)"},
 	 { "VectorDiffusionIntegrator_AssemblePA", _wrap_VectorDiffusionIntegrator_AssemblePA, METH_VARARGS, "\n"
-		"AssemblePA()\n"
-		"VectorDiffusionIntegrator_AssemblePA(FiniteElementSpace fes)\n"
+		"VectorDiffusionIntegrator_AssemblePA(VectorDiffusionIntegrator self, FiniteElementSpace fes)\n"
+		"VectorDiffusionIntegrator_AssemblePA(VectorDiffusionIntegrator self, FiniteElementSpace trial_fes, FiniteElementSpace test_fes)\n"
+		"VectorDiffusionIntegrator_AssemblePA(VectorDiffusionIntegrator self, FiniteElementSpace fes)\n"
 		""},
 	 { "VectorDiffusionIntegrator_AssembleMF", (PyCFunction)(void(*)(void))_wrap_VectorDiffusionIntegrator_AssembleMF, METH_VARARGS|METH_KEYWORDS, "VectorDiffusionIntegrator_AssembleMF(VectorDiffusionIntegrator self, FiniteElementSpace fes)"},
 	 { "VectorDiffusionIntegrator_AssembleDiagonalPA", (PyCFunction)(void(*)(void))_wrap_VectorDiffusionIntegrator_AssembleDiagonalPA, METH_VARARGS|METH_KEYWORDS, "VectorDiffusionIntegrator_AssembleDiagonalPA(VectorDiffusionIntegrator self, Vector diag)"},
@@ -34976,6 +36750,10 @@ static PyMethodDef SwigMethods[] = {
 		"DGTraceIntegrator_AssembleFaceMatrix(DGTraceIntegrator self, FiniteElement el1, FiniteElement el2, FaceElementTransformations Trans, DenseMatrix elmat)\n"
 		"DGTraceIntegrator_AssembleFaceMatrix(DGTraceIntegrator self, FiniteElement trial_face_fe, FiniteElement test_fe1, FiniteElement test_fe2, FaceElementTransformations Trans, DenseMatrix elmat)\n"
 		"DGTraceIntegrator_AssembleFaceMatrix(DGTraceIntegrator self, FiniteElement el1, FiniteElement el2, FaceElementTransformations Trans, DenseMatrix elmat)\n"
+		""},
+	 { "DGTraceIntegrator_AssemblePA", _wrap_DGTraceIntegrator_AssemblePA, METH_VARARGS, "\n"
+		"DGTraceIntegrator_AssemblePA(DGTraceIntegrator self, FiniteElementSpace fes)\n"
+		"DGTraceIntegrator_AssemblePA(DGTraceIntegrator self, FiniteElementSpace trial_fes, FiniteElementSpace test_fes)\n"
 		""},
 	 { "DGTraceIntegrator_AssemblePAInteriorFaces", (PyCFunction)(void(*)(void))_wrap_DGTraceIntegrator_AssemblePAInteriorFaces, METH_VARARGS|METH_KEYWORDS, "DGTraceIntegrator_AssemblePAInteriorFaces(DGTraceIntegrator self, FiniteElementSpace fes)"},
 	 { "DGTraceIntegrator_AssemblePABoundaryFaces", (PyCFunction)(void(*)(void))_wrap_DGTraceIntegrator_AssemblePABoundaryFaces, METH_VARARGS|METH_KEYWORDS, "DGTraceIntegrator_AssemblePABoundaryFaces(DGTraceIntegrator self, FiniteElementSpace fes)"},
@@ -35092,7 +36870,8 @@ static PyMethodDef SwigMethods_proxydocs[] = {
 	 { "SWIG_PyStaticMethod_New", SWIG_PyStaticMethod_New, METH_O, NULL},
 	 { "new_BilinearFormIntegrator", (PyCFunction)(void(*)(void))_wrap_new_BilinearFormIntegrator, METH_VARARGS|METH_KEYWORDS, "new_BilinearFormIntegrator(PyObject * _self, IntegrationRule ir=None) -> BilinearFormIntegrator"},
 	 { "BilinearFormIntegrator_AssemblePA", _wrap_BilinearFormIntegrator_AssemblePA, METH_VARARGS, "\n"
-		"AssemblePA(BilinearFormIntegrator self)\n"
+		"AssemblePA(BilinearFormIntegrator self, FiniteElementSpace fes)\n"
+		"AssemblePA(BilinearFormIntegrator self, FiniteElementSpace trial_fes, FiniteElementSpace test_fes)\n"
 		"AssemblePA(BilinearFormIntegrator self, FiniteElementSpace fes)\n"
 		"AssemblePA(BilinearFormIntegrator self, FiniteElementSpace trial_fes, FiniteElementSpace test_fes)\n"
 		""},
@@ -35134,8 +36913,9 @@ static PyMethodDef SwigMethods_proxydocs[] = {
 		"AssembleFaceMatrix(TransposeIntegrator self, FiniteElement el1, FiniteElement el2, FaceElementTransformations Trans, DenseMatrix elmat)\n"
 		""},
 	 { "TransposeIntegrator_AssemblePA", _wrap_TransposeIntegrator_AssemblePA, METH_VARARGS, "\n"
-		"AssemblePA()\n"
-		"AssemblePA(FiniteElementSpace fes)\n"
+		"AssemblePA(TransposeIntegrator self, FiniteElementSpace fes)\n"
+		"AssemblePA(TransposeIntegrator self, FiniteElementSpace trial_fes, FiniteElementSpace test_fes)\n"
+		"AssemblePA(TransposeIntegrator self, FiniteElementSpace fes)\n"
 		""},
 	 { "TransposeIntegrator_AssemblePAInteriorFaces", (PyCFunction)(void(*)(void))_wrap_TransposeIntegrator_AssemblePAInteriorFaces, METH_VARARGS|METH_KEYWORDS, "AssemblePAInteriorFaces(TransposeIntegrator self, FiniteElementSpace fes)"},
 	 { "TransposeIntegrator_AssemblePABoundaryFaces", (PyCFunction)(void(*)(void))_wrap_TransposeIntegrator_AssemblePABoundaryFaces, METH_VARARGS|METH_KEYWORDS, "AssemblePABoundaryFaces(TransposeIntegrator self, FiniteElementSpace fes)"},
@@ -35454,8 +37234,9 @@ static PyMethodDef SwigMethods_proxydocs[] = {
 		""},
 	 { "GradientIntegrator_AssembleElementMatrix2", (PyCFunction)(void(*)(void))_wrap_GradientIntegrator_AssembleElementMatrix2, METH_VARARGS|METH_KEYWORDS, "AssembleElementMatrix2(GradientIntegrator self, FiniteElement trial_fe, FiniteElement test_fe, ElementTransformation Trans, DenseMatrix elmat)"},
 	 { "GradientIntegrator_AssemblePA", _wrap_GradientIntegrator_AssemblePA, METH_VARARGS, "\n"
-		"AssemblePA()\n"
-		"AssemblePA(FiniteElementSpace trial_fes, FiniteElementSpace test_fes)\n"
+		"AssemblePA(GradientIntegrator self, FiniteElementSpace fes)\n"
+		"AssemblePA(GradientIntegrator self, FiniteElementSpace trial_fes, FiniteElementSpace test_fes)\n"
+		"AssemblePA(GradientIntegrator self, FiniteElementSpace trial_fes, FiniteElementSpace test_fes)\n"
 		""},
 	 { "GradientIntegrator_AddMultPA", (PyCFunction)(void(*)(void))_wrap_GradientIntegrator_AddMultPA, METH_VARARGS|METH_KEYWORDS, "AddMultPA(GradientIntegrator self, Vector x, Vector y)"},
 	 { "GradientIntegrator_AddMultTransposePA", (PyCFunction)(void(*)(void))_wrap_GradientIntegrator_AddMultTransposePA, METH_VARARGS|METH_KEYWORDS, "AddMultTransposePA(GradientIntegrator self, Vector x, Vector y)"},
@@ -35477,8 +37258,9 @@ static PyMethodDef SwigMethods_proxydocs[] = {
 	 { "DiffusionIntegrator_ComputeFluxEnergy", (PyCFunction)(void(*)(void))_wrap_DiffusionIntegrator_ComputeFluxEnergy, METH_VARARGS|METH_KEYWORDS, "ComputeFluxEnergy(DiffusionIntegrator self, FiniteElement fluxelem, ElementTransformation Trans, Vector flux, Vector d_energy=None) -> double"},
 	 { "DiffusionIntegrator_AssembleMF", (PyCFunction)(void(*)(void))_wrap_DiffusionIntegrator_AssembleMF, METH_VARARGS|METH_KEYWORDS, "AssembleMF(DiffusionIntegrator self, FiniteElementSpace fes)"},
 	 { "DiffusionIntegrator_AssemblePA", _wrap_DiffusionIntegrator_AssemblePA, METH_VARARGS, "\n"
-		"AssemblePA()\n"
-		"AssemblePA(FiniteElementSpace fes)\n"
+		"AssemblePA(DiffusionIntegrator self, FiniteElementSpace fes)\n"
+		"AssemblePA(DiffusionIntegrator self, FiniteElementSpace trial_fes, FiniteElementSpace test_fes)\n"
+		"AssemblePA(DiffusionIntegrator self, FiniteElementSpace fes)\n"
 		""},
 	 { "DiffusionIntegrator_AssembleEA", (PyCFunction)(void(*)(void))_wrap_DiffusionIntegrator_AssembleEA, METH_VARARGS|METH_KEYWORDS, "AssembleEA(DiffusionIntegrator self, FiniteElementSpace fes, Vector emat, bool const add)"},
 	 { "DiffusionIntegrator_AssembleDiagonalPA", (PyCFunction)(void(*)(void))_wrap_DiffusionIntegrator_AssembleDiagonalPA, METH_VARARGS|METH_KEYWORDS, "AssembleDiagonalPA(DiffusionIntegrator self, Vector diag)"},
@@ -35497,8 +37279,9 @@ static PyMethodDef SwigMethods_proxydocs[] = {
 	 { "MassIntegrator_AssembleElementMatrix2", (PyCFunction)(void(*)(void))_wrap_MassIntegrator_AssembleElementMatrix2, METH_VARARGS|METH_KEYWORDS, "AssembleElementMatrix2(MassIntegrator self, FiniteElement trial_fe, FiniteElement test_fe, ElementTransformation Trans, DenseMatrix elmat)"},
 	 { "MassIntegrator_AssembleMF", (PyCFunction)(void(*)(void))_wrap_MassIntegrator_AssembleMF, METH_VARARGS|METH_KEYWORDS, "AssembleMF(MassIntegrator self, FiniteElementSpace fes)"},
 	 { "MassIntegrator_AssemblePA", _wrap_MassIntegrator_AssemblePA, METH_VARARGS, "\n"
-		"AssemblePA()\n"
-		"AssemblePA(FiniteElementSpace fes)\n"
+		"AssemblePA(MassIntegrator self, FiniteElementSpace fes)\n"
+		"AssemblePA(MassIntegrator self, FiniteElementSpace trial_fes, FiniteElementSpace test_fes)\n"
+		"AssemblePA(MassIntegrator self, FiniteElementSpace fes)\n"
 		""},
 	 { "MassIntegrator_AssembleEA", (PyCFunction)(void(*)(void))_wrap_MassIntegrator_AssembleEA, METH_VARARGS|METH_KEYWORDS, "AssembleEA(MassIntegrator self, FiniteElementSpace fes, Vector emat, bool const add)"},
 	 { "MassIntegrator_AssembleDiagonalPA", (PyCFunction)(void(*)(void))_wrap_MassIntegrator_AssembleDiagonalPA, METH_VARARGS|METH_KEYWORDS, "AssembleDiagonalPA(MassIntegrator self, Vector diag)"},
@@ -35520,8 +37303,9 @@ static PyMethodDef SwigMethods_proxydocs[] = {
 	 { "new_ConvectionIntegrator", (PyCFunction)(void(*)(void))_wrap_new_ConvectionIntegrator, METH_VARARGS|METH_KEYWORDS, "new_ConvectionIntegrator(VectorCoefficient q, double a=1.0) -> ConvectionIntegrator"},
 	 { "ConvectionIntegrator_AssembleElementMatrix", (PyCFunction)(void(*)(void))_wrap_ConvectionIntegrator_AssembleElementMatrix, METH_VARARGS|METH_KEYWORDS, "AssembleElementMatrix(ConvectionIntegrator self, FiniteElement arg2, ElementTransformation arg3, DenseMatrix arg4)"},
 	 { "ConvectionIntegrator_AssemblePA", _wrap_ConvectionIntegrator_AssemblePA, METH_VARARGS, "\n"
-		"AssemblePA()\n"
-		"AssemblePA(FiniteElementSpace arg1)\n"
+		"AssemblePA(ConvectionIntegrator self, FiniteElementSpace fes)\n"
+		"AssemblePA(ConvectionIntegrator self, FiniteElementSpace trial_fes, FiniteElementSpace test_fes)\n"
+		"AssemblePA(ConvectionIntegrator self, FiniteElementSpace arg2)\n"
 		""},
 	 { "ConvectionIntegrator_AssembleEA", (PyCFunction)(void(*)(void))_wrap_ConvectionIntegrator_AssembleEA, METH_VARARGS|METH_KEYWORDS, "AssembleEA(ConvectionIntegrator self, FiniteElementSpace fes, Vector emat, bool const add)"},
 	 { "ConvectionIntegrator_AddMultPA", (PyCFunction)(void(*)(void))_wrap_ConvectionIntegrator_AddMultPA, METH_VARARGS|METH_KEYWORDS, "AddMultPA(ConvectionIntegrator self, Vector arg2, Vector arg3)"},
@@ -35550,8 +37334,9 @@ static PyMethodDef SwigMethods_proxydocs[] = {
 	 { "VectorMassIntegrator_AssembleElementMatrix", (PyCFunction)(void(*)(void))_wrap_VectorMassIntegrator_AssembleElementMatrix, METH_VARARGS|METH_KEYWORDS, "AssembleElementMatrix(VectorMassIntegrator self, FiniteElement el, ElementTransformation Trans, DenseMatrix elmat)"},
 	 { "VectorMassIntegrator_AssembleElementMatrix2", (PyCFunction)(void(*)(void))_wrap_VectorMassIntegrator_AssembleElementMatrix2, METH_VARARGS|METH_KEYWORDS, "AssembleElementMatrix2(VectorMassIntegrator self, FiniteElement trial_fe, FiniteElement test_fe, ElementTransformation Trans, DenseMatrix elmat)"},
 	 { "VectorMassIntegrator_AssemblePA", _wrap_VectorMassIntegrator_AssemblePA, METH_VARARGS, "\n"
-		"AssemblePA()\n"
-		"AssemblePA(FiniteElementSpace fes)\n"
+		"AssemblePA(VectorMassIntegrator self, FiniteElementSpace fes)\n"
+		"AssemblePA(VectorMassIntegrator self, FiniteElementSpace trial_fes, FiniteElementSpace test_fes)\n"
+		"AssemblePA(VectorMassIntegrator self, FiniteElementSpace fes)\n"
 		""},
 	 { "VectorMassIntegrator_AssembleMF", (PyCFunction)(void(*)(void))_wrap_VectorMassIntegrator_AssembleMF, METH_VARARGS|METH_KEYWORDS, "AssembleMF(VectorMassIntegrator self, FiniteElementSpace fes)"},
 	 { "VectorMassIntegrator_AssembleDiagonalPA", (PyCFunction)(void(*)(void))_wrap_VectorMassIntegrator_AssembleDiagonalPA, METH_VARARGS|METH_KEYWORDS, "AssembleDiagonalPA(VectorMassIntegrator self, Vector diag)"},
@@ -35604,8 +37389,9 @@ static PyMethodDef SwigMethods_proxydocs[] = {
 	 { "CurlCurlIntegrator_ComputeElementFlux", (PyCFunction)(void(*)(void))_wrap_CurlCurlIntegrator_ComputeElementFlux, METH_VARARGS|METH_KEYWORDS, "ComputeElementFlux(CurlCurlIntegrator self, FiniteElement el, ElementTransformation Trans, Vector u, FiniteElement fluxelem, Vector flux, bool with_coef)"},
 	 { "CurlCurlIntegrator_ComputeFluxEnergy", (PyCFunction)(void(*)(void))_wrap_CurlCurlIntegrator_ComputeFluxEnergy, METH_VARARGS|METH_KEYWORDS, "ComputeFluxEnergy(CurlCurlIntegrator self, FiniteElement fluxelem, ElementTransformation Trans, Vector flux, Vector d_energy=None) -> double"},
 	 { "CurlCurlIntegrator_AssemblePA", _wrap_CurlCurlIntegrator_AssemblePA, METH_VARARGS, "\n"
-		"AssemblePA()\n"
-		"AssemblePA(FiniteElementSpace fes)\n"
+		"AssemblePA(CurlCurlIntegrator self, FiniteElementSpace fes)\n"
+		"AssemblePA(CurlCurlIntegrator self, FiniteElementSpace trial_fes, FiniteElementSpace test_fes)\n"
+		"AssemblePA(CurlCurlIntegrator self, FiniteElementSpace fes)\n"
 		""},
 	 { "CurlCurlIntegrator_AddMultPA", (PyCFunction)(void(*)(void))_wrap_CurlCurlIntegrator_AddMultPA, METH_VARARGS|METH_KEYWORDS, "AddMultPA(CurlCurlIntegrator self, Vector x, Vector y)"},
 	 { "CurlCurlIntegrator_AssembleDiagonalPA", (PyCFunction)(void(*)(void))_wrap_CurlCurlIntegrator_AssembleDiagonalPA, METH_VARARGS|METH_KEYWORDS, "AssembleDiagonalPA(CurlCurlIntegrator self, Vector diag)"},
@@ -35633,7 +37419,8 @@ static PyMethodDef SwigMethods_proxydocs[] = {
 	 { "VectorFEMassIntegrator_AssembleElementMatrix", (PyCFunction)(void(*)(void))_wrap_VectorFEMassIntegrator_AssembleElementMatrix, METH_VARARGS|METH_KEYWORDS, "AssembleElementMatrix(VectorFEMassIntegrator self, FiniteElement el, ElementTransformation Trans, DenseMatrix elmat)"},
 	 { "VectorFEMassIntegrator_AssembleElementMatrix2", (PyCFunction)(void(*)(void))_wrap_VectorFEMassIntegrator_AssembleElementMatrix2, METH_VARARGS|METH_KEYWORDS, "AssembleElementMatrix2(VectorFEMassIntegrator self, FiniteElement trial_fe, FiniteElement test_fe, ElementTransformation Trans, DenseMatrix elmat)"},
 	 { "VectorFEMassIntegrator_AssemblePA", _wrap_VectorFEMassIntegrator_AssemblePA, METH_VARARGS, "\n"
-		"AssemblePA(VectorFEMassIntegrator self)\n"
+		"AssemblePA(VectorFEMassIntegrator self, FiniteElementSpace fes)\n"
+		"AssemblePA(VectorFEMassIntegrator self, FiniteElementSpace trial_fes, FiniteElementSpace test_fes)\n"
 		"AssemblePA(VectorFEMassIntegrator self, FiniteElementSpace fes)\n"
 		"AssemblePA(VectorFEMassIntegrator self, FiniteElementSpace trial_fes, FiniteElementSpace test_fes)\n"
 		""},
@@ -35649,8 +37436,9 @@ static PyMethodDef SwigMethods_proxydocs[] = {
 		""},
 	 { "VectorDivergenceIntegrator_AssembleElementMatrix2", (PyCFunction)(void(*)(void))_wrap_VectorDivergenceIntegrator_AssembleElementMatrix2, METH_VARARGS|METH_KEYWORDS, "AssembleElementMatrix2(VectorDivergenceIntegrator self, FiniteElement trial_fe, FiniteElement test_fe, ElementTransformation Trans, DenseMatrix elmat)"},
 	 { "VectorDivergenceIntegrator_AssemblePA", _wrap_VectorDivergenceIntegrator_AssemblePA, METH_VARARGS, "\n"
-		"AssemblePA()\n"
-		"AssemblePA(FiniteElementSpace trial_fes, FiniteElementSpace test_fes)\n"
+		"AssemblePA(VectorDivergenceIntegrator self, FiniteElementSpace fes)\n"
+		"AssemblePA(VectorDivergenceIntegrator self, FiniteElementSpace trial_fes, FiniteElementSpace test_fes)\n"
+		"AssemblePA(VectorDivergenceIntegrator self, FiniteElementSpace trial_fes, FiniteElementSpace test_fes)\n"
 		""},
 	 { "VectorDivergenceIntegrator_AddMultPA", (PyCFunction)(void(*)(void))_wrap_VectorDivergenceIntegrator_AddMultPA, METH_VARARGS|METH_KEYWORDS, "AddMultPA(VectorDivergenceIntegrator self, Vector x, Vector y)"},
 	 { "VectorDivergenceIntegrator_AddMultTransposePA", (PyCFunction)(void(*)(void))_wrap_VectorDivergenceIntegrator_AddMultTransposePA, METH_VARARGS|METH_KEYWORDS, "AddMultTransposePA(VectorDivergenceIntegrator self, Vector x, Vector y)"},
@@ -35674,8 +37462,9 @@ static PyMethodDef SwigMethods_proxydocs[] = {
 	 { "VectorDiffusionIntegrator_AssembleElementMatrix", (PyCFunction)(void(*)(void))_wrap_VectorDiffusionIntegrator_AssembleElementMatrix, METH_VARARGS|METH_KEYWORDS, "AssembleElementMatrix(VectorDiffusionIntegrator self, FiniteElement el, ElementTransformation Trans, DenseMatrix elmat)"},
 	 { "VectorDiffusionIntegrator_AssembleElementVector", (PyCFunction)(void(*)(void))_wrap_VectorDiffusionIntegrator_AssembleElementVector, METH_VARARGS|METH_KEYWORDS, "AssembleElementVector(VectorDiffusionIntegrator self, FiniteElement el, ElementTransformation Tr, Vector elfun, Vector elvect)"},
 	 { "VectorDiffusionIntegrator_AssemblePA", _wrap_VectorDiffusionIntegrator_AssemblePA, METH_VARARGS, "\n"
-		"AssemblePA()\n"
-		"AssemblePA(FiniteElementSpace fes)\n"
+		"AssemblePA(VectorDiffusionIntegrator self, FiniteElementSpace fes)\n"
+		"AssemblePA(VectorDiffusionIntegrator self, FiniteElementSpace trial_fes, FiniteElementSpace test_fes)\n"
+		"AssemblePA(VectorDiffusionIntegrator self, FiniteElementSpace fes)\n"
 		""},
 	 { "VectorDiffusionIntegrator_AssembleMF", (PyCFunction)(void(*)(void))_wrap_VectorDiffusionIntegrator_AssembleMF, METH_VARARGS|METH_KEYWORDS, "AssembleMF(VectorDiffusionIntegrator self, FiniteElementSpace fes)"},
 	 { "VectorDiffusionIntegrator_AssembleDiagonalPA", (PyCFunction)(void(*)(void))_wrap_VectorDiffusionIntegrator_AssembleDiagonalPA, METH_VARARGS|METH_KEYWORDS, "AssembleDiagonalPA(VectorDiffusionIntegrator self, Vector diag)"},
@@ -35702,6 +37491,10 @@ static PyMethodDef SwigMethods_proxydocs[] = {
 		"AssembleFaceMatrix(DGTraceIntegrator self, FiniteElement el1, FiniteElement el2, FaceElementTransformations Trans, DenseMatrix elmat)\n"
 		"AssembleFaceMatrix(DGTraceIntegrator self, FiniteElement trial_face_fe, FiniteElement test_fe1, FiniteElement test_fe2, FaceElementTransformations Trans, DenseMatrix elmat)\n"
 		"AssembleFaceMatrix(DGTraceIntegrator self, FiniteElement el1, FiniteElement el2, FaceElementTransformations Trans, DenseMatrix elmat)\n"
+		""},
+	 { "DGTraceIntegrator_AssemblePA", _wrap_DGTraceIntegrator_AssemblePA, METH_VARARGS, "\n"
+		"AssemblePA(DGTraceIntegrator self, FiniteElementSpace fes)\n"
+		"AssemblePA(DGTraceIntegrator self, FiniteElementSpace trial_fes, FiniteElementSpace test_fes)\n"
 		""},
 	 { "DGTraceIntegrator_AssemblePAInteriorFaces", (PyCFunction)(void(*)(void))_wrap_DGTraceIntegrator_AssemblePAInteriorFaces, METH_VARARGS|METH_KEYWORDS, "AssemblePAInteriorFaces(DGTraceIntegrator self, FiniteElementSpace fes)"},
 	 { "DGTraceIntegrator_AssemblePABoundaryFaces", (PyCFunction)(void(*)(void))_wrap_DGTraceIntegrator_AssemblePABoundaryFaces, METH_VARARGS|METH_KEYWORDS, "AssemblePABoundaryFaces(DGTraceIntegrator self, FiniteElementSpace fes)"},
@@ -36311,6 +38104,246 @@ static void *_p_mfem__VectorCrossProductInterpolatorTo_p_mfem__BilinearFormInteg
 static void *_p_mfem__VectorInnerProductInterpolatorTo_p_mfem__BilinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
     return (void *)((mfem::BilinearFormIntegrator *) (mfem::DiscreteInterpolator *) ((mfem::VectorInnerProductInterpolator *) x));
 }
+static void *_p_mfem__NormalTraceJumpIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *) ((mfem::NormalTraceJumpIntegrator *) x));
+}
+static void *_p_mfem__TraceJumpIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *) ((mfem::TraceJumpIntegrator *) x));
+}
+static void *_p_mfem__DGElasticityIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *) ((mfem::DGElasticityIntegrator *) x));
+}
+static void *_p_mfem__DGDiffusionIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *) ((mfem::DGDiffusionIntegrator *) x));
+}
+static void *_p_mfem__DGTraceIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *) ((mfem::DGTraceIntegrator *) x));
+}
+static void *_p_mfem__ElasticityIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *) ((mfem::ElasticityIntegrator *) x));
+}
+static void *_p_mfem__VectorDiffusionIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *) ((mfem::VectorDiffusionIntegrator *) x));
+}
+static void *_p_mfem__DivDivIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *) ((mfem::DivDivIntegrator *) x));
+}
+static void *_p_mfem__VectorDivergenceIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *) ((mfem::VectorDivergenceIntegrator *) x));
+}
+static void *_p_mfem__VectorFEMassIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *) ((mfem::VectorFEMassIntegrator *) x));
+}
+static void *_p_mfem__VectorCurlCurlIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *) ((mfem::VectorCurlCurlIntegrator *) x));
+}
+static void *_p_mfem__CurlCurlIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *) ((mfem::CurlCurlIntegrator *) x));
+}
+static void *_p_mfem__DerivativeIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *) ((mfem::DerivativeIntegrator *) x));
+}
+static void *_p_mfem__VectorFECurlIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *) ((mfem::VectorFECurlIntegrator *) x));
+}
+static void *_p_mfem__VectorFEWeakDivergenceIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *) ((mfem::VectorFEWeakDivergenceIntegrator *) x));
+}
+static void *_p_mfem__VectorFEDivergenceIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *) ((mfem::VectorFEDivergenceIntegrator *) x));
+}
+static void *_p_mfem__VectorMassIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *) ((mfem::VectorMassIntegrator *) x));
+}
+static void *_p_mfem__GroupConvectionIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *) ((mfem::GroupConvectionIntegrator *) x));
+}
+static void *_p_mfem__ConvectionIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *) ((mfem::ConvectionIntegrator *) x));
+}
+static void *_p_mfem__BoundaryMassIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *)(mfem::MassIntegrator *) ((mfem::BoundaryMassIntegrator *) x));
+}
+static void *_p_mfem__MassIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *) ((mfem::MassIntegrator *) x));
+}
+static void *_p_mfem__DiffusionIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *) ((mfem::DiffusionIntegrator *) x));
+}
+static void *_p_mfem__GradientIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *) ((mfem::GradientIntegrator *) x));
+}
+static void *_p_mfem__MixedVectorWeakDivergenceIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *)(mfem::MixedVectorIntegrator *) ((mfem::MixedVectorWeakDivergenceIntegrator *) x));
+}
+static void *_p_mfem__MixedVectorWeakCurlIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *)(mfem::MixedVectorIntegrator *) ((mfem::MixedVectorWeakCurlIntegrator *) x));
+}
+static void *_p_mfem__MixedVectorCurlIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *)(mfem::MixedVectorIntegrator *) ((mfem::MixedVectorCurlIntegrator *) x));
+}
+static void *_p_mfem__MixedVectorGradientIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *)(mfem::MixedVectorIntegrator *) ((mfem::MixedVectorGradientIntegrator *) x));
+}
+static void *_p_mfem__MixedScalarWeakDivergenceIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *)(mfem::MixedScalarVectorIntegrator *) ((mfem::MixedScalarWeakDivergenceIntegrator *) x));
+}
+static void *_p_mfem__MixedDivGradIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *)(mfem::MixedScalarVectorIntegrator *) ((mfem::MixedDivGradIntegrator *) x));
+}
+static void *_p_mfem__MixedGradDivIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *)(mfem::MixedScalarVectorIntegrator *) ((mfem::MixedGradDivIntegrator *) x));
+}
+static void *_p_mfem__MixedDirectionalDerivativeIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *)(mfem::MixedScalarVectorIntegrator *) ((mfem::MixedDirectionalDerivativeIntegrator *) x));
+}
+static void *_p_mfem__MixedScalarWeakCrossProductIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *)(mfem::MixedScalarVectorIntegrator *) ((mfem::MixedScalarWeakCrossProductIntegrator *) x));
+}
+static void *_p_mfem__MixedScalarCrossProductIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *)(mfem::MixedScalarVectorIntegrator *) ((mfem::MixedScalarCrossProductIntegrator *) x));
+}
+static void *_p_mfem__MixedScalarCrossGradIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *)(mfem::MixedScalarVectorIntegrator *) ((mfem::MixedScalarCrossGradIntegrator *) x));
+}
+static void *_p_mfem__MixedScalarCrossCurlIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *)(mfem::MixedScalarVectorIntegrator *) ((mfem::MixedScalarCrossCurlIntegrator *) x));
+}
+static void *_p_mfem__MixedScalarWeakDerivativeIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *)(mfem::MixedScalarIntegrator *) ((mfem::MixedScalarWeakDerivativeIntegrator *) x));
+}
+static void *_p_mfem__MixedScalarDerivativeIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *)(mfem::MixedScalarIntegrator *) ((mfem::MixedScalarDerivativeIntegrator *) x));
+}
+static void *_p_mfem__MixedVectorProductIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *)(mfem::MixedScalarVectorIntegrator *) ((mfem::MixedVectorProductIntegrator *) x));
+}
+static void *_p_mfem__MixedScalarMassIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *)(mfem::MixedScalarIntegrator *) ((mfem::MixedScalarMassIntegrator *) x));
+}
+static void *_p_mfem__MixedScalarVectorIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *) ((mfem::MixedScalarVectorIntegrator *) x));
+}
+static void *_p_mfem__MixedVectorIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *) ((mfem::MixedVectorIntegrator *) x));
+}
+static void *_p_mfem__MixedScalarIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *) ((mfem::MixedScalarIntegrator *) x));
+}
+static void *_p_mfem__SumIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *) ((mfem::SumIntegrator *) x));
+}
+static void *_p_mfem__InverseIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *) ((mfem::InverseIntegrator *) x));
+}
+static void *_p_mfem__LumpedIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *) ((mfem::LumpedIntegrator *) x));
+}
+static void *_p_mfem__TransposeIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *) ((mfem::TransposeIntegrator *) x));
+}
+static void *_p_mfem__BilinearFormIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *)  ((mfem::BilinearFormIntegrator *) x));
+}
+static void *_p_mfem__VectorConvectionNLFIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *)  ((mfem::VectorConvectionNLFIntegrator *) x));
+}
+static void *_p_mfem__HyperelasticNLFIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *)  ((mfem::HyperelasticNLFIntegrator *) x));
+}
+static void *_p_mfem__MixedScalarDivergenceIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *)(mfem::MixedScalarIntegrator *) ((mfem::MixedScalarDivergenceIntegrator *) x));
+}
+static void *_p_mfem__MixedVectorDivergenceIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *)(mfem::MixedScalarVectorIntegrator *) ((mfem::MixedVectorDivergenceIntegrator *) x));
+}
+static void *_p_mfem__MixedScalarWeakGradientIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *)(mfem::MixedScalarIntegrator *) ((mfem::MixedScalarWeakGradientIntegrator *) x));
+}
+static void *_p_mfem__MixedScalarCurlIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *)(mfem::MixedScalarIntegrator *) ((mfem::MixedScalarCurlIntegrator *) x));
+}
+static void *_p_mfem__MixedScalarWeakCurlIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *)(mfem::MixedScalarIntegrator *) ((mfem::MixedScalarWeakCurlIntegrator *) x));
+}
+static void *_p_mfem__MixedVectorMassIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *)(mfem::MixedVectorIntegrator *) ((mfem::MixedVectorMassIntegrator *) x));
+}
+static void *_p_mfem__MixedCrossProductIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *)(mfem::MixedVectorIntegrator *) ((mfem::MixedCrossProductIntegrator *) x));
+}
+static void *_p_mfem__MixedDotProductIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *)(mfem::MixedScalarVectorIntegrator *) ((mfem::MixedDotProductIntegrator *) x));
+}
+static void *_p_mfem__MixedWeakGradDotIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *)(mfem::MixedScalarVectorIntegrator *) ((mfem::MixedWeakGradDotIntegrator *) x));
+}
+static void *_p_mfem__MixedWeakDivCrossIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *)(mfem::MixedVectorIntegrator *) ((mfem::MixedWeakDivCrossIntegrator *) x));
+}
+static void *_p_mfem__MixedGradGradIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *)(mfem::MixedVectorIntegrator *) ((mfem::MixedGradGradIntegrator *) x));
+}
+static void *_p_mfem__MixedCrossGradGradIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *)(mfem::MixedVectorIntegrator *) ((mfem::MixedCrossGradGradIntegrator *) x));
+}
+static void *_p_mfem__MixedCurlCurlIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *)(mfem::MixedVectorIntegrator *) ((mfem::MixedCurlCurlIntegrator *) x));
+}
+static void *_p_mfem__MixedCrossCurlCurlIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *)(mfem::MixedVectorIntegrator *) ((mfem::MixedCrossCurlCurlIntegrator *) x));
+}
+static void *_p_mfem__MixedCrossCurlGradIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *)(mfem::MixedVectorIntegrator *) ((mfem::MixedCrossCurlGradIntegrator *) x));
+}
+static void *_p_mfem__MixedCrossGradCurlIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *)(mfem::MixedVectorIntegrator *) ((mfem::MixedCrossGradCurlIntegrator *) x));
+}
+static void *_p_mfem__MixedWeakCurlCrossIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *)(mfem::MixedVectorIntegrator *) ((mfem::MixedWeakCurlCrossIntegrator *) x));
+}
+static void *_p_mfem__MixedScalarWeakCurlCrossIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *)(mfem::MixedScalarVectorIntegrator *) ((mfem::MixedScalarWeakCurlCrossIntegrator *) x));
+}
+static void *_p_mfem__MixedCrossGradIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *)(mfem::MixedVectorIntegrator *) ((mfem::MixedCrossGradIntegrator *) x));
+}
+static void *_p_mfem__MixedCrossCurlIntegratorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *)(mfem::MixedVectorIntegrator *) ((mfem::MixedCrossCurlIntegrator *) x));
+}
+static void *_p_mfem__DivergenceInterpolatorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *)(mfem::DiscreteInterpolator *) ((mfem::DivergenceInterpolator *) x));
+}
+static void *_p_mfem__CurlInterpolatorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *)(mfem::DiscreteInterpolator *) ((mfem::CurlInterpolator *) x));
+}
+static void *_p_mfem__IdentityInterpolatorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *)(mfem::DiscreteInterpolator *) ((mfem::IdentityInterpolator *) x));
+}
+static void *_p_mfem__GradientInterpolatorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *)(mfem::DiscreteInterpolator *) ((mfem::GradientInterpolator *) x));
+}
+static void *_p_mfem__DiscreteInterpolatorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *) ((mfem::DiscreteInterpolator *) x));
+}
+static void *_p_mfem__NormalInterpolatorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *)(mfem::DiscreteInterpolator *) ((mfem::NormalInterpolator *) x));
+}
+static void *_p_mfem__ScalarProductInterpolatorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *)(mfem::DiscreteInterpolator *) ((mfem::ScalarProductInterpolator *) x));
+}
+static void *_p_mfem__ScalarVectorProductInterpolatorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *)(mfem::DiscreteInterpolator *) ((mfem::ScalarVectorProductInterpolator *) x));
+}
+static void *_p_mfem__VectorScalarProductInterpolatorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *)(mfem::DiscreteInterpolator *) ((mfem::VectorScalarProductInterpolator *) x));
+}
+static void *_p_mfem__VectorCrossProductInterpolatorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *)(mfem::DiscreteInterpolator *) ((mfem::VectorCrossProductInterpolator *) x));
+}
+static void *_p_mfem__VectorInnerProductInterpolatorTo_p_mfem__NonlinearFormIntegrator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::NonlinearFormIntegrator *) (mfem::BilinearFormIntegrator *)(mfem::DiscreteInterpolator *) ((mfem::VectorInnerProductInterpolator *) x));
+}
 static void *_p_mfem__GradientInterpolatorTo_p_mfem__DiscreteInterpolator(void *x, int *SWIGUNUSEDPARM(newmemory)) {
     return (void *)((mfem::DiscreteInterpolator *)  ((mfem::GradientInterpolator *) x));
 }
@@ -36845,6 +38878,9 @@ static swig_type_info _swigt__p_mfem__MixedVectorWeakDivergenceIntegrator = {"_p
 static swig_type_info _swigt__p_mfem__MixedWeakCurlCrossIntegrator = {"_p_mfem__MixedWeakCurlCrossIntegrator", "mfem::MixedWeakCurlCrossIntegrator *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_mfem__MixedWeakDivCrossIntegrator = {"_p_mfem__MixedWeakDivCrossIntegrator", "mfem::MixedWeakDivCrossIntegrator *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_mfem__MixedWeakGradDotIntegrator = {"_p_mfem__MixedWeakGradDotIntegrator", "mfem::MixedWeakGradDotIntegrator *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_mfem__NonlinearFormIntegrator = {"_p_mfem__NonlinearFormIntegrator", "mfem::NonlinearFormIntegrator *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_mfem__HyperelasticNLFIntegrator = {"_p_mfem__HyperelasticNLFIntegrator", 0, 0, 0, 0, 0};
+static swig_type_info _swigt__p_mfem__VectorConvectionNLFIntegrator = {"_p_mfem__VectorConvectionNLFIntegrator", 0, 0, 0, 0, 0};
 static swig_type_info _swigt__p_mfem__NormalInterpolator = {"_p_mfem__NormalInterpolator", "mfem::NormalInterpolator *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_mfem__NormalTraceJumpIntegrator = {"_p_mfem__NormalTraceJumpIntegrator", "mfem::NormalTraceJumpIntegrator *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_mfem__OperatorHandle = {"_p_mfem__OperatorHandle", "mfem::OperatorPtr *|mfem::OperatorHandle *", 0, 0, (void*)0, 0};
@@ -36959,6 +38995,7 @@ static swig_type_info *swig_type_initial[] = {
   &_swigt__p_mfem__H1_TetrahedronElement,
   &_swigt__p_mfem__H1_TriangleElement,
   &_swigt__p_mfem__H1_WedgeElement,
+  &_swigt__p_mfem__HyperelasticNLFIntegrator,
   &_swigt__p_mfem__IdentityInterpolator,
   &_swigt__p_mfem__IdentityMatrixCoefficient,
   &_swigt__p_mfem__InnerProductCoefficient,
@@ -37048,6 +39085,7 @@ static swig_type_info *swig_type_initial[] = {
   &_swigt__p_mfem__NodalFiniteElement,
   &_swigt__p_mfem__NodalTensorFiniteElement,
   &_swigt__p_mfem__NodeExtrudeCoefficient,
+  &_swigt__p_mfem__NonlinearFormIntegrator,
   &_swigt__p_mfem__NormalInterpolator,
   &_swigt__p_mfem__NormalTraceJumpIntegrator,
   &_swigt__p_mfem__NormalizedVectorCoefficient,
@@ -37113,6 +39151,7 @@ static swig_type_info *swig_type_initial[] = {
   &_swigt__p_mfem__VectorArrayCoefficient,
   &_swigt__p_mfem__VectorCoefficient,
   &_swigt__p_mfem__VectorConstantCoefficient,
+  &_swigt__p_mfem__VectorConvectionNLFIntegrator,
   &_swigt__p_mfem__VectorCrossProductCoefficient,
   &_swigt__p_mfem__VectorCrossProductInterpolator,
   &_swigt__p_mfem__VectorCurlCurlIntegrator,
@@ -37349,6 +39388,9 @@ static swig_cast_info _swigc__p_mfem__MixedVectorWeakDivergenceIntegrator[] = { 
 static swig_cast_info _swigc__p_mfem__MixedWeakCurlCrossIntegrator[] = {  {&_swigt__p_mfem__MixedWeakCurlCrossIntegrator, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_mfem__MixedWeakDivCrossIntegrator[] = {  {&_swigt__p_mfem__MixedWeakDivCrossIntegrator, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_mfem__MixedWeakGradDotIntegrator[] = {  {&_swigt__p_mfem__MixedWeakGradDotIntegrator, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_mfem__HyperelasticNLFIntegrator[] = {{&_swigt__p_mfem__HyperelasticNLFIntegrator, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_mfem__VectorConvectionNLFIntegrator[] = {{&_swigt__p_mfem__VectorConvectionNLFIntegrator, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_mfem__NonlinearFormIntegrator[] = {  {&_swigt__p_mfem__GradientIntegrator, _p_mfem__GradientIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__DiffusionIntegrator, _p_mfem__DiffusionIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__MassIntegrator, _p_mfem__MassIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__BoundaryMassIntegrator, _p_mfem__BoundaryMassIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__ConvectionIntegrator, _p_mfem__ConvectionIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__GroupConvectionIntegrator, _p_mfem__GroupConvectionIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__VectorMassIntegrator, _p_mfem__VectorMassIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__VectorFEDivergenceIntegrator, _p_mfem__VectorFEDivergenceIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__VectorFEWeakDivergenceIntegrator, _p_mfem__VectorFEWeakDivergenceIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__VectorFECurlIntegrator, _p_mfem__VectorFECurlIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__NormalTraceJumpIntegrator, _p_mfem__NormalTraceJumpIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__TraceJumpIntegrator, _p_mfem__TraceJumpIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__DGElasticityIntegrator, _p_mfem__DGElasticityIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__DGDiffusionIntegrator, _p_mfem__DGDiffusionIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__DGTraceIntegrator, _p_mfem__DGTraceIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__ElasticityIntegrator, _p_mfem__ElasticityIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__VectorDiffusionIntegrator, _p_mfem__VectorDiffusionIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__DivDivIntegrator, _p_mfem__DivDivIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__VectorDivergenceIntegrator, _p_mfem__VectorDivergenceIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__VectorFEMassIntegrator, _p_mfem__VectorFEMassIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__VectorCurlCurlIntegrator, _p_mfem__VectorCurlCurlIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__CurlCurlIntegrator, _p_mfem__CurlCurlIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__DerivativeIntegrator, _p_mfem__DerivativeIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__MixedVectorProductIntegrator, _p_mfem__MixedVectorProductIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__MixedScalarWeakCrossProductIntegrator, _p_mfem__MixedScalarWeakCrossProductIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__MixedDirectionalDerivativeIntegrator, _p_mfem__MixedDirectionalDerivativeIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__MixedGradDivIntegrator, _p_mfem__MixedGradDivIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__MixedDivGradIntegrator, _p_mfem__MixedDivGradIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__MixedScalarWeakDivergenceIntegrator, _p_mfem__MixedScalarWeakDivergenceIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__MixedScalarVectorIntegrator, _p_mfem__MixedScalarVectorIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__MixedVectorWeakDivergenceIntegrator, _p_mfem__MixedVectorWeakDivergenceIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__MixedVectorWeakCurlIntegrator, _p_mfem__MixedVectorWeakCurlIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__MixedVectorCurlIntegrator, _p_mfem__MixedVectorCurlIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__MixedVectorGradientIntegrator, _p_mfem__MixedVectorGradientIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__MixedVectorIntegrator, _p_mfem__MixedVectorIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__MixedScalarWeakDerivativeIntegrator, _p_mfem__MixedScalarWeakDerivativeIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__MixedDotProductIntegrator, _p_mfem__MixedDotProductIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__MixedWeakGradDotIntegrator, _p_mfem__MixedWeakGradDotIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__MixedWeakDivCrossIntegrator, _p_mfem__MixedWeakDivCrossIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__MixedGradGradIntegrator, _p_mfem__MixedGradGradIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__MixedCrossGradGradIntegrator, _p_mfem__MixedCrossGradGradIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__MixedCurlCurlIntegrator, _p_mfem__MixedCurlCurlIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__MixedCrossCurlCurlIntegrator, _p_mfem__MixedCrossCurlCurlIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__MixedCrossCurlGradIntegrator, _p_mfem__MixedCrossCurlGradIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__MixedCrossGradCurlIntegrator, _p_mfem__MixedCrossGradCurlIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__MixedWeakCurlCrossIntegrator, _p_mfem__MixedWeakCurlCrossIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__MixedScalarWeakCurlCrossIntegrator, _p_mfem__MixedScalarWeakCurlCrossIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__MixedCrossGradIntegrator, _p_mfem__MixedCrossGradIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__MixedCrossCurlIntegrator, _p_mfem__MixedCrossCurlIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__NonlinearFormIntegrator, 0, 0, 0},  {&_swigt__p_mfem__MixedCrossProductIntegrator, _p_mfem__MixedCrossProductIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__MixedVectorMassIntegrator, _p_mfem__MixedVectorMassIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__MixedScalarWeakCurlIntegrator, _p_mfem__MixedScalarWeakCurlIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__MixedScalarCurlIntegrator, _p_mfem__MixedScalarCurlIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__MixedScalarWeakGradientIntegrator, _p_mfem__MixedScalarWeakGradientIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__MixedVectorDivergenceIntegrator, _p_mfem__MixedVectorDivergenceIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__MixedScalarDivergenceIntegrator, _p_mfem__MixedScalarDivergenceIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__HyperelasticNLFIntegrator, _p_mfem__HyperelasticNLFIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__VectorConvectionNLFIntegrator, _p_mfem__VectorConvectionNLFIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__BilinearFormIntegrator, _p_mfem__BilinearFormIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__MixedScalarCrossProductIntegrator, _p_mfem__MixedScalarCrossProductIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__MixedScalarCrossGradIntegrator, _p_mfem__MixedScalarCrossGradIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__MixedScalarCrossCurlIntegrator, _p_mfem__MixedScalarCrossCurlIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__TransposeIntegrator, _p_mfem__TransposeIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__LumpedIntegrator, _p_mfem__LumpedIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__InverseIntegrator, _p_mfem__InverseIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__SumIntegrator, _p_mfem__SumIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__MixedScalarIntegrator, _p_mfem__MixedScalarIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__MixedScalarMassIntegrator, _p_mfem__MixedScalarMassIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__MixedScalarDerivativeIntegrator, _p_mfem__MixedScalarDerivativeIntegratorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__DivergenceInterpolator, _p_mfem__DivergenceInterpolatorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__CurlInterpolator, _p_mfem__CurlInterpolatorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__IdentityInterpolator, _p_mfem__IdentityInterpolatorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__GradientInterpolator, _p_mfem__GradientInterpolatorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__NormalInterpolator, _p_mfem__NormalInterpolatorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__ScalarProductInterpolator, _p_mfem__ScalarProductInterpolatorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__ScalarVectorProductInterpolator, _p_mfem__ScalarVectorProductInterpolatorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__DiscreteInterpolator, _p_mfem__DiscreteInterpolatorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__VectorScalarProductInterpolator, _p_mfem__VectorScalarProductInterpolatorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__VectorCrossProductInterpolator, _p_mfem__VectorCrossProductInterpolatorTo_p_mfem__NonlinearFormIntegrator, 0, 0},  {&_swigt__p_mfem__VectorInnerProductInterpolator, _p_mfem__VectorInnerProductInterpolatorTo_p_mfem__NonlinearFormIntegrator, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_mfem__NormalInterpolator[] = {  {&_swigt__p_mfem__NormalInterpolator, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_mfem__NormalTraceJumpIntegrator[] = {  {&_swigt__p_mfem__NormalTraceJumpIntegrator, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_mfem__OperatorHandle[] = {  {&_swigt__p_mfem__OperatorHandle, 0, 0, 0},{0, 0, 0, 0}};
@@ -37463,6 +39505,7 @@ static swig_cast_info *swig_cast_initial[] = {
   _swigc__p_mfem__H1_TetrahedronElement,
   _swigc__p_mfem__H1_TriangleElement,
   _swigc__p_mfem__H1_WedgeElement,
+  _swigc__p_mfem__HyperelasticNLFIntegrator,
   _swigc__p_mfem__IdentityInterpolator,
   _swigc__p_mfem__IdentityMatrixCoefficient,
   _swigc__p_mfem__InnerProductCoefficient,
@@ -37552,6 +39595,7 @@ static swig_cast_info *swig_cast_initial[] = {
   _swigc__p_mfem__NodalFiniteElement,
   _swigc__p_mfem__NodalTensorFiniteElement,
   _swigc__p_mfem__NodeExtrudeCoefficient,
+  _swigc__p_mfem__NonlinearFormIntegrator,
   _swigc__p_mfem__NormalInterpolator,
   _swigc__p_mfem__NormalTraceJumpIntegrator,
   _swigc__p_mfem__NormalizedVectorCoefficient,
@@ -37617,6 +39661,7 @@ static swig_cast_info *swig_cast_initial[] = {
   _swigc__p_mfem__VectorArrayCoefficient,
   _swigc__p_mfem__VectorCoefficient,
   _swigc__p_mfem__VectorConstantCoefficient,
+  _swigc__p_mfem__VectorConvectionNLFIntegrator,
   _swigc__p_mfem__VectorCrossProductCoefficient,
   _swigc__p_mfem__VectorCrossProductInterpolator,
   _swigc__p_mfem__VectorCurlCurlIntegrator,

--- a/mfem/_ser/bilininteg_wrap.h
+++ b/mfem/_ser/bilininteg_wrap.h
@@ -19,13 +19,19 @@ class SwigDirector_BilinearFormIntegrator : public mfem::BilinearFormIntegrator,
 
 public:
     SwigDirector_BilinearFormIntegrator(PyObject *self, mfem::IntegrationRule const *ir = NULL);
+    virtual void AssembleElementVector(mfem::FiniteElement const &el, mfem::ElementTransformation &Tr, mfem::Vector const &elfun, mfem::Vector &elvect);
+    virtual void AssembleFaceVector(mfem::FiniteElement const &el1, mfem::FiniteElement const &el2, mfem::FaceElementTransformations &Tr, mfem::Vector const &elfun, mfem::Vector &elvect);
+    virtual void AssembleElementGrad(mfem::FiniteElement const &el, mfem::ElementTransformation &Tr, mfem::Vector const &elfun, mfem::DenseMatrix &elmat);
+    virtual void AssembleFaceGrad(mfem::FiniteElement const &el1, mfem::FiniteElement const &el2, mfem::FaceElementTransformations &Tr, mfem::Vector const &elfun, mfem::DenseMatrix &elmat);
+    virtual double GetElementEnergy(mfem::FiniteElement const &el, mfem::ElementTransformation &Tr, mfem::Vector const &elfun);
     virtual void AssemblePA(mfem::FiniteElementSpace const &fes);
     virtual void AssemblePA(mfem::FiniteElementSpace const &trial_fes, mfem::FiniteElementSpace const &test_fes);
+    virtual void AddMultPA(mfem::Vector const &x, mfem::Vector &y) const;
+    virtual ~SwigDirector_BilinearFormIntegrator();
     virtual void AssemblePAInteriorFaces(mfem::FiniteElementSpace const &fes);
     virtual void AssemblePABoundaryFaces(mfem::FiniteElementSpace const &fes);
     virtual void AssembleDiagonalPA(mfem::Vector &diag);
     virtual void AssembleDiagonalPA_ADAt(mfem::Vector const &D, mfem::Vector &diag);
-    virtual void AddMultPA(mfem::Vector const &x, mfem::Vector &y) const;
     virtual void AddMultTransposePA(mfem::Vector const &x, mfem::Vector &y) const;
     virtual void AssembleEA(mfem::FiniteElementSpace const &fes, mfem::Vector &emat, bool const add = true);
     virtual void AssembleMF(mfem::FiniteElementSpace const &fes);
@@ -38,13 +44,8 @@ public:
     virtual void AssembleElementMatrix2(mfem::FiniteElement const &trial_fe, mfem::FiniteElement const &test_fe, mfem::ElementTransformation &Trans, mfem::DenseMatrix &elmat);
     virtual void AssembleFaceMatrix(mfem::FiniteElement const &el1, mfem::FiniteElement const &el2, mfem::FaceElementTransformations &Trans, mfem::DenseMatrix &elmat);
     virtual void AssembleFaceMatrix(mfem::FiniteElement const &trial_face_fe, mfem::FiniteElement const &test_fe1, mfem::FiniteElement const &test_fe2, mfem::FaceElementTransformations &Trans, mfem::DenseMatrix &elmat);
-    virtual void AssembleElementVector(mfem::FiniteElement const &el, mfem::ElementTransformation &Tr, mfem::Vector const &elfun, mfem::Vector &elvect);
-    virtual void AssembleFaceVector(mfem::FiniteElement const &el1, mfem::FiniteElement const &el2, mfem::FaceElementTransformations &Tr, mfem::Vector const &elfun, mfem::Vector &elvect);
-    virtual void AssembleElementGrad(mfem::FiniteElement const &el, mfem::ElementTransformation &Tr, mfem::Vector const &elfun, mfem::DenseMatrix &elmat);
-    virtual void AssembleFaceGrad(mfem::FiniteElement const &el1, mfem::FiniteElement const &el2, mfem::FaceElementTransformations &Tr, mfem::Vector const &elfun, mfem::DenseMatrix &elmat);
     virtual void ComputeElementFlux(mfem::FiniteElement const &el, mfem::ElementTransformation &Trans, mfem::Vector &u, mfem::FiniteElement const &fluxelem, mfem::Vector &flux, bool with_coef = true);
     virtual double ComputeFluxEnergy(mfem::FiniteElement const &fluxelem, mfem::ElementTransformation &Trans, mfem::Vector &flux, mfem::Vector *d_energy = NULL);
-    virtual ~SwigDirector_BilinearFormIntegrator();
 
 /* Internal director utilities */
 public:
@@ -75,7 +76,7 @@ private:
       return method;
     }
 private:
-    mutable swig::SwigVar_PyObject vtable[25];
+    mutable swig::SwigVar_PyObject vtable[26];
 #endif
 
 };


### PR DESCRIPTION
bilininteg.i is adjusted so that NonlinearIntegrator is properly recognizedas a base class of BilinearIntegrator class. This allows to use SetIntOrder and some others in BilinearIntegrator