### PR TITLE
Fix lib64 and default pip install behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ $ pip3 download mfem
 (expand tar.gz file and move to the downloaded directory)
 $ python setup.py install --with-parallel # it download and build metis/hypre/mfem
 ```
+Choosing compiler
+```
+$ python setup.py install --with-parallel --CC=icc --CXX=icpc --MPICC=mpiicc --MPICXX=mpiicpc
+```
 For other configurations, see docs/install.txt or help
 ```
 $ python setup.py install --help

--- a/docs/development_memo.txt
+++ b/docs/development_memo.txt
@@ -11,3 +11,16 @@ $ python3 -m twine upload dist/*                          # uploade to the offic
 ### building step-by-step
 pip download -i  https://test.pypi.org/simple/ mfem
 python3 setup.py install --prefix=~/sandbox --verbose --with-parallel
+
+### test inside virtualenv
+virtualenv env
+source env/bin/activate
+
+### test verious pip combinations
+pip3 install -i  https://test.pypi.org/simple  mfem --no-binary mfem --verbose
+pip3 install -i  https://test.pypi.org/simple  mfem --no-binary mfem --verbose --prefix=~/sandbox
+
+virtualenv env
+source env/bin/activate
+pip3 install -i  https://test.pypi.org/simple  mfem --no-binary mfem --verbose
+

--- a/mfem/__init__.py
+++ b/mfem/__init__.py
@@ -20,5 +20,5 @@ def debug_print(message):
     
     print(message)
 
-__version__ = '4.2.0.2'
+__version__ = '4.2.1.28'
 

--- a/mfem/__init__.py
+++ b/mfem/__init__.py
@@ -17,9 +17,8 @@ def debug_print(message):
     elif pymfem_debug > 2: # debug = 3
         import traceback as tb
         print(''.join(tb.format_list([tb.extract_stack(limit = 2)[0],])))
-    
+
     print(message)
 
 __version__ = '4.2.0.2'
 
-.

--- a/mfem/__init__.py
+++ b/mfem/__init__.py
@@ -20,5 +20,5 @@ def debug_print(message):
     
     print(message)
 
-__version__ = '4.2.0.1'
+__version__ = '4.2.0.2'
 

--- a/mfem/__init__.py
+++ b/mfem/__init__.py
@@ -20,5 +20,6 @@ def debug_print(message):
     
     print(message)
 
-__version__ = '4.2.1.28'
+__version__ = '4.2.0.2'
 
+.

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 """
   MFEM + PyMFEM (finite element method library)
 """
+from sys import platform
 import sys
 import os
 import urllib
@@ -9,7 +10,7 @@ import site
 import re
 import shutil
 import subprocess
-from subprocess import DEVNULL 
+from subprocess import DEVNULL
 
 import multiprocessing
 
@@ -28,20 +29,19 @@ try:
     from wheel.bdist_wheel import bdist_wheel as _bdist_wheel
     haveWheel = True
 except ImportError:
-    haveWheel = False    
+    haveWheel = False
 
 # To use a consistent encoding
 # from codecs import open
 
-### constants
+# constants
 repos = {"mfem": "https://github.com/mfem/mfem/archive/v4.2.tar.gz",
          "metis": "http://glaros.dtc.umn.edu/gkhome/fetch/sw/metis/metis-5.1.0.tar.gz",
-         "hypre": "https://github.com/hypre-space/hypre/archive/v2.20.0.tar.gz",}
+         "hypre": "https://github.com/hypre-space/hypre/archive/v2.20.0.tar.gz", }
 
 rootdir = os.path.abspath(os.path.dirname(__file__))
 extdir = os.path.join(rootdir, 'external')
 
-from sys import platform
 if platform == "linux" or platform == "linux2":
     dylibext = '.so'
 elif platform == "darwin":
@@ -84,10 +84,14 @@ dry_run = -1
 cc_command = 'cc' if os.getenv("CC") is None else os.getenv("CC")
 cxx_command = 'c++' if os.getenv("CC") is None else os.getenv("CXX")
 mpicc_command = 'mpicc' if os.getenv("MPICC") is None else os.getenv("MPICC")
-mpicxx_command = 'mpic++' if os.getenv("MPICXX") is None else os.getenv("MPICXX")
-cxx11_flag = '-std=c++11' if os.getenv("CXX11FLAG") is None else os.getenv("CXX11FLAG")
+mpicxx_command = 'mpic++' if os.getenv(
+    "MPICXX") is None else os.getenv("MPICXX")
+cxx11_flag = '-std=c++11' if os.getenv(
+    "CXX11FLAG") is None else os.getenv("CXX11FLAG")
 
-### meta data
+# meta data
+
+
 def version():
     VERSIONFILE = os.path.join('mfem', '__init__.py')
     initfile_lines = open(VERSIONFILE, 'rt').readlines()
@@ -98,9 +102,11 @@ def version():
             return mo.group(1)
     raise RuntimeError('Unable to find version string in %s.' % (VERSIONFILE,))
 
+
 def long_description():
     with open(os.path.join(rootdir, 'README.md'), encoding='utf-8') as f:
         return f.read()
+
 
 keywords = """
 scientific computing
@@ -111,31 +117,34 @@ platforms = """
 Mac OS X
 Linux
 """
-metadata = {'name'             : 'mfem', 
-            'version'          : version(),
-            'description'      : __doc__.strip(),
-            'long_description' : long_description(),
-            'long_description_content_type':"text/markdown",
-            'url'              : 'http://mfem.org',
-            'download_url'     : 'https://github.com/mfem',
-            'classifiers'      :['Development Status :: 4 - Beta',
-                                 'Intended Audience :: Developers',
-                                 'Topic :: Scientific/Engineering :: Physics',
-                                 'License :: OSI Approved :: BSD License',
-                                 'Programming Language :: Python :: 3.6',
-                                 'Programming Language :: Python :: 3.7',
-                                 'Programming Language :: Python :: 3.8',  ],
-            'keywords'         : [k for k in keywords.split('\n')    if k],
-            'platforms'        : [p for p in platforms.split('\n')   if p],
-            'license'          : 'BSD-3',
-            'author'           : 'MFEM developement team',
-            'author_email'     : '',
-            'maintainer'       : 'S. Shiraiwa',
-            'maintainer_email' : 'shiraiwa@princeton.edu',}
+metadata = {'name': 'mfem',
+            'version': version(),
+            'description': __doc__.strip(),
+            'long_description': long_description(),
+            'long_description_content_type': "text/markdown",
+            'url': 'http://mfem.org',
+            'download_url': 'https://github.com/mfem',
+            'classifiers': ['Development Status :: 4 - Beta',
+                            'Intended Audience :: Developers',
+                            'Topic :: Scientific/Engineering :: Physics',
+                            'License :: OSI Approved :: BSD License',
+                            'Programming Language :: Python :: 3.6',
+                            'Programming Language :: Python :: 3.7',
+                            'Programming Language :: Python :: 3.8', ],
+            'keywords': [k for k in keywords.split('\n') if k],
+            'platforms': [p for p in platforms.split('\n') if p],
+            'license': 'BSD-3',
+            'author': 'MFEM developement team',
+            'author_email': '',
+            'maintainer': 'S. Shiraiwa',
+            'maintainer_email': 'shiraiwa@princeton.edu', }
 
-##  utilities
+# utilities
+
+
 def abspath(path):
     return os.path.abspath(os.path.expanduser(path))
+
 
 def install_prefix():
     """Return the installation directory, or None"""
@@ -154,14 +163,16 @@ def install_prefix():
     for path in paths:
         if os.path.exists(path):
             path = os.path.dirname(path)
-            path = os.path.dirname(path)            
+            path = os.path.dirname(path)
             return path
     assert False, "no installation path found"
     return None
 
+
 def find_command(name):
     from shutil import which
     return which(name)
+
 
 def make_call(command, target=''):
     '''
@@ -169,7 +180,7 @@ def make_call(command, target=''):
     '''
     if dry_run or verbose:
         print("calling ... " + " ".join(command))
-    if dry_run:        
+    if dry_run:
         return
     kwargs = {}
     if not verbose:
@@ -183,6 +194,7 @@ def make_call(command, target=''):
         print("Failed when calling command: " + target)
         raise
 
+
 def chdir(path):
     '''
     change directory
@@ -193,6 +205,7 @@ def chdir(path):
         print("Moving to a directory : " + path)
     return pwd
 
+
 def remove_files(files):
     for f in files:
         if verbose:
@@ -200,13 +213,15 @@ def remove_files(files):
         if dry_run:
             continue
         os.remove(f)
-    
+
+
 def make(target):
     '''
     make : add -j option automatically
     '''
-    command = ['make', '-j', str(max((multiprocessing.cpu_count()-1, 1)))]
-    make_call(command, target=target) 
+    command = ['make', '-j', str(max((multiprocessing.cpu_count() - 1, 1)))]
+    make_call(command, target=target)
+
 
 def make_install(target):
     '''
@@ -214,6 +229,7 @@ def make_install(target):
     '''
     command = ['make', 'install']
     make_call(command, target=target)
+
 
 def download(xxx):
     '''
@@ -228,12 +244,13 @@ def download(xxx):
         return
     url = repos[xxx]
     print("Downloading :", url)
-    
+
     ftpstream = request.urlopen(url)
     targz = tarfile.open(fileobj=ftpstream, mode="r|gz")
     targz.extractall(path=extdir)
     os.rename(os.path.join(extdir, targz.getnames()[0].split('/')[0]),
               os.path.join(extdir, xxx))
+
 
 def cmake(path, **kwargs):
     '''
@@ -241,23 +258,26 @@ def cmake(path, **kwargs):
     '''
     command = ['cmake', path]
     for key, value in kwargs.items():
-        command.append('-'+key+'='+value)
+        command.append('-' + key + '=' + value)
     make_call(command)
 
 
-def find_libpath_from_prefix(lib, prefix):
-    prefix = abspath(prefix)
-    soname = 'lib'+lib+dylibext
-    path = os.path.join(metis_prefix, 'lib', soname)
+def find_libpath_from_prefix(lib, prefix0):
+    prefix0 = os.path.expanduser(prefix0)
+    prefix0 = abspath(prefix0)
+    soname = 'lib' + lib + dylibext
+    path = os.path.join(prefix0, 'lib', soname)
     if not os.path.exists(path):
-        path = os.path.join(metis_prefix, 'lib64', soname)
+        path = os.path.join(prefix0, 'lib64', soname)
         if not os.path.exists(path):
             return ''
     return path
-    
+
 ###
 #  build libraries
 ###
+
+
 def cmake_make_hypre():
     '''
     build hypre
@@ -271,13 +291,13 @@ def cmake_make_hypre():
 
     pwd = chdir(path)
 
-    cmake_opts = {'DCMAKE_VERBOSE_MAKEFILE':'1',
+    cmake_opts = {'DCMAKE_VERBOSE_MAKEFILE': '1',
                   'DBUILD_SHARED_LIBS': '1',
                   'DHYPRE_INSTALL_PREFIX': os.path.join(prefix, 'mfem'),
                   'DHYPRE_ENABLE_SHARED': '1',
-                  'DCMAKE_INSTALL_PREFIX':os.path.join(prefix, 'mfem'),
-                  'DCMAKE_INSTALL_NAME_DIR':os.path.join(prefix, 'mfem', 'lib'),
-                  'DCMAKE_C_COMPILER': mpicc_command} 
+                  'DCMAKE_INSTALL_PREFIX': os.path.join(prefix, 'mfem'),
+                  'DCMAKE_INSTALL_NAME_DIR': os.path.join(prefix, 'mfem', 'lib'),
+                  'DCMAKE_C_COMPILER': mpicc_command}
 
     cmake('..', **cmake_opts)
 
@@ -286,16 +306,17 @@ def cmake_make_hypre():
 
     os.chdir(pwd)
 
+
 def make_metis(use_int64=False, use_real64=False):
     '''
-    build metis 
+    build metis
     '''
     path = os.path.join(extdir, 'metis')
     if not os.path.exists(path):
         assert False, "metis is not downloaded"
 
     pwd = chdir(path)
-    
+
     sed_command = find_command('sed')
     if sed_command is None:
         assert False, "sed is not foudn"
@@ -320,8 +341,8 @@ def make_metis(use_int64=False, use_real64=False):
     make_call(command)
 
     command = ['make', 'config', 'shared=1',
-               'prefix='+os.path.join(prefix, 'mfem'),
-               'cc='+cc_command]
+               'prefix=' + os.path.join(prefix, 'mfem'),
+               'cc=' + cc_command]
     make_call(command)
     make('metis')
     make_install('metis')
@@ -330,13 +351,14 @@ def make_metis(use_int64=False, use_real64=False):
         command = ['install_name_tool',
                    '-id',
                    os.path.join(prefix, 'lib', 'libmetis.dylib'),
-                   os.path.join(prefix, 'lib', 'libmetis.dylib'),]
+                   os.path.join(prefix, 'lib', 'libmetis.dylib'), ]
         make_call(command)
     os.chdir(pwd)
 
+
 def cmake_make_mfem(serial=True):
     '''
-    build MFEM 
+    build MFEM
     '''
     cmbuild = 'cmbuild_ser' if serial else 'cmbuild_par'
     path = os.path.join(extdir, 'mfem', cmbuild)
@@ -345,30 +367,36 @@ def cmake_make_mfem(serial=True):
     else:
         os.makedirs(path)
 
-    cmake_opts = {'DCMAKE_VERBOSE_MAKEFILE':'1',
+    cmake_opts = {'DCMAKE_VERBOSE_MAKEFILE': '1',
                   'DBUILD_SHARED_LIBS': '1',
                   'DMFEM_ENABLE_EXAMPLES': '1',
                   'DMFEM_ENABLE_MINIAPPS': '1',
-                  'DCMAKE_SHARED_LINKER_FLAGS':'',
+                  'DCMAKE_SHARED_LINKER_FLAGS': '',
                   'DCMAKE_CXX_FLAGS': cxx11_flag}
 
     if serial:
         cmake_opts['DCMAKE_CXX_COMPILER'] = cxx_command
         cmake_opts['DMFEM_USE_EXCEPTIONS'] = '1'
-        cmake_opts['DCMAKE_INSTALL_PREFIX'] = os.path.join(prefix, 'mfem', 'ser')
+        cmake_opts['DCMAKE_INSTALL_PREFIX'] = os.path.join(
+            prefix, 'mfem', 'ser')
     else:
         cmake_opts['DCMAKE_CXX_COMPILER'] = mpicxx_command
         cmake_opts['DMFEM_USE_EXCEPTIONS'] = '0'
-        cmake_opts['DCMAKE_INSTALL_PREFIX'] = os.path.join(prefix, 'mfem', 'par')
+        cmake_opts['DCMAKE_INSTALL_PREFIX'] = os.path.join(
+            prefix, 'mfem', 'par')
         cmake_opts['DMFEM_USE_MPI'] = '1'
         cmake_opts['DMFEM_USE_METIS_5'] = '1'
         cmake_opts['DHYPRE_DIR'] = os.path.join(hypre_prefix)
         cmake_opts['DMETIS_DIR'] = os.path.join(metis_prefix)
         #cmake_opts['DCMAKE_CXX_STANDARD_LIBRARIES'] = "-lHYPRE -lmetis"
 
-        hyprelibpath = os.path.dirname(find_libpath_from_prefix('HYPRE', hypre_prefix))
-        metislibpath = os.path.dirname(find_libpath_from_prefix('metis', metis_prefix))
-        
+        hyprelibpath = os.path.dirname(
+            find_libpath_from_prefix(
+                'HYPRE', hypre_prefix))
+        metislibpath = os.path.dirname(
+            find_libpath_from_prefix(
+                'metis', metis_prefix))
+
         lflags = "-L" + metislibpath
         lflags = lflags + " -L" + hyprelibpath
         cmake_opts['DCMAKE_SHARED_LINKER_FLAGS'] = lflags
@@ -376,22 +404,23 @@ def cmake_make_mfem(serial=True):
 
         if enable_strumpack:
             cmake_opts['DMFEM_USE_STRUMPACK'] = '1'
-            cmake_opts['STRUMPACK_DIR'] = strumpack_prefix            
+            cmake_opts['STRUMPACK_DIR'] = strumpack_prefix
         if enable_pumi:
             cmake_opts['DMFEM_USE_PUMI'] = '1'
             cmake_opts['DPUMI_DIR'] = pumi_prefix
-            
+
     if enable_cuda:
         cmake_opts['DMFEM_USE_CUDA'] = '1'
-        
+
     pwd = chdir(path)
     cmake('..', **cmake_opts)
 
     txt = 'serial' if serial else 'parallel'
-    make('mfem_'+txt)
-    make_install('mfem_'+txt)
-    
+    make('mfem_' + txt)
+    make_install('mfem_' + txt)
+
     os.chdir(pwd)
+
 
 def write_setup_local():
     '''
@@ -407,8 +436,12 @@ def write_setup_local():
         mfemser = mfems_prefix
         mfempar = mfemp_prefix
 
-    hyprelibpath = os.path.dirname(find_libpath_from_prefix('HYPRE', hypre_prefix))
-    metislibpath = os.path.dirname(find_libpath_from_prefix('metis', metis_prefix))
+    hyprelibpath = os.path.dirname(
+        find_libpath_from_prefix(
+            'HYPRE', hypre_prefix))
+    metislibpath = os.path.dirname(
+        find_libpath_from_prefix(
+            'metis', metis_prefix))
     params = {'cxx_ser': cxx_command,
               'cc_ser': cc_command,
               'cxx_par': mpicxx_command,
@@ -431,20 +464,21 @@ def write_setup_local():
               'mfemserlnkdir': os.path.join(mfemser, 'lib'),
               'add_pumi': '',
               'add_strumpack': '',
-              'add_cuda': '',              
+              'add_cuda': '',
               'cxx11flag': cxx11_flag,
               }
 
-
     try:
-        import mpi4py ## avaialbility of this is checked before
+        import mpi4py  # avaialbility of this is checked before
         params['mpi4pyinc'] = mpi4py.get_include()
     except ImportError:
         params['mpi4pyinc'] = ''
 
     def add_extra(xxx):
         params['add_' + xxx] = '1'
-        params[xxx + 'inc'] = os.path.join(globals()[xxx + '_prefix'], 'include')
+        params[xxx +
+               'inc'] = os.path.join(globals()[xxx +
+                                               '_prefix'], 'include')
         params[xxx + 'lib'] = os.path.join(globals()[xxx + '_prefix'], 'lib')
 
     if enable_pumi:
@@ -454,9 +488,8 @@ def write_setup_local():
     if enable_cuda:
         add_extra('cuda')
 
-
     pwd = chdir(rootdir)
-    
+
     fid = open('setup_local.py', 'w')
     fid.write("#  setup_local.py \n")
     fid.write("#  generated from setup.py\n")
@@ -464,10 +497,11 @@ def write_setup_local():
 
     for key, value in params.items():
         text = key.lower() + ' = "' + value + '"'
-        fid.write(text+"\n")
+        fid.write(text + "\n")
     fid.close()
-    
+
     os.chdir(pwd)
+
 
 def generate_wrapper():
     '''
@@ -475,15 +509,16 @@ def generate_wrapper():
     '''
     if dry_run or verbose:
         print("generating SWIG wrapper")
+
     def ifiles():
         ifiles = os.listdir()
         ifiles = [x for x in ifiles if x.endswith('.i')]
         ifiles = [x for x in ifiles if not x.startswith('#')]
-        ifiles = [x for x in ifiles if not x.startswith('.')]                
+        ifiles = [x for x in ifiles if not x.startswith('.')]
         return ifiles
 
     def check_new(ifile):
-        wfile = ifile[:-2]+'_wrap.cxx'
+        wfile = ifile[:-2] + '_wrap.cxx'
         if not os.path.exists(wfile):
             return True
         return os.path.getmtime(ifile) > os.path.getmtime(wfile)
@@ -503,8 +538,8 @@ def generate_wrapper():
 
     pwd = chdir(os.path.join(rootdir, 'mfem', '_ser'))
 
-    serflag = ['-I'+ os.path.join(mfemser, 'include'),
-               '-I'+ os.path.join(mfemser, 'include', 'mfem')]
+    serflag = ['-I' + os.path.join(mfemser, 'include'),
+               '-I' + os.path.join(mfemser, 'include', 'mfem')]
     for file in ifiles():
         if not check_new(file):
             continue
@@ -518,20 +553,20 @@ def generate_wrapper():
     chdir(os.path.join(rootdir, 'mfem', '_par'))
 
     import mpi4py
-    parflag = ['-I'+ os.path.join(mfempar, 'include'),
-               '-I'+ os.path.join(mfempar, 'include', 'mfem'),
-               '-I'+ mpi4py.get_include()]
+    parflag = ['-I' + os.path.join(mfempar, 'include'),
+               '-I' + os.path.join(mfempar, 'include', 'mfem'),
+               '-I' + mpi4py.get_include()]
 
     if enable_pumi:
-        parflag.append('-I'+os.path.join(pumi_prefix, 'include'))
+        parflag.append('-I' + os.path.join(pumi_prefix, 'include'))
     if enable_strumpack:
-        parflag.append('-I'+os.path.join(strumpack_prefix, 'include'))
+        parflag.append('-I' + os.path.join(strumpack_prefix, 'include'))
 
     for file in ifiles():
-#        pumi.i does not depends on pumi specific header so this should
-#        work        
-#        if file == 'pumi.i':# and not enable_pumi:
-#            continue
+        #        pumi.i does not depends on pumi specific header so this should
+        #        work
+        #        if file == 'pumi.i':# and not enable_pumi:
+        #            continue
         if file == 'strumpack.i' and not enable_strumpack:
             continue
         if not check_new(file):
@@ -541,10 +576,11 @@ def generate_wrapper():
 
     os.chdir(pwd)
 
+
 def clean_wrapper():
 
     pwd = chdir(os.path.join(rootdir, 'mfem', '_ser'))
-    
+
     wfiles = [x for x in os.listdir() if x.endswith('_wrap.cxx')]
     remove_files(wfiles)
 
@@ -553,15 +589,16 @@ def clean_wrapper():
     remove_files(wfiles)
 
     chdir(pwd)
-    
+
+
 def clean_so():
-    pwd =chdir(os.path.join(rootdir, 'mfem', '_ser'))
+    pwd = chdir(os.path.join(rootdir, 'mfem', '_ser'))
     for f in os.listdir():
         if f.endswith('.so'):
             os.remove(f)
         if f.endswith('.dylib'):
             os.remove(f)
-            
+
     chdir(os.path.join(rootdir, 'mfem', '_par'))
     for f in os.listdir():
         if f.endswith('.so'):
@@ -569,14 +606,15 @@ def clean_so():
         if f.endswith('.dylib'):
             os.remove(f)
     chdir(pwd)
-    
+
+
 def make_mfem_wrapper(serial=True):
     '''
     compile PyMFEM wrapper code
     '''
     if dry_run or verbose:
-        print("compiling wrapper code, serial="+str(serial))
-    
+        print("compiling wrapper code, serial=" + str(serial))
+
     write_setup_local()
 
     if serial:
@@ -589,12 +627,13 @@ def make_mfem_wrapper(serial=True):
     make_call(command)
     os.chdir(pwd)
 
+
 def print_config():
     print("----configuration----")
     print(" prefix", prefix)
     print(" when needed, the dependency (mfem/hypre/metis) will be installed under " +
           prefix + "/mfem")
-    print(" build mfem : " + ("Yes" if build_mfem else "No"))        
+    print(" build mfem : " + ("Yes" if build_mfem else "No"))
     print(" build metis : " + ("Yes" if build_metis else "No"))
     print(" build hypre : " + ("Yes" if build_hypre else "No"))
     print(" call swig wrapper : " + ("Yes" if run_swig else "No"))
@@ -605,7 +644,8 @@ def print_config():
     print(" mpi-c compiler : " + mpicc_command)
     print(" mpi-c++ compiler : " + mpicxx_command)
     print("")
-    
+
+
 def configure_install(self):
     '''
     called when install workflow is used
@@ -639,7 +679,7 @@ def configure_install(self):
     metis_64 = bool(self.with_metis64)
     enable_pumi = bool(self.with_pumi)
     enable_strumpack = bool(self.with_strumpack)
-    enable_cuda = bool(self.with_cuda)    
+    enable_cuda = bool(self.with_cuda)
 
     if build_parallel:
         try:
@@ -658,9 +698,9 @@ def configure_install(self):
 
         check = find_libpath_from_prefix('mfem', mfems_prefix)
         assert check != '', "libmfem.so is not found in the specified <path>/lib"
-        check = find_libpath_from_prefix('mfem', mfemp_prefix)        
+        check = find_libpath_from_prefix('mfem', mfemp_prefix)
         assert check != '', "libmfem.so is not found in the specified <path>/lib"
-        
+
         build_mfem = False
         hypre_prefix = mfem_prefix
         metis_prefix = mfem_prefix
@@ -681,22 +721,26 @@ def configure_install(self):
         build_metis = build_parallel
         hypre_prefix = os.path.join(prefix, 'mfem')
         metis_prefix = os.path.join(prefix, 'mfem')
-        mfem_prefix  = os.path.join(prefix, 'mfem')
+        mfem_prefix = os.path.join(prefix, 'mfem')
         mfems_prefix = os.path.join(prefix, 'mfem', 'ser')
         mfemp_prefix = os.path.join(prefix, 'mfem', 'par')
 
     if self.hypre_prefix != '':
-       check = find_libpath_from_prefix('HYPRE', self.hypre_prefix)
-       assert check != '', "libHYPRE.so is not found in the specified <path>/lib or lib64"
-       hypre_prefix = self.hypre_prefix
+        check = find_libpath_from_prefix('HYPRE', self.hypre_prefix)
+        assert check != '', "libHYPRE.so is not found in the specified <path>/lib or lib64"
+        hypre_prefix = os.path.expanduser(self.hypre_prefix)
+        build_hypre = False
 
     if self.metis_prefix != '':
-       check = find_libpath_from_prefix('metis', self.metis_prefix)
-       assert check != '', "libmetis.so is not found in the specified <path>/lib or lib64"
-       metis_prefix = self.metis_prefix       
+        check = find_libpath_from_prefix('metis', self.metis_prefix)
+        assert check != '', "libmetis.so is not found in the specified <path>/lib or lib64"
+        metis_prefix = os.path.expanduser(self.metis_prefix)
+        build_metis = False
 
-    if enable_pumi: run_swig = True
-    if enable_strumpack : run_swig = True    
+    if enable_pumi:
+        run_swig = True
+    if enable_strumpack:
+        run_swig = True
     if self.pumi_prefix != '':
         pumi_prefix = abspath(self.pumi_prefix)
     else:
@@ -724,15 +768,16 @@ def configure_install(self):
         build_metis = False
         build_hypre = False
         build_mfem = False
-        build_mfemp = False        
+        build_mfemp = False
     if ext_only:
         clean_swig = False
         run_swig = False
         build_serial = False
         build_parallel = False
-    
+
     global is_configured
     is_configured = True
+
 
 def configure_bdist(self):
     '''
@@ -748,15 +793,15 @@ def configure_bdist(self):
     dry_run = bool(self.dry_run) if dry_run == -1 else dry_run
     verbose = bool(self.verbose) if verbose == -1 else verbose
 
-
     prefix = abspath(self.bdist_dir)
-    
+
     run_swig = False
     build_parallel = False
     build_serial = True
 
     global is_configured
     is_configured = True
+
 
 class Install(_install):
     '''
@@ -773,11 +818,11 @@ class Install(_install):
          'Need to use it with mfem-prefix'),
         ('mfems-prefix=', None, 'Specify locaiton of serial mfem ' +
          'libmfem.so must exits under <mfems-prefix>/lib. ',
-         'Need to use it with mfem-prefix'),        
+         'Need to use it with mfem-prefix'),
         ('mfem-prefix-no-swig', None, 'skip running swig when mfem-prefix is chosen'),
         ('hypre-prefix=', None, 'Specify locaiton of hypre' +
          'libHYPRE.so must exits under <hypre-prefix>/lib'),
-        ('metis-prefix=', None, 'Specify locaiton of metis'+
+        ('metis-prefix=', None, 'Specify locaiton of metis' +
          'libmetis.so must exits under <metis-prefix>/lib'),
         ('swig', None, 'Run Swig and exit'),
         ('ext-only', None, 'Build metis, hypre, mfem(C++) only'),
@@ -828,9 +873,9 @@ class Install(_install):
             assert False, "skip-ext and ext-only can not use together"
         _install.finalize_options(self)
         if (self.prefix == '' or
-            self.prefix is None):
+                self.prefix is None):
             self.prefix = install_prefix()
-        
+
     def run(self):
         if not is_configured:
             configure_install(self)
@@ -841,11 +886,13 @@ class Install(_install):
         else:
             _install.run(self)
 
+
 class BuildPy(_build_py):
     '''
     Called when python setup.py build_py
     '''
     user_options = _build_py.user_options
+
     def initialize_options(self):
         _build_py.initialize_options(self)
 
@@ -853,7 +900,7 @@ class BuildPy(_build_py):
         _build_py.finalize_options(self)
 
     def run(self):
-        if not swig_only:            
+        if not swig_only:
             if build_metis:
                 download('metis')
                 make_metis(use_int64=metis_64)
@@ -863,14 +910,14 @@ class BuildPy(_build_py):
             mfem_downloaded = False
             if build_mfem:
                 download('mfem')
-                mfem_downloaded = True                
+                mfem_downloaded = True
                 cmake_make_mfem(serial=True)
 
             if build_mfemp:
                 if not mfem_downloaded:
-                    download('mfem')                    
+                    download('mfem')
                 cmake_make_mfem(serial=False)
-                    
+
         if clean_swig:
             clean_wrapper()
         if run_swig:
@@ -883,50 +930,56 @@ class BuildPy(_build_py):
         if build_parallel:
             make_mfem_wrapper(serial=False)
         if not skip_install:
-           _build_py.run(self)
+            _build_py.run(self)
 
-class BdistWheel(_bdist_wheel):
-    '''
-    Wheel build performs serial+paralell
-    '''
-    def finalize_options(self):
-        def _has_ext_modules(self):
-            return True
-        from setuptools.dist import Distribution
-        #Distribution.is_pure = _is_pure
-        Distribution.has_ext_modules = _has_ext_modules
-        _bdist_wheel.finalize_options(self)
 
-    def run(self):
-        _bdist_wheel.run(self)        
-        assert False, "bdist install is not supported, use source install"
+if haveWheel:
+    class BdistWheel(_bdist_wheel):
         '''
-        if not is_configured:
-            print('running config')
-            configure_bdist(self)
-            print_config()
-            
-        # Ensure that there is a basic library build for bdist_egg to pull from.
-        self.run_command("build")
-        #_cleanup_symlinks(self)
-
-        # Run the default bdist_wheel command
+        Wheel build performs serial+paralell
         '''
-        
+
+        def finalize_options(self):
+            def _has_ext_modules(self):
+                return True
+            from setuptools.dist import Distribution
+            #Distribution.is_pure = _is_pure
+            Distribution.has_ext_modules = _has_ext_modules
+            _bdist_wheel.finalize_options(self)
+
+        def run(self):
+            _bdist_wheel.run(self)
+            assert False, "bdist install is not supported, use source install"
+            '''
+            if not is_configured:
+                print('running config')
+                configure_bdist(self)
+                print_config()
+
+            # Ensure that there is a basic library build for bdist_egg to pull from.
+            self.run_command("build")
+            #_cleanup_symlinks(self)
+
+            # Run the default bdist_wheel command
+            '''
+
+
 class InstallEggInfo(_install_egg_info):
     def run(self):
         if not dry_run:
             _install_egg_info.run(self)
         else:
             print("skipping regular install_egg_info")
-            
+
+
 class InstallScripts(_install_scripts):
     def run(self):
         if not dry_run:
             _install_scripts.run(self)
         else:
             print("skipping regular install_scripts")
-    
+
+
 class Clean(_clean):
     '''
     Called when python setup.py clean
@@ -936,9 +989,9 @@ class Clean(_clean):
         ('mfem', None, 'clean mfem'),
         ('metis', None, 'clean metis'),
         ('hypre', None, 'clean hypre'),
-        ('swig', None,  'clean swig'),        
+        ('swig', None, 'clean swig'),
         ('all-exts', None, 'delete all externals'),
-        ]
+    ]
 
     def initialize_options(self):
         _clean.initialize_options(self)
@@ -953,11 +1006,11 @@ class Clean(_clean):
         global dry_run, verbose
         dry_run = self.dry_run
         verbose = bool(self.verbose)
-        
+
         os.chdir(extdir)
 
         make_command = find_command('make')
-        
+
         if self.ext or self.mfem:
             path = os.path.join(extdir, 'mfem', 'cmbuild_par')
             if os.path.exists(path):
@@ -965,16 +1018,16 @@ class Clean(_clean):
             path = os.path.join(extdir, 'mfem', 'cmbuild_ser')
             if os.path.exists(path):
                 shutil.rmtree(path)
-        if self.ext or self.hypre:    
+        if self.ext or self.hypre:
             path = os.path.join(extdir, 'hypre', 'cmbuild')
             if os.path.exists(path):
                 shutil.rmtree(path)
         if self.ext or self.metis:
             path = os.path.join(extdir, 'metis')
             if os.path.exists(path):
-                os,chdir(path)
+                os, chdir(path)
                 command = ['make', 'clean']
-                subprocess.check_call(command)                
+                subprocess.check_call(command)
         if self.all_exts or self.hypre:
             for xxx in ('metis', 'hypre', 'mfem'):
                 path = os.path.join(extdir, xxx)
@@ -984,32 +1037,37 @@ class Clean(_clean):
             clean_wrapper()
 
         clean_so()
-        
+
         os.chdir(rootdir)
         _clean.run(self)
 
+
 datafiles = [os.path.join('data', f) for f in os.listdir('data')]
+
+
 def run_setup():
     setup_args = metadata.copy()
-
+    cmdclass = {'build_py': BuildPy,
+                'install': Install,
+                'install_egg_info': InstallEggInfo,
+                'install_scripts': InstallScripts,
+                'clean': Clean}
+    if haveWheel:
+        cmdclass['bdist_wheel'] = BdistWheel
     setup(
-        cmdclass = {'build_py': BuildPy,
-                    'install': Install,
-                    'install_egg_info': InstallEggInfo,
-                    'install_scripts': InstallScripts,
-                    'bdist_wheel': BdistWheel,
-                    'clean': Clean},
+        cmdclass=cmdclass,
         install_requires=[],
         packages=find_packages(),
         extras_require={},
-        package_data={'mfem._par':['*.so'], 'mfem._ser':['*.so']},
+        package_data={'mfem._par': ['*.so'], 'mfem._ser': ['*.so']},
         #data_files=[('data', datafiles)],
         entry_points={},
         **setup_args)
 
+
 def main():
     run_setup()
 
+
 if __name__ == '__main__':
     main()
-

--- a/setup.py
+++ b/setup.py
@@ -366,8 +366,8 @@ def cmake_make_mfem(serial=True):
         cmake_opts['DMETIS_DIR'] = os.path.join(metis_prefix)
         #cmake_opts['DCMAKE_CXX_STANDARD_LIBRARIES'] = "-lHYPRE -lmetis"
 
-        hyprelibpath = find_libpath_from_prefix('HYPRE', hypre_prefix)
-        metislibpath = find_libpath_from_prefix('metis', metis_prefix)            
+        hyprelibpath = os.path.dirname(find_libpath_from_prefix('HYPRE', hypre_prefix))
+        metislibpath = os.path.dirname(find_libpath_from_prefix('metis', metis_prefix))
         
         lflags = "-L" + metislibpath
         lflags = lflags + " -L" + hyprelibpath
@@ -407,8 +407,8 @@ def write_setup_local():
         mfemser = mfems_prefix
         mfempar = mfemp_prefix
 
-    hyprelibpath = find_libpath_from_prefix('HYPRE', hypre_prefix)
-    metislibpath = find_libpath_from_prefix('metis', metis_prefix)
+    hyprelibpath = os.path.dirname(find_libpath_from_prefix('HYPRE', hypre_prefix))
+    metislibpath = os.path.dirname(find_libpath_from_prefix('metis', metis_prefix))
     params = {'cxx_ser': cxx_command,
               'cc_ser': cc_command,
               'cxx_par': mpicxx_command,

--- a/setup.py
+++ b/setup.py
@@ -161,9 +161,14 @@ def install_prefix():
         ))
 
     for path in paths:
+        if verbose:
+            print("testing installation path", path)
         if os.path.exists(path):
             path = os.path.dirname(path)
             path = os.path.dirname(path)
+            path = os.path.dirname(path)
+            if verbose:
+                print("found this one", path)            
             return path
     assert False, "no installation path found"
     return None
@@ -872,9 +877,15 @@ class Install(_install):
         if (bool(self.ext_only) and bool(self.skip_ext)):
             assert False, "skip-ext and ext-only can not use together"
         _install.finalize_options(self)
+
+        global verbose
+        verbose = bool(self.verbose)
         if (self.prefix == '' or
                 self.prefix is None):
             self.prefix = install_prefix()
+        else:
+            if verbose:
+                print("prefix is given :", self.prefix)
 
     def run(self):
         if not is_configured:


### PR DESCRIPTION
This pull request addresses two pip install issue
* pip install w/o prefix failing due to the wrong libmfem.so location
* HYPRE and metis could be in lib64 instead of lib

- [x] test using TestPyPi
- [x] github actions
- [x] HYPRE 64bit lib

--user option will use prefix as follows (which seems reasonable...)
   /home/xxx/.local/ (on linux)
   /Users/xxx/Library/Python/3.8/ (on MacOS)