### PR TITLE
Istream ostream improvement

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -103,6 +103,7 @@ jobs:
         echo $PYTHONPATH
         if [ "${USE_CUDA_PARALLEL}" = "00" ]; then  
            python ../examples/ex1.py;
+           python ../examples/ex9.py;	   
         fi
         if [ "${USE_CUDA_PARALLEL}" = "01" ]; then
            which mpicc;

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -1,4 +1,9 @@
 	<<<  Change Log. >>>
+2021 05.07
+        * vtk.py and datacollection.py was loaded in mfem.ser and mfem.par namespace properly
+	* istream& wrapping was improved in the same way as ostream&
+	* mfem-4.2 does not have Save(const char*, precision) yet. Added it in wrapper code.
+	
 2021 04.30
         * improved std::ostream & wrappring. Methods which takes std::ostream& are
 	wrapped so that it accept either

--- a/docs/manual.txt
+++ b/docs/manual.txt
@@ -387,13 +387,14 @@ to find more details of the MFEM library.
 	 precision. Also, note that sock << flush in c++ should be rephrased
 	 sock.flush()
 	   
-   4-12) std::ostream&
+   4-12) std::ostream& and std::istream&
 
          methods which takes std::ostream& are wrapped so that it accept
 	 either
-	   1) filename (if it ends with .gz, it uses compression)
-	   2) mfem.STDOUT
-	   3) StringIO
+	   1) filename 
+	   2) compressed filename (when the filename ends with .gz)
+	   3) mfem.STDOUT
+	   4) StringIO
 
          (example)
             mesh.PrintVTK("mesh.vtk", 1)
@@ -410,7 +411,15 @@ to find more details of the MFEM library.
          (example)
 	    SparseMat::PrintInfo
 	    STable3D::Print
+
+         std::istream & is also wrapped in a similar way
+	   1) filename 
+	   2) compressed filename (when the filename ends with .gz)
+	   3) StringIO
+
+         See test/test_gz.py to see an example
        
+
    4-13) mfem::table
            GetRowList returns a version of GetRow which returns Python
 	   list instead of int pointer.

--- a/docs/manual.txt
+++ b/docs/manual.txt
@@ -391,7 +391,7 @@ to find more details of the MFEM library.
 
          methods which takes std::ostream& are wrapped so that it accept
 	 either
-	   1) filename
+	   1) filename (if it ends with .gz, it uses compression)
 	   2) mfem.STDOUT
 	   3) StringIO
 

--- a/examples/ex9.py
+++ b/examples/ex9.py
@@ -161,14 +161,11 @@ u.ProjectCoefficient(u0)
 mesh.Print('ex9.mesh', 8)
 u.Save('ex9-init.gf', 8)
 
-from  mfem._ser.vtk import VTKFormat_BINARY
-from  mfem._ser.datacollection import ParaViewDataCollection
-
-pd = ParaViewDataCollection("Example9", mesh)
+pd = mfem.ParaViewDataCollection("Example9", mesh)
 pd.SetPrefixPath("ParaView");
 pd.RegisterField("solution", u);
 pd.SetLevelsOfDetail(order);
-pd.SetDataFormat(VTKFormat_BINARY)
+pd.SetDataFormat(mfem.VTKFormat_BINARY)
 pd.SetHighOrderOutput(True)
 pd.SetCycle(0)
 pd.SetTime(0.0)

--- a/examples/ex9.py
+++ b/examples/ex9.py
@@ -4,10 +4,11 @@
       refinement loop. 
       See c++ version in the MFEM library for more detail 
 '''
+import os
 from mfem import path
 import mfem.ser as mfem
 from mfem.ser import intArray
-from os.path import expanduser, join
+from os.path import expanduser, join, dirname
 import numpy as np
 from numpy import sqrt, pi, cos, sin, hypot, arctan2
 from scipy.special import erfc
@@ -24,6 +25,7 @@ vis_steps = 5
 # 2. Read the mesh from the given mesh file. We can handle geometrically
 #    periodic meshes in this code.
 
+path = dirname(dirname(__file__))
 meshfile = expanduser(join(path, 'data', 'periodic-hexagon.mesh'))
 mesh = mfem.Mesh(meshfile, 1,1)
 dim = mesh.Dimension()
@@ -156,6 +158,8 @@ u.ProjectCoefficient(u0)
 
 mesh.Print('ex9.mesh', 8)
 u.Save('ex9-init.gf', 8)
+
+pd = mfem.ParaViewDataCollection()
 
 class FE_Evolution(mfem.PyTimeDependentOperator):
     def __init__(self, M, K, b):

--- a/examples/ex9p.py
+++ b/examples/ex9p.py
@@ -7,7 +7,7 @@
 from mfem import path
 import mfem.par as mfem
 from mfem.par import intArray
-from os.path import expanduser, join
+from os.path import expanduser, join, dirname, exists
 from mpi4py import MPI
 import numpy as np
 from numpy import sqrt, pi, cos, sin, hypot, arctan2
@@ -29,6 +29,10 @@ vis_steps = 5
 # 3. Read the serial mesh from the given mesh file on all processors. We can
 #    handle geometrically periodic meshes in this code.
 meshfile = expanduser(join(path, 'data', 'periodic-hexagon.mesh'))
+if not exists(meshfile):
+    path = dirname(dirname(__file__))
+    meshfile = expanduser(join(path, 'data', 'periodic-hexagon.mesh'))    
+
 mesh = mfem.Mesh(meshfile, 1,1)
 dim = mesh.Dimension()
 

--- a/mfem/__init__.py
+++ b/mfem/__init__.py
@@ -20,6 +20,6 @@ def debug_print(message):
 
     print(message)
 
-__version__ = '4.2.0.13'
+__version__ = '4.2.0.14'
 
 

--- a/mfem/_par/array.i
+++ b/mfem/_par/array.i
@@ -24,6 +24,7 @@ import_array();
 
 %import "../common/io_stream_typemap.i"
 OSTREAM_TYPEMAP(std::ostream&)
+ISTREAM_TYPEMAP(std::istream&)
 
 %import "mem_manager.i"
 

--- a/mfem/_par/array.i
+++ b/mfem/_par/array.i
@@ -7,7 +7,8 @@
 #include <fstream>  
 #include <iostream>
 #include <stdio.h>  
-#include "../common/io_stream.hpp"    
+#include "../common/io_stream.hpp"
+#include "general/zstr.hpp"  
 #include "general/array.hpp"
 #include "numpy/arrayobject.h"
 %}

--- a/mfem/_par/array_wrap.cxx
+++ b/mfem/_par/array_wrap.cxx
@@ -2783,7 +2783,8 @@ namespace swig {
 #include <fstream>  
 #include <iostream>
 #include <stdio.h>  
-#include "../common/io_stream.hpp"    
+#include "../common/io_stream.hpp"
+#include "general/zstr.hpp"  
 #include "general/array.hpp"
 #include "numpy/arrayobject.h"
 
@@ -5441,7 +5442,6 @@ SWIGINTERN PyObject *_wrap_intArray_Load__SWIG_0(PyObject *SWIGUNUSEDPARM(self),
   PyMFEM::wFILE *temp2 = 0 ;
   std::ifstream in_txt2 ;
   mfem::ifgzstream *in_gz2 = 0 ;
-  PyObject *input_str2 = 0 ;
   std::istringstream *stream2 = 0 ;
   Py_ssize_t len2 = 0 ;
   PyObject *ret2 = 0 ;
@@ -5476,18 +5476,18 @@ SWIGINTERN PyObject *_wrap_intArray_Load__SWIG_0(PyObject *SWIGUNUSEDPARM(self),
           return NULL;
         }
         
-        PyObject *input_str2 = PyObject_CallMethod(swig_obj[1], "getvalue", NULL);
+        PyObject *input_str = PyObject_CallMethod(swig_obj[1], "getvalue", NULL);
         if (PyErr_Occurred()) {
           PyErr_SetString(PyExc_RuntimeError, "Can not read from StringIO");
           return NULL;
         }
         
         char *buf = nullptr;
-        PyObject *str = PyUnicode_AsUTF8String(input_str2);	 
+        PyObject *str = PyUnicode_AsUTF8String(input_str);	 
         PyBytes_AsStringAndSize(str, &buf, &len2);
         stream2 = new std::istringstream(buf);
         Py_DECREF(str);
-        Py_DECREF(input_str2);	 
+        Py_DECREF(input_str);	 
       } else {
         // if it is string, extract filename as char*
         PyObject* str = PyUnicode_AsEncodedString(swig_obj[1], "utf-8", "~E~");	
@@ -5586,7 +5586,6 @@ SWIGINTERN PyObject *_wrap_intArray_Load__SWIG_1(PyObject *SWIGUNUSEDPARM(self),
   PyMFEM::wFILE *temp3 = 0 ;
   std::ifstream in_txt3 ;
   mfem::ifgzstream *in_gz3 = 0 ;
-  PyObject *input_str3 = 0 ;
   std::istringstream *stream3 = 0 ;
   Py_ssize_t len3 = 0 ;
   PyObject *ret3 = 0 ;
@@ -5624,18 +5623,18 @@ SWIGINTERN PyObject *_wrap_intArray_Load__SWIG_1(PyObject *SWIGUNUSEDPARM(self),
           return NULL;
         }
         
-        PyObject *input_str3 = PyObject_CallMethod(swig_obj[2], "getvalue", NULL);
+        PyObject *input_str = PyObject_CallMethod(swig_obj[2], "getvalue", NULL);
         if (PyErr_Occurred()) {
           PyErr_SetString(PyExc_RuntimeError, "Can not read from StringIO");
           return NULL;
         }
         
         char *buf = nullptr;
-        PyObject *str = PyUnicode_AsUTF8String(input_str3);	 
+        PyObject *str = PyUnicode_AsUTF8String(input_str);	 
         PyBytes_AsStringAndSize(str, &buf, &len3);
         stream3 = new std::istringstream(buf);
         Py_DECREF(str);
-        Py_DECREF(input_str3);	 
+        Py_DECREF(input_str);	 
       } else {
         // if it is string, extract filename as char*
         PyObject* str = PyUnicode_AsEncodedString(swig_obj[2], "utf-8", "~E~");	
@@ -6983,7 +6982,6 @@ SWIGINTERN PyObject *_wrap_intArray_Print(PyObject *self, PyObject *args) {
               _v = 0;	   	   	   
             }
           } else {
-            std::cout << "it is text (out)\n";	
             _v = 1;
           }
         } else {
@@ -7194,7 +7192,6 @@ SWIGINTERN PyObject *_wrap_intArray_Save(PyObject *self, PyObject *args) {
               _v = 0;	   	   	   
             }
           } else {
-            std::cout << "it is text (out)\n";	
             _v = 1;
           }
         } else {
@@ -9510,7 +9507,6 @@ SWIGINTERN PyObject *_wrap_doubleArray_Load__SWIG_0(PyObject *SWIGUNUSEDPARM(sel
   PyMFEM::wFILE *temp2 = 0 ;
   std::ifstream in_txt2 ;
   mfem::ifgzstream *in_gz2 = 0 ;
-  PyObject *input_str2 = 0 ;
   std::istringstream *stream2 = 0 ;
   Py_ssize_t len2 = 0 ;
   PyObject *ret2 = 0 ;
@@ -9545,18 +9541,18 @@ SWIGINTERN PyObject *_wrap_doubleArray_Load__SWIG_0(PyObject *SWIGUNUSEDPARM(sel
           return NULL;
         }
         
-        PyObject *input_str2 = PyObject_CallMethod(swig_obj[1], "getvalue", NULL);
+        PyObject *input_str = PyObject_CallMethod(swig_obj[1], "getvalue", NULL);
         if (PyErr_Occurred()) {
           PyErr_SetString(PyExc_RuntimeError, "Can not read from StringIO");
           return NULL;
         }
         
         char *buf = nullptr;
-        PyObject *str = PyUnicode_AsUTF8String(input_str2);	 
+        PyObject *str = PyUnicode_AsUTF8String(input_str);	 
         PyBytes_AsStringAndSize(str, &buf, &len2);
         stream2 = new std::istringstream(buf);
         Py_DECREF(str);
-        Py_DECREF(input_str2);	 
+        Py_DECREF(input_str);	 
       } else {
         // if it is string, extract filename as char*
         PyObject* str = PyUnicode_AsEncodedString(swig_obj[1], "utf-8", "~E~");	
@@ -9655,7 +9651,6 @@ SWIGINTERN PyObject *_wrap_doubleArray_Load__SWIG_1(PyObject *SWIGUNUSEDPARM(sel
   PyMFEM::wFILE *temp3 = 0 ;
   std::ifstream in_txt3 ;
   mfem::ifgzstream *in_gz3 = 0 ;
-  PyObject *input_str3 = 0 ;
   std::istringstream *stream3 = 0 ;
   Py_ssize_t len3 = 0 ;
   PyObject *ret3 = 0 ;
@@ -9693,18 +9688,18 @@ SWIGINTERN PyObject *_wrap_doubleArray_Load__SWIG_1(PyObject *SWIGUNUSEDPARM(sel
           return NULL;
         }
         
-        PyObject *input_str3 = PyObject_CallMethod(swig_obj[2], "getvalue", NULL);
+        PyObject *input_str = PyObject_CallMethod(swig_obj[2], "getvalue", NULL);
         if (PyErr_Occurred()) {
           PyErr_SetString(PyExc_RuntimeError, "Can not read from StringIO");
           return NULL;
         }
         
         char *buf = nullptr;
-        PyObject *str = PyUnicode_AsUTF8String(input_str3);	 
+        PyObject *str = PyUnicode_AsUTF8String(input_str);	 
         PyBytes_AsStringAndSize(str, &buf, &len3);
         stream3 = new std::istringstream(buf);
         Py_DECREF(str);
-        Py_DECREF(input_str3);	 
+        Py_DECREF(input_str);	 
       } else {
         // if it is string, extract filename as char*
         PyObject* str = PyUnicode_AsEncodedString(swig_obj[2], "utf-8", "~E~");	
@@ -11052,7 +11047,6 @@ SWIGINTERN PyObject *_wrap_doubleArray_Print(PyObject *self, PyObject *args) {
               _v = 0;	   	   	   
             }
           } else {
-            std::cout << "it is text (out)\n";	
             _v = 1;
           }
         } else {
@@ -11263,7 +11257,6 @@ SWIGINTERN PyObject *_wrap_doubleArray_Save(PyObject *self, PyObject *args) {
               _v = 0;	   	   	   
             }
           } else {
-            std::cout << "it is text (out)\n";	
             _v = 1;
           }
         } else {

--- a/mfem/_par/array_wrap.cxx
+++ b/mfem/_par/array_wrap.cxx
@@ -2675,9 +2675,8 @@ SWIGINTERN PyObject *SWIG_PyStaticMethod_New(PyObject *SWIGUNUSEDPARM(self), PyO
 #define SWIGTYPE_p_mfem__MemoryT_int_t swig_types[9]
 #define SWIGTYPE_p_p_double swig_types[10]
 #define SWIGTYPE_p_p_int swig_types[11]
-#define SWIGTYPE_p_std__istream swig_types[12]
-static swig_type_info *swig_types[14];
-static swig_module_info swig_module = {swig_types, 13, 0, 0, 0, 0};
+static swig_type_info *swig_types[13];
+static swig_module_info swig_module = {swig_types, 12, 0, 0, 0, 0};
 #define SWIG_TypeQuery(name) SWIG_TypeQueryModule(&swig_module, &swig_module, name)
 #define SWIG_MangledTypeQuery(name) SWIG_MangledTypeQueryModule(&swig_module, &swig_module, name)
 
@@ -5146,10 +5145,10 @@ SWIGINTERN PyObject *_wrap_intArray_Print__SWIG_0(PyObject *SWIGUNUSEDPARM(self)
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyMFEM::wFILE *temp2 = 0 ;
-  std::ofstream out2 ;
-  int use_stringio2 = 0 ;
+  std::ofstream out_txt2 ;
+  mfem::ofgzstream *out_gz2 = 0 ;
   PyObject *string_io2 = 0 ;
-  std::ostringstream stream2 ;
+  std::ostringstream *stream2 = 0 ;
   PyObject *ret2 = 0 ;
   int val3 ;
   int ecode3 = 0 ;
@@ -5182,29 +5181,33 @@ SWIGINTERN PyObject *_wrap_intArray_Print__SWIG_0(PyObject *SWIGUNUSEDPARM(self)
             SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
             return NULL;
           }
-          use_stringio2=1;
           string_io2=swig_obj[1];
+          stream2 = new std::ostringstream();
         } else {
           // if it is string, extract filename as char*
           PyObject* str = PyUnicode_AsEncodedString(swig_obj[1], "utf-8", "~E~");	
           const char* filename = PyBytes_AsString(str);
-          temp2 = new PyMFEM::wFILE(filename, 8, true);	
+          temp2 = new PyMFEM::wFILE(filename, 8, true);
+          Py_DECREF(str);	 
         }
       }
       
-      if (use_stringio2 == 0){
+      if (stream2 == 0){
         if (temp2->isSTDOUT() == 1) {
           arg2 = &std::cout;
+        } else if (temp2->isGZ()){
+          out_gz2 = new mfem::ofgzstream(temp2->getFilename(), true);
+          arg2 = out_gz2;	     
         } else {
-          out2.open(temp2->getFilename());
-          out2.precision(temp2->getPrecision());
-          if (temp2->isTemporary()){
-            delete temp2;
-          }
-          arg2 = &out2;
+          out_txt2.open(temp2->getFilename());
+          out_txt2.precision(temp2->getPrecision());
+          arg2 = &out_txt2;
+        }
+        if (temp2->isTemporary()){
+          delete temp2;
         }
       } else {
-        arg2 = &stream2;
+        arg2 = stream2;
       }
     }
   }
@@ -5233,8 +5236,8 @@ SWIGINTERN PyObject *_wrap_intArray_Print__SWIG_0(PyObject *SWIGUNUSEDPARM(self)
   }
   resultobj = SWIG_Py_Void();
   {
-    if (use_stringio2 == 1) {
-      std::string str =  stream2.str();
+    if (stream2) {
+      std::string str =  stream2->str();
       const char* s = str.c_str();
       const int n = str.length();
       ret2 = PyObject_CallMethod(string_io2, "write", "s#",
@@ -5243,15 +5246,21 @@ SWIGINTERN PyObject *_wrap_intArray_Print__SWIG_0(PyObject *SWIGUNUSEDPARM(self)
         PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
         return NULL;
       }
+      delete stream2;
       Py_XDECREF(resultobj);   /* Blow away any previous result */
       resultobj = ret2;    
     }
   }
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -5259,10 +5268,15 @@ SWIGINTERN PyObject *_wrap_intArray_Print__SWIG_0(PyObject *SWIGUNUSEDPARM(self)
   return resultobj;
 fail:
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -5279,10 +5293,10 @@ SWIGINTERN PyObject *_wrap_intArray_Save__SWIG_0(PyObject *SWIGUNUSEDPARM(self),
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyMFEM::wFILE *temp2 = 0 ;
-  std::ofstream out2 ;
-  int use_stringio2 = 0 ;
+  std::ofstream out_txt2 ;
+  mfem::ofgzstream *out_gz2 = 0 ;
   PyObject *string_io2 = 0 ;
-  std::ostringstream stream2 ;
+  std::ostringstream *stream2 = 0 ;
   PyObject *ret2 = 0 ;
   int val3 ;
   int ecode3 = 0 ;
@@ -5314,29 +5328,33 @@ SWIGINTERN PyObject *_wrap_intArray_Save__SWIG_0(PyObject *SWIGUNUSEDPARM(self),
           SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
           return NULL;
         }
-        use_stringio2=1;
         string_io2=swig_obj[1];
+        stream2 = new std::ostringstream();
       } else {
         // if it is string, extract filename as char*
         PyObject* str = PyUnicode_AsEncodedString(swig_obj[1], "utf-8", "~E~");	
         const char* filename = PyBytes_AsString(str);
-        temp2 = new PyMFEM::wFILE(filename, 8, true);	
+        temp2 = new PyMFEM::wFILE(filename, 8, true);
+        Py_DECREF(str);	 
       }
     }
     
-    if (use_stringio2 == 0){
+    if (stream2 == 0){
       if (temp2->isSTDOUT() == 1) {
         arg2 = &std::cout;
+      } else if (temp2->isGZ()){
+        out_gz2 = new mfem::ofgzstream(temp2->getFilename(), true);
+        arg2 = out_gz2;	     
       } else {
-        out2.open(temp2->getFilename());
-        out2.precision(temp2->getPrecision());
-        if (temp2->isTemporary()){
-          delete temp2;
-        }
-        arg2 = &out2;
+        out_txt2.open(temp2->getFilename());
+        out_txt2.precision(temp2->getPrecision());
+        arg2 = &out_txt2;
+      }
+      if (temp2->isTemporary()){
+        delete temp2;
       }
     } else {
-      arg2 = &stream2;
+      arg2 = stream2;
     }
   }
   if (swig_obj[2]) {
@@ -5364,8 +5382,8 @@ SWIGINTERN PyObject *_wrap_intArray_Save__SWIG_0(PyObject *SWIGUNUSEDPARM(self),
   }
   resultobj = SWIG_Py_Void();
   {
-    if (use_stringio2 == 1) {
-      std::string str =  stream2.str();
+    if (stream2) {
+      std::string str =  stream2->str();
       const char* s = str.c_str();
       const int n = str.length();
       ret2 = PyObject_CallMethod(string_io2, "write", "s#",
@@ -5374,15 +5392,21 @@ SWIGINTERN PyObject *_wrap_intArray_Save__SWIG_0(PyObject *SWIGUNUSEDPARM(self),
         PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
         return NULL;
       }
+      delete stream2;
       Py_XDECREF(resultobj);   /* Blow away any previous result */
       resultobj = ret2;    
     }
   }
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -5390,10 +5414,15 @@ SWIGINTERN PyObject *_wrap_intArray_Save__SWIG_0(PyObject *SWIGUNUSEDPARM(self),
   return resultobj;
 fail:
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -5409,8 +5438,13 @@ SWIGINTERN PyObject *_wrap_intArray_Load__SWIG_0(PyObject *SWIGUNUSEDPARM(self),
   int arg3 = (int) 0 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
-  void *argp2 = 0 ;
-  int res2 = 0 ;
+  PyMFEM::wFILE *temp2 = 0 ;
+  std::ifstream in_txt2 ;
+  mfem::ifgzstream *in_gz2 = 0 ;
+  PyObject *input_str2 = 0 ;
+  std::istringstream *stream2 = 0 ;
+  Py_ssize_t len2 = 0 ;
+  PyObject *ret2 = 0 ;
   int val3 ;
   int ecode3 = 0 ;
   
@@ -5420,14 +5454,64 @@ SWIGINTERN PyObject *_wrap_intArray_Load__SWIG_0(PyObject *SWIGUNUSEDPARM(self),
     SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "intArray_Load" "', argument " "1"" of type '" "mfem::Array< int > *""'"); 
   }
   arg1 = reinterpret_cast< mfem::Array< int > * >(argp1);
-  res2 = SWIG_ConvertPtr(swig_obj[1], &argp2, SWIGTYPE_p_std__istream,  0 );
-  if (!SWIG_IsOK(res2)) {
-    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "intArray_Load" "', argument " "2"" of type '" "std::istream &""'"); 
+  {
+    //  PyMFEM::wFILE or string argument or StringIO
+    if (SWIG_ConvertPtr(swig_obj[1], (void **) &temp2, SWIGTYPE_p_PyMFEM__wFILE, 0 | 0) == -1) {
+      if (!PyString_Check(swig_obj[1]) && !PyUnicode_Check(swig_obj[1])) {
+        // not string, check if it is StringIO
+        PyObject* module = PyImport_ImportModule("io");
+        if (!module){
+          PyErr_SetString(PyExc_RuntimeError, "Can not load io module");
+          return NULL;
+        }      
+        PyObject* cls = PyObject_GetAttrString(module, "StringIO");
+        if (!cls){
+          PyErr_SetString(PyExc_RuntimeError, "Can not load StringIO");
+          return NULL;
+        }      
+        int check = PyObject_IsInstance(swig_obj[1], cls);
+        Py_DECREF(module);
+        if (! check){
+          SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
+          return NULL;
+        }
+        
+        PyObject *input_str2 = PyObject_CallMethod(swig_obj[1], "getvalue", NULL);
+        if (PyErr_Occurred()) {
+          PyErr_SetString(PyExc_RuntimeError, "Can not read from StringIO");
+          return NULL;
+        }
+        
+        char *buf = nullptr;
+        PyObject *str = PyUnicode_AsUTF8String(input_str2);	 
+        PyBytes_AsStringAndSize(str, &buf, &len2);
+        stream2 = new std::istringstream(buf);
+        Py_DECREF(str);
+        Py_DECREF(input_str2);	 
+      } else {
+        // if it is string, extract filename as char*
+        PyObject* str = PyUnicode_AsEncodedString(swig_obj[1], "utf-8", "~E~");	
+        const char* filename = PyBytes_AsString(str);
+        temp2 = new PyMFEM::wFILE(filename, 8, true);
+        Py_DECREF(str);
+      }
+    }
+    if (stream2 == 0){
+      if (temp2->isGZ()){
+        in_gz2 = new mfem::ifgzstream(temp2->getFilename());
+        arg2 = in_gz2;
+      } else {
+        in_txt2.open(temp2->getFilename(), std::ifstream::in);
+        in_txt2.precision(temp2->getPrecision());
+        arg2 = &in_txt2;
+      }
+      if (temp2->isTemporary()){
+        delete temp2;
+      }
+    } else {
+      arg2 = stream2;
+    }
   }
-  if (!argp2) {
-    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "intArray_Load" "', argument " "2"" of type '" "std::istream &""'"); 
-  }
-  arg2 = reinterpret_cast< std::istream * >(argp2);
   if (swig_obj[2]) {
     ecode3 = SWIG_AsVal_int(swig_obj[2], &val3);
     if (!SWIG_IsOK(ecode3)) {
@@ -5452,8 +5536,40 @@ SWIGINTERN PyObject *_wrap_intArray_Load__SWIG_0(PyObject *SWIGUNUSEDPARM(self),
     }	 
   }
   resultobj = SWIG_Py_Void();
+  {
+    if (stream2) {
+      ret2 = PyLong_FromSsize_t(len2);
+      if (PyErr_Occurred()) {
+        PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
+        return NULL;
+      }
+      delete stream2;    
+      Py_XDECREF(resultobj);   /* Blow away any previous result */
+      resultobj = ret2;    
+    }
+  }
+  {
+    if (!stream2) {
+      if (temp2) {
+        in_txt2.close();
+      }
+      if (in_gz2){
+        delete in_gz2;
+      }
+    }  
+  }
   return resultobj;
 fail:
+  {
+    if (!stream2) {
+      if (temp2) {
+        in_txt2.close();
+      }
+      if (in_gz2){
+        delete in_gz2;
+      }
+    }  
+  }
   return NULL;
 }
 
@@ -5467,8 +5583,13 @@ SWIGINTERN PyObject *_wrap_intArray_Load__SWIG_1(PyObject *SWIGUNUSEDPARM(self),
   int res1 = 0 ;
   int val2 ;
   int ecode2 = 0 ;
-  void *argp3 = 0 ;
-  int res3 = 0 ;
+  PyMFEM::wFILE *temp3 = 0 ;
+  std::ifstream in_txt3 ;
+  mfem::ifgzstream *in_gz3 = 0 ;
+  PyObject *input_str3 = 0 ;
+  std::istringstream *stream3 = 0 ;
+  Py_ssize_t len3 = 0 ;
+  PyObject *ret3 = 0 ;
   
   if ((nobjs < 3) || (nobjs > 3)) SWIG_fail;
   res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_mfem__ArrayT_int_t, 0 |  0 );
@@ -5481,14 +5602,64 @@ SWIGINTERN PyObject *_wrap_intArray_Load__SWIG_1(PyObject *SWIGUNUSEDPARM(self),
     SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "intArray_Load" "', argument " "2"" of type '" "int""'");
   } 
   arg2 = static_cast< int >(val2);
-  res3 = SWIG_ConvertPtr(swig_obj[2], &argp3, SWIGTYPE_p_std__istream,  0 );
-  if (!SWIG_IsOK(res3)) {
-    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "intArray_Load" "', argument " "3"" of type '" "std::istream &""'"); 
+  {
+    //  PyMFEM::wFILE or string argument or StringIO
+    if (SWIG_ConvertPtr(swig_obj[2], (void **) &temp3, SWIGTYPE_p_PyMFEM__wFILE, 0 | 0) == -1) {
+      if (!PyString_Check(swig_obj[2]) && !PyUnicode_Check(swig_obj[2])) {
+        // not string, check if it is StringIO
+        PyObject* module = PyImport_ImportModule("io");
+        if (!module){
+          PyErr_SetString(PyExc_RuntimeError, "Can not load io module");
+          return NULL;
+        }      
+        PyObject* cls = PyObject_GetAttrString(module, "StringIO");
+        if (!cls){
+          PyErr_SetString(PyExc_RuntimeError, "Can not load StringIO");
+          return NULL;
+        }      
+        int check = PyObject_IsInstance(swig_obj[2], cls);
+        Py_DECREF(module);
+        if (! check){
+          SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
+          return NULL;
+        }
+        
+        PyObject *input_str3 = PyObject_CallMethod(swig_obj[2], "getvalue", NULL);
+        if (PyErr_Occurred()) {
+          PyErr_SetString(PyExc_RuntimeError, "Can not read from StringIO");
+          return NULL;
+        }
+        
+        char *buf = nullptr;
+        PyObject *str = PyUnicode_AsUTF8String(input_str3);	 
+        PyBytes_AsStringAndSize(str, &buf, &len3);
+        stream3 = new std::istringstream(buf);
+        Py_DECREF(str);
+        Py_DECREF(input_str3);	 
+      } else {
+        // if it is string, extract filename as char*
+        PyObject* str = PyUnicode_AsEncodedString(swig_obj[2], "utf-8", "~E~");	
+        const char* filename = PyBytes_AsString(str);
+        temp3 = new PyMFEM::wFILE(filename, 8, true);
+        Py_DECREF(str);
+      }
+    }
+    if (stream3 == 0){
+      if (temp3->isGZ()){
+        in_gz3 = new mfem::ifgzstream(temp3->getFilename());
+        arg3 = in_gz3;
+      } else {
+        in_txt3.open(temp3->getFilename(), std::ifstream::in);
+        in_txt3.precision(temp3->getPrecision());
+        arg3 = &in_txt3;
+      }
+      if (temp3->isTemporary()){
+        delete temp3;
+      }
+    } else {
+      arg3 = stream3;
+    }
   }
-  if (!argp3) {
-    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "intArray_Load" "', argument " "3"" of type '" "std::istream &""'"); 
-  }
-  arg3 = reinterpret_cast< std::istream * >(argp3);
   {
     try {
       (arg1)->Load(arg2,*arg3);
@@ -5506,8 +5677,40 @@ SWIGINTERN PyObject *_wrap_intArray_Load__SWIG_1(PyObject *SWIGUNUSEDPARM(self),
     }	 
   }
   resultobj = SWIG_Py_Void();
+  {
+    if (stream3) {
+      ret3 = PyLong_FromSsize_t(len3);
+      if (PyErr_Occurred()) {
+        PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
+        return NULL;
+      }
+      delete stream3;    
+      Py_XDECREF(resultobj);   /* Blow away any previous result */
+      resultobj = ret3;    
+    }
+  }
+  {
+    if (!stream3) {
+      if (temp3) {
+        in_txt3.close();
+      }
+      if (in_gz3){
+        delete in_gz3;
+      }
+    }  
+  }
   return resultobj;
 fail:
+  {
+    if (!stream3) {
+      if (temp3) {
+        in_txt3.close();
+      }
+      if (in_gz3){
+        delete in_gz3;
+      }
+    }  
+  }
   return NULL;
 }
 
@@ -5526,9 +5729,34 @@ SWIGINTERN PyObject *_wrap_intArray_Load(PyObject *self, PyObject *args) {
     int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_mfem__ArrayT_int_t, 0);
     _v = SWIG_CheckState(res);
     if (_v) {
-      void *vptr = 0;
-      int res = SWIG_ConvertPtr(argv[1], &vptr, SWIGTYPE_p_std__istream, SWIG_POINTER_NO_NULL);
-      _v = SWIG_CheckState(res);
+      {
+        void *ptr;
+        //std::string *ptr2 = (std::string *)0;
+        if (SWIG_ConvertPtr(argv[1], (void **) &ptr, SWIGTYPE_p_PyMFEM__wFILE, 0 |0) == -1) {
+          PyErr_Clear();
+          if (!PyString_Check(argv[1]) && !PyUnicode_Check(argv[1])) {
+            // not string
+            _v = 1;	   	
+            PyObject* module = PyImport_ImportModule("io");
+            if (!module){
+              _v = 0;	   
+            }      
+            PyObject* cls = PyObject_GetAttrString(module, "StringIO");
+            if (!cls){
+              _v = 0;	   	   
+            }      
+            int check = PyObject_IsInstance(argv[1], cls);
+            Py_DECREF(module);
+            if (! check){
+              _v = 0;	   	   	   
+            }
+          } else {
+            _v = 1;
+          }
+        } else {
+          _v = 1;
+        }
+      }
       if (_v) {
         if (argc <= 2) {
           return _wrap_intArray_Load__SWIG_0(self, argc, argv);
@@ -5554,9 +5782,34 @@ SWIGINTERN PyObject *_wrap_intArray_Load(PyObject *self, PyObject *args) {
         _v = SWIG_CheckState(res);
       }
       if (_v) {
-        void *vptr = 0;
-        int res = SWIG_ConvertPtr(argv[2], &vptr, SWIGTYPE_p_std__istream, SWIG_POINTER_NO_NULL);
-        _v = SWIG_CheckState(res);
+        {
+          void *ptr;
+          //std::string *ptr2 = (std::string *)0;
+          if (SWIG_ConvertPtr(argv[2], (void **) &ptr, SWIGTYPE_p_PyMFEM__wFILE, 0 |0) == -1) {
+            PyErr_Clear();
+            if (!PyString_Check(argv[2]) && !PyUnicode_Check(argv[2])) {
+              // not string
+              _v = 1;	   	
+              PyObject* module = PyImport_ImportModule("io");
+              if (!module){
+                _v = 0;	   
+              }      
+              PyObject* cls = PyObject_GetAttrString(module, "StringIO");
+              if (!cls){
+                _v = 0;	   	   
+              }      
+              int check = PyObject_IsInstance(argv[2], cls);
+              Py_DECREF(module);
+              if (! check){
+                _v = 0;	   	   	   
+              }
+            } else {
+              _v = 1;
+            }
+          } else {
+            _v = 1;
+          }
+        }
         if (_v) {
           return _wrap_intArray_Load__SWIG_1(self, argc, argv);
         }
@@ -6730,7 +6983,8 @@ SWIGINTERN PyObject *_wrap_intArray_Print(PyObject *self, PyObject *args) {
               _v = 0;	   	   	   
             }
           } else {
-            _v = 0;
+            std::cout << "it is text (out)\n";	
+            _v = 1;
           }
         } else {
           _v = 1;
@@ -6940,7 +7194,8 @@ SWIGINTERN PyObject *_wrap_intArray_Save(PyObject *self, PyObject *args) {
               _v = 0;	   	   	   
             }
           } else {
-            _v = 0;
+            std::cout << "it is text (out)\n";	
+            _v = 1;
           }
         } else {
           _v = 1;
@@ -8959,10 +9214,10 @@ SWIGINTERN PyObject *_wrap_doubleArray_Print__SWIG_0(PyObject *SWIGUNUSEDPARM(se
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyMFEM::wFILE *temp2 = 0 ;
-  std::ofstream out2 ;
-  int use_stringio2 = 0 ;
+  std::ofstream out_txt2 ;
+  mfem::ofgzstream *out_gz2 = 0 ;
   PyObject *string_io2 = 0 ;
-  std::ostringstream stream2 ;
+  std::ostringstream *stream2 = 0 ;
   PyObject *ret2 = 0 ;
   int val3 ;
   int ecode3 = 0 ;
@@ -8995,29 +9250,33 @@ SWIGINTERN PyObject *_wrap_doubleArray_Print__SWIG_0(PyObject *SWIGUNUSEDPARM(se
             SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
             return NULL;
           }
-          use_stringio2=1;
           string_io2=swig_obj[1];
+          stream2 = new std::ostringstream();
         } else {
           // if it is string, extract filename as char*
           PyObject* str = PyUnicode_AsEncodedString(swig_obj[1], "utf-8", "~E~");	
           const char* filename = PyBytes_AsString(str);
-          temp2 = new PyMFEM::wFILE(filename, 8, true);	
+          temp2 = new PyMFEM::wFILE(filename, 8, true);
+          Py_DECREF(str);	 
         }
       }
       
-      if (use_stringio2 == 0){
+      if (stream2 == 0){
         if (temp2->isSTDOUT() == 1) {
           arg2 = &std::cout;
+        } else if (temp2->isGZ()){
+          out_gz2 = new mfem::ofgzstream(temp2->getFilename(), true);
+          arg2 = out_gz2;	     
         } else {
-          out2.open(temp2->getFilename());
-          out2.precision(temp2->getPrecision());
-          if (temp2->isTemporary()){
-            delete temp2;
-          }
-          arg2 = &out2;
+          out_txt2.open(temp2->getFilename());
+          out_txt2.precision(temp2->getPrecision());
+          arg2 = &out_txt2;
+        }
+        if (temp2->isTemporary()){
+          delete temp2;
         }
       } else {
-        arg2 = &stream2;
+        arg2 = stream2;
       }
     }
   }
@@ -9046,8 +9305,8 @@ SWIGINTERN PyObject *_wrap_doubleArray_Print__SWIG_0(PyObject *SWIGUNUSEDPARM(se
   }
   resultobj = SWIG_Py_Void();
   {
-    if (use_stringio2 == 1) {
-      std::string str =  stream2.str();
+    if (stream2) {
+      std::string str =  stream2->str();
       const char* s = str.c_str();
       const int n = str.length();
       ret2 = PyObject_CallMethod(string_io2, "write", "s#",
@@ -9056,15 +9315,21 @@ SWIGINTERN PyObject *_wrap_doubleArray_Print__SWIG_0(PyObject *SWIGUNUSEDPARM(se
         PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
         return NULL;
       }
+      delete stream2;
       Py_XDECREF(resultobj);   /* Blow away any previous result */
       resultobj = ret2;    
     }
   }
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -9072,10 +9337,15 @@ SWIGINTERN PyObject *_wrap_doubleArray_Print__SWIG_0(PyObject *SWIGUNUSEDPARM(se
   return resultobj;
 fail:
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -9092,10 +9362,10 @@ SWIGINTERN PyObject *_wrap_doubleArray_Save__SWIG_0(PyObject *SWIGUNUSEDPARM(sel
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyMFEM::wFILE *temp2 = 0 ;
-  std::ofstream out2 ;
-  int use_stringio2 = 0 ;
+  std::ofstream out_txt2 ;
+  mfem::ofgzstream *out_gz2 = 0 ;
   PyObject *string_io2 = 0 ;
-  std::ostringstream stream2 ;
+  std::ostringstream *stream2 = 0 ;
   PyObject *ret2 = 0 ;
   int val3 ;
   int ecode3 = 0 ;
@@ -9127,29 +9397,33 @@ SWIGINTERN PyObject *_wrap_doubleArray_Save__SWIG_0(PyObject *SWIGUNUSEDPARM(sel
           SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
           return NULL;
         }
-        use_stringio2=1;
         string_io2=swig_obj[1];
+        stream2 = new std::ostringstream();
       } else {
         // if it is string, extract filename as char*
         PyObject* str = PyUnicode_AsEncodedString(swig_obj[1], "utf-8", "~E~");	
         const char* filename = PyBytes_AsString(str);
-        temp2 = new PyMFEM::wFILE(filename, 8, true);	
+        temp2 = new PyMFEM::wFILE(filename, 8, true);
+        Py_DECREF(str);	 
       }
     }
     
-    if (use_stringio2 == 0){
+    if (stream2 == 0){
       if (temp2->isSTDOUT() == 1) {
         arg2 = &std::cout;
+      } else if (temp2->isGZ()){
+        out_gz2 = new mfem::ofgzstream(temp2->getFilename(), true);
+        arg2 = out_gz2;	     
       } else {
-        out2.open(temp2->getFilename());
-        out2.precision(temp2->getPrecision());
-        if (temp2->isTemporary()){
-          delete temp2;
-        }
-        arg2 = &out2;
+        out_txt2.open(temp2->getFilename());
+        out_txt2.precision(temp2->getPrecision());
+        arg2 = &out_txt2;
+      }
+      if (temp2->isTemporary()){
+        delete temp2;
       }
     } else {
-      arg2 = &stream2;
+      arg2 = stream2;
     }
   }
   if (swig_obj[2]) {
@@ -9177,8 +9451,8 @@ SWIGINTERN PyObject *_wrap_doubleArray_Save__SWIG_0(PyObject *SWIGUNUSEDPARM(sel
   }
   resultobj = SWIG_Py_Void();
   {
-    if (use_stringio2 == 1) {
-      std::string str =  stream2.str();
+    if (stream2) {
+      std::string str =  stream2->str();
       const char* s = str.c_str();
       const int n = str.length();
       ret2 = PyObject_CallMethod(string_io2, "write", "s#",
@@ -9187,15 +9461,21 @@ SWIGINTERN PyObject *_wrap_doubleArray_Save__SWIG_0(PyObject *SWIGUNUSEDPARM(sel
         PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
         return NULL;
       }
+      delete stream2;
       Py_XDECREF(resultobj);   /* Blow away any previous result */
       resultobj = ret2;    
     }
   }
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -9203,10 +9483,15 @@ SWIGINTERN PyObject *_wrap_doubleArray_Save__SWIG_0(PyObject *SWIGUNUSEDPARM(sel
   return resultobj;
 fail:
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -9222,8 +9507,13 @@ SWIGINTERN PyObject *_wrap_doubleArray_Load__SWIG_0(PyObject *SWIGUNUSEDPARM(sel
   int arg3 = (int) 0 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
-  void *argp2 = 0 ;
-  int res2 = 0 ;
+  PyMFEM::wFILE *temp2 = 0 ;
+  std::ifstream in_txt2 ;
+  mfem::ifgzstream *in_gz2 = 0 ;
+  PyObject *input_str2 = 0 ;
+  std::istringstream *stream2 = 0 ;
+  Py_ssize_t len2 = 0 ;
+  PyObject *ret2 = 0 ;
   int val3 ;
   int ecode3 = 0 ;
   
@@ -9233,14 +9523,64 @@ SWIGINTERN PyObject *_wrap_doubleArray_Load__SWIG_0(PyObject *SWIGUNUSEDPARM(sel
     SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "doubleArray_Load" "', argument " "1"" of type '" "mfem::Array< double > *""'"); 
   }
   arg1 = reinterpret_cast< mfem::Array< double > * >(argp1);
-  res2 = SWIG_ConvertPtr(swig_obj[1], &argp2, SWIGTYPE_p_std__istream,  0 );
-  if (!SWIG_IsOK(res2)) {
-    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "doubleArray_Load" "', argument " "2"" of type '" "std::istream &""'"); 
+  {
+    //  PyMFEM::wFILE or string argument or StringIO
+    if (SWIG_ConvertPtr(swig_obj[1], (void **) &temp2, SWIGTYPE_p_PyMFEM__wFILE, 0 | 0) == -1) {
+      if (!PyString_Check(swig_obj[1]) && !PyUnicode_Check(swig_obj[1])) {
+        // not string, check if it is StringIO
+        PyObject* module = PyImport_ImportModule("io");
+        if (!module){
+          PyErr_SetString(PyExc_RuntimeError, "Can not load io module");
+          return NULL;
+        }      
+        PyObject* cls = PyObject_GetAttrString(module, "StringIO");
+        if (!cls){
+          PyErr_SetString(PyExc_RuntimeError, "Can not load StringIO");
+          return NULL;
+        }      
+        int check = PyObject_IsInstance(swig_obj[1], cls);
+        Py_DECREF(module);
+        if (! check){
+          SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
+          return NULL;
+        }
+        
+        PyObject *input_str2 = PyObject_CallMethod(swig_obj[1], "getvalue", NULL);
+        if (PyErr_Occurred()) {
+          PyErr_SetString(PyExc_RuntimeError, "Can not read from StringIO");
+          return NULL;
+        }
+        
+        char *buf = nullptr;
+        PyObject *str = PyUnicode_AsUTF8String(input_str2);	 
+        PyBytes_AsStringAndSize(str, &buf, &len2);
+        stream2 = new std::istringstream(buf);
+        Py_DECREF(str);
+        Py_DECREF(input_str2);	 
+      } else {
+        // if it is string, extract filename as char*
+        PyObject* str = PyUnicode_AsEncodedString(swig_obj[1], "utf-8", "~E~");	
+        const char* filename = PyBytes_AsString(str);
+        temp2 = new PyMFEM::wFILE(filename, 8, true);
+        Py_DECREF(str);
+      }
+    }
+    if (stream2 == 0){
+      if (temp2->isGZ()){
+        in_gz2 = new mfem::ifgzstream(temp2->getFilename());
+        arg2 = in_gz2;
+      } else {
+        in_txt2.open(temp2->getFilename(), std::ifstream::in);
+        in_txt2.precision(temp2->getPrecision());
+        arg2 = &in_txt2;
+      }
+      if (temp2->isTemporary()){
+        delete temp2;
+      }
+    } else {
+      arg2 = stream2;
+    }
   }
-  if (!argp2) {
-    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "doubleArray_Load" "', argument " "2"" of type '" "std::istream &""'"); 
-  }
-  arg2 = reinterpret_cast< std::istream * >(argp2);
   if (swig_obj[2]) {
     ecode3 = SWIG_AsVal_int(swig_obj[2], &val3);
     if (!SWIG_IsOK(ecode3)) {
@@ -9265,8 +9605,40 @@ SWIGINTERN PyObject *_wrap_doubleArray_Load__SWIG_0(PyObject *SWIGUNUSEDPARM(sel
     }	 
   }
   resultobj = SWIG_Py_Void();
+  {
+    if (stream2) {
+      ret2 = PyLong_FromSsize_t(len2);
+      if (PyErr_Occurred()) {
+        PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
+        return NULL;
+      }
+      delete stream2;    
+      Py_XDECREF(resultobj);   /* Blow away any previous result */
+      resultobj = ret2;    
+    }
+  }
+  {
+    if (!stream2) {
+      if (temp2) {
+        in_txt2.close();
+      }
+      if (in_gz2){
+        delete in_gz2;
+      }
+    }  
+  }
   return resultobj;
 fail:
+  {
+    if (!stream2) {
+      if (temp2) {
+        in_txt2.close();
+      }
+      if (in_gz2){
+        delete in_gz2;
+      }
+    }  
+  }
   return NULL;
 }
 
@@ -9280,8 +9652,13 @@ SWIGINTERN PyObject *_wrap_doubleArray_Load__SWIG_1(PyObject *SWIGUNUSEDPARM(sel
   int res1 = 0 ;
   int val2 ;
   int ecode2 = 0 ;
-  void *argp3 = 0 ;
-  int res3 = 0 ;
+  PyMFEM::wFILE *temp3 = 0 ;
+  std::ifstream in_txt3 ;
+  mfem::ifgzstream *in_gz3 = 0 ;
+  PyObject *input_str3 = 0 ;
+  std::istringstream *stream3 = 0 ;
+  Py_ssize_t len3 = 0 ;
+  PyObject *ret3 = 0 ;
   
   if ((nobjs < 3) || (nobjs > 3)) SWIG_fail;
   res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_mfem__ArrayT_double_t, 0 |  0 );
@@ -9294,14 +9671,64 @@ SWIGINTERN PyObject *_wrap_doubleArray_Load__SWIG_1(PyObject *SWIGUNUSEDPARM(sel
     SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "doubleArray_Load" "', argument " "2"" of type '" "int""'");
   } 
   arg2 = static_cast< int >(val2);
-  res3 = SWIG_ConvertPtr(swig_obj[2], &argp3, SWIGTYPE_p_std__istream,  0 );
-  if (!SWIG_IsOK(res3)) {
-    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "doubleArray_Load" "', argument " "3"" of type '" "std::istream &""'"); 
+  {
+    //  PyMFEM::wFILE or string argument or StringIO
+    if (SWIG_ConvertPtr(swig_obj[2], (void **) &temp3, SWIGTYPE_p_PyMFEM__wFILE, 0 | 0) == -1) {
+      if (!PyString_Check(swig_obj[2]) && !PyUnicode_Check(swig_obj[2])) {
+        // not string, check if it is StringIO
+        PyObject* module = PyImport_ImportModule("io");
+        if (!module){
+          PyErr_SetString(PyExc_RuntimeError, "Can not load io module");
+          return NULL;
+        }      
+        PyObject* cls = PyObject_GetAttrString(module, "StringIO");
+        if (!cls){
+          PyErr_SetString(PyExc_RuntimeError, "Can not load StringIO");
+          return NULL;
+        }      
+        int check = PyObject_IsInstance(swig_obj[2], cls);
+        Py_DECREF(module);
+        if (! check){
+          SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
+          return NULL;
+        }
+        
+        PyObject *input_str3 = PyObject_CallMethod(swig_obj[2], "getvalue", NULL);
+        if (PyErr_Occurred()) {
+          PyErr_SetString(PyExc_RuntimeError, "Can not read from StringIO");
+          return NULL;
+        }
+        
+        char *buf = nullptr;
+        PyObject *str = PyUnicode_AsUTF8String(input_str3);	 
+        PyBytes_AsStringAndSize(str, &buf, &len3);
+        stream3 = new std::istringstream(buf);
+        Py_DECREF(str);
+        Py_DECREF(input_str3);	 
+      } else {
+        // if it is string, extract filename as char*
+        PyObject* str = PyUnicode_AsEncodedString(swig_obj[2], "utf-8", "~E~");	
+        const char* filename = PyBytes_AsString(str);
+        temp3 = new PyMFEM::wFILE(filename, 8, true);
+        Py_DECREF(str);
+      }
+    }
+    if (stream3 == 0){
+      if (temp3->isGZ()){
+        in_gz3 = new mfem::ifgzstream(temp3->getFilename());
+        arg3 = in_gz3;
+      } else {
+        in_txt3.open(temp3->getFilename(), std::ifstream::in);
+        in_txt3.precision(temp3->getPrecision());
+        arg3 = &in_txt3;
+      }
+      if (temp3->isTemporary()){
+        delete temp3;
+      }
+    } else {
+      arg3 = stream3;
+    }
   }
-  if (!argp3) {
-    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "doubleArray_Load" "', argument " "3"" of type '" "std::istream &""'"); 
-  }
-  arg3 = reinterpret_cast< std::istream * >(argp3);
   {
     try {
       (arg1)->Load(arg2,*arg3);
@@ -9319,8 +9746,40 @@ SWIGINTERN PyObject *_wrap_doubleArray_Load__SWIG_1(PyObject *SWIGUNUSEDPARM(sel
     }	 
   }
   resultobj = SWIG_Py_Void();
+  {
+    if (stream3) {
+      ret3 = PyLong_FromSsize_t(len3);
+      if (PyErr_Occurred()) {
+        PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
+        return NULL;
+      }
+      delete stream3;    
+      Py_XDECREF(resultobj);   /* Blow away any previous result */
+      resultobj = ret3;    
+    }
+  }
+  {
+    if (!stream3) {
+      if (temp3) {
+        in_txt3.close();
+      }
+      if (in_gz3){
+        delete in_gz3;
+      }
+    }  
+  }
   return resultobj;
 fail:
+  {
+    if (!stream3) {
+      if (temp3) {
+        in_txt3.close();
+      }
+      if (in_gz3){
+        delete in_gz3;
+      }
+    }  
+  }
   return NULL;
 }
 
@@ -9339,9 +9798,34 @@ SWIGINTERN PyObject *_wrap_doubleArray_Load(PyObject *self, PyObject *args) {
     int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_mfem__ArrayT_double_t, 0);
     _v = SWIG_CheckState(res);
     if (_v) {
-      void *vptr = 0;
-      int res = SWIG_ConvertPtr(argv[1], &vptr, SWIGTYPE_p_std__istream, SWIG_POINTER_NO_NULL);
-      _v = SWIG_CheckState(res);
+      {
+        void *ptr;
+        //std::string *ptr2 = (std::string *)0;
+        if (SWIG_ConvertPtr(argv[1], (void **) &ptr, SWIGTYPE_p_PyMFEM__wFILE, 0 |0) == -1) {
+          PyErr_Clear();
+          if (!PyString_Check(argv[1]) && !PyUnicode_Check(argv[1])) {
+            // not string
+            _v = 1;	   	
+            PyObject* module = PyImport_ImportModule("io");
+            if (!module){
+              _v = 0;	   
+            }      
+            PyObject* cls = PyObject_GetAttrString(module, "StringIO");
+            if (!cls){
+              _v = 0;	   	   
+            }      
+            int check = PyObject_IsInstance(argv[1], cls);
+            Py_DECREF(module);
+            if (! check){
+              _v = 0;	   	   	   
+            }
+          } else {
+            _v = 1;
+          }
+        } else {
+          _v = 1;
+        }
+      }
       if (_v) {
         if (argc <= 2) {
           return _wrap_doubleArray_Load__SWIG_0(self, argc, argv);
@@ -9367,9 +9851,34 @@ SWIGINTERN PyObject *_wrap_doubleArray_Load(PyObject *self, PyObject *args) {
         _v = SWIG_CheckState(res);
       }
       if (_v) {
-        void *vptr = 0;
-        int res = SWIG_ConvertPtr(argv[2], &vptr, SWIGTYPE_p_std__istream, SWIG_POINTER_NO_NULL);
-        _v = SWIG_CheckState(res);
+        {
+          void *ptr;
+          //std::string *ptr2 = (std::string *)0;
+          if (SWIG_ConvertPtr(argv[2], (void **) &ptr, SWIGTYPE_p_PyMFEM__wFILE, 0 |0) == -1) {
+            PyErr_Clear();
+            if (!PyString_Check(argv[2]) && !PyUnicode_Check(argv[2])) {
+              // not string
+              _v = 1;	   	
+              PyObject* module = PyImport_ImportModule("io");
+              if (!module){
+                _v = 0;	   
+              }      
+              PyObject* cls = PyObject_GetAttrString(module, "StringIO");
+              if (!cls){
+                _v = 0;	   	   
+              }      
+              int check = PyObject_IsInstance(argv[2], cls);
+              Py_DECREF(module);
+              if (! check){
+                _v = 0;	   	   	   
+              }
+            } else {
+              _v = 1;
+            }
+          } else {
+            _v = 1;
+          }
+        }
         if (_v) {
           return _wrap_doubleArray_Load__SWIG_1(self, argc, argv);
         }
@@ -10543,7 +11052,8 @@ SWIGINTERN PyObject *_wrap_doubleArray_Print(PyObject *self, PyObject *args) {
               _v = 0;	   	   	   
             }
           } else {
-            _v = 0;
+            std::cout << "it is text (out)\n";	
+            _v = 1;
           }
         } else {
           _v = 1;
@@ -10753,7 +11263,8 @@ SWIGINTERN PyObject *_wrap_doubleArray_Save(PyObject *self, PyObject *args) {
               _v = 0;	   	   	   
             }
           } else {
-            _v = 0;
+            std::cout << "it is text (out)\n";	
+            _v = 1;
           }
         } else {
           _v = 1;
@@ -11638,7 +12149,6 @@ static swig_type_info _swigt__p_mfem__MemoryT_double_t = {"_p_mfem__MemoryT_doub
 static swig_type_info _swigt__p_mfem__MemoryT_int_t = {"_p_mfem__MemoryT_int_t", "mfem::Memory< int > *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_p_double = {"_p_p_double", "double **", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_p_int = {"_p_p_int", "int **", 0, 0, (void*)0, 0};
-static swig_type_info _swigt__p_std__istream = {"_p_std__istream", "std::istream *", 0, 0, (void*)0, 0};
 
 static swig_type_info *swig_type_initial[] = {
   &_swigt__p_PyMFEM__wFILE,
@@ -11653,7 +12163,6 @@ static swig_type_info *swig_type_initial[] = {
   &_swigt__p_mfem__MemoryT_int_t,
   &_swigt__p_p_double,
   &_swigt__p_p_int,
-  &_swigt__p_std__istream,
 };
 
 static swig_cast_info _swigc__p_PyMFEM__wFILE[] = {  {&_swigt__p_PyMFEM__wFILE, 0, 0, 0},{0, 0, 0, 0}};
@@ -11668,7 +12177,6 @@ static swig_cast_info _swigc__p_mfem__MemoryT_double_t[] = {  {&_swigt__p_mfem__
 static swig_cast_info _swigc__p_mfem__MemoryT_int_t[] = {  {&_swigt__p_mfem__MemoryT_int_t, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_p_double[] = {  {&_swigt__p_p_double, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_p_int[] = {  {&_swigt__p_p_int, 0, 0, 0},{0, 0, 0, 0}};
-static swig_cast_info _swigc__p_std__istream[] = {  {&_swigt__p_std__istream, 0, 0, 0},{0, 0, 0, 0}};
 
 static swig_cast_info *swig_cast_initial[] = {
   _swigc__p_PyMFEM__wFILE,
@@ -11683,7 +12191,6 @@ static swig_cast_info *swig_cast_initial[] = {
   _swigc__p_mfem__MemoryT_int_t,
   _swigc__p_p_double,
   _swigc__p_p_int,
-  _swigc__p_std__istream,
 };
 
 

--- a/mfem/_par/blockmatrix.i
+++ b/mfem/_par/blockmatrix.i
@@ -3,6 +3,7 @@
 %{
 #include <fstream>  
 #include <iostream>
+#include "general/zstr.hpp"  
 #include "linalg/blockmatrix.hpp"
 #include "numpy/arrayobject.h"
 #include "pyoperator.hpp"

--- a/mfem/_par/blockmatrix_wrap.cxx
+++ b/mfem/_par/blockmatrix_wrap.cxx
@@ -5551,7 +5551,6 @@ SWIGINTERN PyObject *_wrap_BlockMatrix_PrintMatlab(PyObject *self, PyObject *arg
               _v = 0;	   	   	   
             }
           } else {
-            std::cout << "it is text (out)\n";	
             _v = 1;
           }
         } else {

--- a/mfem/_par/common_functions.i
+++ b/mfem/_par/common_functions.i
@@ -2,6 +2,7 @@
 
 %{
 #include <fstream>
+#include "general/zstr.hpp"    
 #include "../common/io_stream.hpp"            
 #include "linalg/blockmatrix.hpp"
 #include "linalg/sparsemat.hpp"

--- a/mfem/_par/communication.i
+++ b/mfem/_par/communication.i
@@ -5,7 +5,8 @@
 #include <fstream>
 #include <iostream>  
 #include <mpi.h>
-#include "../common/io_stream.hpp"      
+#include "../common/io_stream.hpp"
+#include "general/zstr.hpp"  
 #include "config/config.hpp"    
 #include "general/sets.hpp"
 #include "general/communication.hpp"

--- a/mfem/_par/communication_wrap.cxx
+++ b/mfem/_par/communication_wrap.cxx
@@ -2780,7 +2780,8 @@ namespace swig {
 #include <fstream>
 #include <iostream>  
 #include <mpi.h>
-#include "../common/io_stream.hpp"      
+#include "../common/io_stream.hpp"
+#include "general/zstr.hpp"  
 #include "config/config.hpp"    
 #include "general/sets.hpp"
 #include "general/communication.hpp"
@@ -4357,7 +4358,6 @@ SWIGINTERN PyObject *_wrap_GroupTopology_Load(PyObject *SWIGUNUSEDPARM(self), Py
   PyMFEM::wFILE *temp2 = 0 ;
   std::ifstream in_txt2 ;
   mfem::ifgzstream *in_gz2 = 0 ;
-  PyObject *input_str2 = 0 ;
   std::istringstream *stream2 = 0 ;
   Py_ssize_t len2 = 0 ;
   PyObject *ret2 = 0 ;
@@ -4395,18 +4395,18 @@ SWIGINTERN PyObject *_wrap_GroupTopology_Load(PyObject *SWIGUNUSEDPARM(self), Py
           return NULL;
         }
         
-        PyObject *input_str2 = PyObject_CallMethod(obj1, "getvalue", NULL);
+        PyObject *input_str = PyObject_CallMethod(obj1, "getvalue", NULL);
         if (PyErr_Occurred()) {
           PyErr_SetString(PyExc_RuntimeError, "Can not read from StringIO");
           return NULL;
         }
         
         char *buf = nullptr;
-        PyObject *str = PyUnicode_AsUTF8String(input_str2);	 
+        PyObject *str = PyUnicode_AsUTF8String(input_str);	 
         PyBytes_AsStringAndSize(str, &buf, &len2);
         stream2 = new std::istringstream(buf);
         Py_DECREF(str);
-        Py_DECREF(input_str2);	 
+        Py_DECREF(input_str);	 
       } else {
         // if it is string, extract filename as char*
         PyObject* str = PyUnicode_AsEncodedString(obj1, "utf-8", "~E~");	
@@ -4691,7 +4691,6 @@ SWIGINTERN PyObject *_wrap_GroupTopology_Save(PyObject *self, PyObject *args) {
               _v = 0;	   	   	   
             }
           } else {
-            std::cout << "it is text (out)\n";	
             _v = 1;
           }
         } else {
@@ -5505,7 +5504,6 @@ SWIGINTERN PyObject *_wrap_GroupCommunicator_PrintInfo(PyObject *self, PyObject 
               _v = 0;	   	   	   
             }
           } else {
-            std::cout << "it is text (out)\n";	
             _v = 1;
           }
         } else {

--- a/mfem/_par/communication_wrap.cxx
+++ b/mfem/_par/communication_wrap.cxx
@@ -2672,9 +2672,8 @@ SWIGINTERN PyObject *SWIG_PyStaticMethod_New(PyObject *SWIGUNUSEDPARM(self), PyO
 #define SWIGTYPE_p_mfem__STable swig_types[9]
 #define SWIGTYPE_p_mfem__Table swig_types[10]
 #define SWIGTYPE_p_p_p_char swig_types[11]
-#define SWIGTYPE_p_std__istream swig_types[12]
-static swig_type_info *swig_types[14];
-static swig_module_info swig_module = {swig_types, 13, 0, 0, 0, 0};
+static swig_type_info *swig_types[13];
+static swig_module_info swig_module = {swig_types, 12, 0, 0, 0, 0};
 #define SWIG_TypeQuery(name) SWIG_TypeQueryModule(&swig_module, &swig_module, name)
 #define SWIG_MangledTypeQuery(name) SWIG_MangledTypeQueryModule(&swig_module, &swig_module, name)
 
@@ -4220,10 +4219,10 @@ SWIGINTERN PyObject *_wrap_GroupTopology_Save__SWIG_0(PyObject *SWIGUNUSEDPARM(s
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyMFEM::wFILE *temp2 = 0 ;
-  std::ofstream out2 ;
-  int use_stringio2 = 0 ;
+  std::ofstream out_txt2 ;
+  mfem::ofgzstream *out_gz2 = 0 ;
   PyObject *string_io2 = 0 ;
-  std::ostringstream stream2 ;
+  std::ostringstream *stream2 = 0 ;
   PyObject *ret2 = 0 ;
   
   if ((nobjs < 2) || (nobjs > 2)) SWIG_fail;
@@ -4253,29 +4252,33 @@ SWIGINTERN PyObject *_wrap_GroupTopology_Save__SWIG_0(PyObject *SWIGUNUSEDPARM(s
           SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
           return NULL;
         }
-        use_stringio2=1;
         string_io2=swig_obj[1];
+        stream2 = new std::ostringstream();
       } else {
         // if it is string, extract filename as char*
         PyObject* str = PyUnicode_AsEncodedString(swig_obj[1], "utf-8", "~E~");	
         const char* filename = PyBytes_AsString(str);
-        temp2 = new PyMFEM::wFILE(filename, 8, true);	
+        temp2 = new PyMFEM::wFILE(filename, 8, true);
+        Py_DECREF(str);	 
       }
     }
     
-    if (use_stringio2 == 0){
+    if (stream2 == 0){
       if (temp2->isSTDOUT() == 1) {
         arg2 = &std::cout;
+      } else if (temp2->isGZ()){
+        out_gz2 = new mfem::ofgzstream(temp2->getFilename(), true);
+        arg2 = out_gz2;	     
       } else {
-        out2.open(temp2->getFilename());
-        out2.precision(temp2->getPrecision());
-        if (temp2->isTemporary()){
-          delete temp2;
-        }
-        arg2 = &out2;
+        out_txt2.open(temp2->getFilename());
+        out_txt2.precision(temp2->getPrecision());
+        arg2 = &out_txt2;
+      }
+      if (temp2->isTemporary()){
+        delete temp2;
       }
     } else {
-      arg2 = &stream2;
+      arg2 = stream2;
     }
   }
   {
@@ -4296,8 +4299,8 @@ SWIGINTERN PyObject *_wrap_GroupTopology_Save__SWIG_0(PyObject *SWIGUNUSEDPARM(s
   }
   resultobj = SWIG_Py_Void();
   {
-    if (use_stringio2 == 1) {
-      std::string str =  stream2.str();
+    if (stream2) {
+      std::string str =  stream2->str();
       const char* s = str.c_str();
       const int n = str.length();
       ret2 = PyObject_CallMethod(string_io2, "write", "s#",
@@ -4306,15 +4309,21 @@ SWIGINTERN PyObject *_wrap_GroupTopology_Save__SWIG_0(PyObject *SWIGUNUSEDPARM(s
         PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
         return NULL;
       }
+      delete stream2;
       Py_XDECREF(resultobj);   /* Blow away any previous result */
       resultobj = ret2;    
     }
   }
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -4322,10 +4331,15 @@ SWIGINTERN PyObject *_wrap_GroupTopology_Save__SWIG_0(PyObject *SWIGUNUSEDPARM(s
   return resultobj;
 fail:
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -4340,8 +4354,13 @@ SWIGINTERN PyObject *_wrap_GroupTopology_Load(PyObject *SWIGUNUSEDPARM(self), Py
   std::istream *arg2 = 0 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
-  void *argp2 = 0 ;
-  int res2 = 0 ;
+  PyMFEM::wFILE *temp2 = 0 ;
+  std::ifstream in_txt2 ;
+  mfem::ifgzstream *in_gz2 = 0 ;
+  PyObject *input_str2 = 0 ;
+  std::istringstream *stream2 = 0 ;
+  Py_ssize_t len2 = 0 ;
+  PyObject *ret2 = 0 ;
   PyObject * obj0 = 0 ;
   PyObject * obj1 = 0 ;
   char * kwnames[] = {
@@ -4354,14 +4373,64 @@ SWIGINTERN PyObject *_wrap_GroupTopology_Load(PyObject *SWIGUNUSEDPARM(self), Py
     SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "GroupTopology_Load" "', argument " "1"" of type '" "mfem::GroupTopology *""'"); 
   }
   arg1 = reinterpret_cast< mfem::GroupTopology * >(argp1);
-  res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_std__istream,  0 );
-  if (!SWIG_IsOK(res2)) {
-    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "GroupTopology_Load" "', argument " "2"" of type '" "std::istream &""'"); 
+  {
+    //  PyMFEM::wFILE or string argument or StringIO
+    if (SWIG_ConvertPtr(obj1, (void **) &temp2, SWIGTYPE_p_PyMFEM__wFILE, 0 | 0) == -1) {
+      if (!PyString_Check(obj1) && !PyUnicode_Check(obj1)) {
+        // not string, check if it is StringIO
+        PyObject* module = PyImport_ImportModule("io");
+        if (!module){
+          PyErr_SetString(PyExc_RuntimeError, "Can not load io module");
+          return NULL;
+        }      
+        PyObject* cls = PyObject_GetAttrString(module, "StringIO");
+        if (!cls){
+          PyErr_SetString(PyExc_RuntimeError, "Can not load StringIO");
+          return NULL;
+        }      
+        int check = PyObject_IsInstance(obj1, cls);
+        Py_DECREF(module);
+        if (! check){
+          SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
+          return NULL;
+        }
+        
+        PyObject *input_str2 = PyObject_CallMethod(obj1, "getvalue", NULL);
+        if (PyErr_Occurred()) {
+          PyErr_SetString(PyExc_RuntimeError, "Can not read from StringIO");
+          return NULL;
+        }
+        
+        char *buf = nullptr;
+        PyObject *str = PyUnicode_AsUTF8String(input_str2);	 
+        PyBytes_AsStringAndSize(str, &buf, &len2);
+        stream2 = new std::istringstream(buf);
+        Py_DECREF(str);
+        Py_DECREF(input_str2);	 
+      } else {
+        // if it is string, extract filename as char*
+        PyObject* str = PyUnicode_AsEncodedString(obj1, "utf-8", "~E~");	
+        const char* filename = PyBytes_AsString(str);
+        temp2 = new PyMFEM::wFILE(filename, 8, true);
+        Py_DECREF(str);
+      }
+    }
+    if (stream2 == 0){
+      if (temp2->isGZ()){
+        in_gz2 = new mfem::ifgzstream(temp2->getFilename());
+        arg2 = in_gz2;
+      } else {
+        in_txt2.open(temp2->getFilename(), std::ifstream::in);
+        in_txt2.precision(temp2->getPrecision());
+        arg2 = &in_txt2;
+      }
+      if (temp2->isTemporary()){
+        delete temp2;
+      }
+    } else {
+      arg2 = stream2;
+    }
   }
-  if (!argp2) {
-    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "GroupTopology_Load" "', argument " "2"" of type '" "std::istream &""'"); 
-  }
-  arg2 = reinterpret_cast< std::istream * >(argp2);
   {
     try {
       (arg1)->Load(*arg2);
@@ -4379,8 +4448,40 @@ SWIGINTERN PyObject *_wrap_GroupTopology_Load(PyObject *SWIGUNUSEDPARM(self), Py
     }	 
   }
   resultobj = SWIG_Py_Void();
+  {
+    if (stream2) {
+      ret2 = PyLong_FromSsize_t(len2);
+      if (PyErr_Occurred()) {
+        PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
+        return NULL;
+      }
+      delete stream2;    
+      Py_XDECREF(resultobj);   /* Blow away any previous result */
+      resultobj = ret2;    
+    }
+  }
+  {
+    if (!stream2) {
+      if (temp2) {
+        in_txt2.close();
+      }
+      if (in_gz2){
+        delete in_gz2;
+      }
+    }  
+  }
   return resultobj;
 fail:
+  {
+    if (!stream2) {
+      if (temp2) {
+        in_txt2.close();
+      }
+      if (in_gz2){
+        delete in_gz2;
+      }
+    }  
+  }
   return NULL;
 }
 
@@ -4590,7 +4691,8 @@ SWIGINTERN PyObject *_wrap_GroupTopology_Save(PyObject *self, PyObject *args) {
               _v = 0;	   	   	   
             }
           } else {
-            _v = 0;
+            std::cout << "it is text (out)\n";	
+            _v = 1;
           }
         } else {
           _v = 1;
@@ -5141,10 +5243,10 @@ SWIGINTERN PyObject *_wrap_GroupCommunicator_PrintInfo__SWIG_0(PyObject *SWIGUNU
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyMFEM::wFILE *temp2 = 0 ;
-  std::ofstream out2 ;
-  int use_stringio2 = 0 ;
+  std::ofstream out_txt2 ;
+  mfem::ofgzstream *out_gz2 = 0 ;
   PyObject *string_io2 = 0 ;
-  std::ostringstream stream2 ;
+  std::ostringstream *stream2 = 0 ;
   PyObject *ret2 = 0 ;
   
   if ((nobjs < 1) || (nobjs > 2)) SWIG_fail;
@@ -5175,29 +5277,33 @@ SWIGINTERN PyObject *_wrap_GroupCommunicator_PrintInfo__SWIG_0(PyObject *SWIGUNU
             SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
             return NULL;
           }
-          use_stringio2=1;
           string_io2=swig_obj[1];
+          stream2 = new std::ostringstream();
         } else {
           // if it is string, extract filename as char*
           PyObject* str = PyUnicode_AsEncodedString(swig_obj[1], "utf-8", "~E~");	
           const char* filename = PyBytes_AsString(str);
-          temp2 = new PyMFEM::wFILE(filename, 8, true);	
+          temp2 = new PyMFEM::wFILE(filename, 8, true);
+          Py_DECREF(str);	 
         }
       }
       
-      if (use_stringio2 == 0){
+      if (stream2 == 0){
         if (temp2->isSTDOUT() == 1) {
           arg2 = &std::cout;
+        } else if (temp2->isGZ()){
+          out_gz2 = new mfem::ofgzstream(temp2->getFilename(), true);
+          arg2 = out_gz2;	     
         } else {
-          out2.open(temp2->getFilename());
-          out2.precision(temp2->getPrecision());
-          if (temp2->isTemporary()){
-            delete temp2;
-          }
-          arg2 = &out2;
+          out_txt2.open(temp2->getFilename());
+          out_txt2.precision(temp2->getPrecision());
+          arg2 = &out_txt2;
+        }
+        if (temp2->isTemporary()){
+          delete temp2;
         }
       } else {
-        arg2 = &stream2;
+        arg2 = stream2;
       }
     }
   }
@@ -5219,8 +5325,8 @@ SWIGINTERN PyObject *_wrap_GroupCommunicator_PrintInfo__SWIG_0(PyObject *SWIGUNU
   }
   resultobj = SWIG_Py_Void();
   {
-    if (use_stringio2 == 1) {
-      std::string str =  stream2.str();
+    if (stream2) {
+      std::string str =  stream2->str();
       const char* s = str.c_str();
       const int n = str.length();
       ret2 = PyObject_CallMethod(string_io2, "write", "s#",
@@ -5229,15 +5335,21 @@ SWIGINTERN PyObject *_wrap_GroupCommunicator_PrintInfo__SWIG_0(PyObject *SWIGUNU
         PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
         return NULL;
       }
+      delete stream2;
       Py_XDECREF(resultobj);   /* Blow away any previous result */
       resultobj = ret2;    
     }
   }
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -5245,10 +5357,15 @@ SWIGINTERN PyObject *_wrap_GroupCommunicator_PrintInfo__SWIG_0(PyObject *SWIGUNU
   return resultobj;
 fail:
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -5388,7 +5505,8 @@ SWIGINTERN PyObject *_wrap_GroupCommunicator_PrintInfo(PyObject *self, PyObject 
               _v = 0;	   	   	   
             }
           } else {
-            _v = 0;
+            std::cout << "it is text (out)\n";	
+            _v = 1;
           }
         } else {
           _v = 1;
@@ -5638,7 +5756,6 @@ static swig_type_info _swigt__p_mfem__MPI_Session = {"_p_mfem__MPI_Session", "mf
 static swig_type_info _swigt__p_mfem__Table = {"_p_mfem__Table", "mfem::Table *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_mfem__STable = {"_p_mfem__STable", 0, 0, 0, 0, 0};
 static swig_type_info _swigt__p_p_p_char = {"_p_p_p_char", "char ***", 0, 0, (void*)0, 0};
-static swig_type_info _swigt__p_std__istream = {"_p_std__istream", "std::istream *", 0, 0, (void*)0, 0};
 
 static swig_type_info *swig_type_initial[] = {
   &_swigt__p_MPI_Comm,
@@ -5653,7 +5770,6 @@ static swig_type_info *swig_type_initial[] = {
   &_swigt__p_mfem__STable,
   &_swigt__p_mfem__Table,
   &_swigt__p_p_p_char,
-  &_swigt__p_std__istream,
 };
 
 static swig_cast_info _swigc__p_MPI_Comm[] = {  {&_swigt__p_MPI_Comm, 0, 0, 0},{0, 0, 0, 0}};
@@ -5668,7 +5784,6 @@ static swig_cast_info _swigc__p_mfem__MPI_Session[] = {  {&_swigt__p_mfem__MPI_S
 static swig_cast_info _swigc__p_mfem__STable[] = {{&_swigt__p_mfem__STable, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_mfem__Table[] = {  {&_swigt__p_mfem__STable, _p_mfem__STableTo_p_mfem__Table, 0, 0},  {&_swigt__p_mfem__Table, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_p_p_char[] = {  {&_swigt__p_p_p_char, 0, 0, 0},{0, 0, 0, 0}};
-static swig_cast_info _swigc__p_std__istream[] = {  {&_swigt__p_std__istream, 0, 0, 0},{0, 0, 0, 0}};
 
 static swig_cast_info *swig_cast_initial[] = {
   _swigc__p_MPI_Comm,
@@ -5683,7 +5798,6 @@ static swig_cast_info *swig_cast_initial[] = {
   _swigc__p_mfem__STable,
   _swigc__p_mfem__Table,
   _swigc__p_p_p_char,
-  _swigc__p_std__istream,
 };
 
 

--- a/mfem/_par/densemat.i
+++ b/mfem/_par/densemat.i
@@ -8,7 +8,8 @@
 %feature("autodoc", "1");
 %{
 #include <fstream>
-#include <iostream>      
+#include <iostream>
+#include "general/zstr.hpp"
 #include "linalg/sparsemat.hpp"
 #include "numpy/arrayobject.h"
 #include "pyoperator.hpp"

--- a/mfem/_par/densemat_wrap.cxx
+++ b/mfem/_par/densemat_wrap.cxx
@@ -11401,7 +11401,6 @@ SWIGINTERN PyObject *_wrap_DenseMatrix_Print(PyObject *self, PyObject *args) {
               _v = 0;	   	   	   
             }
           } else {
-            std::cout << "it is text (out)\n";	
             _v = 1;
           }
         } else {
@@ -11553,7 +11552,6 @@ SWIGINTERN PyObject *_wrap_DenseMatrix_PrintT(PyObject *self, PyObject *args) {
               _v = 0;	   	   	   
             }
           } else {
-            std::cout << "it is text (out)\n";	
             _v = 1;
           }
         } else {
@@ -11705,7 +11703,6 @@ SWIGINTERN PyObject *_wrap_DenseMatrix_PrintMatlab(PyObject *self, PyObject *arg
               _v = 0;	   	   	   
             }
           } else {
-            std::cout << "it is text (out)\n";	
             _v = 1;
           }
         } else {

--- a/mfem/_par/densemat_wrap.cxx
+++ b/mfem/_par/densemat_wrap.cxx
@@ -3204,7 +3204,8 @@ namespace swig {
 
 
 #include <fstream>
-#include <iostream>      
+#include <iostream>
+#include "general/zstr.hpp"
 #include "linalg/sparsemat.hpp"
 #include "numpy/arrayobject.h"
 #include "pyoperator.hpp"
@@ -10215,10 +10216,10 @@ SWIGINTERN PyObject *_wrap_DenseMatrix_Print__SWIG_0(PyObject *SWIGUNUSEDPARM(se
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyMFEM::wFILE *temp2 = 0 ;
-  std::ofstream out2 ;
-  int use_stringio2 = 0 ;
+  std::ofstream out_txt2 ;
+  mfem::ofgzstream *out_gz2 = 0 ;
   PyObject *string_io2 = 0 ;
-  std::ostringstream stream2 ;
+  std::ostringstream *stream2 = 0 ;
   PyObject *ret2 = 0 ;
   
   if ((nobjs < 1) || (nobjs > 3)) SWIG_fail;
@@ -10249,29 +10250,33 @@ SWIGINTERN PyObject *_wrap_DenseMatrix_Print__SWIG_0(PyObject *SWIGUNUSEDPARM(se
             SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
             return NULL;
           }
-          use_stringio2=1;
           string_io2=swig_obj[1];
+          stream2 = new std::ostringstream();
         } else {
           // if it is string, extract filename as char*
           PyObject* str = PyUnicode_AsEncodedString(swig_obj[1], "utf-8", "~E~");	
           const char* filename = PyBytes_AsString(str);
-          temp2 = new PyMFEM::wFILE(filename, 8, true);	
+          temp2 = new PyMFEM::wFILE(filename, 8, true);
+          Py_DECREF(str);	 
         }
       }
       
-      if (use_stringio2 == 0){
+      if (stream2 == 0){
         if (temp2->isSTDOUT() == 1) {
           arg2 = &std::cout;
+        } else if (temp2->isGZ()){
+          out_gz2 = new mfem::ofgzstream(temp2->getFilename(), true);
+          arg2 = out_gz2;	     
         } else {
-          out2.open(temp2->getFilename());
-          out2.precision(temp2->getPrecision());
-          if (temp2->isTemporary()){
-            delete temp2;
-          }
-          arg2 = &out2;
+          out_txt2.open(temp2->getFilename());
+          out_txt2.precision(temp2->getPrecision());
+          arg2 = &out_txt2;
+        }
+        if (temp2->isTemporary()){
+          delete temp2;
         }
       } else {
-        arg2 = &stream2;
+        arg2 = stream2;
       }
     }
   }
@@ -10298,8 +10303,8 @@ SWIGINTERN PyObject *_wrap_DenseMatrix_Print__SWIG_0(PyObject *SWIGUNUSEDPARM(se
   }
   resultobj = SWIG_Py_Void();
   {
-    if (use_stringio2 == 1) {
-      std::string str =  stream2.str();
+    if (stream2) {
+      std::string str =  stream2->str();
       const char* s = str.c_str();
       const int n = str.length();
       ret2 = PyObject_CallMethod(string_io2, "write", "s#",
@@ -10308,15 +10313,21 @@ SWIGINTERN PyObject *_wrap_DenseMatrix_Print__SWIG_0(PyObject *SWIGUNUSEDPARM(se
         PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
         return NULL;
       }
+      delete stream2;
       Py_XDECREF(resultobj);   /* Blow away any previous result */
       resultobj = ret2;    
     }
   }
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -10324,10 +10335,15 @@ SWIGINTERN PyObject *_wrap_DenseMatrix_Print__SWIG_0(PyObject *SWIGUNUSEDPARM(se
   return resultobj;
 fail:
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -10344,10 +10360,10 @@ SWIGINTERN PyObject *_wrap_DenseMatrix_PrintMatlab__SWIG_0(PyObject *SWIGUNUSEDP
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyMFEM::wFILE *temp2 = 0 ;
-  std::ofstream out2 ;
-  int use_stringio2 = 0 ;
+  std::ofstream out_txt2 ;
+  mfem::ofgzstream *out_gz2 = 0 ;
   PyObject *string_io2 = 0 ;
-  std::ostringstream stream2 ;
+  std::ostringstream *stream2 = 0 ;
   PyObject *ret2 = 0 ;
   
   if ((nobjs < 1) || (nobjs > 2)) SWIG_fail;
@@ -10378,29 +10394,33 @@ SWIGINTERN PyObject *_wrap_DenseMatrix_PrintMatlab__SWIG_0(PyObject *SWIGUNUSEDP
             SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
             return NULL;
           }
-          use_stringio2=1;
           string_io2=swig_obj[1];
+          stream2 = new std::ostringstream();
         } else {
           // if it is string, extract filename as char*
           PyObject* str = PyUnicode_AsEncodedString(swig_obj[1], "utf-8", "~E~");	
           const char* filename = PyBytes_AsString(str);
-          temp2 = new PyMFEM::wFILE(filename, 8, true);	
+          temp2 = new PyMFEM::wFILE(filename, 8, true);
+          Py_DECREF(str);	 
         }
       }
       
-      if (use_stringio2 == 0){
+      if (stream2 == 0){
         if (temp2->isSTDOUT() == 1) {
           arg2 = &std::cout;
+        } else if (temp2->isGZ()){
+          out_gz2 = new mfem::ofgzstream(temp2->getFilename(), true);
+          arg2 = out_gz2;	     
         } else {
-          out2.open(temp2->getFilename());
-          out2.precision(temp2->getPrecision());
-          if (temp2->isTemporary()){
-            delete temp2;
-          }
-          arg2 = &out2;
+          out_txt2.open(temp2->getFilename());
+          out_txt2.precision(temp2->getPrecision());
+          arg2 = &out_txt2;
+        }
+        if (temp2->isTemporary()){
+          delete temp2;
         }
       } else {
-        arg2 = &stream2;
+        arg2 = stream2;
       }
     }
   }
@@ -10419,8 +10439,8 @@ SWIGINTERN PyObject *_wrap_DenseMatrix_PrintMatlab__SWIG_0(PyObject *SWIGUNUSEDP
   }
   resultobj = SWIG_Py_Void();
   {
-    if (use_stringio2 == 1) {
-      std::string str =  stream2.str();
+    if (stream2) {
+      std::string str =  stream2->str();
       const char* s = str.c_str();
       const int n = str.length();
       ret2 = PyObject_CallMethod(string_io2, "write", "s#",
@@ -10429,15 +10449,21 @@ SWIGINTERN PyObject *_wrap_DenseMatrix_PrintMatlab__SWIG_0(PyObject *SWIGUNUSEDP
         PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
         return NULL;
       }
+      delete stream2;
       Py_XDECREF(resultobj);   /* Blow away any previous result */
       resultobj = ret2;    
     }
   }
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -10445,10 +10471,15 @@ SWIGINTERN PyObject *_wrap_DenseMatrix_PrintMatlab__SWIG_0(PyObject *SWIGUNUSEDP
   return resultobj;
 fail:
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -10466,10 +10497,10 @@ SWIGINTERN PyObject *_wrap_DenseMatrix_PrintT__SWIG_0(PyObject *SWIGUNUSEDPARM(s
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyMFEM::wFILE *temp2 = 0 ;
-  std::ofstream out2 ;
-  int use_stringio2 = 0 ;
+  std::ofstream out_txt2 ;
+  mfem::ofgzstream *out_gz2 = 0 ;
   PyObject *string_io2 = 0 ;
-  std::ostringstream stream2 ;
+  std::ostringstream *stream2 = 0 ;
   PyObject *ret2 = 0 ;
   
   if ((nobjs < 1) || (nobjs > 3)) SWIG_fail;
@@ -10500,29 +10531,33 @@ SWIGINTERN PyObject *_wrap_DenseMatrix_PrintT__SWIG_0(PyObject *SWIGUNUSEDPARM(s
             SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
             return NULL;
           }
-          use_stringio2=1;
           string_io2=swig_obj[1];
+          stream2 = new std::ostringstream();
         } else {
           // if it is string, extract filename as char*
           PyObject* str = PyUnicode_AsEncodedString(swig_obj[1], "utf-8", "~E~");	
           const char* filename = PyBytes_AsString(str);
-          temp2 = new PyMFEM::wFILE(filename, 8, true);	
+          temp2 = new PyMFEM::wFILE(filename, 8, true);
+          Py_DECREF(str);	 
         }
       }
       
-      if (use_stringio2 == 0){
+      if (stream2 == 0){
         if (temp2->isSTDOUT() == 1) {
           arg2 = &std::cout;
+        } else if (temp2->isGZ()){
+          out_gz2 = new mfem::ofgzstream(temp2->getFilename(), true);
+          arg2 = out_gz2;	     
         } else {
-          out2.open(temp2->getFilename());
-          out2.precision(temp2->getPrecision());
-          if (temp2->isTemporary()){
-            delete temp2;
-          }
-          arg2 = &out2;
+          out_txt2.open(temp2->getFilename());
+          out_txt2.precision(temp2->getPrecision());
+          arg2 = &out_txt2;
+        }
+        if (temp2->isTemporary()){
+          delete temp2;
         }
       } else {
-        arg2 = &stream2;
+        arg2 = stream2;
       }
     }
   }
@@ -10549,8 +10584,8 @@ SWIGINTERN PyObject *_wrap_DenseMatrix_PrintT__SWIG_0(PyObject *SWIGUNUSEDPARM(s
   }
   resultobj = SWIG_Py_Void();
   {
-    if (use_stringio2 == 1) {
-      std::string str =  stream2.str();
+    if (stream2) {
+      std::string str =  stream2->str();
       const char* s = str.c_str();
       const int n = str.length();
       ret2 = PyObject_CallMethod(string_io2, "write", "s#",
@@ -10559,15 +10594,21 @@ SWIGINTERN PyObject *_wrap_DenseMatrix_PrintT__SWIG_0(PyObject *SWIGUNUSEDPARM(s
         PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
         return NULL;
       }
+      delete stream2;
       Py_XDECREF(resultobj);   /* Blow away any previous result */
       resultobj = ret2;    
     }
   }
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -10575,10 +10616,15 @@ SWIGINTERN PyObject *_wrap_DenseMatrix_PrintT__SWIG_0(PyObject *SWIGUNUSEDPARM(s
   return resultobj;
 fail:
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -11355,7 +11401,8 @@ SWIGINTERN PyObject *_wrap_DenseMatrix_Print(PyObject *self, PyObject *args) {
               _v = 0;	   	   	   
             }
           } else {
-            _v = 0;
+            std::cout << "it is text (out)\n";	
+            _v = 1;
           }
         } else {
           _v = 1;
@@ -11506,7 +11553,8 @@ SWIGINTERN PyObject *_wrap_DenseMatrix_PrintT(PyObject *self, PyObject *args) {
               _v = 0;	   	   	   
             }
           } else {
-            _v = 0;
+            std::cout << "it is text (out)\n";	
+            _v = 1;
           }
         } else {
           _v = 1;
@@ -11657,7 +11705,8 @@ SWIGINTERN PyObject *_wrap_DenseMatrix_PrintMatlab(PyObject *self, PyObject *arg
               _v = 0;	   	   	   
             }
           } else {
-            _v = 0;
+            std::cout << "it is text (out)\n";	
+            _v = 1;
           }
         } else {
           _v = 1;

--- a/mfem/_par/eltrans_wrap.cxx
+++ b/mfem/_par/eltrans_wrap.cxx
@@ -7471,10 +7471,10 @@ SWIGINTERN PyObject *_wrap_FaceElementTransformations_CheckConsistency(PyObject 
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyMFEM::wFILE *temp3 = 0 ;
-  std::ofstream out3 ;
-  int use_stringio3 = 0 ;
+  std::ofstream out_txt3 ;
+  mfem::ofgzstream *out_gz3 = 0 ;
   PyObject *string_io3 = 0 ;
-  std::ostringstream stream3 ;
+  std::ostringstream *stream3 = 0 ;
   PyObject *ret3 = 0 ;
   PyObject * obj0 = 0 ;
   PyObject * obj1 = 0 ;
@@ -7520,29 +7520,33 @@ SWIGINTERN PyObject *_wrap_FaceElementTransformations_CheckConsistency(PyObject 
             SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
             return NULL;
           }
-          use_stringio3=1;
           string_io3=obj2;
+          stream3 = new std::ostringstream();
         } else {
           // if it is string, extract filename as char*
           PyObject* str = PyUnicode_AsEncodedString(obj2, "utf-8", "~E~");	
           const char* filename = PyBytes_AsString(str);
-          temp3 = new PyMFEM::wFILE(filename, 8, true);	
+          temp3 = new PyMFEM::wFILE(filename, 8, true);
+          Py_DECREF(str);	 
         }
       }
       
-      if (use_stringio3 == 0){
+      if (stream3 == 0){
         if (temp3->isSTDOUT() == 1) {
           arg3 = &std::cout;
+        } else if (temp3->isGZ()){
+          out_gz3 = new mfem::ofgzstream(temp3->getFilename(), true);
+          arg3 = out_gz3;	     
         } else {
-          out3.open(temp3->getFilename());
-          out3.precision(temp3->getPrecision());
-          if (temp3->isTemporary()){
-            delete temp3;
-          }
-          arg3 = &out3;
+          out_txt3.open(temp3->getFilename());
+          out_txt3.precision(temp3->getPrecision());
+          arg3 = &out_txt3;
+        }
+        if (temp3->isTemporary()){
+          delete temp3;
         }
       } else {
-        arg3 = &stream3;
+        arg3 = stream3;
       }
     }
   }
@@ -7561,8 +7565,8 @@ SWIGINTERN PyObject *_wrap_FaceElementTransformations_CheckConsistency(PyObject 
   }
   resultobj = SWIG_From_double(static_cast< double >(result));
   {
-    if (use_stringio3 == 1) {
-      std::string str =  stream3.str();
+    if (stream3) {
+      std::string str =  stream3->str();
       const char* s = str.c_str();
       const int n = str.length();
       ret3 = PyObject_CallMethod(string_io3, "write", "s#",
@@ -7571,15 +7575,21 @@ SWIGINTERN PyObject *_wrap_FaceElementTransformations_CheckConsistency(PyObject 
         PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
         return NULL;
       }
+      delete stream3;
       Py_XDECREF(resultobj);   /* Blow away any previous result */
       resultobj = ret3;    
     }
   }
   {
-    if (use_stringio3 == 0) {
+    if (!stream3) {
       if (temp3) {
         if (temp3->isSTDOUT() != 1) {
-          out3.close();
+          if (out_txt3.is_open()){
+            out_txt3.close();
+          }
+          if (out_gz3){
+            delete out_gz3;
+          }
         }
       }
     }
@@ -7587,10 +7597,15 @@ SWIGINTERN PyObject *_wrap_FaceElementTransformations_CheckConsistency(PyObject 
   return resultobj;
 fail:
   {
-    if (use_stringio3 == 0) {
+    if (!stream3) {
       if (temp3) {
         if (temp3->isSTDOUT() != 1) {
-          out3.close();
+          if (out_txt3.is_open()){
+            out_txt3.close();
+          }
+          if (out_gz3){
+            delete out_gz3;
+          }
         }
       }
     }

--- a/mfem/_par/fespace.i
+++ b/mfem/_par/fespace.i
@@ -46,6 +46,7 @@ import_array();
 
 %import "../common/io_stream_typemap.i"
 OSTREAM_TYPEMAP(std::ostream&)
+ISTREAM_TYPEMAP(std::istream&)
 
 // default number is -1, which conflict with error code of PyArray_PyIntAsInt...
 INT_DEFAULT_NEGATIVE_ONE(int ndofs = -1)

--- a/mfem/_par/fespace_wrap.cxx
+++ b/mfem/_par/fespace_wrap.cxx
@@ -8920,7 +8920,6 @@ SWIGINTERN PyObject *_wrap_FiniteElementSpace_Load(PyObject *SWIGUNUSEDPARM(self
   PyMFEM::wFILE *temp3 = 0 ;
   std::ifstream in_txt3 ;
   mfem::ifgzstream *in_gz3 = 0 ;
-  PyObject *input_str3 = 0 ;
   std::istringstream *stream3 = 0 ;
   Py_ssize_t len3 = 0 ;
   PyObject *ret3 = 0 ;
@@ -8965,18 +8964,18 @@ SWIGINTERN PyObject *_wrap_FiniteElementSpace_Load(PyObject *SWIGUNUSEDPARM(self
           return NULL;
         }
         
-        PyObject *input_str3 = PyObject_CallMethod(obj2, "getvalue", NULL);
+        PyObject *input_str = PyObject_CallMethod(obj2, "getvalue", NULL);
         if (PyErr_Occurred()) {
           PyErr_SetString(PyExc_RuntimeError, "Can not read from StringIO");
           return NULL;
         }
         
         char *buf = nullptr;
-        PyObject *str = PyUnicode_AsUTF8String(input_str3);	 
+        PyObject *str = PyUnicode_AsUTF8String(input_str);	 
         PyBytes_AsStringAndSize(str, &buf, &len3);
         stream3 = new std::istringstream(buf);
         Py_DECREF(str);
-        Py_DECREF(input_str3);	 
+        Py_DECREF(input_str);	 
       } else {
         // if it is string, extract filename as char*
         PyObject* str = PyUnicode_AsEncodedString(obj2, "utf-8", "~E~");	
@@ -9242,7 +9241,6 @@ SWIGINTERN PyObject *_wrap_FiniteElementSpace_Save(PyObject *self, PyObject *arg
               _v = 0;	   	   	   
             }
           } else {
-            std::cout << "it is text (out)\n";	
             _v = 1;
           }
         } else {
@@ -9325,7 +9323,6 @@ SWIGINTERN PyObject *_wrap_new_QuadratureSpace__SWIG_1(PyObject *SWIGUNUSEDPARM(
   PyMFEM::wFILE *temp2 = 0 ;
   std::ifstream in_txt2 ;
   mfem::ifgzstream *in_gz2 = 0 ;
-  PyObject *input_str2 = 0 ;
   std::istringstream *stream2 = 0 ;
   Py_ssize_t len2 = 0 ;
   PyObject *ret2 = 0 ;
@@ -9359,18 +9356,18 @@ SWIGINTERN PyObject *_wrap_new_QuadratureSpace__SWIG_1(PyObject *SWIGUNUSEDPARM(
           return NULL;
         }
         
-        PyObject *input_str2 = PyObject_CallMethod(swig_obj[1], "getvalue", NULL);
+        PyObject *input_str = PyObject_CallMethod(swig_obj[1], "getvalue", NULL);
         if (PyErr_Occurred()) {
           PyErr_SetString(PyExc_RuntimeError, "Can not read from StringIO");
           return NULL;
         }
         
         char *buf = nullptr;
-        PyObject *str = PyUnicode_AsUTF8String(input_str2);	 
+        PyObject *str = PyUnicode_AsUTF8String(input_str);	 
         PyBytes_AsStringAndSize(str, &buf, &len2);
         stream2 = new std::istringstream(buf);
         Py_DECREF(str);
-        Py_DECREF(input_str2);	 
+        Py_DECREF(input_str);	 
       } else {
         // if it is string, extract filename as char*
         PyObject* str = PyUnicode_AsEncodedString(swig_obj[1], "utf-8", "~E~");	
@@ -9995,7 +9992,6 @@ SWIGINTERN PyObject *_wrap_QuadratureSpace_Save(PyObject *self, PyObject *args) 
               _v = 0;	   	   	   
             }
           } else {
-            std::cout << "it is text (out)\n";	
             _v = 1;
           }
         } else {

--- a/mfem/_par/fespace_wrap.cxx
+++ b/mfem/_par/fespace_wrap.cxx
@@ -3348,12 +3348,11 @@ namespace Swig {
 #define SWIGTYPE_p_pri_t swig_types[280]
 #define SWIGTYPE_p_quad_t swig_types[281]
 #define SWIGTYPE_p_seg_t swig_types[282]
-#define SWIGTYPE_p_std__istream swig_types[283]
-#define SWIGTYPE_p_tet_t swig_types[284]
-#define SWIGTYPE_p_tri_t swig_types[285]
-#define SWIGTYPE_p_void swig_types[286]
-static swig_type_info *swig_types[288];
-static swig_module_info swig_module = {swig_types, 287, 0, 0, 0, 0};
+#define SWIGTYPE_p_tet_t swig_types[283]
+#define SWIGTYPE_p_tri_t swig_types[284]
+#define SWIGTYPE_p_void swig_types[285]
+static swig_type_info *swig_types[287];
+static swig_module_info swig_module = {swig_types, 286, 0, 0, 0, 0};
 #define SWIG_TypeQuery(name) SWIG_TypeQueryModule(&swig_module, &swig_module, name)
 #define SWIG_MangledTypeQuery(name) SWIG_MangledTypeQueryModule(&swig_module, &swig_module, name)
 
@@ -8783,10 +8782,10 @@ SWIGINTERN PyObject *_wrap_FiniteElementSpace_Save__SWIG_0(PyObject *SWIGUNUSEDP
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyMFEM::wFILE *temp2 = 0 ;
-  std::ofstream out2 ;
-  int use_stringio2 = 0 ;
+  std::ofstream out_txt2 ;
+  mfem::ofgzstream *out_gz2 = 0 ;
   PyObject *string_io2 = 0 ;
-  std::ostringstream stream2 ;
+  std::ostringstream *stream2 = 0 ;
   PyObject *ret2 = 0 ;
   
   if ((nobjs < 2) || (nobjs > 2)) SWIG_fail;
@@ -8816,29 +8815,33 @@ SWIGINTERN PyObject *_wrap_FiniteElementSpace_Save__SWIG_0(PyObject *SWIGUNUSEDP
           SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
           return NULL;
         }
-        use_stringio2=1;
         string_io2=swig_obj[1];
+        stream2 = new std::ostringstream();
       } else {
         // if it is string, extract filename as char*
         PyObject* str = PyUnicode_AsEncodedString(swig_obj[1], "utf-8", "~E~");	
         const char* filename = PyBytes_AsString(str);
-        temp2 = new PyMFEM::wFILE(filename, 8, true);	
+        temp2 = new PyMFEM::wFILE(filename, 8, true);
+        Py_DECREF(str);	 
       }
     }
     
-    if (use_stringio2 == 0){
+    if (stream2 == 0){
       if (temp2->isSTDOUT() == 1) {
         arg2 = &std::cout;
+      } else if (temp2->isGZ()){
+        out_gz2 = new mfem::ofgzstream(temp2->getFilename(), true);
+        arg2 = out_gz2;	     
       } else {
-        out2.open(temp2->getFilename());
-        out2.precision(temp2->getPrecision());
-        if (temp2->isTemporary()){
-          delete temp2;
-        }
-        arg2 = &out2;
+        out_txt2.open(temp2->getFilename());
+        out_txt2.precision(temp2->getPrecision());
+        arg2 = &out_txt2;
+      }
+      if (temp2->isTemporary()){
+        delete temp2;
       }
     } else {
-      arg2 = &stream2;
+      arg2 = stream2;
     }
   }
   {
@@ -8856,8 +8859,8 @@ SWIGINTERN PyObject *_wrap_FiniteElementSpace_Save__SWIG_0(PyObject *SWIGUNUSEDP
   }
   resultobj = SWIG_Py_Void();
   {
-    if (use_stringio2 == 1) {
-      std::string str =  stream2.str();
+    if (stream2) {
+      std::string str =  stream2->str();
       const char* s = str.c_str();
       const int n = str.length();
       ret2 = PyObject_CallMethod(string_io2, "write", "s#",
@@ -8866,15 +8869,21 @@ SWIGINTERN PyObject *_wrap_FiniteElementSpace_Save__SWIG_0(PyObject *SWIGUNUSEDP
         PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
         return NULL;
       }
+      delete stream2;
       Py_XDECREF(resultobj);   /* Blow away any previous result */
       resultobj = ret2;    
     }
   }
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -8882,10 +8891,15 @@ SWIGINTERN PyObject *_wrap_FiniteElementSpace_Save__SWIG_0(PyObject *SWIGUNUSEDP
   return resultobj;
 fail:
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -8903,8 +8917,13 @@ SWIGINTERN PyObject *_wrap_FiniteElementSpace_Load(PyObject *SWIGUNUSEDPARM(self
   int res1 = 0 ;
   void *argp2 = 0 ;
   int res2 = 0 ;
-  void *argp3 = 0 ;
-  int res3 = 0 ;
+  PyMFEM::wFILE *temp3 = 0 ;
+  std::ifstream in_txt3 ;
+  mfem::ifgzstream *in_gz3 = 0 ;
+  PyObject *input_str3 = 0 ;
+  std::istringstream *stream3 = 0 ;
+  Py_ssize_t len3 = 0 ;
+  PyObject *ret3 = 0 ;
   PyObject * obj0 = 0 ;
   PyObject * obj1 = 0 ;
   PyObject * obj2 = 0 ;
@@ -8924,14 +8943,64 @@ SWIGINTERN PyObject *_wrap_FiniteElementSpace_Load(PyObject *SWIGUNUSEDPARM(self
     SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "FiniteElementSpace_Load" "', argument " "2"" of type '" "mfem::Mesh *""'"); 
   }
   arg2 = reinterpret_cast< mfem::Mesh * >(argp2);
-  res3 = SWIG_ConvertPtr(obj2, &argp3, SWIGTYPE_p_std__istream,  0 );
-  if (!SWIG_IsOK(res3)) {
-    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "FiniteElementSpace_Load" "', argument " "3"" of type '" "std::istream &""'"); 
+  {
+    //  PyMFEM::wFILE or string argument or StringIO
+    if (SWIG_ConvertPtr(obj2, (void **) &temp3, SWIGTYPE_p_PyMFEM__wFILE, 0 | 0) == -1) {
+      if (!PyString_Check(obj2) && !PyUnicode_Check(obj2)) {
+        // not string, check if it is StringIO
+        PyObject* module = PyImport_ImportModule("io");
+        if (!module){
+          PyErr_SetString(PyExc_RuntimeError, "Can not load io module");
+          return NULL;
+        }      
+        PyObject* cls = PyObject_GetAttrString(module, "StringIO");
+        if (!cls){
+          PyErr_SetString(PyExc_RuntimeError, "Can not load StringIO");
+          return NULL;
+        }      
+        int check = PyObject_IsInstance(obj2, cls);
+        Py_DECREF(module);
+        if (! check){
+          SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
+          return NULL;
+        }
+        
+        PyObject *input_str3 = PyObject_CallMethod(obj2, "getvalue", NULL);
+        if (PyErr_Occurred()) {
+          PyErr_SetString(PyExc_RuntimeError, "Can not read from StringIO");
+          return NULL;
+        }
+        
+        char *buf = nullptr;
+        PyObject *str = PyUnicode_AsUTF8String(input_str3);	 
+        PyBytes_AsStringAndSize(str, &buf, &len3);
+        stream3 = new std::istringstream(buf);
+        Py_DECREF(str);
+        Py_DECREF(input_str3);	 
+      } else {
+        // if it is string, extract filename as char*
+        PyObject* str = PyUnicode_AsEncodedString(obj2, "utf-8", "~E~");	
+        const char* filename = PyBytes_AsString(str);
+        temp3 = new PyMFEM::wFILE(filename, 8, true);
+        Py_DECREF(str);
+      }
+    }
+    if (stream3 == 0){
+      if (temp3->isGZ()){
+        in_gz3 = new mfem::ifgzstream(temp3->getFilename());
+        arg3 = in_gz3;
+      } else {
+        in_txt3.open(temp3->getFilename(), std::ifstream::in);
+        in_txt3.precision(temp3->getPrecision());
+        arg3 = &in_txt3;
+      }
+      if (temp3->isTemporary()){
+        delete temp3;
+      }
+    } else {
+      arg3 = stream3;
+    }
   }
-  if (!argp3) {
-    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "FiniteElementSpace_Load" "', argument " "3"" of type '" "std::istream &""'"); 
-  }
-  arg3 = reinterpret_cast< std::istream * >(argp3);
   {
     try {
       result = (mfem::FiniteElementCollection *)(arg1)->Load(arg2,*arg3); 
@@ -8946,8 +9015,40 @@ SWIGINTERN PyObject *_wrap_FiniteElementSpace_Load(PyObject *SWIGUNUSEDPARM(self
     //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__FiniteElementCollection, 0 |  0 );
+  {
+    if (stream3) {
+      ret3 = PyLong_FromSsize_t(len3);
+      if (PyErr_Occurred()) {
+        PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
+        return NULL;
+      }
+      delete stream3;    
+      Py_XDECREF(resultobj);   /* Blow away any previous result */
+      resultobj = ret3;    
+    }
+  }
+  {
+    if (!stream3) {
+      if (temp3) {
+        in_txt3.close();
+      }
+      if (in_gz3){
+        delete in_gz3;
+      }
+    }  
+  }
   return resultobj;
 fail:
+  {
+    if (!stream3) {
+      if (temp3) {
+        in_txt3.close();
+      }
+      if (in_gz3){
+        delete in_gz3;
+      }
+    }  
+  }
   return NULL;
 }
 
@@ -9141,7 +9242,8 @@ SWIGINTERN PyObject *_wrap_FiniteElementSpace_Save(PyObject *self, PyObject *arg
               _v = 0;	   	   	   
             }
           } else {
-            _v = 0;
+            std::cout << "it is text (out)\n";	
+            _v = 1;
           }
         } else {
           _v = 1;
@@ -9220,8 +9322,13 @@ SWIGINTERN PyObject *_wrap_new_QuadratureSpace__SWIG_1(PyObject *SWIGUNUSEDPARM(
   std::istream *arg2 = 0 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
-  void *argp2 = 0 ;
-  int res2 = 0 ;
+  PyMFEM::wFILE *temp2 = 0 ;
+  std::ifstream in_txt2 ;
+  mfem::ifgzstream *in_gz2 = 0 ;
+  PyObject *input_str2 = 0 ;
+  std::istringstream *stream2 = 0 ;
+  Py_ssize_t len2 = 0 ;
+  PyObject *ret2 = 0 ;
   mfem::QuadratureSpace *result = 0 ;
   
   if ((nobjs < 2) || (nobjs > 2)) SWIG_fail;
@@ -9230,14 +9337,64 @@ SWIGINTERN PyObject *_wrap_new_QuadratureSpace__SWIG_1(PyObject *SWIGUNUSEDPARM(
     SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "new_QuadratureSpace" "', argument " "1"" of type '" "mfem::Mesh *""'"); 
   }
   arg1 = reinterpret_cast< mfem::Mesh * >(argp1);
-  res2 = SWIG_ConvertPtr(swig_obj[1], &argp2, SWIGTYPE_p_std__istream,  0 );
-  if (!SWIG_IsOK(res2)) {
-    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "new_QuadratureSpace" "', argument " "2"" of type '" "std::istream &""'"); 
+  {
+    //  PyMFEM::wFILE or string argument or StringIO
+    if (SWIG_ConvertPtr(swig_obj[1], (void **) &temp2, SWIGTYPE_p_PyMFEM__wFILE, 0 | 0) == -1) {
+      if (!PyString_Check(swig_obj[1]) && !PyUnicode_Check(swig_obj[1])) {
+        // not string, check if it is StringIO
+        PyObject* module = PyImport_ImportModule("io");
+        if (!module){
+          PyErr_SetString(PyExc_RuntimeError, "Can not load io module");
+          return NULL;
+        }      
+        PyObject* cls = PyObject_GetAttrString(module, "StringIO");
+        if (!cls){
+          PyErr_SetString(PyExc_RuntimeError, "Can not load StringIO");
+          return NULL;
+        }      
+        int check = PyObject_IsInstance(swig_obj[1], cls);
+        Py_DECREF(module);
+        if (! check){
+          SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
+          return NULL;
+        }
+        
+        PyObject *input_str2 = PyObject_CallMethod(swig_obj[1], "getvalue", NULL);
+        if (PyErr_Occurred()) {
+          PyErr_SetString(PyExc_RuntimeError, "Can not read from StringIO");
+          return NULL;
+        }
+        
+        char *buf = nullptr;
+        PyObject *str = PyUnicode_AsUTF8String(input_str2);	 
+        PyBytes_AsStringAndSize(str, &buf, &len2);
+        stream2 = new std::istringstream(buf);
+        Py_DECREF(str);
+        Py_DECREF(input_str2);	 
+      } else {
+        // if it is string, extract filename as char*
+        PyObject* str = PyUnicode_AsEncodedString(swig_obj[1], "utf-8", "~E~");	
+        const char* filename = PyBytes_AsString(str);
+        temp2 = new PyMFEM::wFILE(filename, 8, true);
+        Py_DECREF(str);
+      }
+    }
+    if (stream2 == 0){
+      if (temp2->isGZ()){
+        in_gz2 = new mfem::ifgzstream(temp2->getFilename());
+        arg2 = in_gz2;
+      } else {
+        in_txt2.open(temp2->getFilename(), std::ifstream::in);
+        in_txt2.precision(temp2->getPrecision());
+        arg2 = &in_txt2;
+      }
+      if (temp2->isTemporary()){
+        delete temp2;
+      }
+    } else {
+      arg2 = stream2;
+    }
   }
-  if (!argp2) {
-    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "new_QuadratureSpace" "', argument " "2"" of type '" "std::istream &""'"); 
-  }
-  arg2 = reinterpret_cast< std::istream * >(argp2);
   {
     try {
       result = (mfem::QuadratureSpace *)new mfem::QuadratureSpace(arg1,*arg2); 
@@ -9252,8 +9409,40 @@ SWIGINTERN PyObject *_wrap_new_QuadratureSpace__SWIG_1(PyObject *SWIGUNUSEDPARM(
     //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__QuadratureSpace, SWIG_POINTER_NEW |  0 );
+  {
+    if (stream2) {
+      ret2 = PyLong_FromSsize_t(len2);
+      if (PyErr_Occurred()) {
+        PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
+        return NULL;
+      }
+      delete stream2;    
+      Py_XDECREF(resultobj);   /* Blow away any previous result */
+      resultobj = ret2;    
+    }
+  }
+  {
+    if (!stream2) {
+      if (temp2) {
+        in_txt2.close();
+      }
+      if (in_gz2){
+        delete in_gz2;
+      }
+    }  
+  }
   return resultobj;
 fail:
+  {
+    if (!stream2) {
+      if (temp2) {
+        in_txt2.close();
+      }
+      if (in_gz2){
+        delete in_gz2;
+      }
+    }  
+  }
   return NULL;
 }
 
@@ -9272,20 +9461,6 @@ SWIGINTERN PyObject *_wrap_new_QuadratureSpace(PyObject *self, PyObject *args) {
     int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_mfem__Mesh, 0);
     _v = SWIG_CheckState(res);
     if (_v) {
-      void *vptr = 0;
-      int res = SWIG_ConvertPtr(argv[1], &vptr, SWIGTYPE_p_std__istream, SWIG_POINTER_NO_NULL);
-      _v = SWIG_CheckState(res);
-      if (_v) {
-        return _wrap_new_QuadratureSpace__SWIG_1(self, argc, argv);
-      }
-    }
-  }
-  if (argc == 2) {
-    int _v;
-    void *vptr = 0;
-    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_mfem__Mesh, 0);
-    _v = SWIG_CheckState(res);
-    if (_v) {
       {
         if ((PyArray_PyIntAsInt(argv[1]) == -1) && PyErr_Occurred()) {
           PyErr_Clear();
@@ -9296,6 +9471,45 @@ SWIGINTERN PyObject *_wrap_new_QuadratureSpace(PyObject *self, PyObject *args) {
       }
       if (_v) {
         return _wrap_new_QuadratureSpace__SWIG_0(self, argc, argv);
+      }
+    }
+  }
+  if (argc == 2) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_mfem__Mesh, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      {
+        void *ptr;
+        //std::string *ptr2 = (std::string *)0;
+        if (SWIG_ConvertPtr(argv[1], (void **) &ptr, SWIGTYPE_p_PyMFEM__wFILE, 0 |0) == -1) {
+          PyErr_Clear();
+          if (!PyString_Check(argv[1]) && !PyUnicode_Check(argv[1])) {
+            // not string
+            _v = 1;	   	
+            PyObject* module = PyImport_ImportModule("io");
+            if (!module){
+              _v = 0;	   
+            }      
+            PyObject* cls = PyObject_GetAttrString(module, "StringIO");
+            if (!cls){
+              _v = 0;	   	   
+            }      
+            int check = PyObject_IsInstance(argv[1], cls);
+            Py_DECREF(module);
+            if (! check){
+              _v = 0;	   	   	   
+            }
+          } else {
+            _v = 1;
+          }
+        } else {
+          _v = 1;
+        }
+      }
+      if (_v) {
+        return _wrap_new_QuadratureSpace__SWIG_1(self, argc, argv);
       }
     }
   }
@@ -9500,10 +9714,10 @@ SWIGINTERN PyObject *_wrap_QuadratureSpace_Save__SWIG_0(PyObject *SWIGUNUSEDPARM
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyMFEM::wFILE *temp2 = 0 ;
-  std::ofstream out2 ;
-  int use_stringio2 = 0 ;
+  std::ofstream out_txt2 ;
+  mfem::ofgzstream *out_gz2 = 0 ;
   PyObject *string_io2 = 0 ;
-  std::ostringstream stream2 ;
+  std::ostringstream *stream2 = 0 ;
   PyObject *ret2 = 0 ;
   
   if ((nobjs < 2) || (nobjs > 2)) SWIG_fail;
@@ -9533,29 +9747,33 @@ SWIGINTERN PyObject *_wrap_QuadratureSpace_Save__SWIG_0(PyObject *SWIGUNUSEDPARM
           SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
           return NULL;
         }
-        use_stringio2=1;
         string_io2=swig_obj[1];
+        stream2 = new std::ostringstream();
       } else {
         // if it is string, extract filename as char*
         PyObject* str = PyUnicode_AsEncodedString(swig_obj[1], "utf-8", "~E~");	
         const char* filename = PyBytes_AsString(str);
-        temp2 = new PyMFEM::wFILE(filename, 8, true);	
+        temp2 = new PyMFEM::wFILE(filename, 8, true);
+        Py_DECREF(str);	 
       }
     }
     
-    if (use_stringio2 == 0){
+    if (stream2 == 0){
       if (temp2->isSTDOUT() == 1) {
         arg2 = &std::cout;
+      } else if (temp2->isGZ()){
+        out_gz2 = new mfem::ofgzstream(temp2->getFilename(), true);
+        arg2 = out_gz2;	     
       } else {
-        out2.open(temp2->getFilename());
-        out2.precision(temp2->getPrecision());
-        if (temp2->isTemporary()){
-          delete temp2;
-        }
-        arg2 = &out2;
+        out_txt2.open(temp2->getFilename());
+        out_txt2.precision(temp2->getPrecision());
+        arg2 = &out_txt2;
+      }
+      if (temp2->isTemporary()){
+        delete temp2;
       }
     } else {
-      arg2 = &stream2;
+      arg2 = stream2;
     }
   }
   {
@@ -9573,8 +9791,8 @@ SWIGINTERN PyObject *_wrap_QuadratureSpace_Save__SWIG_0(PyObject *SWIGUNUSEDPARM
   }
   resultobj = SWIG_Py_Void();
   {
-    if (use_stringio2 == 1) {
-      std::string str =  stream2.str();
+    if (stream2) {
+      std::string str =  stream2->str();
       const char* s = str.c_str();
       const int n = str.length();
       ret2 = PyObject_CallMethod(string_io2, "write", "s#",
@@ -9583,15 +9801,21 @@ SWIGINTERN PyObject *_wrap_QuadratureSpace_Save__SWIG_0(PyObject *SWIGUNUSEDPARM
         PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
         return NULL;
       }
+      delete stream2;
       Py_XDECREF(resultobj);   /* Blow away any previous result */
       resultobj = ret2;    
     }
   }
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -9599,10 +9823,15 @@ SWIGINTERN PyObject *_wrap_QuadratureSpace_Save__SWIG_0(PyObject *SWIGUNUSEDPARM
   return resultobj;
 fail:
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -9766,7 +9995,8 @@ SWIGINTERN PyObject *_wrap_QuadratureSpace_Save(PyObject *self, PyObject *args) 
               _v = 0;	   	   	   
             }
           } else {
-            _v = 0;
+            std::cout << "it is text (out)\n";	
+            _v = 1;
           }
         } else {
           _v = 1;
@@ -11841,7 +12071,6 @@ static swig_type_info _swigt__p_mfem__STable = {"_p_mfem__STable", 0, 0, 0, 0, 0
 static swig_type_info _swigt__p_pri_t = {"_p_pri_t", "pri_t *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_quad_t = {"_p_quad_t", "quad_t *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_seg_t = {"_p_seg_t", "seg_t *", 0, 0, (void*)0, 0};
-static swig_type_info _swigt__p_std__istream = {"_p_std__istream", "std::istream *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_tet_t = {"_p_tet_t", "tet_t *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_tri_t = {"_p_tri_t", "tri_t *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_void = {"_p_void", "void *", 0, 0, (void*)0, 0};
@@ -12130,7 +12359,6 @@ static swig_type_info *swig_type_initial[] = {
   &_swigt__p_pri_t,
   &_swigt__p_quad_t,
   &_swigt__p_seg_t,
-  &_swigt__p_std__istream,
   &_swigt__p_tet_t,
   &_swigt__p_tri_t,
   &_swigt__p_void,
@@ -12419,7 +12647,6 @@ static swig_cast_info _swigc__p_mfem__Table[] = {  {&_swigt__p_mfem__STable, _p_
 static swig_cast_info _swigc__p_pri_t[] = {  {&_swigt__p_pri_t, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_quad_t[] = {  {&_swigt__p_quad_t, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_seg_t[] = {  {&_swigt__p_seg_t, 0, 0, 0},{0, 0, 0, 0}};
-static swig_cast_info _swigc__p_std__istream[] = {  {&_swigt__p_std__istream, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_tet_t[] = {  {&_swigt__p_tet_t, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_tri_t[] = {  {&_swigt__p_tri_t, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_void[] = {  {&_swigt__p_void, 0, 0, 0},{0, 0, 0, 0}};
@@ -12708,7 +12935,6 @@ static swig_cast_info *swig_cast_initial[] = {
   _swigc__p_pri_t,
   _swigc__p_quad_t,
   _swigc__p_seg_t,
-  _swigc__p_std__istream,
   _swigc__p_tet_t,
   _swigc__p_tri_t,
   _swigc__p_void,

--- a/mfem/_par/gridfunc.i
+++ b/mfem/_par/gridfunc.i
@@ -89,16 +89,7 @@ def GetNodalValues(self, *args):
 
 namespace mfem{
 %extend GridFunction{
-GridFunction(Mesh *m, const char *grid_file){
-   mfem::GridFunction *gf;
-   std::ifstream igrid(grid_file);
-   if (!igrid) {
-      std::cerr << "\nCan not open grid function file: " << grid_file << '\n' << std::endl;
-      return NULL;
-   }
-   gf = new mfem::GridFunction(m, igrid);
-   return gf;
-}
+     
 GridFunction(mfem::FiniteElementSpace *fes, const mfem::Vector &v, int offset){
    mfem::GridFunction *gf;   
    gf = new mfem::GridFunction(fes, v.GetData() + offset);

--- a/mfem/_par/gridfunc.py
+++ b/mfem/_par/gridfunc.py
@@ -527,7 +527,6 @@ class GridFunction(mfem._par.vector.Vector):
         __init__(GridFunction self, FiniteElementSpace f, double * data) -> GridFunction
         __init__(GridFunction self, Mesh m, std::istream & input) -> GridFunction
         __init__(GridFunction self, Mesh m, mfem::GridFunction *[] gf_array, int num_pieces) -> GridFunction
-        __init__(GridFunction self, Mesh m, char const * grid_file) -> GridFunction
         __init__(GridFunction self, FiniteElementSpace fes, Vector v, int offset) -> GridFunction
         """
         _gridfunc.GridFunction_swiginit(self, _gridfunc.new_GridFunction(*args))

--- a/mfem/_par/gridfunc_wrap.cxx
+++ b/mfem/_par/gridfunc_wrap.cxx
@@ -3268,12 +3268,11 @@ namespace Swig {
 #define SWIGTYPE_p_pri_t swig_types[197]
 #define SWIGTYPE_p_quad_t swig_types[198]
 #define SWIGTYPE_p_seg_t swig_types[199]
-#define SWIGTYPE_p_std__istream swig_types[200]
-#define SWIGTYPE_p_std__ostream swig_types[201]
-#define SWIGTYPE_p_tet_t swig_types[202]
-#define SWIGTYPE_p_tri_t swig_types[203]
-static swig_type_info *swig_types[205];
-static swig_module_info swig_module = {swig_types, 204, 0, 0, 0, 0};
+#define SWIGTYPE_p_std__ostream swig_types[200]
+#define SWIGTYPE_p_tet_t swig_types[201]
+#define SWIGTYPE_p_tri_t swig_types[202]
+static swig_type_info *swig_types[204];
+static swig_module_info swig_module = {swig_types, 203, 0, 0, 0, 0};
 #define SWIG_TypeQuery(name) SWIG_TypeQueryModule(&swig_module, &swig_module, name)
 #define SWIG_MangledTypeQuery(name) SWIG_MangledTypeQueryModule(&swig_module, &swig_module, name)
 
@@ -3973,8 +3972,13 @@ SWIGINTERN PyObject *_wrap_new_GridFunction__SWIG_4(PyObject *SWIGUNUSEDPARM(sel
   std::istream *arg2 = 0 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
-  void *argp2 = 0 ;
-  int res2 = 0 ;
+  PyMFEM::wFILE *temp2 = 0 ;
+  std::ifstream in_txt2 ;
+  mfem::ifgzstream *in_gz2 = 0 ;
+  PyObject *input_str2 = 0 ;
+  std::istringstream *stream2 = 0 ;
+  Py_ssize_t len2 = 0 ;
+  PyObject *ret2 = 0 ;
   mfem::GridFunction *result = 0 ;
   
   if ((nobjs < 2) || (nobjs > 2)) SWIG_fail;
@@ -3983,14 +3987,64 @@ SWIGINTERN PyObject *_wrap_new_GridFunction__SWIG_4(PyObject *SWIGUNUSEDPARM(sel
     SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "new_GridFunction" "', argument " "1"" of type '" "mfem::Mesh *""'"); 
   }
   arg1 = reinterpret_cast< mfem::Mesh * >(argp1);
-  res2 = SWIG_ConvertPtr(swig_obj[1], &argp2, SWIGTYPE_p_std__istream,  0 );
-  if (!SWIG_IsOK(res2)) {
-    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "new_GridFunction" "', argument " "2"" of type '" "std::istream &""'"); 
+  {
+    //  PyMFEM::wFILE or string argument or StringIO
+    if (SWIG_ConvertPtr(swig_obj[1], (void **) &temp2, SWIGTYPE_p_PyMFEM__wFILE, 0 | 0) == -1) {
+      if (!PyString_Check(swig_obj[1]) && !PyUnicode_Check(swig_obj[1])) {
+        // not string, check if it is StringIO
+        PyObject* module = PyImport_ImportModule("io");
+        if (!module){
+          PyErr_SetString(PyExc_RuntimeError, "Can not load io module");
+          return NULL;
+        }      
+        PyObject* cls = PyObject_GetAttrString(module, "StringIO");
+        if (!cls){
+          PyErr_SetString(PyExc_RuntimeError, "Can not load StringIO");
+          return NULL;
+        }      
+        int check = PyObject_IsInstance(swig_obj[1], cls);
+        Py_DECREF(module);
+        if (! check){
+          SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
+          return NULL;
+        }
+        
+        PyObject *input_str2 = PyObject_CallMethod(swig_obj[1], "getvalue", NULL);
+        if (PyErr_Occurred()) {
+          PyErr_SetString(PyExc_RuntimeError, "Can not read from StringIO");
+          return NULL;
+        }
+        
+        char *buf = nullptr;
+        PyObject *str = PyUnicode_AsUTF8String(input_str2);	 
+        PyBytes_AsStringAndSize(str, &buf, &len2);
+        stream2 = new std::istringstream(buf);
+        Py_DECREF(str);
+        Py_DECREF(input_str2);	 
+      } else {
+        // if it is string, extract filename as char*
+        PyObject* str = PyUnicode_AsEncodedString(swig_obj[1], "utf-8", "~E~");	
+        const char* filename = PyBytes_AsString(str);
+        temp2 = new PyMFEM::wFILE(filename, 8, true);
+        Py_DECREF(str);
+      }
+    }
+    if (stream2 == 0){
+      if (temp2->isGZ()){
+        in_gz2 = new mfem::ifgzstream(temp2->getFilename());
+        arg2 = in_gz2;
+      } else {
+        in_txt2.open(temp2->getFilename(), std::ifstream::in);
+        in_txt2.precision(temp2->getPrecision());
+        arg2 = &in_txt2;
+      }
+      if (temp2->isTemporary()){
+        delete temp2;
+      }
+    } else {
+      arg2 = stream2;
+    }
   }
-  if (!argp2) {
-    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "new_GridFunction" "', argument " "2"" of type '" "std::istream &""'"); 
-  }
-  arg2 = reinterpret_cast< std::istream * >(argp2);
   {
     try {
       result = (mfem::GridFunction *)new mfem::GridFunction(arg1,*arg2); 
@@ -4005,8 +4059,40 @@ SWIGINTERN PyObject *_wrap_new_GridFunction__SWIG_4(PyObject *SWIGUNUSEDPARM(sel
     //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__GridFunction, SWIG_POINTER_NEW |  0 );
+  {
+    if (stream2) {
+      ret2 = PyLong_FromSsize_t(len2);
+      if (PyErr_Occurred()) {
+        PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
+        return NULL;
+      }
+      delete stream2;    
+      Py_XDECREF(resultobj);   /* Blow away any previous result */
+      resultobj = ret2;    
+    }
+  }
+  {
+    if (!stream2) {
+      if (temp2) {
+        in_txt2.close();
+      }
+      if (in_gz2){
+        delete in_gz2;
+      }
+    }  
+  }
   return resultobj;
 fail:
+  {
+    if (!stream2) {
+      if (temp2) {
+        in_txt2.close();
+      }
+      if (in_gz2){
+        delete in_gz2;
+      }
+    }  
+  }
   return NULL;
 }
 
@@ -12277,10 +12363,10 @@ SWIGINTERN PyObject *_wrap_GridFunction_Save__SWIG_0(PyObject *SWIGUNUSEDPARM(se
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyMFEM::wFILE *temp2 = 0 ;
-  std::ofstream out2 ;
-  int use_stringio2 = 0 ;
+  std::ofstream out_txt2 ;
+  mfem::ofgzstream *out_gz2 = 0 ;
   PyObject *string_io2 = 0 ;
-  std::ostringstream stream2 ;
+  std::ostringstream *stream2 = 0 ;
   PyObject *ret2 = 0 ;
   
   if ((nobjs < 2) || (nobjs > 2)) SWIG_fail;
@@ -12310,29 +12396,33 @@ SWIGINTERN PyObject *_wrap_GridFunction_Save__SWIG_0(PyObject *SWIGUNUSEDPARM(se
           SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
           return NULL;
         }
-        use_stringio2=1;
         string_io2=swig_obj[1];
+        stream2 = new std::ostringstream();
       } else {
         // if it is string, extract filename as char*
         PyObject* str = PyUnicode_AsEncodedString(swig_obj[1], "utf-8", "~E~");	
         const char* filename = PyBytes_AsString(str);
-        temp2 = new PyMFEM::wFILE(filename, 8, true);	
+        temp2 = new PyMFEM::wFILE(filename, 8, true);
+        Py_DECREF(str);	 
       }
     }
     
-    if (use_stringio2 == 0){
+    if (stream2 == 0){
       if (temp2->isSTDOUT() == 1) {
         arg2 = &std::cout;
+      } else if (temp2->isGZ()){
+        out_gz2 = new mfem::ofgzstream(temp2->getFilename(), true);
+        arg2 = out_gz2;	     
       } else {
-        out2.open(temp2->getFilename());
-        out2.precision(temp2->getPrecision());
-        if (temp2->isTemporary()){
-          delete temp2;
-        }
-        arg2 = &out2;
+        out_txt2.open(temp2->getFilename());
+        out_txt2.precision(temp2->getPrecision());
+        arg2 = &out_txt2;
+      }
+      if (temp2->isTemporary()){
+        delete temp2;
       }
     } else {
-      arg2 = &stream2;
+      arg2 = stream2;
     }
   }
   {
@@ -12350,8 +12440,8 @@ SWIGINTERN PyObject *_wrap_GridFunction_Save__SWIG_0(PyObject *SWIGUNUSEDPARM(se
   }
   resultobj = SWIG_Py_Void();
   {
-    if (use_stringio2 == 1) {
-      std::string str =  stream2.str();
+    if (stream2) {
+      std::string str =  stream2->str();
       const char* s = str.c_str();
       const int n = str.length();
       ret2 = PyObject_CallMethod(string_io2, "write", "s#",
@@ -12360,15 +12450,21 @@ SWIGINTERN PyObject *_wrap_GridFunction_Save__SWIG_0(PyObject *SWIGUNUSEDPARM(se
         PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
         return NULL;
       }
+      delete stream2;
       Py_XDECREF(resultobj);   /* Blow away any previous result */
       resultobj = ret2;    
     }
   }
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -12376,10 +12472,15 @@ SWIGINTERN PyObject *_wrap_GridFunction_Save__SWIG_0(PyObject *SWIGUNUSEDPARM(se
   return resultobj;
 fail:
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -12397,10 +12498,10 @@ SWIGINTERN PyObject *_wrap_GridFunction_SaveVTK(PyObject *SWIGUNUSEDPARM(self), 
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyMFEM::wFILE *temp2 = 0 ;
-  std::ofstream out2 ;
-  int use_stringio2 = 0 ;
+  std::ofstream out_txt2 ;
+  mfem::ofgzstream *out_gz2 = 0 ;
   PyObject *string_io2 = 0 ;
-  std::ostringstream stream2 ;
+  std::ostringstream *stream2 = 0 ;
   PyObject *ret2 = 0 ;
   int res3 = SWIG_OLDOBJ ;
   PyObject * obj0 = 0 ;
@@ -12438,29 +12539,33 @@ SWIGINTERN PyObject *_wrap_GridFunction_SaveVTK(PyObject *SWIGUNUSEDPARM(self), 
           SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
           return NULL;
         }
-        use_stringio2=1;
         string_io2=obj1;
+        stream2 = new std::ostringstream();
       } else {
         // if it is string, extract filename as char*
         PyObject* str = PyUnicode_AsEncodedString(obj1, "utf-8", "~E~");	
         const char* filename = PyBytes_AsString(str);
-        temp2 = new PyMFEM::wFILE(filename, 8, true);	
+        temp2 = new PyMFEM::wFILE(filename, 8, true);
+        Py_DECREF(str);	 
       }
     }
     
-    if (use_stringio2 == 0){
+    if (stream2 == 0){
       if (temp2->isSTDOUT() == 1) {
         arg2 = &std::cout;
+      } else if (temp2->isGZ()){
+        out_gz2 = new mfem::ofgzstream(temp2->getFilename(), true);
+        arg2 = out_gz2;	     
       } else {
-        out2.open(temp2->getFilename());
-        out2.precision(temp2->getPrecision());
-        if (temp2->isTemporary()){
-          delete temp2;
-        }
-        arg2 = &out2;
+        out_txt2.open(temp2->getFilename());
+        out_txt2.precision(temp2->getPrecision());
+        arg2 = &out_txt2;
+      }
+      if (temp2->isTemporary()){
+        delete temp2;
       }
     } else {
-      arg2 = &stream2;
+      arg2 = stream2;
     }
   }
   {
@@ -12495,8 +12600,8 @@ SWIGINTERN PyObject *_wrap_GridFunction_SaveVTK(PyObject *SWIGUNUSEDPARM(self), 
   }
   resultobj = SWIG_Py_Void();
   {
-    if (use_stringio2 == 1) {
-      std::string str =  stream2.str();
+    if (stream2) {
+      std::string str =  stream2->str();
       const char* s = str.c_str();
       const int n = str.length();
       ret2 = PyObject_CallMethod(string_io2, "write", "s#",
@@ -12505,15 +12610,21 @@ SWIGINTERN PyObject *_wrap_GridFunction_SaveVTK(PyObject *SWIGUNUSEDPARM(self), 
         PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
         return NULL;
       }
+      delete stream2;
       Py_XDECREF(resultobj);   /* Blow away any previous result */
       resultobj = ret2;    
     }
   }
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -12522,10 +12633,15 @@ SWIGINTERN PyObject *_wrap_GridFunction_SaveVTK(PyObject *SWIGUNUSEDPARM(self), 
   return resultobj;
 fail:
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -12543,10 +12659,10 @@ SWIGINTERN PyObject *_wrap_GridFunction_SaveSTL(PyObject *SWIGUNUSEDPARM(self), 
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyMFEM::wFILE *temp2 = 0 ;
-  std::ofstream out2 ;
-  int use_stringio2 = 0 ;
+  std::ofstream out_txt2 ;
+  mfem::ofgzstream *out_gz2 = 0 ;
   PyObject *string_io2 = 0 ;
-  std::ostringstream stream2 ;
+  std::ostringstream *stream2 = 0 ;
   PyObject *ret2 = 0 ;
   PyObject * obj0 = 0 ;
   PyObject * obj1 = 0 ;
@@ -12582,29 +12698,33 @@ SWIGINTERN PyObject *_wrap_GridFunction_SaveSTL(PyObject *SWIGUNUSEDPARM(self), 
           SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
           return NULL;
         }
-        use_stringio2=1;
         string_io2=obj1;
+        stream2 = new std::ostringstream();
       } else {
         // if it is string, extract filename as char*
         PyObject* str = PyUnicode_AsEncodedString(obj1, "utf-8", "~E~");	
         const char* filename = PyBytes_AsString(str);
-        temp2 = new PyMFEM::wFILE(filename, 8, true);	
+        temp2 = new PyMFEM::wFILE(filename, 8, true);
+        Py_DECREF(str);	 
       }
     }
     
-    if (use_stringio2 == 0){
+    if (stream2 == 0){
       if (temp2->isSTDOUT() == 1) {
         arg2 = &std::cout;
+      } else if (temp2->isGZ()){
+        out_gz2 = new mfem::ofgzstream(temp2->getFilename(), true);
+        arg2 = out_gz2;	     
       } else {
-        out2.open(temp2->getFilename());
-        out2.precision(temp2->getPrecision());
-        if (temp2->isTemporary()){
-          delete temp2;
-        }
-        arg2 = &out2;
+        out_txt2.open(temp2->getFilename());
+        out_txt2.precision(temp2->getPrecision());
+        arg2 = &out_txt2;
+      }
+      if (temp2->isTemporary()){
+        delete temp2;
       }
     } else {
-      arg2 = &stream2;
+      arg2 = stream2;
     }
   }
   if (obj2) {
@@ -12630,8 +12750,8 @@ SWIGINTERN PyObject *_wrap_GridFunction_SaveSTL(PyObject *SWIGUNUSEDPARM(self), 
   }
   resultobj = SWIG_Py_Void();
   {
-    if (use_stringio2 == 1) {
-      std::string str =  stream2.str();
+    if (stream2) {
+      std::string str =  stream2->str();
       const char* s = str.c_str();
       const int n = str.length();
       ret2 = PyObject_CallMethod(string_io2, "write", "s#",
@@ -12640,15 +12760,21 @@ SWIGINTERN PyObject *_wrap_GridFunction_SaveSTL(PyObject *SWIGUNUSEDPARM(self), 
         PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
         return NULL;
       }
+      delete stream2;
       Py_XDECREF(resultobj);   /* Blow away any previous result */
       resultobj = ret2;    
     }
   }
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -12656,10 +12782,15 @@ SWIGINTERN PyObject *_wrap_GridFunction_SaveSTL(PyObject *SWIGUNUSEDPARM(self), 
   return resultobj;
 fail:
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -12845,11 +12976,10 @@ SWIGINTERN PyObject *_wrap_new_GridFunction(PyObject *self, PyObject *args) {
     int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_mfem__Mesh, 0);
     _v = SWIG_CheckState(res);
     if (_v) {
-      void *vptr = 0;
-      int res = SWIG_ConvertPtr(argv[1], &vptr, SWIGTYPE_p_std__istream, SWIG_POINTER_NO_NULL);
+      int res = SWIG_AsCharPtrAndSize(argv[1], 0, NULL, 0);
       _v = SWIG_CheckState(res);
       if (_v) {
-        return _wrap_new_GridFunction__SWIG_4(self, argc, argv);
+        return _wrap_new_GridFunction__SWIG_6(self, argc, argv);
       }
     }
   }
@@ -12859,10 +12989,36 @@ SWIGINTERN PyObject *_wrap_new_GridFunction(PyObject *self, PyObject *args) {
     int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_mfem__Mesh, 0);
     _v = SWIG_CheckState(res);
     if (_v) {
-      int res = SWIG_AsCharPtrAndSize(argv[1], 0, NULL, 0);
-      _v = SWIG_CheckState(res);
+      {
+        void *ptr;
+        //std::string *ptr2 = (std::string *)0;
+        if (SWIG_ConvertPtr(argv[1], (void **) &ptr, SWIGTYPE_p_PyMFEM__wFILE, 0 |0) == -1) {
+          PyErr_Clear();
+          if (!PyString_Check(argv[1]) && !PyUnicode_Check(argv[1])) {
+            // not string
+            _v = 1;	   	
+            PyObject* module = PyImport_ImportModule("io");
+            if (!module){
+              _v = 0;	   
+            }      
+            PyObject* cls = PyObject_GetAttrString(module, "StringIO");
+            if (!cls){
+              _v = 0;	   	   
+            }      
+            int check = PyObject_IsInstance(argv[1], cls);
+            Py_DECREF(module);
+            if (! check){
+              _v = 0;	   	   	   
+            }
+          } else {
+            _v = 1;
+          }
+        } else {
+          _v = 1;
+        }
+      }
       if (_v) {
-        return _wrap_new_GridFunction__SWIG_6(self, argc, argv);
+        return _wrap_new_GridFunction__SWIG_4(self, argc, argv);
       }
     }
   }
@@ -13412,7 +13568,8 @@ SWIGINTERN PyObject *_wrap_GridFunction_Save(PyObject *self, PyObject *args) {
               _v = 0;	   	   	   
             }
           } else {
-            _v = 0;
+            std::cout << "it is text (out)\n";	
+            _v = 1;
           }
         } else {
           _v = 1;
@@ -13449,10 +13606,10 @@ SWIGINTERN PyObject *_wrap___lshift____SWIG_2(PyObject *SWIGUNUSEDPARM(self), Py
   std::ostream *arg1 = 0 ;
   mfem::GridFunction *arg2 = 0 ;
   PyMFEM::wFILE *temp1 = 0 ;
-  std::ofstream out1 ;
-  int use_stringio1 = 0 ;
+  std::ofstream out_txt1 ;
+  mfem::ofgzstream *out_gz1 = 0 ;
   PyObject *string_io1 = 0 ;
-  std::ostringstream stream1 ;
+  std::ostringstream *stream1 = 0 ;
   PyObject *ret1 = 0 ;
   void *argp2 = 0 ;
   int res2 = 0 ;
@@ -13480,29 +13637,33 @@ SWIGINTERN PyObject *_wrap___lshift____SWIG_2(PyObject *SWIGUNUSEDPARM(self), Py
           SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
           return NULL;
         }
-        use_stringio1=1;
         string_io1=swig_obj[0];
+        stream1 = new std::ostringstream();
       } else {
         // if it is string, extract filename as char*
         PyObject* str = PyUnicode_AsEncodedString(swig_obj[0], "utf-8", "~E~");	
         const char* filename = PyBytes_AsString(str);
-        temp1 = new PyMFEM::wFILE(filename, 8, true);	
+        temp1 = new PyMFEM::wFILE(filename, 8, true);
+        Py_DECREF(str);	 
       }
     }
     
-    if (use_stringio1 == 0){
+    if (stream1 == 0){
       if (temp1->isSTDOUT() == 1) {
         arg1 = &std::cout;
+      } else if (temp1->isGZ()){
+        out_gz1 = new mfem::ofgzstream(temp1->getFilename(), true);
+        arg1 = out_gz1;	     
       } else {
-        out1.open(temp1->getFilename());
-        out1.precision(temp1->getPrecision());
-        if (temp1->isTemporary()){
-          delete temp1;
-        }
-        arg1 = &out1;
+        out_txt1.open(temp1->getFilename());
+        out_txt1.precision(temp1->getPrecision());
+        arg1 = &out_txt1;
+      }
+      if (temp1->isTemporary()){
+        delete temp1;
       }
     } else {
-      arg1 = &stream1;
+      arg1 = stream1;
     }
   }
   res2 = SWIG_ConvertPtr(swig_obj[1], &argp2, SWIGTYPE_p_mfem__GridFunction,  0  | 0);
@@ -13528,8 +13689,8 @@ SWIGINTERN PyObject *_wrap___lshift____SWIG_2(PyObject *SWIGUNUSEDPARM(self), Py
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_std__ostream, 0 |  0 );
   {
-    if (use_stringio1 == 1) {
-      std::string str =  stream1.str();
+    if (stream1) {
+      std::string str =  stream1->str();
       const char* s = str.c_str();
       const int n = str.length();
       ret1 = PyObject_CallMethod(string_io1, "write", "s#",
@@ -13538,15 +13699,21 @@ SWIGINTERN PyObject *_wrap___lshift____SWIG_2(PyObject *SWIGUNUSEDPARM(self), Py
         PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
         return NULL;
       }
+      delete stream1;
       Py_XDECREF(resultobj);   /* Blow away any previous result */
       resultobj = ret1;    
     }
   }
   {
-    if (use_stringio1 == 0) {
+    if (!stream1) {
       if (temp1) {
         if (temp1->isSTDOUT() != 1) {
-          out1.close();
+          if (out_txt1.is_open()){
+            out_txt1.close();
+          }
+          if (out_gz1){
+            delete out_gz1;
+          }
         }
       }
     }
@@ -13554,10 +13721,15 @@ SWIGINTERN PyObject *_wrap___lshift____SWIG_2(PyObject *SWIGUNUSEDPARM(self), Py
   return resultobj;
 fail:
   {
-    if (use_stringio1 == 0) {
+    if (!stream1) {
       if (temp1) {
         if (temp1->isSTDOUT() != 1) {
-          out1.close();
+          if (out_txt1.is_open()){
+            out_txt1.close();
+          }
+          if (out_gz1){
+            delete out_gz1;
+          }
         }
       }
     }
@@ -13727,8 +13899,13 @@ SWIGINTERN PyObject *_wrap_new_QuadratureFunction__SWIG_4(PyObject *SWIGUNUSEDPA
   std::istream *arg2 = 0 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
-  void *argp2 = 0 ;
-  int res2 = 0 ;
+  PyMFEM::wFILE *temp2 = 0 ;
+  std::ifstream in_txt2 ;
+  mfem::ifgzstream *in_gz2 = 0 ;
+  PyObject *input_str2 = 0 ;
+  std::istringstream *stream2 = 0 ;
+  Py_ssize_t len2 = 0 ;
+  PyObject *ret2 = 0 ;
   mfem::QuadratureFunction *result = 0 ;
   
   if ((nobjs < 2) || (nobjs > 2)) SWIG_fail;
@@ -13737,14 +13914,64 @@ SWIGINTERN PyObject *_wrap_new_QuadratureFunction__SWIG_4(PyObject *SWIGUNUSEDPA
     SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "new_QuadratureFunction" "', argument " "1"" of type '" "mfem::Mesh *""'"); 
   }
   arg1 = reinterpret_cast< mfem::Mesh * >(argp1);
-  res2 = SWIG_ConvertPtr(swig_obj[1], &argp2, SWIGTYPE_p_std__istream,  0 );
-  if (!SWIG_IsOK(res2)) {
-    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "new_QuadratureFunction" "', argument " "2"" of type '" "std::istream &""'"); 
+  {
+    //  PyMFEM::wFILE or string argument or StringIO
+    if (SWIG_ConvertPtr(swig_obj[1], (void **) &temp2, SWIGTYPE_p_PyMFEM__wFILE, 0 | 0) == -1) {
+      if (!PyString_Check(swig_obj[1]) && !PyUnicode_Check(swig_obj[1])) {
+        // not string, check if it is StringIO
+        PyObject* module = PyImport_ImportModule("io");
+        if (!module){
+          PyErr_SetString(PyExc_RuntimeError, "Can not load io module");
+          return NULL;
+        }      
+        PyObject* cls = PyObject_GetAttrString(module, "StringIO");
+        if (!cls){
+          PyErr_SetString(PyExc_RuntimeError, "Can not load StringIO");
+          return NULL;
+        }      
+        int check = PyObject_IsInstance(swig_obj[1], cls);
+        Py_DECREF(module);
+        if (! check){
+          SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
+          return NULL;
+        }
+        
+        PyObject *input_str2 = PyObject_CallMethod(swig_obj[1], "getvalue", NULL);
+        if (PyErr_Occurred()) {
+          PyErr_SetString(PyExc_RuntimeError, "Can not read from StringIO");
+          return NULL;
+        }
+        
+        char *buf = nullptr;
+        PyObject *str = PyUnicode_AsUTF8String(input_str2);	 
+        PyBytes_AsStringAndSize(str, &buf, &len2);
+        stream2 = new std::istringstream(buf);
+        Py_DECREF(str);
+        Py_DECREF(input_str2);	 
+      } else {
+        // if it is string, extract filename as char*
+        PyObject* str = PyUnicode_AsEncodedString(swig_obj[1], "utf-8", "~E~");	
+        const char* filename = PyBytes_AsString(str);
+        temp2 = new PyMFEM::wFILE(filename, 8, true);
+        Py_DECREF(str);
+      }
+    }
+    if (stream2 == 0){
+      if (temp2->isGZ()){
+        in_gz2 = new mfem::ifgzstream(temp2->getFilename());
+        arg2 = in_gz2;
+      } else {
+        in_txt2.open(temp2->getFilename(), std::ifstream::in);
+        in_txt2.precision(temp2->getPrecision());
+        arg2 = &in_txt2;
+      }
+      if (temp2->isTemporary()){
+        delete temp2;
+      }
+    } else {
+      arg2 = stream2;
+    }
   }
-  if (!argp2) {
-    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "new_QuadratureFunction" "', argument " "2"" of type '" "std::istream &""'"); 
-  }
-  arg2 = reinterpret_cast< std::istream * >(argp2);
   {
     try {
       result = (mfem::QuadratureFunction *)new mfem::QuadratureFunction(arg1,*arg2); 
@@ -13759,8 +13986,40 @@ SWIGINTERN PyObject *_wrap_new_QuadratureFunction__SWIG_4(PyObject *SWIGUNUSEDPA
     //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__QuadratureFunction, SWIG_POINTER_NEW |  0 );
+  {
+    if (stream2) {
+      ret2 = PyLong_FromSsize_t(len2);
+      if (PyErr_Occurred()) {
+        PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
+        return NULL;
+      }
+      delete stream2;    
+      Py_XDECREF(resultobj);   /* Blow away any previous result */
+      resultobj = ret2;    
+    }
+  }
+  {
+    if (!stream2) {
+      if (temp2) {
+        in_txt2.close();
+      }
+      if (in_gz2){
+        delete in_gz2;
+      }
+    }  
+  }
   return resultobj;
 fail:
+  {
+    if (!stream2) {
+      if (temp2) {
+        in_txt2.close();
+      }
+      if (in_gz2){
+        delete in_gz2;
+      }
+    }  
+  }
   return NULL;
 }
 
@@ -13839,9 +14098,34 @@ SWIGINTERN PyObject *_wrap_new_QuadratureFunction(PyObject *self, PyObject *args
     int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_mfem__Mesh, 0);
     _v = SWIG_CheckState(res);
     if (_v) {
-      void *vptr = 0;
-      int res = SWIG_ConvertPtr(argv[1], &vptr, SWIGTYPE_p_std__istream, SWIG_POINTER_NO_NULL);
-      _v = SWIG_CheckState(res);
+      {
+        void *ptr;
+        //std::string *ptr2 = (std::string *)0;
+        if (SWIG_ConvertPtr(argv[1], (void **) &ptr, SWIGTYPE_p_PyMFEM__wFILE, 0 |0) == -1) {
+          PyErr_Clear();
+          if (!PyString_Check(argv[1]) && !PyUnicode_Check(argv[1])) {
+            // not string
+            _v = 1;	   	
+            PyObject* module = PyImport_ImportModule("io");
+            if (!module){
+              _v = 0;	   
+            }      
+            PyObject* cls = PyObject_GetAttrString(module, "StringIO");
+            if (!cls){
+              _v = 0;	   	   
+            }      
+            int check = PyObject_IsInstance(argv[1], cls);
+            Py_DECREF(module);
+            if (! check){
+              _v = 0;	   	   	   
+            }
+          } else {
+            _v = 1;
+          }
+        } else {
+          _v = 1;
+        }
+      }
       if (_v) {
         return _wrap_new_QuadratureFunction__SWIG_4(self, argc, argv);
       }
@@ -14823,10 +15107,10 @@ SWIGINTERN PyObject *_wrap_QuadratureFunction_Save__SWIG_0(PyObject *SWIGUNUSEDP
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyMFEM::wFILE *temp2 = 0 ;
-  std::ofstream out2 ;
-  int use_stringio2 = 0 ;
+  std::ofstream out_txt2 ;
+  mfem::ofgzstream *out_gz2 = 0 ;
   PyObject *string_io2 = 0 ;
-  std::ostringstream stream2 ;
+  std::ostringstream *stream2 = 0 ;
   PyObject *ret2 = 0 ;
   
   if ((nobjs < 2) || (nobjs > 2)) SWIG_fail;
@@ -14856,29 +15140,33 @@ SWIGINTERN PyObject *_wrap_QuadratureFunction_Save__SWIG_0(PyObject *SWIGUNUSEDP
           SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
           return NULL;
         }
-        use_stringio2=1;
         string_io2=swig_obj[1];
+        stream2 = new std::ostringstream();
       } else {
         // if it is string, extract filename as char*
         PyObject* str = PyUnicode_AsEncodedString(swig_obj[1], "utf-8", "~E~");	
         const char* filename = PyBytes_AsString(str);
-        temp2 = new PyMFEM::wFILE(filename, 8, true);	
+        temp2 = new PyMFEM::wFILE(filename, 8, true);
+        Py_DECREF(str);	 
       }
     }
     
-    if (use_stringio2 == 0){
+    if (stream2 == 0){
       if (temp2->isSTDOUT() == 1) {
         arg2 = &std::cout;
+      } else if (temp2->isGZ()){
+        out_gz2 = new mfem::ofgzstream(temp2->getFilename(), true);
+        arg2 = out_gz2;	     
       } else {
-        out2.open(temp2->getFilename());
-        out2.precision(temp2->getPrecision());
-        if (temp2->isTemporary()){
-          delete temp2;
-        }
-        arg2 = &out2;
+        out_txt2.open(temp2->getFilename());
+        out_txt2.precision(temp2->getPrecision());
+        arg2 = &out_txt2;
+      }
+      if (temp2->isTemporary()){
+        delete temp2;
       }
     } else {
-      arg2 = &stream2;
+      arg2 = stream2;
     }
   }
   {
@@ -14896,8 +15184,8 @@ SWIGINTERN PyObject *_wrap_QuadratureFunction_Save__SWIG_0(PyObject *SWIGUNUSEDP
   }
   resultobj = SWIG_Py_Void();
   {
-    if (use_stringio2 == 1) {
-      std::string str =  stream2.str();
+    if (stream2) {
+      std::string str =  stream2->str();
       const char* s = str.c_str();
       const int n = str.length();
       ret2 = PyObject_CallMethod(string_io2, "write", "s#",
@@ -14906,15 +15194,21 @@ SWIGINTERN PyObject *_wrap_QuadratureFunction_Save__SWIG_0(PyObject *SWIGUNUSEDP
         PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
         return NULL;
       }
+      delete stream2;
       Py_XDECREF(resultobj);   /* Blow away any previous result */
       resultobj = ret2;    
     }
   }
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -14922,10 +15216,15 @@ SWIGINTERN PyObject *_wrap_QuadratureFunction_Save__SWIG_0(PyObject *SWIGUNUSEDP
   return resultobj;
 fail:
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -15048,7 +15347,8 @@ SWIGINTERN PyObject *_wrap_QuadratureFunction_Save(PyObject *self, PyObject *arg
               _v = 0;	   	   	   
             }
           } else {
-            _v = 0;
+            std::cout << "it is text (out)\n";	
+            _v = 1;
           }
         } else {
           _v = 1;
@@ -15085,10 +15385,10 @@ SWIGINTERN PyObject *_wrap___lshift____SWIG_3(PyObject *SWIGUNUSEDPARM(self), Py
   std::ostream *arg1 = 0 ;
   mfem::QuadratureFunction *arg2 = 0 ;
   PyMFEM::wFILE *temp1 = 0 ;
-  std::ofstream out1 ;
-  int use_stringio1 = 0 ;
+  std::ofstream out_txt1 ;
+  mfem::ofgzstream *out_gz1 = 0 ;
   PyObject *string_io1 = 0 ;
-  std::ostringstream stream1 ;
+  std::ostringstream *stream1 = 0 ;
   PyObject *ret1 = 0 ;
   void *argp2 = 0 ;
   int res2 = 0 ;
@@ -15116,29 +15416,33 @@ SWIGINTERN PyObject *_wrap___lshift____SWIG_3(PyObject *SWIGUNUSEDPARM(self), Py
           SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
           return NULL;
         }
-        use_stringio1=1;
         string_io1=swig_obj[0];
+        stream1 = new std::ostringstream();
       } else {
         // if it is string, extract filename as char*
         PyObject* str = PyUnicode_AsEncodedString(swig_obj[0], "utf-8", "~E~");	
         const char* filename = PyBytes_AsString(str);
-        temp1 = new PyMFEM::wFILE(filename, 8, true);	
+        temp1 = new PyMFEM::wFILE(filename, 8, true);
+        Py_DECREF(str);	 
       }
     }
     
-    if (use_stringio1 == 0){
+    if (stream1 == 0){
       if (temp1->isSTDOUT() == 1) {
         arg1 = &std::cout;
+      } else if (temp1->isGZ()){
+        out_gz1 = new mfem::ofgzstream(temp1->getFilename(), true);
+        arg1 = out_gz1;	     
       } else {
-        out1.open(temp1->getFilename());
-        out1.precision(temp1->getPrecision());
-        if (temp1->isTemporary()){
-          delete temp1;
-        }
-        arg1 = &out1;
+        out_txt1.open(temp1->getFilename());
+        out_txt1.precision(temp1->getPrecision());
+        arg1 = &out_txt1;
+      }
+      if (temp1->isTemporary()){
+        delete temp1;
       }
     } else {
-      arg1 = &stream1;
+      arg1 = stream1;
     }
   }
   res2 = SWIG_ConvertPtr(swig_obj[1], &argp2, SWIGTYPE_p_mfem__QuadratureFunction,  0  | 0);
@@ -15164,8 +15468,8 @@ SWIGINTERN PyObject *_wrap___lshift____SWIG_3(PyObject *SWIGUNUSEDPARM(self), Py
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_std__ostream, 0 |  0 );
   {
-    if (use_stringio1 == 1) {
-      std::string str =  stream1.str();
+    if (stream1) {
+      std::string str =  stream1->str();
       const char* s = str.c_str();
       const int n = str.length();
       ret1 = PyObject_CallMethod(string_io1, "write", "s#",
@@ -15174,15 +15478,21 @@ SWIGINTERN PyObject *_wrap___lshift____SWIG_3(PyObject *SWIGUNUSEDPARM(self), Py
         PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
         return NULL;
       }
+      delete stream1;
       Py_XDECREF(resultobj);   /* Blow away any previous result */
       resultobj = ret1;    
     }
   }
   {
-    if (use_stringio1 == 0) {
+    if (!stream1) {
       if (temp1) {
         if (temp1->isSTDOUT() != 1) {
-          out1.close();
+          if (out_txt1.is_open()){
+            out_txt1.close();
+          }
+          if (out_gz1){
+            delete out_gz1;
+          }
         }
       }
     }
@@ -15190,10 +15500,15 @@ SWIGINTERN PyObject *_wrap___lshift____SWIG_3(PyObject *SWIGUNUSEDPARM(self), Py
   return resultobj;
 fail:
   {
-    if (use_stringio1 == 0) {
+    if (!stream1) {
       if (temp1) {
         if (temp1->isSTDOUT() != 1) {
-          out1.close();
+          if (out_txt1.is_open()){
+            out_txt1.close();
+          }
+          if (out_gz1){
+            delete out_gz1;
+          }
         }
       }
     }
@@ -15236,7 +15551,8 @@ SWIGINTERN PyObject *_wrap___lshift__(PyObject *self, PyObject *args) {
             _v = 0;	   	   	   
           }
         } else {
-          _v = 0;
+          std::cout << "it is text (out)\n";	
+          _v = 1;
         }
       } else {
         _v = 1;
@@ -15274,7 +15590,8 @@ SWIGINTERN PyObject *_wrap___lshift__(PyObject *self, PyObject *args) {
             _v = 0;	   	   	   
           }
         } else {
-          _v = 0;
+          std::cout << "it is text (out)\n";	
+          _v = 1;
         }
       } else {
         _v = 1;
@@ -16876,7 +17193,6 @@ static swig_type_info _swigt__p_p_mfem__GridFunction = {"_p_p_mfem__GridFunction
 static swig_type_info _swigt__p_pri_t = {"_p_pri_t", "pri_t *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_quad_t = {"_p_quad_t", "quad_t *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_seg_t = {"_p_seg_t", "seg_t *", 0, 0, (void*)0, 0};
-static swig_type_info _swigt__p_std__istream = {"_p_std__istream", "std::istream *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_std__ostream = {"_p_std__ostream", "std::ostream *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_mfem__OutStream = {"_p_mfem__OutStream", 0, 0, 0, 0, 0};
 static swig_type_info _swigt__p_tet_t = {"_p_tet_t", "tet_t *", 0, 0, (void*)0, 0};
@@ -17083,7 +17399,6 @@ static swig_type_info *swig_type_initial[] = {
   &_swigt__p_pri_t,
   &_swigt__p_quad_t,
   &_swigt__p_seg_t,
-  &_swigt__p_std__istream,
   &_swigt__p_std__ostream,
   &_swigt__p_tet_t,
   &_swigt__p_tri_t,
@@ -17288,7 +17603,6 @@ static swig_cast_info _swigc__p_p_mfem__GridFunction[] = {  {&_swigt__p_p_mfem__
 static swig_cast_info _swigc__p_pri_t[] = {  {&_swigt__p_pri_t, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_quad_t[] = {  {&_swigt__p_quad_t, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_seg_t[] = {  {&_swigt__p_seg_t, 0, 0, 0},{0, 0, 0, 0}};
-static swig_cast_info _swigc__p_std__istream[] = {  {&_swigt__p_std__istream, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_mfem__OutStream[] = {{&_swigt__p_mfem__OutStream, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_std__ostream[] = {  {&_swigt__p_std__ostream, 0, 0, 0},  {&_swigt__p_mfem__OutStream, _p_mfem__OutStreamTo_p_std__ostream, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_tet_t[] = {  {&_swigt__p_tet_t, 0, 0, 0},{0, 0, 0, 0}};
@@ -17495,7 +17809,6 @@ static swig_cast_info *swig_cast_initial[] = {
   _swigc__p_pri_t,
   _swigc__p_quad_t,
   _swigc__p_seg_t,
-  _swigc__p_std__istream,
   _swigc__p_std__ostream,
   _swigc__p_tet_t,
   _swigc__p_tri_t,

--- a/mfem/_par/gridfunc_wrap.cxx
+++ b/mfem/_par/gridfunc_wrap.cxx
@@ -3718,24 +3718,14 @@ SWIG_AsPtr_std_string (PyObject * obj, std::string **val)
   return SWIG_ERROR;
 }
 
-
-
-
-SWIGINTERN mfem::GridFunction *new_mfem_GridFunction__SWIG_6(mfem::Mesh *m,char const *grid_file){
-   mfem::GridFunction *gf;
-   std::ifstream igrid(grid_file);
-   if (!igrid) {
-      std::cerr << "\nCan not open grid function file: " << grid_file << '\n' << std::endl;
-      return NULL;
-   }
-   gf = new mfem::GridFunction(m, igrid);
-   return gf;
-}
-SWIGINTERN mfem::GridFunction *new_mfem_GridFunction__SWIG_7(mfem::FiniteElementSpace *fes,mfem::Vector const &v,int offset){
+SWIGINTERN mfem::GridFunction *new_mfem_GridFunction__SWIG_6(mfem::FiniteElementSpace *fes,mfem::Vector const &v,int offset){
    mfem::GridFunction *gf;   
    gf = new mfem::GridFunction(fes, v.GetData() + offset);
    return gf;
 }
+
+
+
 SWIGINTERN void mfem_GridFunction_SaveToFile(mfem::GridFunction const *self,char const *gf_file,int const precision){
         std::cerr << "\nWarning Deprecated : Use Save(filename) insteead of SaveToFile \n";  
 	std::ofstream mesh_ofs(gf_file);	
@@ -3975,7 +3965,6 @@ SWIGINTERN PyObject *_wrap_new_GridFunction__SWIG_4(PyObject *SWIGUNUSEDPARM(sel
   PyMFEM::wFILE *temp2 = 0 ;
   std::ifstream in_txt2 ;
   mfem::ifgzstream *in_gz2 = 0 ;
-  PyObject *input_str2 = 0 ;
   std::istringstream *stream2 = 0 ;
   Py_ssize_t len2 = 0 ;
   PyObject *ret2 = 0 ;
@@ -4009,18 +3998,18 @@ SWIGINTERN PyObject *_wrap_new_GridFunction__SWIG_4(PyObject *SWIGUNUSEDPARM(sel
           return NULL;
         }
         
-        PyObject *input_str2 = PyObject_CallMethod(swig_obj[1], "getvalue", NULL);
+        PyObject *input_str = PyObject_CallMethod(swig_obj[1], "getvalue", NULL);
         if (PyErr_Occurred()) {
           PyErr_SetString(PyExc_RuntimeError, "Can not read from StringIO");
           return NULL;
         }
         
         char *buf = nullptr;
-        PyObject *str = PyUnicode_AsUTF8String(input_str2);	 
+        PyObject *str = PyUnicode_AsUTF8String(input_str);	 
         PyBytes_AsStringAndSize(str, &buf, &len2);
         stream2 = new std::istringstream(buf);
         Py_DECREF(str);
-        Py_DECREF(input_str2);	 
+        Py_DECREF(input_str);	 
       } else {
         // if it is string, extract filename as char*
         PyObject* str = PyUnicode_AsEncodedString(swig_obj[1], "utf-8", "~E~");	
@@ -12835,50 +12824,6 @@ fail:
 
 SWIGINTERN PyObject *_wrap_new_GridFunction__SWIG_6(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
   PyObject *resultobj = 0;
-  mfem::Mesh *arg1 = (mfem::Mesh *) 0 ;
-  char *arg2 = (char *) 0 ;
-  void *argp1 = 0 ;
-  int res1 = 0 ;
-  int res2 ;
-  char *buf2 = 0 ;
-  int alloc2 = 0 ;
-  mfem::GridFunction *result = 0 ;
-  
-  if ((nobjs < 2) || (nobjs > 2)) SWIG_fail;
-  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_mfem__Mesh, 0 |  0 );
-  if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "new_GridFunction" "', argument " "1"" of type '" "mfem::Mesh *""'"); 
-  }
-  arg1 = reinterpret_cast< mfem::Mesh * >(argp1);
-  res2 = SWIG_AsCharPtrAndSize(swig_obj[1], &buf2, NULL, &alloc2);
-  if (!SWIG_IsOK(res2)) {
-    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "new_GridFunction" "', argument " "2"" of type '" "char const *""'");
-  }
-  arg2 = reinterpret_cast< char * >(buf2);
-  {
-    try {
-      result = (mfem::GridFunction *)new_mfem_GridFunction__SWIG_6(arg1,(char const *)arg2); 
-    }
-    catch (Swig::DirectorException &e) {
-      SWIG_fail; 
-    }    
-    //catch (...){
-    //  SWIG_fail;
-    //}
-    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
-    //    catch (std::exception &e) { SWIG_fail; }    
-  }
-  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__GridFunction, SWIG_POINTER_NEW |  0 );
-  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
-  return resultobj;
-fail:
-  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
-  return NULL;
-}
-
-
-SWIGINTERN PyObject *_wrap_new_GridFunction__SWIG_7(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
-  PyObject *resultobj = 0;
   mfem::FiniteElementSpace *arg1 = (mfem::FiniteElementSpace *) 0 ;
   mfem::Vector *arg2 = 0 ;
   int arg3 ;
@@ -12910,7 +12855,7 @@ SWIGINTERN PyObject *_wrap_new_GridFunction__SWIG_7(PyObject *SWIGUNUSEDPARM(sel
   }
   {
     try {
-      result = (mfem::GridFunction *)new_mfem_GridFunction__SWIG_7(arg1,(mfem::Vector const &)*arg2,arg3); 
+      result = (mfem::GridFunction *)new_mfem_GridFunction__SWIG_6(arg1,(mfem::Vector const &)*arg2,arg3); 
     }
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
@@ -12967,19 +12912,6 @@ SWIGINTERN PyObject *_wrap_new_GridFunction(PyObject *self, PyObject *args) {
       _v = SWIG_CheckState(res);
       if (_v) {
         return _wrap_new_GridFunction__SWIG_3(self, argc, argv);
-      }
-    }
-  }
-  if (argc == 2) {
-    int _v;
-    void *vptr = 0;
-    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_mfem__Mesh, 0);
-    _v = SWIG_CheckState(res);
-    if (_v) {
-      int res = SWIG_AsCharPtrAndSize(argv[1], 0, NULL, 0);
-      _v = SWIG_CheckState(res);
-      if (_v) {
-        return _wrap_new_GridFunction__SWIG_6(self, argc, argv);
       }
     }
   }
@@ -13064,7 +12996,7 @@ SWIGINTERN PyObject *_wrap_new_GridFunction(PyObject *self, PyObject *args) {
           }
         }
         if (_v) {
-          return _wrap_new_GridFunction__SWIG_7(self, argc, argv);
+          return _wrap_new_GridFunction__SWIG_6(self, argc, argv);
         }
       }
     }
@@ -13079,7 +13011,6 @@ fail:
     "    mfem::GridFunction::GridFunction(mfem::FiniteElementSpace *,double *)\n"
     "    mfem::GridFunction::GridFunction(mfem::Mesh *,std::istream &)\n"
     "    mfem::GridFunction::GridFunction(mfem::Mesh *,mfem::GridFunction *[],int)\n"
-    "    mfem::GridFunction::GridFunction(mfem::Mesh *,char const *)\n"
     "    mfem::GridFunction::GridFunction(mfem::FiniteElementSpace *,mfem::Vector const &,int)\n");
   return 0;
 }
@@ -13568,7 +13499,6 @@ SWIGINTERN PyObject *_wrap_GridFunction_Save(PyObject *self, PyObject *args) {
               _v = 0;	   	   	   
             }
           } else {
-            std::cout << "it is text (out)\n";	
             _v = 1;
           }
         } else {
@@ -13902,7 +13832,6 @@ SWIGINTERN PyObject *_wrap_new_QuadratureFunction__SWIG_4(PyObject *SWIGUNUSEDPA
   PyMFEM::wFILE *temp2 = 0 ;
   std::ifstream in_txt2 ;
   mfem::ifgzstream *in_gz2 = 0 ;
-  PyObject *input_str2 = 0 ;
   std::istringstream *stream2 = 0 ;
   Py_ssize_t len2 = 0 ;
   PyObject *ret2 = 0 ;
@@ -13936,18 +13865,18 @@ SWIGINTERN PyObject *_wrap_new_QuadratureFunction__SWIG_4(PyObject *SWIGUNUSEDPA
           return NULL;
         }
         
-        PyObject *input_str2 = PyObject_CallMethod(swig_obj[1], "getvalue", NULL);
+        PyObject *input_str = PyObject_CallMethod(swig_obj[1], "getvalue", NULL);
         if (PyErr_Occurred()) {
           PyErr_SetString(PyExc_RuntimeError, "Can not read from StringIO");
           return NULL;
         }
         
         char *buf = nullptr;
-        PyObject *str = PyUnicode_AsUTF8String(input_str2);	 
+        PyObject *str = PyUnicode_AsUTF8String(input_str);	 
         PyBytes_AsStringAndSize(str, &buf, &len2);
         stream2 = new std::istringstream(buf);
         Py_DECREF(str);
-        Py_DECREF(input_str2);	 
+        Py_DECREF(input_str);	 
       } else {
         // if it is string, extract filename as char*
         PyObject* str = PyUnicode_AsEncodedString(swig_obj[1], "utf-8", "~E~");	
@@ -15347,7 +15276,6 @@ SWIGINTERN PyObject *_wrap_QuadratureFunction_Save(PyObject *self, PyObject *arg
               _v = 0;	   	   	   
             }
           } else {
-            std::cout << "it is text (out)\n";	
             _v = 1;
           }
         } else {
@@ -15551,7 +15479,6 @@ SWIGINTERN PyObject *_wrap___lshift__(PyObject *self, PyObject *args) {
             _v = 0;	   	   	   
           }
         } else {
-          std::cout << "it is text (out)\n";	
           _v = 1;
         }
       } else {
@@ -15590,7 +15517,6 @@ SWIGINTERN PyObject *_wrap___lshift__(PyObject *self, PyObject *args) {
             _v = 0;	   	   	   
           }
         } else {
-          std::cout << "it is text (out)\n";	
           _v = 1;
         }
       } else {
@@ -16178,7 +16104,6 @@ static PyMethodDef SwigMethods[] = {
 		"GridFunction(FiniteElementSpace f, double * data)\n"
 		"GridFunction(Mesh m, std::istream & input)\n"
 		"GridFunction(Mesh m, mfem::GridFunction *[] gf_array, int num_pieces)\n"
-		"GridFunction(Mesh m, char const * grid_file)\n"
 		"new_GridFunction(FiniteElementSpace fes, Vector v, int offset) -> GridFunction\n"
 		""},
 	 { "GridFunction_SaveToFile", (PyCFunction)(void(*)(void))_wrap_GridFunction_SaveToFile, METH_VARARGS|METH_KEYWORDS, "GridFunction_SaveToFile(GridFunction self, char const * gf_file, int const precision)"},
@@ -16408,7 +16333,6 @@ static PyMethodDef SwigMethods_proxydocs[] = {
 		"GridFunction(FiniteElementSpace f, double * data)\n"
 		"GridFunction(Mesh m, std::istream & input)\n"
 		"GridFunction(Mesh m, mfem::GridFunction *[] gf_array, int num_pieces)\n"
-		"GridFunction(Mesh m, char const * grid_file)\n"
 		"new_GridFunction(FiniteElementSpace fes, Vector v, int offset) -> GridFunction\n"
 		""},
 	 { "GridFunction_SaveToFile", (PyCFunction)(void(*)(void))_wrap_GridFunction_SaveToFile, METH_VARARGS|METH_KEYWORDS, "SaveToFile(GridFunction self, char const * gf_file, int const precision)"},

--- a/mfem/_par/handle_wrap.cxx
+++ b/mfem/_par/handle_wrap.cxx
@@ -5875,10 +5875,10 @@ SWIGINTERN PyObject *_wrap_OperatorHandle_PrintMatlab(PyObject *SWIGUNUSEDPARM(s
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyMFEM::wFILE *temp2 = 0 ;
-  std::ofstream out2 ;
-  int use_stringio2 = 0 ;
+  std::ofstream out_txt2 ;
+  mfem::ofgzstream *out_gz2 = 0 ;
   PyObject *string_io2 = 0 ;
-  std::ostringstream stream2 ;
+  std::ostringstream *stream2 = 0 ;
   PyObject *ret2 = 0 ;
   PyObject * obj0 = 0 ;
   PyObject * obj1 = 0 ;
@@ -5915,29 +5915,33 @@ SWIGINTERN PyObject *_wrap_OperatorHandle_PrintMatlab(PyObject *SWIGUNUSEDPARM(s
           SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
           return NULL;
         }
-        use_stringio2=1;
         string_io2=obj1;
+        stream2 = new std::ostringstream();
       } else {
         // if it is string, extract filename as char*
         PyObject* str = PyUnicode_AsEncodedString(obj1, "utf-8", "~E~");	
         const char* filename = PyBytes_AsString(str);
-        temp2 = new PyMFEM::wFILE(filename, 8, true);	
+        temp2 = new PyMFEM::wFILE(filename, 8, true);
+        Py_DECREF(str);	 
       }
     }
     
-    if (use_stringio2 == 0){
+    if (stream2 == 0){
       if (temp2->isSTDOUT() == 1) {
         arg2 = &std::cout;
+      } else if (temp2->isGZ()){
+        out_gz2 = new mfem::ofgzstream(temp2->getFilename(), true);
+        arg2 = out_gz2;	     
       } else {
-        out2.open(temp2->getFilename());
-        out2.precision(temp2->getPrecision());
-        if (temp2->isTemporary()){
-          delete temp2;
-        }
-        arg2 = &out2;
+        out_txt2.open(temp2->getFilename());
+        out_txt2.precision(temp2->getPrecision());
+        arg2 = &out_txt2;
+      }
+      if (temp2->isTemporary()){
+        delete temp2;
       }
     } else {
-      arg2 = &stream2;
+      arg2 = stream2;
     }
   }
   if (obj2) {
@@ -5971,8 +5975,8 @@ SWIGINTERN PyObject *_wrap_OperatorHandle_PrintMatlab(PyObject *SWIGUNUSEDPARM(s
   }
   resultobj = SWIG_Py_Void();
   {
-    if (use_stringio2 == 1) {
-      std::string str =  stream2.str();
+    if (stream2) {
+      std::string str =  stream2->str();
       const char* s = str.c_str();
       const int n = str.length();
       ret2 = PyObject_CallMethod(string_io2, "write", "s#",
@@ -5981,15 +5985,21 @@ SWIGINTERN PyObject *_wrap_OperatorHandle_PrintMatlab(PyObject *SWIGUNUSEDPARM(s
         PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
         return NULL;
       }
+      delete stream2;
       Py_XDECREF(resultobj);   /* Blow away any previous result */
       resultobj = ret2;    
     }
   }
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -5997,10 +6007,15 @@ SWIGINTERN PyObject *_wrap_OperatorHandle_PrintMatlab(PyObject *SWIGUNUSEDPARM(s
   return resultobj;
 fail:
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }

--- a/mfem/_par/hypre_wrap.cxx
+++ b/mfem/_par/hypre_wrap.cxx
@@ -9823,7 +9823,6 @@ SWIGINTERN PyObject *_wrap_HypreParMatrix_PrintCommPkg(PyObject *self, PyObject 
               _v = 0;	   	   	   
             }
           } else {
-            std::cout << "it is text (out)\n";	
             _v = 1;
           }
         } else {

--- a/mfem/_par/io_stream.py
+++ b/mfem/_par/io_stream.py
@@ -92,6 +92,11 @@ class wFILE(object):
         return _io_stream.wFILE_getFilename(self)
     getFilename = _swig_new_instance_method(_io_stream.wFILE_getFilename)
 
+    def isGZ(self):
+        r"""isGZ(wFILE self) -> bool"""
+        return _io_stream.wFILE_isGZ(self)
+    isGZ = _swig_new_instance_method(_io_stream.wFILE_isGZ)
+
     def getPrecision(self):
         r"""getPrecision(wFILE self) -> int"""
         return _io_stream.wFILE_getPrecision(self)

--- a/mfem/_par/io_stream_wrap.cxx
+++ b/mfem/_par/io_stream_wrap.cxx
@@ -3279,6 +3279,29 @@ fail:
 }
 
 
+SWIGINTERN PyObject *_wrap_wFILE_isGZ(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  PyMFEM::wFILE *arg1 = (PyMFEM::wFILE *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject *swig_obj[1] ;
+  bool result;
+  
+  if (!args) SWIG_fail;
+  swig_obj[0] = args;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_PyMFEM__wFILE, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "wFILE_isGZ" "', argument " "1"" of type '" "PyMFEM::wFILE *""'"); 
+  }
+  arg1 = reinterpret_cast< PyMFEM::wFILE * >(argp1);
+  result = (bool)(arg1)->isGZ();
+  resultobj = SWIG_From_bool(static_cast< bool >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
 SWIGINTERN PyObject *_wrap_wFILE_getPrecision(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   PyMFEM::wFILE *arg1 = (PyMFEM::wFILE *) 0 ;
@@ -3378,6 +3401,7 @@ static PyMethodDef SwigMethods[] = {
 	 { "wFILE_isSTDOUT", _wrap_wFILE_isSTDOUT, METH_O, "wFILE_isSTDOUT(wFILE self) -> int"},
 	 { "wFILE_isTemporary", _wrap_wFILE_isTemporary, METH_O, "wFILE_isTemporary(wFILE self) -> bool"},
 	 { "wFILE_getFilename", _wrap_wFILE_getFilename, METH_O, "wFILE_getFilename(wFILE self) -> char *"},
+	 { "wFILE_isGZ", _wrap_wFILE_isGZ, METH_O, "wFILE_isGZ(wFILE self) -> bool"},
 	 { "wFILE_getPrecision", _wrap_wFILE_getPrecision, METH_O, "wFILE_getPrecision(wFILE self) -> int"},
 	 { "wFILE_setPrecision", (PyCFunction)(void(*)(void))_wrap_wFILE_setPrecision, METH_VARARGS|METH_KEYWORDS, "wFILE_setPrecision(wFILE self, int precision)"},
 	 { "delete_wFILE", _wrap_delete_wFILE, METH_O, "delete_wFILE(wFILE self)"},
@@ -3396,6 +3420,7 @@ static PyMethodDef SwigMethods_proxydocs[] = {
 	 { "wFILE_isSTDOUT", _wrap_wFILE_isSTDOUT, METH_O, "isSTDOUT(wFILE self) -> int"},
 	 { "wFILE_isTemporary", _wrap_wFILE_isTemporary, METH_O, "isTemporary(wFILE self) -> bool"},
 	 { "wFILE_getFilename", _wrap_wFILE_getFilename, METH_O, "getFilename(wFILE self) -> char *"},
+	 { "wFILE_isGZ", _wrap_wFILE_isGZ, METH_O, "isGZ(wFILE self) -> bool"},
 	 { "wFILE_getPrecision", _wrap_wFILE_getPrecision, METH_O, "getPrecision(wFILE self) -> int"},
 	 { "wFILE_setPrecision", (PyCFunction)(void(*)(void))_wrap_wFILE_setPrecision, METH_VARARGS|METH_KEYWORDS, "setPrecision(wFILE self, int precision)"},
 	 { "delete_wFILE", _wrap_delete_wFILE, METH_O, "delete_wFILE(wFILE self)"},

--- a/mfem/_par/matrix.i
+++ b/mfem/_par/matrix.i
@@ -5,6 +5,7 @@
 %{
 #include <fstream>
 #include <iostream>
+#include "general/zstr.hpp"  
 #include "numpy/arrayobject.h"  
 #include "../common/io_stream.hpp"  
 #include "pyoperator.hpp"

--- a/mfem/_par/matrix_wrap.cxx
+++ b/mfem/_par/matrix_wrap.cxx
@@ -3966,7 +3966,6 @@ SWIGINTERN PyObject *_wrap_Matrix_Print(PyObject *self, PyObject *args) {
               _v = 0;	   	   	   
             }
           } else {
-            std::cout << "it is text (out)\n";	
             _v = 1;
           }
         } else {

--- a/mfem/_par/matrix_wrap.cxx
+++ b/mfem/_par/matrix_wrap.cxx
@@ -3198,6 +3198,7 @@ namespace swig {
 
 #include <fstream>
 #include <iostream>
+#include "general/zstr.hpp"  
 #include "numpy/arrayobject.h"  
 #include "../common/io_stream.hpp"  
 #include "pyoperator.hpp"
@@ -3704,10 +3705,10 @@ SWIGINTERN PyObject *_wrap_Matrix_Print__SWIG_0(PyObject *SWIGUNUSEDPARM(self), 
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyMFEM::wFILE *temp2 = 0 ;
-  std::ofstream out2 ;
-  int use_stringio2 = 0 ;
+  std::ofstream out_txt2 ;
+  mfem::ofgzstream *out_gz2 = 0 ;
   PyObject *string_io2 = 0 ;
-  std::ostringstream stream2 ;
+  std::ostringstream *stream2 = 0 ;
   PyObject *ret2 = 0 ;
   
   if ((nobjs < 1) || (nobjs > 3)) SWIG_fail;
@@ -3738,29 +3739,33 @@ SWIGINTERN PyObject *_wrap_Matrix_Print__SWIG_0(PyObject *SWIGUNUSEDPARM(self), 
             SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
             return NULL;
           }
-          use_stringio2=1;
           string_io2=swig_obj[1];
+          stream2 = new std::ostringstream();
         } else {
           // if it is string, extract filename as char*
           PyObject* str = PyUnicode_AsEncodedString(swig_obj[1], "utf-8", "~E~");	
           const char* filename = PyBytes_AsString(str);
-          temp2 = new PyMFEM::wFILE(filename, 8, true);	
+          temp2 = new PyMFEM::wFILE(filename, 8, true);
+          Py_DECREF(str);	 
         }
       }
       
-      if (use_stringio2 == 0){
+      if (stream2 == 0){
         if (temp2->isSTDOUT() == 1) {
           arg2 = &std::cout;
+        } else if (temp2->isGZ()){
+          out_gz2 = new mfem::ofgzstream(temp2->getFilename(), true);
+          arg2 = out_gz2;	     
         } else {
-          out2.open(temp2->getFilename());
-          out2.precision(temp2->getPrecision());
-          if (temp2->isTemporary()){
-            delete temp2;
-          }
-          arg2 = &out2;
+          out_txt2.open(temp2->getFilename());
+          out_txt2.precision(temp2->getPrecision());
+          arg2 = &out_txt2;
+        }
+        if (temp2->isTemporary()){
+          delete temp2;
         }
       } else {
-        arg2 = &stream2;
+        arg2 = stream2;
       }
     }
   }
@@ -3787,8 +3792,8 @@ SWIGINTERN PyObject *_wrap_Matrix_Print__SWIG_0(PyObject *SWIGUNUSEDPARM(self), 
   }
   resultobj = SWIG_Py_Void();
   {
-    if (use_stringio2 == 1) {
-      std::string str =  stream2.str();
+    if (stream2) {
+      std::string str =  stream2->str();
       const char* s = str.c_str();
       const int n = str.length();
       ret2 = PyObject_CallMethod(string_io2, "write", "s#",
@@ -3797,15 +3802,21 @@ SWIGINTERN PyObject *_wrap_Matrix_Print__SWIG_0(PyObject *SWIGUNUSEDPARM(self), 
         PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
         return NULL;
       }
+      delete stream2;
       Py_XDECREF(resultobj);   /* Blow away any previous result */
       resultobj = ret2;    
     }
   }
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -3813,10 +3824,15 @@ SWIGINTERN PyObject *_wrap_Matrix_Print__SWIG_0(PyObject *SWIGUNUSEDPARM(self), 
   return resultobj;
 fail:
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -3950,7 +3966,8 @@ SWIGINTERN PyObject *_wrap_Matrix_Print(PyObject *self, PyObject *args) {
               _v = 0;	   	   	   
             }
           } else {
-            _v = 0;
+            std::cout << "it is text (out)\n";	
+            _v = 1;
           }
         } else {
           _v = 1;

--- a/mfem/_par/mesh.i
+++ b/mfem/_par/mesh.i
@@ -335,19 +335,19 @@ def CartesianPartitioning(self, nxyz, return_list=False):
 
 namespace mfem{
 %extend Mesh{
-   Mesh(const char *mesh_file, int generate_edges, int refine,
-        bool fix_orientation = true){
-
-        mfem::Mesh *mesh;
-        std::ifstream imesh(mesh_file);
-        if (!imesh)
-        {
-	  std::cerr << "\nCan not open mesh file: " << mesh_file << '\n' << std::endl;
-   	  return NULL;
-        }
-	mesh = new mfem::Mesh(imesh, generate_edges, refine, fix_orientation);
-	return mesh;
-   }
+    //   Mesh(const char *mesh_file, int generate_edges, int refine,
+    //        bool fix_orientation = true){
+    //
+    //        mfem::Mesh *mesh;
+    //        std::ifstream imesh(mesh_file);
+    //        if (!imesh)
+    //        {
+    //	  std::cerr << "\nCan not open mesh file: " << mesh_file << '\n' << std::endl;
+    //   	  return NULL;
+    //        }
+    //	mesh = new mfem::Mesh(imesh, generate_edges, refine, fix_orientation);
+    //	return mesh;
+    //   }
    Mesh(int nx, int ny, int nz, const char *type, bool generate_edges = 0,
         double sx = 1.0, double sy = 1.0, double sz = 1.0,
 	bool sfc_ordering = true){

--- a/mfem/_par/mesh.i
+++ b/mfem/_par/mesh.i
@@ -55,6 +55,7 @@ import_array();
 
 %import "../common/io_stream_typemap.i"
 OSTREAM_TYPEMAP(std::ostream&)
+ISTREAM_TYPEMAP(std::istream&)
 
 
 // ignore these constructors, since in python element::type is given by 

--- a/mfem/_par/mesh_wrap.cxx
+++ b/mfem/_par/mesh_wrap.cxx
@@ -3236,12 +3236,11 @@ namespace Swig {
 #define SWIGTYPE_p_pri_t swig_types[165]
 #define SWIGTYPE_p_quad_t swig_types[166]
 #define SWIGTYPE_p_seg_t swig_types[167]
-#define SWIGTYPE_p_std__istream swig_types[168]
-#define SWIGTYPE_p_std__ostream swig_types[169]
-#define SWIGTYPE_p_tet_t swig_types[170]
-#define SWIGTYPE_p_tri_t swig_types[171]
-static swig_type_info *swig_types[173];
-static swig_module_info swig_module = {swig_types, 172, 0, 0, 0, 0};
+#define SWIGTYPE_p_std__ostream swig_types[168]
+#define SWIGTYPE_p_tet_t swig_types[169]
+#define SWIGTYPE_p_tri_t swig_types[170]
+static swig_type_info *swig_types[172];
+static swig_module_info swig_module = {swig_types, 171, 0, 0, 0, 0};
 #define SWIG_TypeQuery(name) SWIG_TypeQueryModule(&swig_module, &swig_module, name)
 #define SWIG_MangledTypeQuery(name) SWIG_MangledTypeQueryModule(&swig_module, &swig_module, name)
 
@@ -8488,21 +8487,76 @@ SWIGINTERN PyObject *_wrap_new_Mesh__SWIG_9(PyObject *SWIGUNUSEDPARM(self), Py_s
   int arg2 = (int) 0 ;
   int arg3 = (int) 1 ;
   bool arg4 = (bool) true ;
-  void *argp1 = 0 ;
-  int res1 = 0 ;
+  PyMFEM::wFILE *temp1 = 0 ;
+  std::ifstream in_txt1 ;
+  mfem::ifgzstream *in_gz1 = 0 ;
+  PyObject *input_str1 = 0 ;
+  std::istringstream *stream1 = 0 ;
+  Py_ssize_t len1 = 0 ;
+  PyObject *ret1 = 0 ;
   bool val4 ;
   int ecode4 = 0 ;
   mfem::Mesh *result = 0 ;
   
   if ((nobjs < 1) || (nobjs > 4)) SWIG_fail;
-  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1, SWIGTYPE_p_std__istream,  0 );
-  if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "new_Mesh" "', argument " "1"" of type '" "std::istream &""'"); 
+  {
+    //  PyMFEM::wFILE or string argument or StringIO
+    if (SWIG_ConvertPtr(swig_obj[0], (void **) &temp1, SWIGTYPE_p_PyMFEM__wFILE, 0 | 0) == -1) {
+      if (!PyString_Check(swig_obj[0]) && !PyUnicode_Check(swig_obj[0])) {
+        // not string, check if it is StringIO
+        PyObject* module = PyImport_ImportModule("io");
+        if (!module){
+          PyErr_SetString(PyExc_RuntimeError, "Can not load io module");
+          return NULL;
+        }      
+        PyObject* cls = PyObject_GetAttrString(module, "StringIO");
+        if (!cls){
+          PyErr_SetString(PyExc_RuntimeError, "Can not load StringIO");
+          return NULL;
+        }      
+        int check = PyObject_IsInstance(swig_obj[0], cls);
+        Py_DECREF(module);
+        if (! check){
+          SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
+          return NULL;
+        }
+        
+        PyObject *input_str1 = PyObject_CallMethod(swig_obj[0], "getvalue", NULL);
+        if (PyErr_Occurred()) {
+          PyErr_SetString(PyExc_RuntimeError, "Can not read from StringIO");
+          return NULL;
+        }
+        
+        char *buf = nullptr;
+        PyObject *str = PyUnicode_AsUTF8String(input_str1);	 
+        PyBytes_AsStringAndSize(str, &buf, &len1);
+        stream1 = new std::istringstream(buf);
+        Py_DECREF(str);
+        Py_DECREF(input_str1);	 
+      } else {
+        // if it is string, extract filename as char*
+        PyObject* str = PyUnicode_AsEncodedString(swig_obj[0], "utf-8", "~E~");	
+        const char* filename = PyBytes_AsString(str);
+        temp1 = new PyMFEM::wFILE(filename, 8, true);
+        Py_DECREF(str);
+      }
+    }
+    if (stream1 == 0){
+      if (temp1->isGZ()){
+        in_gz1 = new mfem::ifgzstream(temp1->getFilename());
+        arg1 = in_gz1;
+      } else {
+        in_txt1.open(temp1->getFilename(), std::ifstream::in);
+        in_txt1.precision(temp1->getPrecision());
+        arg1 = &in_txt1;
+      }
+      if (temp1->isTemporary()){
+        delete temp1;
+      }
+    } else {
+      arg1 = stream1;
+    }
   }
-  if (!argp1) {
-    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "new_Mesh" "', argument " "1"" of type '" "std::istream &""'"); 
-  }
-  arg1 = reinterpret_cast< std::istream * >(argp1);
   if (swig_obj[1]) {
     {
       if ((PyArray_PyIntAsInt(swig_obj[1]) == -1) && PyErr_Occurred()) {
@@ -8540,8 +8594,40 @@ SWIGINTERN PyObject *_wrap_new_Mesh__SWIG_9(PyObject *SWIGUNUSEDPARM(self), Py_s
     //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__Mesh, SWIG_POINTER_NEW |  0 );
+  {
+    if (stream1) {
+      ret1 = PyLong_FromSsize_t(len1);
+      if (PyErr_Occurred()) {
+        PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
+        return NULL;
+      }
+      delete stream1;    
+      Py_XDECREF(resultobj);   /* Blow away any previous result */
+      resultobj = ret1;    
+    }
+  }
+  {
+    if (!stream1) {
+      if (temp1) {
+        in_txt1.close();
+      }
+      if (in_gz1){
+        delete in_gz1;
+      }
+    }  
+  }
   return resultobj;
 fail:
+  {
+    if (!stream1) {
+      if (temp1) {
+        in_txt1.close();
+      }
+      if (in_gz1){
+        delete in_gz1;
+      }
+    }  
+  }
   return NULL;
 }
 
@@ -8642,8 +8728,13 @@ SWIGINTERN PyObject *_wrap_Mesh_Load(PyObject *SWIGUNUSEDPARM(self), PyObject *a
   bool arg5 = (bool) true ;
   void *argp1 = 0 ;
   int res1 = 0 ;
-  void *argp2 = 0 ;
-  int res2 = 0 ;
+  PyMFEM::wFILE *temp2 = 0 ;
+  std::ifstream in_txt2 ;
+  mfem::ifgzstream *in_gz2 = 0 ;
+  PyObject *input_str2 = 0 ;
+  std::istringstream *stream2 = 0 ;
+  Py_ssize_t len2 = 0 ;
+  PyObject *ret2 = 0 ;
   bool val5 ;
   int ecode5 = 0 ;
   PyObject * obj0 = 0 ;
@@ -8661,14 +8752,64 @@ SWIGINTERN PyObject *_wrap_Mesh_Load(PyObject *SWIGUNUSEDPARM(self), PyObject *a
     SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "Mesh_Load" "', argument " "1"" of type '" "mfem::Mesh *""'"); 
   }
   arg1 = reinterpret_cast< mfem::Mesh * >(argp1);
-  res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_std__istream,  0 );
-  if (!SWIG_IsOK(res2)) {
-    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "Mesh_Load" "', argument " "2"" of type '" "std::istream &""'"); 
+  {
+    //  PyMFEM::wFILE or string argument or StringIO
+    if (SWIG_ConvertPtr(obj1, (void **) &temp2, SWIGTYPE_p_PyMFEM__wFILE, 0 | 0) == -1) {
+      if (!PyString_Check(obj1) && !PyUnicode_Check(obj1)) {
+        // not string, check if it is StringIO
+        PyObject* module = PyImport_ImportModule("io");
+        if (!module){
+          PyErr_SetString(PyExc_RuntimeError, "Can not load io module");
+          return NULL;
+        }      
+        PyObject* cls = PyObject_GetAttrString(module, "StringIO");
+        if (!cls){
+          PyErr_SetString(PyExc_RuntimeError, "Can not load StringIO");
+          return NULL;
+        }      
+        int check = PyObject_IsInstance(obj1, cls);
+        Py_DECREF(module);
+        if (! check){
+          SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
+          return NULL;
+        }
+        
+        PyObject *input_str2 = PyObject_CallMethod(obj1, "getvalue", NULL);
+        if (PyErr_Occurred()) {
+          PyErr_SetString(PyExc_RuntimeError, "Can not read from StringIO");
+          return NULL;
+        }
+        
+        char *buf = nullptr;
+        PyObject *str = PyUnicode_AsUTF8String(input_str2);	 
+        PyBytes_AsStringAndSize(str, &buf, &len2);
+        stream2 = new std::istringstream(buf);
+        Py_DECREF(str);
+        Py_DECREF(input_str2);	 
+      } else {
+        // if it is string, extract filename as char*
+        PyObject* str = PyUnicode_AsEncodedString(obj1, "utf-8", "~E~");	
+        const char* filename = PyBytes_AsString(str);
+        temp2 = new PyMFEM::wFILE(filename, 8, true);
+        Py_DECREF(str);
+      }
+    }
+    if (stream2 == 0){
+      if (temp2->isGZ()){
+        in_gz2 = new mfem::ifgzstream(temp2->getFilename());
+        arg2 = in_gz2;
+      } else {
+        in_txt2.open(temp2->getFilename(), std::ifstream::in);
+        in_txt2.precision(temp2->getPrecision());
+        arg2 = &in_txt2;
+      }
+      if (temp2->isTemporary()){
+        delete temp2;
+      }
+    } else {
+      arg2 = stream2;
+    }
   }
-  if (!argp2) {
-    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "Mesh_Load" "', argument " "2"" of type '" "std::istream &""'"); 
-  }
-  arg2 = reinterpret_cast< std::istream * >(argp2);
   if (obj2) {
     {
       if ((PyArray_PyIntAsInt(obj2) == -1) && PyErr_Occurred()) {
@@ -8706,8 +8847,40 @@ SWIGINTERN PyObject *_wrap_Mesh_Load(PyObject *SWIGUNUSEDPARM(self), PyObject *a
     //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
+  {
+    if (stream2) {
+      ret2 = PyLong_FromSsize_t(len2);
+      if (PyErr_Occurred()) {
+        PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
+        return NULL;
+      }
+      delete stream2;    
+      Py_XDECREF(resultobj);   /* Blow away any previous result */
+      resultobj = ret2;    
+    }
+  }
+  {
+    if (!stream2) {
+      if (temp2) {
+        in_txt2.close();
+      }
+      if (in_gz2){
+        delete in_gz2;
+      }
+    }  
+  }
   return resultobj;
 fail:
+  {
+    if (!stream2) {
+      if (temp2) {
+        in_txt2.close();
+      }
+      if (in_gz2){
+        delete in_gz2;
+      }
+    }  
+  }
   return NULL;
 }
 
@@ -15491,10 +15664,10 @@ SWIGINTERN PyObject *_wrap_Mesh_PrintXG__SWIG_0(PyObject *SWIGUNUSEDPARM(self), 
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyMFEM::wFILE *temp2 = 0 ;
-  std::ofstream out2 ;
-  int use_stringio2 = 0 ;
+  std::ofstream out_txt2 ;
+  mfem::ofgzstream *out_gz2 = 0 ;
   PyObject *string_io2 = 0 ;
-  std::ostringstream stream2 ;
+  std::ostringstream *stream2 = 0 ;
   PyObject *ret2 = 0 ;
   
   if ((nobjs < 1) || (nobjs > 2)) SWIG_fail;
@@ -15525,29 +15698,33 @@ SWIGINTERN PyObject *_wrap_Mesh_PrintXG__SWIG_0(PyObject *SWIGUNUSEDPARM(self), 
             SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
             return NULL;
           }
-          use_stringio2=1;
           string_io2=swig_obj[1];
+          stream2 = new std::ostringstream();
         } else {
           // if it is string, extract filename as char*
           PyObject* str = PyUnicode_AsEncodedString(swig_obj[1], "utf-8", "~E~");	
           const char* filename = PyBytes_AsString(str);
-          temp2 = new PyMFEM::wFILE(filename, 8, true);	
+          temp2 = new PyMFEM::wFILE(filename, 8, true);
+          Py_DECREF(str);	 
         }
       }
       
-      if (use_stringio2 == 0){
+      if (stream2 == 0){
         if (temp2->isSTDOUT() == 1) {
           arg2 = &std::cout;
+        } else if (temp2->isGZ()){
+          out_gz2 = new mfem::ofgzstream(temp2->getFilename(), true);
+          arg2 = out_gz2;	     
         } else {
-          out2.open(temp2->getFilename());
-          out2.precision(temp2->getPrecision());
-          if (temp2->isTemporary()){
-            delete temp2;
-          }
-          arg2 = &out2;
+          out_txt2.open(temp2->getFilename());
+          out_txt2.precision(temp2->getPrecision());
+          arg2 = &out_txt2;
+        }
+        if (temp2->isTemporary()){
+          delete temp2;
         }
       } else {
-        arg2 = &stream2;
+        arg2 = stream2;
       }
     }
   }
@@ -15566,8 +15743,8 @@ SWIGINTERN PyObject *_wrap_Mesh_PrintXG__SWIG_0(PyObject *SWIGUNUSEDPARM(self), 
   }
   resultobj = SWIG_Py_Void();
   {
-    if (use_stringio2 == 1) {
-      std::string str =  stream2.str();
+    if (stream2) {
+      std::string str =  stream2->str();
       const char* s = str.c_str();
       const int n = str.length();
       ret2 = PyObject_CallMethod(string_io2, "write", "s#",
@@ -15576,15 +15753,21 @@ SWIGINTERN PyObject *_wrap_Mesh_PrintXG__SWIG_0(PyObject *SWIGUNUSEDPARM(self), 
         PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
         return NULL;
       }
+      delete stream2;
       Py_XDECREF(resultobj);   /* Blow away any previous result */
       resultobj = ret2;    
     }
   }
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -15592,10 +15775,15 @@ SWIGINTERN PyObject *_wrap_Mesh_PrintXG__SWIG_0(PyObject *SWIGUNUSEDPARM(self), 
   return resultobj;
 fail:
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -15612,10 +15800,10 @@ SWIGINTERN PyObject *_wrap_Mesh_Print__SWIG_0(PyObject *SWIGUNUSEDPARM(self), Py
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyMFEM::wFILE *temp2 = 0 ;
-  std::ofstream out2 ;
-  int use_stringio2 = 0 ;
+  std::ofstream out_txt2 ;
+  mfem::ofgzstream *out_gz2 = 0 ;
   PyObject *string_io2 = 0 ;
-  std::ostringstream stream2 ;
+  std::ostringstream *stream2 = 0 ;
   PyObject *ret2 = 0 ;
   
   if ((nobjs < 1) || (nobjs > 2)) SWIG_fail;
@@ -15646,29 +15834,33 @@ SWIGINTERN PyObject *_wrap_Mesh_Print__SWIG_0(PyObject *SWIGUNUSEDPARM(self), Py
             SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
             return NULL;
           }
-          use_stringio2=1;
           string_io2=swig_obj[1];
+          stream2 = new std::ostringstream();
         } else {
           // if it is string, extract filename as char*
           PyObject* str = PyUnicode_AsEncodedString(swig_obj[1], "utf-8", "~E~");	
           const char* filename = PyBytes_AsString(str);
-          temp2 = new PyMFEM::wFILE(filename, 8, true);	
+          temp2 = new PyMFEM::wFILE(filename, 8, true);
+          Py_DECREF(str);	 
         }
       }
       
-      if (use_stringio2 == 0){
+      if (stream2 == 0){
         if (temp2->isSTDOUT() == 1) {
           arg2 = &std::cout;
+        } else if (temp2->isGZ()){
+          out_gz2 = new mfem::ofgzstream(temp2->getFilename(), true);
+          arg2 = out_gz2;	     
         } else {
-          out2.open(temp2->getFilename());
-          out2.precision(temp2->getPrecision());
-          if (temp2->isTemporary()){
-            delete temp2;
-          }
-          arg2 = &out2;
+          out_txt2.open(temp2->getFilename());
+          out_txt2.precision(temp2->getPrecision());
+          arg2 = &out_txt2;
+        }
+        if (temp2->isTemporary()){
+          delete temp2;
         }
       } else {
-        arg2 = &stream2;
+        arg2 = stream2;
       }
     }
   }
@@ -15687,8 +15879,8 @@ SWIGINTERN PyObject *_wrap_Mesh_Print__SWIG_0(PyObject *SWIGUNUSEDPARM(self), Py
   }
   resultobj = SWIG_Py_Void();
   {
-    if (use_stringio2 == 1) {
-      std::string str =  stream2.str();
+    if (stream2) {
+      std::string str =  stream2->str();
       const char* s = str.c_str();
       const int n = str.length();
       ret2 = PyObject_CallMethod(string_io2, "write", "s#",
@@ -15697,15 +15889,21 @@ SWIGINTERN PyObject *_wrap_Mesh_Print__SWIG_0(PyObject *SWIGUNUSEDPARM(self), Py
         PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
         return NULL;
       }
+      delete stream2;
       Py_XDECREF(resultobj);   /* Blow away any previous result */
       resultobj = ret2;    
     }
   }
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -15713,10 +15911,15 @@ SWIGINTERN PyObject *_wrap_Mesh_Print__SWIG_0(PyObject *SWIGUNUSEDPARM(self), Py
   return resultobj;
 fail:
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -15732,10 +15935,10 @@ SWIGINTERN PyObject *_wrap_Mesh_PrintVTK__SWIG_0(PyObject *SWIGUNUSEDPARM(self),
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyMFEM::wFILE *temp2 = 0 ;
-  std::ofstream out2 ;
-  int use_stringio2 = 0 ;
+  std::ofstream out_txt2 ;
+  mfem::ofgzstream *out_gz2 = 0 ;
   PyObject *string_io2 = 0 ;
-  std::ostringstream stream2 ;
+  std::ostringstream *stream2 = 0 ;
   PyObject *ret2 = 0 ;
   
   if ((nobjs < 2) || (nobjs > 2)) SWIG_fail;
@@ -15765,29 +15968,33 @@ SWIGINTERN PyObject *_wrap_Mesh_PrintVTK__SWIG_0(PyObject *SWIGUNUSEDPARM(self),
           SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
           return NULL;
         }
-        use_stringio2=1;
         string_io2=swig_obj[1];
+        stream2 = new std::ostringstream();
       } else {
         // if it is string, extract filename as char*
         PyObject* str = PyUnicode_AsEncodedString(swig_obj[1], "utf-8", "~E~");	
         const char* filename = PyBytes_AsString(str);
-        temp2 = new PyMFEM::wFILE(filename, 8, true);	
+        temp2 = new PyMFEM::wFILE(filename, 8, true);
+        Py_DECREF(str);	 
       }
     }
     
-    if (use_stringio2 == 0){
+    if (stream2 == 0){
       if (temp2->isSTDOUT() == 1) {
         arg2 = &std::cout;
+      } else if (temp2->isGZ()){
+        out_gz2 = new mfem::ofgzstream(temp2->getFilename(), true);
+        arg2 = out_gz2;	     
       } else {
-        out2.open(temp2->getFilename());
-        out2.precision(temp2->getPrecision());
-        if (temp2->isTemporary()){
-          delete temp2;
-        }
-        arg2 = &out2;
+        out_txt2.open(temp2->getFilename());
+        out_txt2.precision(temp2->getPrecision());
+        arg2 = &out_txt2;
+      }
+      if (temp2->isTemporary()){
+        delete temp2;
       }
     } else {
-      arg2 = &stream2;
+      arg2 = stream2;
     }
   }
   {
@@ -15805,8 +16012,8 @@ SWIGINTERN PyObject *_wrap_Mesh_PrintVTK__SWIG_0(PyObject *SWIGUNUSEDPARM(self),
   }
   resultobj = SWIG_Py_Void();
   {
-    if (use_stringio2 == 1) {
-      std::string str =  stream2.str();
+    if (stream2) {
+      std::string str =  stream2->str();
       const char* s = str.c_str();
       const int n = str.length();
       ret2 = PyObject_CallMethod(string_io2, "write", "s#",
@@ -15815,15 +16022,21 @@ SWIGINTERN PyObject *_wrap_Mesh_PrintVTK__SWIG_0(PyObject *SWIGUNUSEDPARM(self),
         PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
         return NULL;
       }
+      delete stream2;
       Py_XDECREF(resultobj);   /* Blow away any previous result */
       resultobj = ret2;    
     }
   }
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -15831,10 +16044,15 @@ SWIGINTERN PyObject *_wrap_Mesh_PrintVTK__SWIG_0(PyObject *SWIGUNUSEDPARM(self),
   return resultobj;
 fail:
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -15852,10 +16070,10 @@ SWIGINTERN PyObject *_wrap_Mesh_PrintVTK__SWIG_1(PyObject *SWIGUNUSEDPARM(self),
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyMFEM::wFILE *temp2 = 0 ;
-  std::ofstream out2 ;
-  int use_stringio2 = 0 ;
+  std::ofstream out_txt2 ;
+  mfem::ofgzstream *out_gz2 = 0 ;
   PyObject *string_io2 = 0 ;
-  std::ostringstream stream2 ;
+  std::ostringstream *stream2 = 0 ;
   PyObject *ret2 = 0 ;
   
   if ((nobjs < 3) || (nobjs > 4)) SWIG_fail;
@@ -15885,29 +16103,33 @@ SWIGINTERN PyObject *_wrap_Mesh_PrintVTK__SWIG_1(PyObject *SWIGUNUSEDPARM(self),
           SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
           return NULL;
         }
-        use_stringio2=1;
         string_io2=swig_obj[1];
+        stream2 = new std::ostringstream();
       } else {
         // if it is string, extract filename as char*
         PyObject* str = PyUnicode_AsEncodedString(swig_obj[1], "utf-8", "~E~");	
         const char* filename = PyBytes_AsString(str);
-        temp2 = new PyMFEM::wFILE(filename, 8, true);	
+        temp2 = new PyMFEM::wFILE(filename, 8, true);
+        Py_DECREF(str);	 
       }
     }
     
-    if (use_stringio2 == 0){
+    if (stream2 == 0){
       if (temp2->isSTDOUT() == 1) {
         arg2 = &std::cout;
+      } else if (temp2->isGZ()){
+        out_gz2 = new mfem::ofgzstream(temp2->getFilename(), true);
+        arg2 = out_gz2;	     
       } else {
-        out2.open(temp2->getFilename());
-        out2.precision(temp2->getPrecision());
-        if (temp2->isTemporary()){
-          delete temp2;
-        }
-        arg2 = &out2;
+        out_txt2.open(temp2->getFilename());
+        out_txt2.precision(temp2->getPrecision());
+        arg2 = &out_txt2;
+      }
+      if (temp2->isTemporary()){
+        delete temp2;
       }
     } else {
-      arg2 = &stream2;
+      arg2 = stream2;
     }
   }
   {
@@ -15939,8 +16161,8 @@ SWIGINTERN PyObject *_wrap_Mesh_PrintVTK__SWIG_1(PyObject *SWIGUNUSEDPARM(self),
   }
   resultobj = SWIG_Py_Void();
   {
-    if (use_stringio2 == 1) {
-      std::string str =  stream2.str();
+    if (stream2) {
+      std::string str =  stream2->str();
       const char* s = str.c_str();
       const int n = str.length();
       ret2 = PyObject_CallMethod(string_io2, "write", "s#",
@@ -15949,15 +16171,21 @@ SWIGINTERN PyObject *_wrap_Mesh_PrintVTK__SWIG_1(PyObject *SWIGUNUSEDPARM(self),
         PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
         return NULL;
       }
+      delete stream2;
       Py_XDECREF(resultobj);   /* Blow away any previous result */
       resultobj = ret2;    
     }
   }
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -15965,10 +16193,15 @@ SWIGINTERN PyObject *_wrap_Mesh_PrintVTK__SWIG_1(PyObject *SWIGUNUSEDPARM(self),
   return resultobj;
 fail:
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -15989,10 +16222,10 @@ SWIGINTERN PyObject *_wrap_Mesh_PrintVTU__SWIG_0(PyObject *SWIGUNUSEDPARM(self),
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyMFEM::wFILE *temp2 = 0 ;
-  std::ofstream out2 ;
-  int use_stringio2 = 0 ;
+  std::ofstream out_txt2 ;
+  mfem::ofgzstream *out_gz2 = 0 ;
   PyObject *string_io2 = 0 ;
-  std::ostringstream stream2 ;
+  std::ostringstream *stream2 = 0 ;
   PyObject *ret2 = 0 ;
   int val4 ;
   int ecode4 = 0 ;
@@ -16028,29 +16261,33 @@ SWIGINTERN PyObject *_wrap_Mesh_PrintVTU__SWIG_0(PyObject *SWIGUNUSEDPARM(self),
           SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
           return NULL;
         }
-        use_stringio2=1;
         string_io2=swig_obj[1];
+        stream2 = new std::ostringstream();
       } else {
         // if it is string, extract filename as char*
         PyObject* str = PyUnicode_AsEncodedString(swig_obj[1], "utf-8", "~E~");	
         const char* filename = PyBytes_AsString(str);
-        temp2 = new PyMFEM::wFILE(filename, 8, true);	
+        temp2 = new PyMFEM::wFILE(filename, 8, true);
+        Py_DECREF(str);	 
       }
     }
     
-    if (use_stringio2 == 0){
+    if (stream2 == 0){
       if (temp2->isSTDOUT() == 1) {
         arg2 = &std::cout;
+      } else if (temp2->isGZ()){
+        out_gz2 = new mfem::ofgzstream(temp2->getFilename(), true);
+        arg2 = out_gz2;	     
       } else {
-        out2.open(temp2->getFilename());
-        out2.precision(temp2->getPrecision());
-        if (temp2->isTemporary()){
-          delete temp2;
-        }
-        arg2 = &out2;
+        out_txt2.open(temp2->getFilename());
+        out_txt2.precision(temp2->getPrecision());
+        arg2 = &out_txt2;
+      }
+      if (temp2->isTemporary()){
+        delete temp2;
       }
     } else {
-      arg2 = &stream2;
+      arg2 = stream2;
     }
   }
   if (swig_obj[2]) {
@@ -16105,8 +16342,8 @@ SWIGINTERN PyObject *_wrap_Mesh_PrintVTU__SWIG_0(PyObject *SWIGUNUSEDPARM(self),
   }
   resultobj = SWIG_Py_Void();
   {
-    if (use_stringio2 == 1) {
-      std::string str =  stream2.str();
+    if (stream2) {
+      std::string str =  stream2->str();
       const char* s = str.c_str();
       const int n = str.length();
       ret2 = PyObject_CallMethod(string_io2, "write", "s#",
@@ -16115,15 +16352,21 @@ SWIGINTERN PyObject *_wrap_Mesh_PrintVTU__SWIG_0(PyObject *SWIGUNUSEDPARM(self),
         PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
         return NULL;
       }
+      delete stream2;
       Py_XDECREF(resultobj);   /* Blow away any previous result */
       resultobj = ret2;    
     }
   }
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -16131,10 +16374,15 @@ SWIGINTERN PyObject *_wrap_Mesh_PrintVTU__SWIG_0(PyObject *SWIGUNUSEDPARM(self),
   return resultobj;
 fail:
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -16313,7 +16561,8 @@ SWIGINTERN PyObject *_wrap_Mesh_PrintVTU(PyObject *self, PyObject *args) {
               _v = 0;	   	   	   
             }
           } else {
-            _v = 0;
+            std::cout << "it is text (out)\n";	
+            _v = 1;
           }
         } else {
           _v = 1;
@@ -16535,10 +16784,10 @@ SWIGINTERN PyObject *_wrap_Mesh_PrintWithPartitioning(PyObject *SWIGUNUSEDPARM(s
   void *argp2 = 0 ;
   int res2 = 0 ;
   PyMFEM::wFILE *temp3 = 0 ;
-  std::ofstream out3 ;
-  int use_stringio3 = 0 ;
+  std::ofstream out_txt3 ;
+  mfem::ofgzstream *out_gz3 = 0 ;
   PyObject *string_io3 = 0 ;
-  std::ostringstream stream3 ;
+  std::ostringstream *stream3 = 0 ;
   PyObject *ret3 = 0 ;
   PyObject * obj0 = 0 ;
   PyObject * obj1 = 0 ;
@@ -16580,29 +16829,33 @@ SWIGINTERN PyObject *_wrap_Mesh_PrintWithPartitioning(PyObject *SWIGUNUSEDPARM(s
           SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
           return NULL;
         }
-        use_stringio3=1;
         string_io3=obj2;
+        stream3 = new std::ostringstream();
       } else {
         // if it is string, extract filename as char*
         PyObject* str = PyUnicode_AsEncodedString(obj2, "utf-8", "~E~");	
         const char* filename = PyBytes_AsString(str);
-        temp3 = new PyMFEM::wFILE(filename, 8, true);	
+        temp3 = new PyMFEM::wFILE(filename, 8, true);
+        Py_DECREF(str);	 
       }
     }
     
-    if (use_stringio3 == 0){
+    if (stream3 == 0){
       if (temp3->isSTDOUT() == 1) {
         arg3 = &std::cout;
+      } else if (temp3->isGZ()){
+        out_gz3 = new mfem::ofgzstream(temp3->getFilename(), true);
+        arg3 = out_gz3;	     
       } else {
-        out3.open(temp3->getFilename());
-        out3.precision(temp3->getPrecision());
-        if (temp3->isTemporary()){
-          delete temp3;
-        }
-        arg3 = &out3;
+        out_txt3.open(temp3->getFilename());
+        out_txt3.precision(temp3->getPrecision());
+        arg3 = &out_txt3;
+      }
+      if (temp3->isTemporary()){
+        delete temp3;
       }
     } else {
-      arg3 = &stream3;
+      arg3 = stream3;
     }
   }
   if (obj3) {
@@ -16628,8 +16881,8 @@ SWIGINTERN PyObject *_wrap_Mesh_PrintWithPartitioning(PyObject *SWIGUNUSEDPARM(s
   }
   resultobj = SWIG_Py_Void();
   {
-    if (use_stringio3 == 1) {
-      std::string str =  stream3.str();
+    if (stream3) {
+      std::string str =  stream3->str();
       const char* s = str.c_str();
       const int n = str.length();
       ret3 = PyObject_CallMethod(string_io3, "write", "s#",
@@ -16638,15 +16891,21 @@ SWIGINTERN PyObject *_wrap_Mesh_PrintWithPartitioning(PyObject *SWIGUNUSEDPARM(s
         PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
         return NULL;
       }
+      delete stream3;
       Py_XDECREF(resultobj);   /* Blow away any previous result */
       resultobj = ret3;    
     }
   }
   {
-    if (use_stringio3 == 0) {
+    if (!stream3) {
       if (temp3) {
         if (temp3->isSTDOUT() != 1) {
-          out3.close();
+          if (out_txt3.is_open()){
+            out_txt3.close();
+          }
+          if (out_gz3){
+            delete out_gz3;
+          }
         }
       }
     }
@@ -16654,10 +16913,15 @@ SWIGINTERN PyObject *_wrap_Mesh_PrintWithPartitioning(PyObject *SWIGUNUSEDPARM(s
   return resultobj;
 fail:
   {
-    if (use_stringio3 == 0) {
+    if (!stream3) {
       if (temp3) {
         if (temp3->isSTDOUT() != 1) {
-          out3.close();
+          if (out_txt3.is_open()){
+            out_txt3.close();
+          }
+          if (out_gz3){
+            delete out_gz3;
+          }
         }
       }
     }
@@ -16677,10 +16941,10 @@ SWIGINTERN PyObject *_wrap_Mesh_PrintElementsWithPartitioning(PyObject *SWIGUNUS
   void *argp2 = 0 ;
   int res2 = 0 ;
   PyMFEM::wFILE *temp3 = 0 ;
-  std::ofstream out3 ;
-  int use_stringio3 = 0 ;
+  std::ofstream out_txt3 ;
+  mfem::ofgzstream *out_gz3 = 0 ;
   PyObject *string_io3 = 0 ;
-  std::ostringstream stream3 ;
+  std::ostringstream *stream3 = 0 ;
   PyObject *ret3 = 0 ;
   PyObject * obj0 = 0 ;
   PyObject * obj1 = 0 ;
@@ -16722,29 +16986,33 @@ SWIGINTERN PyObject *_wrap_Mesh_PrintElementsWithPartitioning(PyObject *SWIGUNUS
           SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
           return NULL;
         }
-        use_stringio3=1;
         string_io3=obj2;
+        stream3 = new std::ostringstream();
       } else {
         // if it is string, extract filename as char*
         PyObject* str = PyUnicode_AsEncodedString(obj2, "utf-8", "~E~");	
         const char* filename = PyBytes_AsString(str);
-        temp3 = new PyMFEM::wFILE(filename, 8, true);	
+        temp3 = new PyMFEM::wFILE(filename, 8, true);
+        Py_DECREF(str);	 
       }
     }
     
-    if (use_stringio3 == 0){
+    if (stream3 == 0){
       if (temp3->isSTDOUT() == 1) {
         arg3 = &std::cout;
+      } else if (temp3->isGZ()){
+        out_gz3 = new mfem::ofgzstream(temp3->getFilename(), true);
+        arg3 = out_gz3;	     
       } else {
-        out3.open(temp3->getFilename());
-        out3.precision(temp3->getPrecision());
-        if (temp3->isTemporary()){
-          delete temp3;
-        }
-        arg3 = &out3;
+        out_txt3.open(temp3->getFilename());
+        out_txt3.precision(temp3->getPrecision());
+        arg3 = &out_txt3;
+      }
+      if (temp3->isTemporary()){
+        delete temp3;
       }
     } else {
-      arg3 = &stream3;
+      arg3 = stream3;
     }
   }
   if (obj3) {
@@ -16770,8 +17038,8 @@ SWIGINTERN PyObject *_wrap_Mesh_PrintElementsWithPartitioning(PyObject *SWIGUNUS
   }
   resultobj = SWIG_Py_Void();
   {
-    if (use_stringio3 == 1) {
-      std::string str =  stream3.str();
+    if (stream3) {
+      std::string str =  stream3->str();
       const char* s = str.c_str();
       const int n = str.length();
       ret3 = PyObject_CallMethod(string_io3, "write", "s#",
@@ -16780,15 +17048,21 @@ SWIGINTERN PyObject *_wrap_Mesh_PrintElementsWithPartitioning(PyObject *SWIGUNUS
         PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
         return NULL;
       }
+      delete stream3;
       Py_XDECREF(resultobj);   /* Blow away any previous result */
       resultobj = ret3;    
     }
   }
   {
-    if (use_stringio3 == 0) {
+    if (!stream3) {
       if (temp3) {
         if (temp3->isSTDOUT() != 1) {
-          out3.close();
+          if (out_txt3.is_open()){
+            out_txt3.close();
+          }
+          if (out_gz3){
+            delete out_gz3;
+          }
         }
       }
     }
@@ -16796,10 +17070,15 @@ SWIGINTERN PyObject *_wrap_Mesh_PrintElementsWithPartitioning(PyObject *SWIGUNUS
   return resultobj;
 fail:
   {
-    if (use_stringio3 == 0) {
+    if (!stream3) {
       if (temp3) {
         if (temp3->isSTDOUT() != 1) {
-          out3.close();
+          if (out_txt3.is_open()){
+            out_txt3.close();
+          }
+          if (out_gz3){
+            delete out_gz3;
+          }
         }
       }
     }
@@ -16818,10 +17097,10 @@ SWIGINTERN PyObject *_wrap_Mesh_PrintSurfaces(PyObject *SWIGUNUSEDPARM(self), Py
   void *argp2 = 0 ;
   int res2 = 0 ;
   PyMFEM::wFILE *temp3 = 0 ;
-  std::ofstream out3 ;
-  int use_stringio3 = 0 ;
+  std::ofstream out_txt3 ;
+  mfem::ofgzstream *out_gz3 = 0 ;
   PyObject *string_io3 = 0 ;
-  std::ostringstream stream3 ;
+  std::ostringstream *stream3 = 0 ;
   PyObject *ret3 = 0 ;
   PyObject * obj0 = 0 ;
   PyObject * obj1 = 0 ;
@@ -16865,29 +17144,33 @@ SWIGINTERN PyObject *_wrap_Mesh_PrintSurfaces(PyObject *SWIGUNUSEDPARM(self), Py
           SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
           return NULL;
         }
-        use_stringio3=1;
         string_io3=obj2;
+        stream3 = new std::ostringstream();
       } else {
         // if it is string, extract filename as char*
         PyObject* str = PyUnicode_AsEncodedString(obj2, "utf-8", "~E~");	
         const char* filename = PyBytes_AsString(str);
-        temp3 = new PyMFEM::wFILE(filename, 8, true);	
+        temp3 = new PyMFEM::wFILE(filename, 8, true);
+        Py_DECREF(str);	 
       }
     }
     
-    if (use_stringio3 == 0){
+    if (stream3 == 0){
       if (temp3->isSTDOUT() == 1) {
         arg3 = &std::cout;
+      } else if (temp3->isGZ()){
+        out_gz3 = new mfem::ofgzstream(temp3->getFilename(), true);
+        arg3 = out_gz3;	     
       } else {
-        out3.open(temp3->getFilename());
-        out3.precision(temp3->getPrecision());
-        if (temp3->isTemporary()){
-          delete temp3;
-        }
-        arg3 = &out3;
+        out_txt3.open(temp3->getFilename());
+        out_txt3.precision(temp3->getPrecision());
+        arg3 = &out_txt3;
+      }
+      if (temp3->isTemporary()){
+        delete temp3;
       }
     } else {
-      arg3 = &stream3;
+      arg3 = stream3;
     }
   }
   {
@@ -16905,8 +17188,8 @@ SWIGINTERN PyObject *_wrap_Mesh_PrintSurfaces(PyObject *SWIGUNUSEDPARM(self), Py
   }
   resultobj = SWIG_Py_Void();
   {
-    if (use_stringio3 == 1) {
-      std::string str =  stream3.str();
+    if (stream3) {
+      std::string str =  stream3->str();
       const char* s = str.c_str();
       const int n = str.length();
       ret3 = PyObject_CallMethod(string_io3, "write", "s#",
@@ -16915,15 +17198,21 @@ SWIGINTERN PyObject *_wrap_Mesh_PrintSurfaces(PyObject *SWIGUNUSEDPARM(self), Py
         PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
         return NULL;
       }
+      delete stream3;
       Py_XDECREF(resultobj);   /* Blow away any previous result */
       resultobj = ret3;    
     }
   }
   {
-    if (use_stringio3 == 0) {
+    if (!stream3) {
       if (temp3) {
         if (temp3->isSTDOUT() != 1) {
-          out3.close();
+          if (out_txt3.is_open()){
+            out_txt3.close();
+          }
+          if (out_gz3){
+            delete out_gz3;
+          }
         }
       }
     }
@@ -16931,10 +17220,15 @@ SWIGINTERN PyObject *_wrap_Mesh_PrintSurfaces(PyObject *SWIGUNUSEDPARM(self), Py
   return resultobj;
 fail:
   {
-    if (use_stringio3 == 0) {
+    if (!stream3) {
       if (temp3) {
         if (temp3->isSTDOUT() != 1) {
-          out3.close();
+          if (out_txt3.is_open()){
+            out_txt3.close();
+          }
+          if (out_gz3){
+            delete out_gz3;
+          }
         }
       }
     }
@@ -17687,10 +17981,10 @@ SWIGINTERN PyObject *_wrap_Mesh_PrintElementsByGeometry(PyObject *SWIGUNUSEDPARM
   void *argp2 = 0 ;
   int res2 = 0 ;
   PyMFEM::wFILE *temp3 = 0 ;
-  std::ofstream out3 ;
-  int use_stringio3 = 0 ;
+  std::ofstream out_txt3 ;
+  mfem::ofgzstream *out_gz3 = 0 ;
   PyObject *string_io3 = 0 ;
-  std::ostringstream stream3 ;
+  std::ostringstream *stream3 = 0 ;
   PyObject *ret3 = 0 ;
   PyObject * obj0 = 0 ;
   PyObject * obj1 = 0 ;
@@ -17735,29 +18029,33 @@ SWIGINTERN PyObject *_wrap_Mesh_PrintElementsByGeometry(PyObject *SWIGUNUSEDPARM
           SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
           return NULL;
         }
-        use_stringio3=1;
         string_io3=obj2;
+        stream3 = new std::ostringstream();
       } else {
         // if it is string, extract filename as char*
         PyObject* str = PyUnicode_AsEncodedString(obj2, "utf-8", "~E~");	
         const char* filename = PyBytes_AsString(str);
-        temp3 = new PyMFEM::wFILE(filename, 8, true);	
+        temp3 = new PyMFEM::wFILE(filename, 8, true);
+        Py_DECREF(str);	 
       }
     }
     
-    if (use_stringio3 == 0){
+    if (stream3 == 0){
       if (temp3->isSTDOUT() == 1) {
         arg3 = &std::cout;
+      } else if (temp3->isGZ()){
+        out_gz3 = new mfem::ofgzstream(temp3->getFilename(), true);
+        arg3 = out_gz3;	     
       } else {
-        out3.open(temp3->getFilename());
-        out3.precision(temp3->getPrecision());
-        if (temp3->isTemporary()){
-          delete temp3;
-        }
-        arg3 = &out3;
+        out_txt3.open(temp3->getFilename());
+        out_txt3.precision(temp3->getPrecision());
+        arg3 = &out_txt3;
+      }
+      if (temp3->isTemporary()){
+        delete temp3;
       }
     } else {
-      arg3 = &stream3;
+      arg3 = stream3;
     }
   }
   {
@@ -17775,8 +18073,8 @@ SWIGINTERN PyObject *_wrap_Mesh_PrintElementsByGeometry(PyObject *SWIGUNUSEDPARM
   }
   resultobj = SWIG_Py_Void();
   {
-    if (use_stringio3 == 1) {
-      std::string str =  stream3.str();
+    if (stream3) {
+      std::string str =  stream3->str();
       const char* s = str.c_str();
       const int n = str.length();
       ret3 = PyObject_CallMethod(string_io3, "write", "s#",
@@ -17785,15 +18083,21 @@ SWIGINTERN PyObject *_wrap_Mesh_PrintElementsByGeometry(PyObject *SWIGUNUSEDPARM
         PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
         return NULL;
       }
+      delete stream3;
       Py_XDECREF(resultobj);   /* Blow away any previous result */
       resultobj = ret3;    
     }
   }
   {
-    if (use_stringio3 == 0) {
+    if (!stream3) {
       if (temp3) {
         if (temp3->isSTDOUT() != 1) {
-          out3.close();
+          if (out_txt3.is_open()){
+            out_txt3.close();
+          }
+          if (out_gz3){
+            delete out_gz3;
+          }
         }
       }
     }
@@ -17801,10 +18105,15 @@ SWIGINTERN PyObject *_wrap_Mesh_PrintElementsByGeometry(PyObject *SWIGUNUSEDPARM
   return resultobj;
 fail:
   {
-    if (use_stringio3 == 0) {
+    if (!stream3) {
       if (temp3) {
         if (temp3->isSTDOUT() != 1) {
-          out3.close();
+          if (out_txt3.is_open()){
+            out_txt3.close();
+          }
+          if (out_gz3){
+            delete out_gz3;
+          }
         }
       }
     }
@@ -17827,10 +18136,10 @@ SWIGINTERN PyObject *_wrap_Mesh_PrintCharacteristics(PyObject *SWIGUNUSEDPARM(se
   void *argp3 = 0 ;
   int res3 = 0 ;
   PyMFEM::wFILE *temp4 = 0 ;
-  std::ofstream out4 ;
-  int use_stringio4 = 0 ;
+  std::ofstream out_txt4 ;
+  mfem::ofgzstream *out_gz4 = 0 ;
   PyObject *string_io4 = 0 ;
-  std::ostringstream stream4 ;
+  std::ostringstream *stream4 = 0 ;
   PyObject *ret4 = 0 ;
   PyObject * obj0 = 0 ;
   PyObject * obj1 = 0 ;
@@ -17882,29 +18191,33 @@ SWIGINTERN PyObject *_wrap_Mesh_PrintCharacteristics(PyObject *SWIGUNUSEDPARM(se
             SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
             return NULL;
           }
-          use_stringio4=1;
           string_io4=obj3;
+          stream4 = new std::ostringstream();
         } else {
           // if it is string, extract filename as char*
           PyObject* str = PyUnicode_AsEncodedString(obj3, "utf-8", "~E~");	
           const char* filename = PyBytes_AsString(str);
-          temp4 = new PyMFEM::wFILE(filename, 8, true);	
+          temp4 = new PyMFEM::wFILE(filename, 8, true);
+          Py_DECREF(str);	 
         }
       }
       
-      if (use_stringio4 == 0){
+      if (stream4 == 0){
         if (temp4->isSTDOUT() == 1) {
           arg4 = &std::cout;
+        } else if (temp4->isGZ()){
+          out_gz4 = new mfem::ofgzstream(temp4->getFilename(), true);
+          arg4 = out_gz4;	     
         } else {
-          out4.open(temp4->getFilename());
-          out4.precision(temp4->getPrecision());
-          if (temp4->isTemporary()){
-            delete temp4;
-          }
-          arg4 = &out4;
+          out_txt4.open(temp4->getFilename());
+          out_txt4.precision(temp4->getPrecision());
+          arg4 = &out_txt4;
+        }
+        if (temp4->isTemporary()){
+          delete temp4;
         }
       } else {
-        arg4 = &stream4;
+        arg4 = stream4;
       }
     }
   }
@@ -17923,8 +18236,8 @@ SWIGINTERN PyObject *_wrap_Mesh_PrintCharacteristics(PyObject *SWIGUNUSEDPARM(se
   }
   resultobj = SWIG_Py_Void();
   {
-    if (use_stringio4 == 1) {
-      std::string str =  stream4.str();
+    if (stream4) {
+      std::string str =  stream4->str();
       const char* s = str.c_str();
       const int n = str.length();
       ret4 = PyObject_CallMethod(string_io4, "write", "s#",
@@ -17933,15 +18246,21 @@ SWIGINTERN PyObject *_wrap_Mesh_PrintCharacteristics(PyObject *SWIGUNUSEDPARM(se
         PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
         return NULL;
       }
+      delete stream4;
       Py_XDECREF(resultobj);   /* Blow away any previous result */
       resultobj = ret4;    
     }
   }
   {
-    if (use_stringio4 == 0) {
+    if (!stream4) {
       if (temp4) {
         if (temp4->isSTDOUT() != 1) {
-          out4.close();
+          if (out_txt4.is_open()){
+            out_txt4.close();
+          }
+          if (out_gz4){
+            delete out_gz4;
+          }
         }
       }
     }
@@ -17949,10 +18268,15 @@ SWIGINTERN PyObject *_wrap_Mesh_PrintCharacteristics(PyObject *SWIGUNUSEDPARM(se
   return resultobj;
 fail:
   {
-    if (use_stringio4 == 0) {
+    if (!stream4) {
       if (temp4) {
         if (temp4->isSTDOUT() != 1) {
-          out4.close();
+          if (out_txt4.is_open()){
+            out_txt4.close();
+          }
+          if (out_gz4){
+            delete out_gz4;
+          }
         }
       }
     }
@@ -17969,10 +18293,10 @@ SWIGINTERN PyObject *_wrap_Mesh_PrintInfo__SWIG_0(PyObject *SWIGUNUSEDPARM(self)
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyMFEM::wFILE *temp2 = 0 ;
-  std::ofstream out2 ;
-  int use_stringio2 = 0 ;
+  std::ofstream out_txt2 ;
+  mfem::ofgzstream *out_gz2 = 0 ;
   PyObject *string_io2 = 0 ;
-  std::ostringstream stream2 ;
+  std::ostringstream *stream2 = 0 ;
   PyObject *ret2 = 0 ;
   
   if ((nobjs < 1) || (nobjs > 2)) SWIG_fail;
@@ -18003,29 +18327,33 @@ SWIGINTERN PyObject *_wrap_Mesh_PrintInfo__SWIG_0(PyObject *SWIGUNUSEDPARM(self)
             SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
             return NULL;
           }
-          use_stringio2=1;
           string_io2=swig_obj[1];
+          stream2 = new std::ostringstream();
         } else {
           // if it is string, extract filename as char*
           PyObject* str = PyUnicode_AsEncodedString(swig_obj[1], "utf-8", "~E~");	
           const char* filename = PyBytes_AsString(str);
-          temp2 = new PyMFEM::wFILE(filename, 8, true);	
+          temp2 = new PyMFEM::wFILE(filename, 8, true);
+          Py_DECREF(str);	 
         }
       }
       
-      if (use_stringio2 == 0){
+      if (stream2 == 0){
         if (temp2->isSTDOUT() == 1) {
           arg2 = &std::cout;
+        } else if (temp2->isGZ()){
+          out_gz2 = new mfem::ofgzstream(temp2->getFilename(), true);
+          arg2 = out_gz2;	     
         } else {
-          out2.open(temp2->getFilename());
-          out2.precision(temp2->getPrecision());
-          if (temp2->isTemporary()){
-            delete temp2;
-          }
-          arg2 = &out2;
+          out_txt2.open(temp2->getFilename());
+          out_txt2.precision(temp2->getPrecision());
+          arg2 = &out_txt2;
+        }
+        if (temp2->isTemporary()){
+          delete temp2;
         }
       } else {
-        arg2 = &stream2;
+        arg2 = stream2;
       }
     }
   }
@@ -18044,8 +18372,8 @@ SWIGINTERN PyObject *_wrap_Mesh_PrintInfo__SWIG_0(PyObject *SWIGUNUSEDPARM(self)
   }
   resultobj = SWIG_Py_Void();
   {
-    if (use_stringio2 == 1) {
-      std::string str =  stream2.str();
+    if (stream2) {
+      std::string str =  stream2->str();
       const char* s = str.c_str();
       const int n = str.length();
       ret2 = PyObject_CallMethod(string_io2, "write", "s#",
@@ -18054,15 +18382,21 @@ SWIGINTERN PyObject *_wrap_Mesh_PrintInfo__SWIG_0(PyObject *SWIGUNUSEDPARM(self)
         PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
         return NULL;
       }
+      delete stream2;
       Py_XDECREF(resultobj);   /* Blow away any previous result */
       resultobj = ret2;    
     }
   }
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -18070,10 +18404,15 @@ SWIGINTERN PyObject *_wrap_Mesh_PrintInfo__SWIG_0(PyObject *SWIGUNUSEDPARM(self)
   return resultobj;
 fail:
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -18436,50 +18775,6 @@ SWIGINTERN PyObject *_wrap_new_Mesh(PyObject *self, PyObject *args) {
       }
     }
   }
-  if ((argc >= 1) && (argc <= 4)) {
-    int _v;
-    void *vptr = 0;
-    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_std__istream, SWIG_POINTER_NO_NULL);
-    _v = SWIG_CheckState(res);
-    if (_v) {
-      if (argc <= 1) {
-        return _wrap_new_Mesh__SWIG_9(self, argc, argv);
-      }
-      {
-        if ((PyArray_PyIntAsInt(argv[1]) == -1) && PyErr_Occurred()) {
-          PyErr_Clear();
-          _v = 0;
-        } else {
-          _v = 1;    
-        }
-      }
-      if (_v) {
-        if (argc <= 2) {
-          return _wrap_new_Mesh__SWIG_9(self, argc, argv);
-        }
-        {
-          if ((PyArray_PyIntAsInt(argv[2]) == -1) && PyErr_Occurred()) {
-            PyErr_Clear();
-            _v = 0;
-          } else {
-            _v = 1;    
-          }
-        }
-        if (_v) {
-          if (argc <= 3) {
-            return _wrap_new_Mesh__SWIG_9(self, argc, argv);
-          }
-          {
-            int res = SWIG_AsVal_bool(argv[3], NULL);
-            _v = SWIG_CheckState(res);
-          }
-          if (_v) {
-            return _wrap_new_Mesh__SWIG_9(self, argc, argv);
-          }
-        }
-      }
-    }
-  }
   if ((argc >= 1) && (argc <= 2)) {
     int _v;
     {
@@ -18541,6 +18836,75 @@ SWIGINTERN PyObject *_wrap_new_Mesh(PyObject *self, PyObject *args) {
           }
           if (_v) {
             return _wrap_new_Mesh__SWIG_8(self, argc, argv);
+          }
+        }
+      }
+    }
+  }
+  if ((argc >= 1) && (argc <= 4)) {
+    int _v;
+    {
+      void *ptr;
+      //std::string *ptr2 = (std::string *)0;
+      if (SWIG_ConvertPtr(argv[0], (void **) &ptr, SWIGTYPE_p_PyMFEM__wFILE, 0 |0) == -1) {
+        PyErr_Clear();
+        if (!PyString_Check(argv[0]) && !PyUnicode_Check(argv[0])) {
+          // not string
+          _v = 1;	   	
+          PyObject* module = PyImport_ImportModule("io");
+          if (!module){
+            _v = 0;	   
+          }      
+          PyObject* cls = PyObject_GetAttrString(module, "StringIO");
+          if (!cls){
+            _v = 0;	   	   
+          }      
+          int check = PyObject_IsInstance(argv[0], cls);
+          Py_DECREF(module);
+          if (! check){
+            _v = 0;	   	   	   
+          }
+        } else {
+          _v = 1;
+        }
+      } else {
+        _v = 1;
+      }
+    }
+    if (_v) {
+      if (argc <= 1) {
+        return _wrap_new_Mesh__SWIG_9(self, argc, argv);
+      }
+      {
+        if ((PyArray_PyIntAsInt(argv[1]) == -1) && PyErr_Occurred()) {
+          PyErr_Clear();
+          _v = 0;
+        } else {
+          _v = 1;    
+        }
+      }
+      if (_v) {
+        if (argc <= 2) {
+          return _wrap_new_Mesh__SWIG_9(self, argc, argv);
+        }
+        {
+          if ((PyArray_PyIntAsInt(argv[2]) == -1) && PyErr_Occurred()) {
+            PyErr_Clear();
+            _v = 0;
+          } else {
+            _v = 1;    
+          }
+        }
+        if (_v) {
+          if (argc <= 3) {
+            return _wrap_new_Mesh__SWIG_9(self, argc, argv);
+          }
+          {
+            int res = SWIG_AsVal_bool(argv[3], NULL);
+            _v = SWIG_CheckState(res);
+          }
+          if (_v) {
+            return _wrap_new_Mesh__SWIG_9(self, argc, argv);
           }
         }
       }
@@ -19687,7 +20051,8 @@ SWIGINTERN PyObject *_wrap_Mesh_PrintInfo(PyObject *self, PyObject *args) {
               _v = 0;	   	   	   
             }
           } else {
-            _v = 0;
+            std::cout << "it is text (out)\n";	
+            _v = 1;
           }
         } else {
           _v = 1;
@@ -19825,7 +20190,8 @@ SWIGINTERN PyObject *_wrap_Mesh_Print(PyObject *self, PyObject *args) {
               _v = 0;	   	   	   
             }
           } else {
-            _v = 0;
+            std::cout << "it is text (out)\n";	
+            _v = 1;
           }
         } else {
           _v = 1;
@@ -19963,7 +20329,8 @@ SWIGINTERN PyObject *_wrap_Mesh_PrintXG(PyObject *self, PyObject *args) {
               _v = 0;	   	   	   
             }
           } else {
-            _v = 0;
+            std::cout << "it is text (out)\n";	
+            _v = 1;
           }
         } else {
           _v = 1;
@@ -20124,7 +20491,8 @@ SWIGINTERN PyObject *_wrap_Mesh_PrintVTK(PyObject *self, PyObject *args) {
               _v = 0;	   	   	   
             }
           } else {
-            _v = 0;
+            std::cout << "it is text (out)\n";	
+            _v = 1;
           }
         } else {
           _v = 1;
@@ -20163,7 +20531,8 @@ SWIGINTERN PyObject *_wrap_Mesh_PrintVTK(PyObject *self, PyObject *args) {
               _v = 0;	   	   	   
             }
           } else {
-            _v = 0;
+            std::cout << "it is text (out)\n";	
+            _v = 1;
           }
         } else {
           _v = 1;
@@ -20224,10 +20593,10 @@ SWIGINTERN PyObject *_wrap___lshift____SWIG_3(PyObject *SWIGUNUSEDPARM(self), Py
   std::ostream *arg1 = 0 ;
   mfem::Mesh *arg2 = 0 ;
   PyMFEM::wFILE *temp1 = 0 ;
-  std::ofstream out1 ;
-  int use_stringio1 = 0 ;
+  std::ofstream out_txt1 ;
+  mfem::ofgzstream *out_gz1 = 0 ;
   PyObject *string_io1 = 0 ;
-  std::ostringstream stream1 ;
+  std::ostringstream *stream1 = 0 ;
   PyObject *ret1 = 0 ;
   void *argp2 = 0 ;
   int res2 = 0 ;
@@ -20255,29 +20624,33 @@ SWIGINTERN PyObject *_wrap___lshift____SWIG_3(PyObject *SWIGUNUSEDPARM(self), Py
           SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
           return NULL;
         }
-        use_stringio1=1;
         string_io1=swig_obj[0];
+        stream1 = new std::ostringstream();
       } else {
         // if it is string, extract filename as char*
         PyObject* str = PyUnicode_AsEncodedString(swig_obj[0], "utf-8", "~E~");	
         const char* filename = PyBytes_AsString(str);
-        temp1 = new PyMFEM::wFILE(filename, 8, true);	
+        temp1 = new PyMFEM::wFILE(filename, 8, true);
+        Py_DECREF(str);	 
       }
     }
     
-    if (use_stringio1 == 0){
+    if (stream1 == 0){
       if (temp1->isSTDOUT() == 1) {
         arg1 = &std::cout;
+      } else if (temp1->isGZ()){
+        out_gz1 = new mfem::ofgzstream(temp1->getFilename(), true);
+        arg1 = out_gz1;	     
       } else {
-        out1.open(temp1->getFilename());
-        out1.precision(temp1->getPrecision());
-        if (temp1->isTemporary()){
-          delete temp1;
-        }
-        arg1 = &out1;
+        out_txt1.open(temp1->getFilename());
+        out_txt1.precision(temp1->getPrecision());
+        arg1 = &out_txt1;
+      }
+      if (temp1->isTemporary()){
+        delete temp1;
       }
     } else {
-      arg1 = &stream1;
+      arg1 = stream1;
     }
   }
   res2 = SWIG_ConvertPtr(swig_obj[1], &argp2, SWIGTYPE_p_mfem__Mesh,  0  | 0);
@@ -20303,8 +20676,8 @@ SWIGINTERN PyObject *_wrap___lshift____SWIG_3(PyObject *SWIGUNUSEDPARM(self), Py
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_std__ostream, 0 |  0 );
   {
-    if (use_stringio1 == 1) {
-      std::string str =  stream1.str();
+    if (stream1) {
+      std::string str =  stream1->str();
       const char* s = str.c_str();
       const int n = str.length();
       ret1 = PyObject_CallMethod(string_io1, "write", "s#",
@@ -20313,15 +20686,21 @@ SWIGINTERN PyObject *_wrap___lshift____SWIG_3(PyObject *SWIGUNUSEDPARM(self), Py
         PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
         return NULL;
       }
+      delete stream1;
       Py_XDECREF(resultobj);   /* Blow away any previous result */
       resultobj = ret1;    
     }
   }
   {
-    if (use_stringio1 == 0) {
+    if (!stream1) {
       if (temp1) {
         if (temp1->isSTDOUT() != 1) {
-          out1.close();
+          if (out_txt1.is_open()){
+            out_txt1.close();
+          }
+          if (out_gz1){
+            delete out_gz1;
+          }
         }
       }
     }
@@ -20329,10 +20708,15 @@ SWIGINTERN PyObject *_wrap___lshift____SWIG_3(PyObject *SWIGUNUSEDPARM(self), Py
   return resultobj;
 fail:
   {
-    if (use_stringio1 == 0) {
+    if (!stream1) {
       if (temp1) {
         if (temp1->isSTDOUT() != 1) {
-          out1.close();
+          if (out_txt1.is_open()){
+            out_txt1.close();
+          }
+          if (out_gz1){
+            delete out_gz1;
+          }
         }
       }
     }
@@ -20375,7 +20759,8 @@ SWIGINTERN PyObject *_wrap___lshift__(PyObject *self, PyObject *args) {
             _v = 0;	   	   	   
           }
         } else {
-          _v = 0;
+          std::cout << "it is text (out)\n";	
+          _v = 1;
         }
       } else {
         _v = 1;
@@ -23152,7 +23537,6 @@ static swig_type_info _swigt__p_p_mfem__Mesh = {"_p_p_mfem__Mesh", "mfem::Mesh *
 static swig_type_info _swigt__p_pri_t = {"_p_pri_t", "pri_t *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_quad_t = {"_p_quad_t", "quad_t *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_seg_t = {"_p_seg_t", "seg_t *", 0, 0, (void*)0, 0};
-static swig_type_info _swigt__p_std__istream = {"_p_std__istream", "std::istream *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_std__ostream = {"_p_std__ostream", "std::ostream *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_mfem__OutStream = {"_p_mfem__OutStream", 0, 0, 0, 0, 0};
 static swig_type_info _swigt__p_tet_t = {"_p_tet_t", "tet_t *", 0, 0, (void*)0, 0};
@@ -23327,7 +23711,6 @@ static swig_type_info *swig_type_initial[] = {
   &_swigt__p_pri_t,
   &_swigt__p_quad_t,
   &_swigt__p_seg_t,
-  &_swigt__p_std__istream,
   &_swigt__p_std__ostream,
   &_swigt__p_tet_t,
   &_swigt__p_tri_t,
@@ -23500,7 +23883,6 @@ static swig_cast_info _swigc__p_p_mfem__Mesh[] = {  {&_swigt__p_p_mfem__Mesh, 0,
 static swig_cast_info _swigc__p_pri_t[] = {  {&_swigt__p_pri_t, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_quad_t[] = {  {&_swigt__p_quad_t, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_seg_t[] = {  {&_swigt__p_seg_t, 0, 0, 0},{0, 0, 0, 0}};
-static swig_cast_info _swigc__p_std__istream[] = {  {&_swigt__p_std__istream, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_mfem__OutStream[] = {{&_swigt__p_mfem__OutStream, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_std__ostream[] = {  {&_swigt__p_std__ostream, 0, 0, 0},  {&_swigt__p_mfem__OutStream, _p_mfem__OutStreamTo_p_std__ostream, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_tet_t[] = {  {&_swigt__p_tet_t, 0, 0, 0},{0, 0, 0, 0}};
@@ -23675,7 +24057,6 @@ static swig_cast_info *swig_cast_initial[] = {
   _swigc__p_pri_t,
   _swigc__p_quad_t,
   _swigc__p_seg_t,
-  _swigc__p_std__istream,
   _swigc__p_std__ostream,
   _swigc__p_tet_t,
   _swigc__p_tri_t,

--- a/mfem/_par/mesh_wrap.cxx
+++ b/mfem/_par/mesh_wrap.cxx
@@ -8490,7 +8490,6 @@ SWIGINTERN PyObject *_wrap_new_Mesh__SWIG_9(PyObject *SWIGUNUSEDPARM(self), Py_s
   PyMFEM::wFILE *temp1 = 0 ;
   std::ifstream in_txt1 ;
   mfem::ifgzstream *in_gz1 = 0 ;
-  PyObject *input_str1 = 0 ;
   std::istringstream *stream1 = 0 ;
   Py_ssize_t len1 = 0 ;
   PyObject *ret1 = 0 ;
@@ -8521,18 +8520,18 @@ SWIGINTERN PyObject *_wrap_new_Mesh__SWIG_9(PyObject *SWIGUNUSEDPARM(self), Py_s
           return NULL;
         }
         
-        PyObject *input_str1 = PyObject_CallMethod(swig_obj[0], "getvalue", NULL);
+        PyObject *input_str = PyObject_CallMethod(swig_obj[0], "getvalue", NULL);
         if (PyErr_Occurred()) {
           PyErr_SetString(PyExc_RuntimeError, "Can not read from StringIO");
           return NULL;
         }
         
         char *buf = nullptr;
-        PyObject *str = PyUnicode_AsUTF8String(input_str1);	 
+        PyObject *str = PyUnicode_AsUTF8String(input_str);	 
         PyBytes_AsStringAndSize(str, &buf, &len1);
         stream1 = new std::istringstream(buf);
         Py_DECREF(str);
-        Py_DECREF(input_str1);	 
+        Py_DECREF(input_str);	 
       } else {
         // if it is string, extract filename as char*
         PyObject* str = PyUnicode_AsEncodedString(swig_obj[0], "utf-8", "~E~");	
@@ -8731,7 +8730,6 @@ SWIGINTERN PyObject *_wrap_Mesh_Load(PyObject *SWIGUNUSEDPARM(self), PyObject *a
   PyMFEM::wFILE *temp2 = 0 ;
   std::ifstream in_txt2 ;
   mfem::ifgzstream *in_gz2 = 0 ;
-  PyObject *input_str2 = 0 ;
   std::istringstream *stream2 = 0 ;
   Py_ssize_t len2 = 0 ;
   PyObject *ret2 = 0 ;
@@ -8774,18 +8772,18 @@ SWIGINTERN PyObject *_wrap_Mesh_Load(PyObject *SWIGUNUSEDPARM(self), PyObject *a
           return NULL;
         }
         
-        PyObject *input_str2 = PyObject_CallMethod(obj1, "getvalue", NULL);
+        PyObject *input_str = PyObject_CallMethod(obj1, "getvalue", NULL);
         if (PyErr_Occurred()) {
           PyErr_SetString(PyExc_RuntimeError, "Can not read from StringIO");
           return NULL;
         }
         
         char *buf = nullptr;
-        PyObject *str = PyUnicode_AsUTF8String(input_str2);	 
+        PyObject *str = PyUnicode_AsUTF8String(input_str);	 
         PyBytes_AsStringAndSize(str, &buf, &len2);
         stream2 = new std::istringstream(buf);
         Py_DECREF(str);
-        Py_DECREF(input_str2);	 
+        Py_DECREF(input_str);	 
       } else {
         // if it is string, extract filename as char*
         PyObject* str = PyUnicode_AsEncodedString(obj1, "utf-8", "~E~");	
@@ -16561,7 +16559,6 @@ SWIGINTERN PyObject *_wrap_Mesh_PrintVTU(PyObject *self, PyObject *args) {
               _v = 0;	   	   	   
             }
           } else {
-            std::cout << "it is text (out)\n";	
             _v = 1;
           }
         } else {
@@ -20051,7 +20048,6 @@ SWIGINTERN PyObject *_wrap_Mesh_PrintInfo(PyObject *self, PyObject *args) {
               _v = 0;	   	   	   
             }
           } else {
-            std::cout << "it is text (out)\n";	
             _v = 1;
           }
         } else {
@@ -20190,7 +20186,6 @@ SWIGINTERN PyObject *_wrap_Mesh_Print(PyObject *self, PyObject *args) {
               _v = 0;	   	   	   
             }
           } else {
-            std::cout << "it is text (out)\n";	
             _v = 1;
           }
         } else {
@@ -20329,7 +20324,6 @@ SWIGINTERN PyObject *_wrap_Mesh_PrintXG(PyObject *self, PyObject *args) {
               _v = 0;	   	   	   
             }
           } else {
-            std::cout << "it is text (out)\n";	
             _v = 1;
           }
         } else {
@@ -20491,7 +20485,6 @@ SWIGINTERN PyObject *_wrap_Mesh_PrintVTK(PyObject *self, PyObject *args) {
               _v = 0;	   	   	   
             }
           } else {
-            std::cout << "it is text (out)\n";	
             _v = 1;
           }
         } else {
@@ -20531,7 +20524,6 @@ SWIGINTERN PyObject *_wrap_Mesh_PrintVTK(PyObject *self, PyObject *args) {
               _v = 0;	   	   	   
             }
           } else {
-            std::cout << "it is text (out)\n";	
             _v = 1;
           }
         } else {
@@ -20759,7 +20751,6 @@ SWIGINTERN PyObject *_wrap___lshift__(PyObject *self, PyObject *args) {
             _v = 0;	   	   	   
           }
         } else {
-          std::cout << "it is text (out)\n";	
           _v = 1;
         }
       } else {

--- a/mfem/_par/ncmesh.i
+++ b/mfem/_par/ncmesh.i
@@ -5,9 +5,10 @@
 %{
 #include <fstream>
 #include <iostream>
-  
-#include "../common/io_stream.hpp"         
+
+#include "../common/io_stream.hpp"
 #include "mesh/ncmesh.hpp"
+#include "general/zstr.hpp"
 #include "numpy/arrayobject.h"      
 %}
 
@@ -23,6 +24,7 @@ import_array();
 
 %import "../common/io_stream_typemap.i"
 OSTREAM_TYPEMAP(std::ostream&)
+ISTREAM_TYPEMAP(std::istream&)
 
 %immutable embeddings;
 %include  "mesh/ncmesh.hpp"

--- a/mfem/_par/ncmesh_wrap.cxx
+++ b/mfem/_par/ncmesh_wrap.cxx
@@ -6385,7 +6385,6 @@ SWIGINTERN PyObject *_wrap_NCMesh_LoadVertexParents(PyObject *SWIGUNUSEDPARM(sel
   PyMFEM::wFILE *temp2 = 0 ;
   std::ifstream in_txt2 ;
   mfem::ifgzstream *in_gz2 = 0 ;
-  PyObject *input_str2 = 0 ;
   std::istringstream *stream2 = 0 ;
   Py_ssize_t len2 = 0 ;
   PyObject *ret2 = 0 ;
@@ -6423,18 +6422,18 @@ SWIGINTERN PyObject *_wrap_NCMesh_LoadVertexParents(PyObject *SWIGUNUSEDPARM(sel
           return NULL;
         }
         
-        PyObject *input_str2 = PyObject_CallMethod(obj1, "getvalue", NULL);
+        PyObject *input_str = PyObject_CallMethod(obj1, "getvalue", NULL);
         if (PyErr_Occurred()) {
           PyErr_SetString(PyExc_RuntimeError, "Can not read from StringIO");
           return NULL;
         }
         
         char *buf = nullptr;
-        PyObject *str = PyUnicode_AsUTF8String(input_str2);	 
+        PyObject *str = PyUnicode_AsUTF8String(input_str);	 
         PyBytes_AsStringAndSize(str, &buf, &len2);
         stream2 = new std::istringstream(buf);
         Py_DECREF(str);
-        Py_DECREF(input_str2);	 
+        Py_DECREF(input_str);	 
       } else {
         // if it is string, extract filename as char*
         PyObject* str = PyUnicode_AsEncodedString(obj1, "utf-8", "~E~");	
@@ -6520,7 +6519,6 @@ SWIGINTERN PyObject *_wrap_NCMesh_LoadCoarseElements(PyObject *SWIGUNUSEDPARM(se
   PyMFEM::wFILE *temp2 = 0 ;
   std::ifstream in_txt2 ;
   mfem::ifgzstream *in_gz2 = 0 ;
-  PyObject *input_str2 = 0 ;
   std::istringstream *stream2 = 0 ;
   Py_ssize_t len2 = 0 ;
   PyObject *ret2 = 0 ;
@@ -6558,18 +6556,18 @@ SWIGINTERN PyObject *_wrap_NCMesh_LoadCoarseElements(PyObject *SWIGUNUSEDPARM(se
           return NULL;
         }
         
-        PyObject *input_str2 = PyObject_CallMethod(obj1, "getvalue", NULL);
+        PyObject *input_str = PyObject_CallMethod(obj1, "getvalue", NULL);
         if (PyErr_Occurred()) {
           PyErr_SetString(PyExc_RuntimeError, "Can not read from StringIO");
           return NULL;
         }
         
         char *buf = nullptr;
-        PyObject *str = PyUnicode_AsUTF8String(input_str2);	 
+        PyObject *str = PyUnicode_AsUTF8String(input_str);	 
         PyBytes_AsStringAndSize(str, &buf, &len2);
         stream2 = new std::istringstream(buf);
         Py_DECREF(str);
-        Py_DECREF(input_str2);	 
+        Py_DECREF(input_str);	 
       } else {
         // if it is string, extract filename as char*
         PyObject* str = PyUnicode_AsEncodedString(obj1, "utf-8", "~E~");	
@@ -7089,7 +7087,6 @@ SWIGINTERN PyObject *_wrap_NCMesh_PrintVertexParents(PyObject *self, PyObject *a
               _v = 0;	   	   	   
             }
           } else {
-            std::cout << "it is text (out)\n";	
             _v = 1;
           }
         } else {
@@ -7267,7 +7264,6 @@ SWIGINTERN PyObject *_wrap_NCMesh_PrintCoarseElements(PyObject *self, PyObject *
               _v = 0;	   	   	   
             }
           } else {
-            std::cout << "it is text (out)\n";	
             _v = 1;
           }
         } else {
@@ -7381,7 +7377,6 @@ SWIGINTERN PyObject *_wrap_NCMesh_PrintStats(PyObject *self, PyObject *args) {
               _v = 0;	   	   	   
             }
           } else {
-            std::cout << "it is text (out)\n";	
             _v = 1;
           }
         } else {

--- a/mfem/_par/ncmesh_wrap.cxx
+++ b/mfem/_par/ncmesh_wrap.cxx
@@ -3207,9 +3207,10 @@ namespace swig {
 
 #include <fstream>
 #include <iostream>
-  
-#include "../common/io_stream.hpp"         
+
+#include "../common/io_stream.hpp"
 #include "mesh/ncmesh.hpp"
+#include "general/zstr.hpp"
 #include "numpy/arrayobject.h"      
 
 
@@ -6116,10 +6117,10 @@ SWIGINTERN PyObject *_wrap_NCMesh_PrintVertexParents__SWIG_0(PyObject *SWIGUNUSE
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyMFEM::wFILE *temp2 = 0 ;
-  std::ofstream out2 ;
-  int use_stringio2 = 0 ;
+  std::ofstream out_txt2 ;
+  mfem::ofgzstream *out_gz2 = 0 ;
   PyObject *string_io2 = 0 ;
-  std::ostringstream stream2 ;
+  std::ostringstream *stream2 = 0 ;
   PyObject *ret2 = 0 ;
   
   if ((nobjs < 2) || (nobjs > 2)) SWIG_fail;
@@ -6149,29 +6150,33 @@ SWIGINTERN PyObject *_wrap_NCMesh_PrintVertexParents__SWIG_0(PyObject *SWIGUNUSE
           SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
           return NULL;
         }
-        use_stringio2=1;
         string_io2=swig_obj[1];
+        stream2 = new std::ostringstream();
       } else {
         // if it is string, extract filename as char*
         PyObject* str = PyUnicode_AsEncodedString(swig_obj[1], "utf-8", "~E~");	
         const char* filename = PyBytes_AsString(str);
-        temp2 = new PyMFEM::wFILE(filename, 8, true);	
+        temp2 = new PyMFEM::wFILE(filename, 8, true);
+        Py_DECREF(str);	 
       }
     }
     
-    if (use_stringio2 == 0){
+    if (stream2 == 0){
       if (temp2->isSTDOUT() == 1) {
         arg2 = &std::cout;
+      } else if (temp2->isGZ()){
+        out_gz2 = new mfem::ofgzstream(temp2->getFilename(), true);
+        arg2 = out_gz2;	     
       } else {
-        out2.open(temp2->getFilename());
-        out2.precision(temp2->getPrecision());
-        if (temp2->isTemporary()){
-          delete temp2;
-        }
-        arg2 = &out2;
+        out_txt2.open(temp2->getFilename());
+        out_txt2.precision(temp2->getPrecision());
+        arg2 = &out_txt2;
+      }
+      if (temp2->isTemporary()){
+        delete temp2;
       }
     } else {
-      arg2 = &stream2;
+      arg2 = stream2;
     }
   }
   {
@@ -6189,8 +6194,8 @@ SWIGINTERN PyObject *_wrap_NCMesh_PrintVertexParents__SWIG_0(PyObject *SWIGUNUSE
   }
   resultobj = SWIG_Py_Void();
   {
-    if (use_stringio2 == 1) {
-      std::string str =  stream2.str();
+    if (stream2) {
+      std::string str =  stream2->str();
       const char* s = str.c_str();
       const int n = str.length();
       ret2 = PyObject_CallMethod(string_io2, "write", "s#",
@@ -6199,15 +6204,21 @@ SWIGINTERN PyObject *_wrap_NCMesh_PrintVertexParents__SWIG_0(PyObject *SWIGUNUSE
         PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
         return NULL;
       }
+      delete stream2;
       Py_XDECREF(resultobj);   /* Blow away any previous result */
       resultobj = ret2;    
     }
   }
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -6215,10 +6226,15 @@ SWIGINTERN PyObject *_wrap_NCMesh_PrintVertexParents__SWIG_0(PyObject *SWIGUNUSE
   return resultobj;
 fail:
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -6234,10 +6250,10 @@ SWIGINTERN PyObject *_wrap_NCMesh_PrintCoarseElements__SWIG_0(PyObject *SWIGUNUS
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyMFEM::wFILE *temp2 = 0 ;
-  std::ofstream out2 ;
-  int use_stringio2 = 0 ;
+  std::ofstream out_txt2 ;
+  mfem::ofgzstream *out_gz2 = 0 ;
   PyObject *string_io2 = 0 ;
-  std::ostringstream stream2 ;
+  std::ostringstream *stream2 = 0 ;
   PyObject *ret2 = 0 ;
   
   if ((nobjs < 2) || (nobjs > 2)) SWIG_fail;
@@ -6267,29 +6283,33 @@ SWIGINTERN PyObject *_wrap_NCMesh_PrintCoarseElements__SWIG_0(PyObject *SWIGUNUS
           SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
           return NULL;
         }
-        use_stringio2=1;
         string_io2=swig_obj[1];
+        stream2 = new std::ostringstream();
       } else {
         // if it is string, extract filename as char*
         PyObject* str = PyUnicode_AsEncodedString(swig_obj[1], "utf-8", "~E~");	
         const char* filename = PyBytes_AsString(str);
-        temp2 = new PyMFEM::wFILE(filename, 8, true);	
+        temp2 = new PyMFEM::wFILE(filename, 8, true);
+        Py_DECREF(str);	 
       }
     }
     
-    if (use_stringio2 == 0){
+    if (stream2 == 0){
       if (temp2->isSTDOUT() == 1) {
         arg2 = &std::cout;
+      } else if (temp2->isGZ()){
+        out_gz2 = new mfem::ofgzstream(temp2->getFilename(), true);
+        arg2 = out_gz2;	     
       } else {
-        out2.open(temp2->getFilename());
-        out2.precision(temp2->getPrecision());
-        if (temp2->isTemporary()){
-          delete temp2;
-        }
-        arg2 = &out2;
+        out_txt2.open(temp2->getFilename());
+        out_txt2.precision(temp2->getPrecision());
+        arg2 = &out_txt2;
+      }
+      if (temp2->isTemporary()){
+        delete temp2;
       }
     } else {
-      arg2 = &stream2;
+      arg2 = stream2;
     }
   }
   {
@@ -6307,8 +6327,8 @@ SWIGINTERN PyObject *_wrap_NCMesh_PrintCoarseElements__SWIG_0(PyObject *SWIGUNUS
   }
   resultobj = SWIG_Py_Void();
   {
-    if (use_stringio2 == 1) {
-      std::string str =  stream2.str();
+    if (stream2) {
+      std::string str =  stream2->str();
       const char* s = str.c_str();
       const int n = str.length();
       ret2 = PyObject_CallMethod(string_io2, "write", "s#",
@@ -6317,15 +6337,21 @@ SWIGINTERN PyObject *_wrap_NCMesh_PrintCoarseElements__SWIG_0(PyObject *SWIGUNUS
         PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
         return NULL;
       }
+      delete stream2;
       Py_XDECREF(resultobj);   /* Blow away any previous result */
       resultobj = ret2;    
     }
   }
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -6333,10 +6359,15 @@ SWIGINTERN PyObject *_wrap_NCMesh_PrintCoarseElements__SWIG_0(PyObject *SWIGUNUS
   return resultobj;
 fail:
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -6351,8 +6382,13 @@ SWIGINTERN PyObject *_wrap_NCMesh_LoadVertexParents(PyObject *SWIGUNUSEDPARM(sel
   std::istream *arg2 = 0 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
-  void *argp2 = 0 ;
-  int res2 = 0 ;
+  PyMFEM::wFILE *temp2 = 0 ;
+  std::ifstream in_txt2 ;
+  mfem::ifgzstream *in_gz2 = 0 ;
+  PyObject *input_str2 = 0 ;
+  std::istringstream *stream2 = 0 ;
+  Py_ssize_t len2 = 0 ;
+  PyObject *ret2 = 0 ;
   PyObject * obj0 = 0 ;
   PyObject * obj1 = 0 ;
   char * kwnames[] = {
@@ -6365,14 +6401,64 @@ SWIGINTERN PyObject *_wrap_NCMesh_LoadVertexParents(PyObject *SWIGUNUSEDPARM(sel
     SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "NCMesh_LoadVertexParents" "', argument " "1"" of type '" "mfem::NCMesh *""'"); 
   }
   arg1 = reinterpret_cast< mfem::NCMesh * >(argp1);
-  res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_std__istream,  0 );
-  if (!SWIG_IsOK(res2)) {
-    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "NCMesh_LoadVertexParents" "', argument " "2"" of type '" "std::istream &""'"); 
+  {
+    //  PyMFEM::wFILE or string argument or StringIO
+    if (SWIG_ConvertPtr(obj1, (void **) &temp2, SWIGTYPE_p_PyMFEM__wFILE, 0 | 0) == -1) {
+      if (!PyString_Check(obj1) && !PyUnicode_Check(obj1)) {
+        // not string, check if it is StringIO
+        PyObject* module = PyImport_ImportModule("io");
+        if (!module){
+          PyErr_SetString(PyExc_RuntimeError, "Can not load io module");
+          return NULL;
+        }      
+        PyObject* cls = PyObject_GetAttrString(module, "StringIO");
+        if (!cls){
+          PyErr_SetString(PyExc_RuntimeError, "Can not load StringIO");
+          return NULL;
+        }      
+        int check = PyObject_IsInstance(obj1, cls);
+        Py_DECREF(module);
+        if (! check){
+          SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
+          return NULL;
+        }
+        
+        PyObject *input_str2 = PyObject_CallMethod(obj1, "getvalue", NULL);
+        if (PyErr_Occurred()) {
+          PyErr_SetString(PyExc_RuntimeError, "Can not read from StringIO");
+          return NULL;
+        }
+        
+        char *buf = nullptr;
+        PyObject *str = PyUnicode_AsUTF8String(input_str2);	 
+        PyBytes_AsStringAndSize(str, &buf, &len2);
+        stream2 = new std::istringstream(buf);
+        Py_DECREF(str);
+        Py_DECREF(input_str2);	 
+      } else {
+        // if it is string, extract filename as char*
+        PyObject* str = PyUnicode_AsEncodedString(obj1, "utf-8", "~E~");	
+        const char* filename = PyBytes_AsString(str);
+        temp2 = new PyMFEM::wFILE(filename, 8, true);
+        Py_DECREF(str);
+      }
+    }
+    if (stream2 == 0){
+      if (temp2->isGZ()){
+        in_gz2 = new mfem::ifgzstream(temp2->getFilename());
+        arg2 = in_gz2;
+      } else {
+        in_txt2.open(temp2->getFilename(), std::ifstream::in);
+        in_txt2.precision(temp2->getPrecision());
+        arg2 = &in_txt2;
+      }
+      if (temp2->isTemporary()){
+        delete temp2;
+      }
+    } else {
+      arg2 = stream2;
+    }
   }
-  if (!argp2) {
-    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "NCMesh_LoadVertexParents" "', argument " "2"" of type '" "std::istream &""'"); 
-  }
-  arg2 = reinterpret_cast< std::istream * >(argp2);
   {
     try {
       (arg1)->LoadVertexParents(*arg2); 
@@ -6387,8 +6473,40 @@ SWIGINTERN PyObject *_wrap_NCMesh_LoadVertexParents(PyObject *SWIGUNUSEDPARM(sel
     //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
+  {
+    if (stream2) {
+      ret2 = PyLong_FromSsize_t(len2);
+      if (PyErr_Occurred()) {
+        PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
+        return NULL;
+      }
+      delete stream2;    
+      Py_XDECREF(resultobj);   /* Blow away any previous result */
+      resultobj = ret2;    
+    }
+  }
+  {
+    if (!stream2) {
+      if (temp2) {
+        in_txt2.close();
+      }
+      if (in_gz2){
+        delete in_gz2;
+      }
+    }  
+  }
   return resultobj;
 fail:
+  {
+    if (!stream2) {
+      if (temp2) {
+        in_txt2.close();
+      }
+      if (in_gz2){
+        delete in_gz2;
+      }
+    }  
+  }
   return NULL;
 }
 
@@ -6399,8 +6517,13 @@ SWIGINTERN PyObject *_wrap_NCMesh_LoadCoarseElements(PyObject *SWIGUNUSEDPARM(se
   std::istream *arg2 = 0 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
-  void *argp2 = 0 ;
-  int res2 = 0 ;
+  PyMFEM::wFILE *temp2 = 0 ;
+  std::ifstream in_txt2 ;
+  mfem::ifgzstream *in_gz2 = 0 ;
+  PyObject *input_str2 = 0 ;
+  std::istringstream *stream2 = 0 ;
+  Py_ssize_t len2 = 0 ;
+  PyObject *ret2 = 0 ;
   PyObject * obj0 = 0 ;
   PyObject * obj1 = 0 ;
   char * kwnames[] = {
@@ -6413,14 +6536,64 @@ SWIGINTERN PyObject *_wrap_NCMesh_LoadCoarseElements(PyObject *SWIGUNUSEDPARM(se
     SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "NCMesh_LoadCoarseElements" "', argument " "1"" of type '" "mfem::NCMesh *""'"); 
   }
   arg1 = reinterpret_cast< mfem::NCMesh * >(argp1);
-  res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_std__istream,  0 );
-  if (!SWIG_IsOK(res2)) {
-    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "NCMesh_LoadCoarseElements" "', argument " "2"" of type '" "std::istream &""'"); 
+  {
+    //  PyMFEM::wFILE or string argument or StringIO
+    if (SWIG_ConvertPtr(obj1, (void **) &temp2, SWIGTYPE_p_PyMFEM__wFILE, 0 | 0) == -1) {
+      if (!PyString_Check(obj1) && !PyUnicode_Check(obj1)) {
+        // not string, check if it is StringIO
+        PyObject* module = PyImport_ImportModule("io");
+        if (!module){
+          PyErr_SetString(PyExc_RuntimeError, "Can not load io module");
+          return NULL;
+        }      
+        PyObject* cls = PyObject_GetAttrString(module, "StringIO");
+        if (!cls){
+          PyErr_SetString(PyExc_RuntimeError, "Can not load StringIO");
+          return NULL;
+        }      
+        int check = PyObject_IsInstance(obj1, cls);
+        Py_DECREF(module);
+        if (! check){
+          SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
+          return NULL;
+        }
+        
+        PyObject *input_str2 = PyObject_CallMethod(obj1, "getvalue", NULL);
+        if (PyErr_Occurred()) {
+          PyErr_SetString(PyExc_RuntimeError, "Can not read from StringIO");
+          return NULL;
+        }
+        
+        char *buf = nullptr;
+        PyObject *str = PyUnicode_AsUTF8String(input_str2);	 
+        PyBytes_AsStringAndSize(str, &buf, &len2);
+        stream2 = new std::istringstream(buf);
+        Py_DECREF(str);
+        Py_DECREF(input_str2);	 
+      } else {
+        // if it is string, extract filename as char*
+        PyObject* str = PyUnicode_AsEncodedString(obj1, "utf-8", "~E~");	
+        const char* filename = PyBytes_AsString(str);
+        temp2 = new PyMFEM::wFILE(filename, 8, true);
+        Py_DECREF(str);
+      }
+    }
+    if (stream2 == 0){
+      if (temp2->isGZ()){
+        in_gz2 = new mfem::ifgzstream(temp2->getFilename());
+        arg2 = in_gz2;
+      } else {
+        in_txt2.open(temp2->getFilename(), std::ifstream::in);
+        in_txt2.precision(temp2->getPrecision());
+        arg2 = &in_txt2;
+      }
+      if (temp2->isTemporary()){
+        delete temp2;
+      }
+    } else {
+      arg2 = stream2;
+    }
   }
-  if (!argp2) {
-    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "NCMesh_LoadCoarseElements" "', argument " "2"" of type '" "std::istream &""'"); 
-  }
-  arg2 = reinterpret_cast< std::istream * >(argp2);
   {
     try {
       (arg1)->LoadCoarseElements(*arg2); 
@@ -6435,8 +6608,40 @@ SWIGINTERN PyObject *_wrap_NCMesh_LoadCoarseElements(PyObject *SWIGUNUSEDPARM(se
     //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
+  {
+    if (stream2) {
+      ret2 = PyLong_FromSsize_t(len2);
+      if (PyErr_Occurred()) {
+        PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
+        return NULL;
+      }
+      delete stream2;    
+      Py_XDECREF(resultobj);   /* Blow away any previous result */
+      resultobj = ret2;    
+    }
+  }
+  {
+    if (!stream2) {
+      if (temp2) {
+        in_txt2.close();
+      }
+      if (in_gz2){
+        delete in_gz2;
+      }
+    }  
+  }
   return resultobj;
 fail:
+  {
+    if (!stream2) {
+      if (temp2) {
+        in_txt2.close();
+      }
+      if (in_gz2){
+        delete in_gz2;
+      }
+    }  
+  }
   return NULL;
 }
 
@@ -6601,10 +6806,10 @@ SWIGINTERN PyObject *_wrap_NCMesh_PrintStats__SWIG_0(PyObject *SWIGUNUSEDPARM(se
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyMFEM::wFILE *temp2 = 0 ;
-  std::ofstream out2 ;
-  int use_stringio2 = 0 ;
+  std::ofstream out_txt2 ;
+  mfem::ofgzstream *out_gz2 = 0 ;
   PyObject *string_io2 = 0 ;
-  std::ostringstream stream2 ;
+  std::ostringstream *stream2 = 0 ;
   PyObject *ret2 = 0 ;
   
   if ((nobjs < 1) || (nobjs > 2)) SWIG_fail;
@@ -6635,29 +6840,33 @@ SWIGINTERN PyObject *_wrap_NCMesh_PrintStats__SWIG_0(PyObject *SWIGUNUSEDPARM(se
             SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
             return NULL;
           }
-          use_stringio2=1;
           string_io2=swig_obj[1];
+          stream2 = new std::ostringstream();
         } else {
           // if it is string, extract filename as char*
           PyObject* str = PyUnicode_AsEncodedString(swig_obj[1], "utf-8", "~E~");	
           const char* filename = PyBytes_AsString(str);
-          temp2 = new PyMFEM::wFILE(filename, 8, true);	
+          temp2 = new PyMFEM::wFILE(filename, 8, true);
+          Py_DECREF(str);	 
         }
       }
       
-      if (use_stringio2 == 0){
+      if (stream2 == 0){
         if (temp2->isSTDOUT() == 1) {
           arg2 = &std::cout;
+        } else if (temp2->isGZ()){
+          out_gz2 = new mfem::ofgzstream(temp2->getFilename(), true);
+          arg2 = out_gz2;	     
         } else {
-          out2.open(temp2->getFilename());
-          out2.precision(temp2->getPrecision());
-          if (temp2->isTemporary()){
-            delete temp2;
-          }
-          arg2 = &out2;
+          out_txt2.open(temp2->getFilename());
+          out_txt2.precision(temp2->getPrecision());
+          arg2 = &out_txt2;
+        }
+        if (temp2->isTemporary()){
+          delete temp2;
         }
       } else {
-        arg2 = &stream2;
+        arg2 = stream2;
       }
     }
   }
@@ -6676,8 +6885,8 @@ SWIGINTERN PyObject *_wrap_NCMesh_PrintStats__SWIG_0(PyObject *SWIGUNUSEDPARM(se
   }
   resultobj = SWIG_Py_Void();
   {
-    if (use_stringio2 == 1) {
-      std::string str =  stream2.str();
+    if (stream2) {
+      std::string str =  stream2->str();
       const char* s = str.c_str();
       const int n = str.length();
       ret2 = PyObject_CallMethod(string_io2, "write", "s#",
@@ -6686,15 +6895,21 @@ SWIGINTERN PyObject *_wrap_NCMesh_PrintStats__SWIG_0(PyObject *SWIGUNUSEDPARM(se
         PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
         return NULL;
       }
+      delete stream2;
       Py_XDECREF(resultobj);   /* Blow away any previous result */
       resultobj = ret2;    
     }
   }
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -6702,10 +6917,15 @@ SWIGINTERN PyObject *_wrap_NCMesh_PrintStats__SWIG_0(PyObject *SWIGUNUSEDPARM(se
   return resultobj;
 fail:
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -6869,7 +7089,8 @@ SWIGINTERN PyObject *_wrap_NCMesh_PrintVertexParents(PyObject *self, PyObject *a
               _v = 0;	   	   	   
             }
           } else {
-            _v = 0;
+            std::cout << "it is text (out)\n";	
+            _v = 1;
           }
         } else {
           _v = 1;
@@ -7046,7 +7267,8 @@ SWIGINTERN PyObject *_wrap_NCMesh_PrintCoarseElements(PyObject *self, PyObject *
               _v = 0;	   	   	   
             }
           } else {
-            _v = 0;
+            std::cout << "it is text (out)\n";	
+            _v = 1;
           }
         } else {
           _v = 1;
@@ -7159,7 +7381,8 @@ SWIGINTERN PyObject *_wrap_NCMesh_PrintStats(PyObject *self, PyObject *args) {
               _v = 0;	   	   	   
             }
           } else {
-            _v = 0;
+            std::cout << "it is text (out)\n";	
+            _v = 1;
           }
         } else {
           _v = 1;

--- a/mfem/_par/ode_wrap.cxx
+++ b/mfem/_par/ode_wrap.cxx
@@ -9341,10 +9341,10 @@ SWIGINTERN PyObject *_wrap_NewmarkSolver_PrintProperties(PyObject *SWIGUNUSEDPAR
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyMFEM::wFILE *temp2 = 0 ;
-  std::ofstream out2 ;
-  int use_stringio2 = 0 ;
+  std::ofstream out_txt2 ;
+  mfem::ofgzstream *out_gz2 = 0 ;
   PyObject *string_io2 = 0 ;
-  std::ostringstream stream2 ;
+  std::ostringstream *stream2 = 0 ;
   PyObject *ret2 = 0 ;
   PyObject * obj0 = 0 ;
   PyObject * obj1 = 0 ;
@@ -9380,29 +9380,33 @@ SWIGINTERN PyObject *_wrap_NewmarkSolver_PrintProperties(PyObject *SWIGUNUSEDPAR
             SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
             return NULL;
           }
-          use_stringio2=1;
           string_io2=obj1;
+          stream2 = new std::ostringstream();
         } else {
           // if it is string, extract filename as char*
           PyObject* str = PyUnicode_AsEncodedString(obj1, "utf-8", "~E~");	
           const char* filename = PyBytes_AsString(str);
-          temp2 = new PyMFEM::wFILE(filename, 8, true);	
+          temp2 = new PyMFEM::wFILE(filename, 8, true);
+          Py_DECREF(str);	 
         }
       }
       
-      if (use_stringio2 == 0){
+      if (stream2 == 0){
         if (temp2->isSTDOUT() == 1) {
           arg2 = &std::cout;
+        } else if (temp2->isGZ()){
+          out_gz2 = new mfem::ofgzstream(temp2->getFilename(), true);
+          arg2 = out_gz2;	     
         } else {
-          out2.open(temp2->getFilename());
-          out2.precision(temp2->getPrecision());
-          if (temp2->isTemporary()){
-            delete temp2;
-          }
-          arg2 = &out2;
+          out_txt2.open(temp2->getFilename());
+          out_txt2.precision(temp2->getPrecision());
+          arg2 = &out_txt2;
+        }
+        if (temp2->isTemporary()){
+          delete temp2;
         }
       } else {
-        arg2 = &stream2;
+        arg2 = stream2;
       }
     }
   }
@@ -9421,8 +9425,8 @@ SWIGINTERN PyObject *_wrap_NewmarkSolver_PrintProperties(PyObject *SWIGUNUSEDPAR
   }
   resultobj = SWIG_Py_Void();
   {
-    if (use_stringio2 == 1) {
-      std::string str =  stream2.str();
+    if (stream2) {
+      std::string str =  stream2->str();
       const char* s = str.c_str();
       const int n = str.length();
       ret2 = PyObject_CallMethod(string_io2, "write", "s#",
@@ -9431,15 +9435,21 @@ SWIGINTERN PyObject *_wrap_NewmarkSolver_PrintProperties(PyObject *SWIGUNUSEDPAR
         PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
         return NULL;
       }
+      delete stream2;
       Py_XDECREF(resultobj);   /* Blow away any previous result */
       resultobj = ret2;    
     }
   }
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -9447,10 +9457,15 @@ SWIGINTERN PyObject *_wrap_NewmarkSolver_PrintProperties(PyObject *SWIGUNUSEDPAR
   return resultobj;
 fail:
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -9889,10 +9904,10 @@ SWIGINTERN PyObject *_wrap_GeneralizedAlpha2Solver_PrintProperties(PyObject *SWI
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyMFEM::wFILE *temp2 = 0 ;
-  std::ofstream out2 ;
-  int use_stringio2 = 0 ;
+  std::ofstream out_txt2 ;
+  mfem::ofgzstream *out_gz2 = 0 ;
   PyObject *string_io2 = 0 ;
-  std::ostringstream stream2 ;
+  std::ostringstream *stream2 = 0 ;
   PyObject *ret2 = 0 ;
   PyObject * obj0 = 0 ;
   PyObject * obj1 = 0 ;
@@ -9928,29 +9943,33 @@ SWIGINTERN PyObject *_wrap_GeneralizedAlpha2Solver_PrintProperties(PyObject *SWI
             SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
             return NULL;
           }
-          use_stringio2=1;
           string_io2=obj1;
+          stream2 = new std::ostringstream();
         } else {
           // if it is string, extract filename as char*
           PyObject* str = PyUnicode_AsEncodedString(obj1, "utf-8", "~E~");	
           const char* filename = PyBytes_AsString(str);
-          temp2 = new PyMFEM::wFILE(filename, 8, true);	
+          temp2 = new PyMFEM::wFILE(filename, 8, true);
+          Py_DECREF(str);	 
         }
       }
       
-      if (use_stringio2 == 0){
+      if (stream2 == 0){
         if (temp2->isSTDOUT() == 1) {
           arg2 = &std::cout;
+        } else if (temp2->isGZ()){
+          out_gz2 = new mfem::ofgzstream(temp2->getFilename(), true);
+          arg2 = out_gz2;	     
         } else {
-          out2.open(temp2->getFilename());
-          out2.precision(temp2->getPrecision());
-          if (temp2->isTemporary()){
-            delete temp2;
-          }
-          arg2 = &out2;
+          out_txt2.open(temp2->getFilename());
+          out_txt2.precision(temp2->getPrecision());
+          arg2 = &out_txt2;
+        }
+        if (temp2->isTemporary()){
+          delete temp2;
         }
       } else {
-        arg2 = &stream2;
+        arg2 = stream2;
       }
     }
   }
@@ -9969,8 +9988,8 @@ SWIGINTERN PyObject *_wrap_GeneralizedAlpha2Solver_PrintProperties(PyObject *SWI
   }
   resultobj = SWIG_Py_Void();
   {
-    if (use_stringio2 == 1) {
-      std::string str =  stream2.str();
+    if (stream2) {
+      std::string str =  stream2->str();
       const char* s = str.c_str();
       const int n = str.length();
       ret2 = PyObject_CallMethod(string_io2, "write", "s#",
@@ -9979,15 +9998,21 @@ SWIGINTERN PyObject *_wrap_GeneralizedAlpha2Solver_PrintProperties(PyObject *SWI
         PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
         return NULL;
       }
+      delete stream2;
       Py_XDECREF(resultobj);   /* Blow away any previous result */
       resultobj = ret2;    
     }
   }
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -9995,10 +10020,15 @@ SWIGINTERN PyObject *_wrap_GeneralizedAlpha2Solver_PrintProperties(PyObject *SWI
   return resultobj;
 fail:
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }

--- a/mfem/_par/operators.i
+++ b/mfem/_par/operators.i
@@ -5,7 +5,7 @@
 %{
 #include <fstream>
 #include <iostream>
-  
+#include "general/zstr.hpp"  
 #include "../common/io_stream.hpp"        
 #include "numpy/arrayobject.h"
 #include "pyoperator.hpp"

--- a/mfem/_par/operators_wrap.cxx
+++ b/mfem/_par/operators_wrap.cxx
@@ -7919,7 +7919,6 @@ SWIGINTERN PyObject *_wrap_Operator_PrintMatlab(PyObject *self, PyObject *args) 
               _v = 0;	   	   	   
             }
           } else {
-            std::cout << "it is text (out)\n";	
             _v = 1;
           }
         } else {

--- a/mfem/_par/operators_wrap.cxx
+++ b/mfem/_par/operators_wrap.cxx
@@ -3208,7 +3208,7 @@ namespace swig {
 
 #include <fstream>
 #include <iostream>
-  
+#include "general/zstr.hpp"  
 #include "../common/io_stream.hpp"        
 #include "numpy/arrayobject.h"
 #include "pyoperator.hpp"
@@ -7594,10 +7594,10 @@ SWIGINTERN PyObject *_wrap_Operator_PrintMatlab__SWIG_0(PyObject *SWIGUNUSEDPARM
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyMFEM::wFILE *temp2 = 0 ;
-  std::ofstream out2 ;
-  int use_stringio2 = 0 ;
+  std::ofstream out_txt2 ;
+  mfem::ofgzstream *out_gz2 = 0 ;
   PyObject *string_io2 = 0 ;
-  std::ostringstream stream2 ;
+  std::ostringstream *stream2 = 0 ;
   PyObject *ret2 = 0 ;
   
   if ((nobjs < 2) || (nobjs > 4)) SWIG_fail;
@@ -7627,29 +7627,33 @@ SWIGINTERN PyObject *_wrap_Operator_PrintMatlab__SWIG_0(PyObject *SWIGUNUSEDPARM
           SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
           return NULL;
         }
-        use_stringio2=1;
         string_io2=swig_obj[1];
+        stream2 = new std::ostringstream();
       } else {
         // if it is string, extract filename as char*
         PyObject* str = PyUnicode_AsEncodedString(swig_obj[1], "utf-8", "~E~");	
         const char* filename = PyBytes_AsString(str);
-        temp2 = new PyMFEM::wFILE(filename, 8, true);	
+        temp2 = new PyMFEM::wFILE(filename, 8, true);
+        Py_DECREF(str);	 
       }
     }
     
-    if (use_stringio2 == 0){
+    if (stream2 == 0){
       if (temp2->isSTDOUT() == 1) {
         arg2 = &std::cout;
+      } else if (temp2->isGZ()){
+        out_gz2 = new mfem::ofgzstream(temp2->getFilename(), true);
+        arg2 = out_gz2;	     
       } else {
-        out2.open(temp2->getFilename());
-        out2.precision(temp2->getPrecision());
-        if (temp2->isTemporary()){
-          delete temp2;
-        }
-        arg2 = &out2;
+        out_txt2.open(temp2->getFilename());
+        out_txt2.precision(temp2->getPrecision());
+        arg2 = &out_txt2;
+      }
+      if (temp2->isTemporary()){
+        delete temp2;
       }
     } else {
-      arg2 = &stream2;
+      arg2 = stream2;
     }
   }
   if (swig_obj[2]) {
@@ -7683,8 +7687,8 @@ SWIGINTERN PyObject *_wrap_Operator_PrintMatlab__SWIG_0(PyObject *SWIGUNUSEDPARM
   }
   resultobj = SWIG_Py_Void();
   {
-    if (use_stringio2 == 1) {
-      std::string str =  stream2.str();
+    if (stream2) {
+      std::string str =  stream2->str();
       const char* s = str.c_str();
       const int n = str.length();
       ret2 = PyObject_CallMethod(string_io2, "write", "s#",
@@ -7693,15 +7697,21 @@ SWIGINTERN PyObject *_wrap_Operator_PrintMatlab__SWIG_0(PyObject *SWIGUNUSEDPARM
         PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
         return NULL;
       }
+      delete stream2;
       Py_XDECREF(resultobj);   /* Blow away any previous result */
       resultobj = ret2;    
     }
   }
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -7709,10 +7719,15 @@ SWIGINTERN PyObject *_wrap_Operator_PrintMatlab__SWIG_0(PyObject *SWIGUNUSEDPARM
   return resultobj;
 fail:
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -7904,7 +7919,8 @@ SWIGINTERN PyObject *_wrap_Operator_PrintMatlab(PyObject *self, PyObject *args) 
               _v = 0;	   	   	   
             }
           } else {
-            _v = 0;
+            std::cout << "it is text (out)\n";	
+            _v = 1;
           }
         } else {
           _v = 1;

--- a/mfem/_par/pgridfunc.i
+++ b/mfem/_par/pgridfunc.i
@@ -43,6 +43,7 @@ import_array();
 
 %import "../common/io_stream_typemap.i"
 OSTREAM_TYPEMAP(std::ostream&)
+ISTREAM_TYPEMAP(std::istream&)
 
 %pointer_class(int, intp);
 

--- a/mfem/_par/pgridfunc_wrap.cxx
+++ b/mfem/_par/pgridfunc_wrap.cxx
@@ -4074,7 +4074,6 @@ SWIGINTERN PyObject *_wrap_new_ParGridFunction__SWIG_7(PyObject *SWIGUNUSEDPARM(
   PyMFEM::wFILE *temp2 = 0 ;
   std::ifstream in_txt2 ;
   mfem::ifgzstream *in_gz2 = 0 ;
-  PyObject *input_str2 = 0 ;
   std::istringstream *stream2 = 0 ;
   Py_ssize_t len2 = 0 ;
   PyObject *ret2 = 0 ;
@@ -4108,18 +4107,18 @@ SWIGINTERN PyObject *_wrap_new_ParGridFunction__SWIG_7(PyObject *SWIGUNUSEDPARM(
           return NULL;
         }
         
-        PyObject *input_str2 = PyObject_CallMethod(swig_obj[1], "getvalue", NULL);
+        PyObject *input_str = PyObject_CallMethod(swig_obj[1], "getvalue", NULL);
         if (PyErr_Occurred()) {
           PyErr_SetString(PyExc_RuntimeError, "Can not read from StringIO");
           return NULL;
         }
         
         char *buf = nullptr;
-        PyObject *str = PyUnicode_AsUTF8String(input_str2);	 
+        PyObject *str = PyUnicode_AsUTF8String(input_str);	 
         PyBytes_AsStringAndSize(str, &buf, &len2);
         stream2 = new std::istringstream(buf);
         Py_DECREF(str);
-        Py_DECREF(input_str2);	 
+        Py_DECREF(input_str);	 
       } else {
         // if it is string, extract filename as char*
         PyObject* str = PyUnicode_AsEncodedString(swig_obj[1], "utf-8", "~E~");	
@@ -10629,7 +10628,6 @@ SWIGINTERN PyObject *_wrap_ParGridFunction_Save(PyObject *self, PyObject *args) 
               _v = 0;	   	   	   
             }
           } else {
-            std::cout << "it is text (out)\n";	
             _v = 1;
           }
         } else {
@@ -10742,7 +10740,6 @@ SWIGINTERN PyObject *_wrap_ParGridFunction_SaveAsOne(PyObject *self, PyObject *a
               _v = 0;	   	   	   
             }
           } else {
-            std::cout << "it is text (out)\n";	
             _v = 1;
           }
         } else {

--- a/mfem/_par/pgridfunc_wrap.cxx
+++ b/mfem/_par/pgridfunc_wrap.cxx
@@ -3227,11 +3227,10 @@ namespace Swig {
 #define SWIGTYPE_p_pri_t swig_types[159]
 #define SWIGTYPE_p_quad_t swig_types[160]
 #define SWIGTYPE_p_seg_t swig_types[161]
-#define SWIGTYPE_p_std__istream swig_types[162]
-#define SWIGTYPE_p_tet_t swig_types[163]
-#define SWIGTYPE_p_tri_t swig_types[164]
-static swig_type_info *swig_types[166];
-static swig_module_info swig_module = {swig_types, 165, 0, 0, 0, 0};
+#define SWIGTYPE_p_tet_t swig_types[162]
+#define SWIGTYPE_p_tri_t swig_types[163]
+static swig_type_info *swig_types[165];
+static swig_module_info swig_module = {swig_types, 164, 0, 0, 0, 0};
 #define SWIG_TypeQuery(name) SWIG_TypeQueryModule(&swig_module, &swig_module, name)
 #define SWIG_MangledTypeQuery(name) SWIG_MangledTypeQueryModule(&swig_module, &swig_module, name)
 
@@ -4072,8 +4071,13 @@ SWIGINTERN PyObject *_wrap_new_ParGridFunction__SWIG_7(PyObject *SWIGUNUSEDPARM(
   std::istream *arg2 = 0 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
-  void *argp2 = 0 ;
-  int res2 = 0 ;
+  PyMFEM::wFILE *temp2 = 0 ;
+  std::ifstream in_txt2 ;
+  mfem::ifgzstream *in_gz2 = 0 ;
+  PyObject *input_str2 = 0 ;
+  std::istringstream *stream2 = 0 ;
+  Py_ssize_t len2 = 0 ;
+  PyObject *ret2 = 0 ;
   mfem::ParGridFunction *result = 0 ;
   
   if ((nobjs < 2) || (nobjs > 2)) SWIG_fail;
@@ -4082,14 +4086,64 @@ SWIGINTERN PyObject *_wrap_new_ParGridFunction__SWIG_7(PyObject *SWIGUNUSEDPARM(
     SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "new_ParGridFunction" "', argument " "1"" of type '" "mfem::ParMesh *""'"); 
   }
   arg1 = reinterpret_cast< mfem::ParMesh * >(argp1);
-  res2 = SWIG_ConvertPtr(swig_obj[1], &argp2, SWIGTYPE_p_std__istream,  0 );
-  if (!SWIG_IsOK(res2)) {
-    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "new_ParGridFunction" "', argument " "2"" of type '" "std::istream &""'"); 
+  {
+    //  PyMFEM::wFILE or string argument or StringIO
+    if (SWIG_ConvertPtr(swig_obj[1], (void **) &temp2, SWIGTYPE_p_PyMFEM__wFILE, 0 | 0) == -1) {
+      if (!PyString_Check(swig_obj[1]) && !PyUnicode_Check(swig_obj[1])) {
+        // not string, check if it is StringIO
+        PyObject* module = PyImport_ImportModule("io");
+        if (!module){
+          PyErr_SetString(PyExc_RuntimeError, "Can not load io module");
+          return NULL;
+        }      
+        PyObject* cls = PyObject_GetAttrString(module, "StringIO");
+        if (!cls){
+          PyErr_SetString(PyExc_RuntimeError, "Can not load StringIO");
+          return NULL;
+        }      
+        int check = PyObject_IsInstance(swig_obj[1], cls);
+        Py_DECREF(module);
+        if (! check){
+          SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
+          return NULL;
+        }
+        
+        PyObject *input_str2 = PyObject_CallMethod(swig_obj[1], "getvalue", NULL);
+        if (PyErr_Occurred()) {
+          PyErr_SetString(PyExc_RuntimeError, "Can not read from StringIO");
+          return NULL;
+        }
+        
+        char *buf = nullptr;
+        PyObject *str = PyUnicode_AsUTF8String(input_str2);	 
+        PyBytes_AsStringAndSize(str, &buf, &len2);
+        stream2 = new std::istringstream(buf);
+        Py_DECREF(str);
+        Py_DECREF(input_str2);	 
+      } else {
+        // if it is string, extract filename as char*
+        PyObject* str = PyUnicode_AsEncodedString(swig_obj[1], "utf-8", "~E~");	
+        const char* filename = PyBytes_AsString(str);
+        temp2 = new PyMFEM::wFILE(filename, 8, true);
+        Py_DECREF(str);
+      }
+    }
+    if (stream2 == 0){
+      if (temp2->isGZ()){
+        in_gz2 = new mfem::ifgzstream(temp2->getFilename());
+        arg2 = in_gz2;
+      } else {
+        in_txt2.open(temp2->getFilename(), std::ifstream::in);
+        in_txt2.precision(temp2->getPrecision());
+        arg2 = &in_txt2;
+      }
+      if (temp2->isTemporary()){
+        delete temp2;
+      }
+    } else {
+      arg2 = stream2;
+    }
   }
-  if (!argp2) {
-    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "new_ParGridFunction" "', argument " "2"" of type '" "std::istream &""'"); 
-  }
-  arg2 = reinterpret_cast< std::istream * >(argp2);
   {
     try {
       result = (mfem::ParGridFunction *)new mfem::ParGridFunction(arg1,*arg2); 
@@ -4104,8 +4158,40 @@ SWIGINTERN PyObject *_wrap_new_ParGridFunction__SWIG_7(PyObject *SWIGUNUSEDPARM(
     //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__ParGridFunction, SWIG_POINTER_NEW |  0 );
+  {
+    if (stream2) {
+      ret2 = PyLong_FromSsize_t(len2);
+      if (PyErr_Occurred()) {
+        PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
+        return NULL;
+      }
+      delete stream2;    
+      Py_XDECREF(resultobj);   /* Blow away any previous result */
+      resultobj = ret2;    
+    }
+  }
+  {
+    if (!stream2) {
+      if (temp2) {
+        in_txt2.close();
+      }
+      if (in_gz2){
+        delete in_gz2;
+      }
+    }  
+  }
   return resultobj;
 fail:
+  {
+    if (!stream2) {
+      if (temp2) {
+        in_txt2.close();
+      }
+      if (in_gz2){
+        delete in_gz2;
+      }
+    }  
+  }
   return NULL;
 }
 
@@ -9911,10 +9997,10 @@ SWIGINTERN PyObject *_wrap_ParGridFunction_Save__SWIG_0(PyObject *SWIGUNUSEDPARM
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyMFEM::wFILE *temp2 = 0 ;
-  std::ofstream out2 ;
-  int use_stringio2 = 0 ;
+  std::ofstream out_txt2 ;
+  mfem::ofgzstream *out_gz2 = 0 ;
   PyObject *string_io2 = 0 ;
-  std::ostringstream stream2 ;
+  std::ostringstream *stream2 = 0 ;
   PyObject *ret2 = 0 ;
   
   if ((nobjs < 2) || (nobjs > 2)) SWIG_fail;
@@ -9944,29 +10030,33 @@ SWIGINTERN PyObject *_wrap_ParGridFunction_Save__SWIG_0(PyObject *SWIGUNUSEDPARM
           SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
           return NULL;
         }
-        use_stringio2=1;
         string_io2=swig_obj[1];
+        stream2 = new std::ostringstream();
       } else {
         // if it is string, extract filename as char*
         PyObject* str = PyUnicode_AsEncodedString(swig_obj[1], "utf-8", "~E~");	
         const char* filename = PyBytes_AsString(str);
-        temp2 = new PyMFEM::wFILE(filename, 8, true);	
+        temp2 = new PyMFEM::wFILE(filename, 8, true);
+        Py_DECREF(str);	 
       }
     }
     
-    if (use_stringio2 == 0){
+    if (stream2 == 0){
       if (temp2->isSTDOUT() == 1) {
         arg2 = &std::cout;
+      } else if (temp2->isGZ()){
+        out_gz2 = new mfem::ofgzstream(temp2->getFilename(), true);
+        arg2 = out_gz2;	     
       } else {
-        out2.open(temp2->getFilename());
-        out2.precision(temp2->getPrecision());
-        if (temp2->isTemporary()){
-          delete temp2;
-        }
-        arg2 = &out2;
+        out_txt2.open(temp2->getFilename());
+        out_txt2.precision(temp2->getPrecision());
+        arg2 = &out_txt2;
+      }
+      if (temp2->isTemporary()){
+        delete temp2;
       }
     } else {
-      arg2 = &stream2;
+      arg2 = stream2;
     }
   }
   {
@@ -9984,8 +10074,8 @@ SWIGINTERN PyObject *_wrap_ParGridFunction_Save__SWIG_0(PyObject *SWIGUNUSEDPARM
   }
   resultobj = SWIG_Py_Void();
   {
-    if (use_stringio2 == 1) {
-      std::string str =  stream2.str();
+    if (stream2) {
+      std::string str =  stream2->str();
       const char* s = str.c_str();
       const int n = str.length();
       ret2 = PyObject_CallMethod(string_io2, "write", "s#",
@@ -9994,15 +10084,21 @@ SWIGINTERN PyObject *_wrap_ParGridFunction_Save__SWIG_0(PyObject *SWIGUNUSEDPARM
         PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
         return NULL;
       }
+      delete stream2;
       Py_XDECREF(resultobj);   /* Blow away any previous result */
       resultobj = ret2;    
     }
   }
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -10010,10 +10106,15 @@ SWIGINTERN PyObject *_wrap_ParGridFunction_Save__SWIG_0(PyObject *SWIGUNUSEDPARM
   return resultobj;
 fail:
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -10030,10 +10131,10 @@ SWIGINTERN PyObject *_wrap_ParGridFunction_SaveAsOne__SWIG_0(PyObject *SWIGUNUSE
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyMFEM::wFILE *temp2 = 0 ;
-  std::ofstream out2 ;
-  int use_stringio2 = 0 ;
+  std::ofstream out_txt2 ;
+  mfem::ofgzstream *out_gz2 = 0 ;
   PyObject *string_io2 = 0 ;
-  std::ostringstream stream2 ;
+  std::ostringstream *stream2 = 0 ;
   PyObject *ret2 = 0 ;
   
   if ((nobjs < 1) || (nobjs > 2)) SWIG_fail;
@@ -10064,29 +10165,33 @@ SWIGINTERN PyObject *_wrap_ParGridFunction_SaveAsOne__SWIG_0(PyObject *SWIGUNUSE
             SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
             return NULL;
           }
-          use_stringio2=1;
           string_io2=swig_obj[1];
+          stream2 = new std::ostringstream();
         } else {
           // if it is string, extract filename as char*
           PyObject* str = PyUnicode_AsEncodedString(swig_obj[1], "utf-8", "~E~");	
           const char* filename = PyBytes_AsString(str);
-          temp2 = new PyMFEM::wFILE(filename, 8, true);	
+          temp2 = new PyMFEM::wFILE(filename, 8, true);
+          Py_DECREF(str);	 
         }
       }
       
-      if (use_stringio2 == 0){
+      if (stream2 == 0){
         if (temp2->isSTDOUT() == 1) {
           arg2 = &std::cout;
+        } else if (temp2->isGZ()){
+          out_gz2 = new mfem::ofgzstream(temp2->getFilename(), true);
+          arg2 = out_gz2;	     
         } else {
-          out2.open(temp2->getFilename());
-          out2.precision(temp2->getPrecision());
-          if (temp2->isTemporary()){
-            delete temp2;
-          }
-          arg2 = &out2;
+          out_txt2.open(temp2->getFilename());
+          out_txt2.precision(temp2->getPrecision());
+          arg2 = &out_txt2;
+        }
+        if (temp2->isTemporary()){
+          delete temp2;
         }
       } else {
-        arg2 = &stream2;
+        arg2 = stream2;
       }
     }
   }
@@ -10105,8 +10210,8 @@ SWIGINTERN PyObject *_wrap_ParGridFunction_SaveAsOne__SWIG_0(PyObject *SWIGUNUSE
   }
   resultobj = SWIG_Py_Void();
   {
-    if (use_stringio2 == 1) {
-      std::string str =  stream2.str();
+    if (stream2) {
+      std::string str =  stream2->str();
       const char* s = str.c_str();
       const int n = str.length();
       ret2 = PyObject_CallMethod(string_io2, "write", "s#",
@@ -10115,15 +10220,21 @@ SWIGINTERN PyObject *_wrap_ParGridFunction_SaveAsOne__SWIG_0(PyObject *SWIGUNUSE
         PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
         return NULL;
       }
+      delete stream2;
       Py_XDECREF(resultobj);   /* Blow away any previous result */
       resultobj = ret2;    
     }
   }
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -10131,10 +10242,15 @@ SWIGINTERN PyObject *_wrap_ParGridFunction_SaveAsOne__SWIG_0(PyObject *SWIGUNUSE
   return resultobj;
 fail:
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -10326,9 +10442,34 @@ SWIGINTERN PyObject *_wrap_new_ParGridFunction(PyObject *self, PyObject *args) {
     int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_mfem__ParMesh, 0);
     _v = SWIG_CheckState(res);
     if (_v) {
-      void *vptr = 0;
-      int res = SWIG_ConvertPtr(argv[1], &vptr, SWIGTYPE_p_std__istream, SWIG_POINTER_NO_NULL);
-      _v = SWIG_CheckState(res);
+      {
+        void *ptr;
+        //std::string *ptr2 = (std::string *)0;
+        if (SWIG_ConvertPtr(argv[1], (void **) &ptr, SWIGTYPE_p_PyMFEM__wFILE, 0 |0) == -1) {
+          PyErr_Clear();
+          if (!PyString_Check(argv[1]) && !PyUnicode_Check(argv[1])) {
+            // not string
+            _v = 1;	   	
+            PyObject* module = PyImport_ImportModule("io");
+            if (!module){
+              _v = 0;	   
+            }      
+            PyObject* cls = PyObject_GetAttrString(module, "StringIO");
+            if (!cls){
+              _v = 0;	   	   
+            }      
+            int check = PyObject_IsInstance(argv[1], cls);
+            Py_DECREF(module);
+            if (! check){
+              _v = 0;	   	   	   
+            }
+          } else {
+            _v = 1;
+          }
+        } else {
+          _v = 1;
+        }
+      }
       if (_v) {
         return _wrap_new_ParGridFunction__SWIG_7(self, argc, argv);
       }
@@ -10488,7 +10629,8 @@ SWIGINTERN PyObject *_wrap_ParGridFunction_Save(PyObject *self, PyObject *args) 
               _v = 0;	   	   	   
             }
           } else {
-            _v = 0;
+            std::cout << "it is text (out)\n";	
+            _v = 1;
           }
         } else {
           _v = 1;
@@ -10600,7 +10742,8 @@ SWIGINTERN PyObject *_wrap_ParGridFunction_SaveAsOne(PyObject *self, PyObject *a
               _v = 0;	   	   	   
             }
           } else {
-            _v = 0;
+            std::cout << "it is text (out)\n";	
+            _v = 1;
           }
         } else {
           _v = 1;
@@ -11650,7 +11793,6 @@ static swig_type_info _swigt__p_p_mfem__ExtrudeCoefficient = {"_p_p_mfem__Extrud
 static swig_type_info _swigt__p_pri_t = {"_p_pri_t", "pri_t *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_quad_t = {"_p_quad_t", "quad_t *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_seg_t = {"_p_seg_t", "seg_t *", 0, 0, (void*)0, 0};
-static swig_type_info _swigt__p_std__istream = {"_p_std__istream", "std::istream *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_tet_t = {"_p_tet_t", "tet_t *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_tri_t = {"_p_tri_t", "tri_t *", 0, 0, (void*)0, 0};
 
@@ -11817,7 +11959,6 @@ static swig_type_info *swig_type_initial[] = {
   &_swigt__p_pri_t,
   &_swigt__p_quad_t,
   &_swigt__p_seg_t,
-  &_swigt__p_std__istream,
   &_swigt__p_tet_t,
   &_swigt__p_tri_t,
 };
@@ -11984,7 +12125,6 @@ static swig_cast_info _swigc__p_p_mfem__Coefficient[] = {  {&_swigt__p_p_mfem__P
 static swig_cast_info _swigc__p_pri_t[] = {  {&_swigt__p_pri_t, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_quad_t[] = {  {&_swigt__p_quad_t, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_seg_t[] = {  {&_swigt__p_seg_t, 0, 0, 0},{0, 0, 0, 0}};
-static swig_cast_info _swigc__p_std__istream[] = {  {&_swigt__p_std__istream, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_tet_t[] = {  {&_swigt__p_tet_t, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_tri_t[] = {  {&_swigt__p_tri_t, 0, 0, 0},{0, 0, 0, 0}};
 
@@ -12151,7 +12291,6 @@ static swig_cast_info *swig_cast_initial[] = {
   _swigc__p_pri_t,
   _swigc__p_quad_t,
   _swigc__p_seg_t,
-  _swigc__p_std__istream,
   _swigc__p_tet_t,
   _swigc__p_tri_t,
 };

--- a/mfem/_par/pmesh.i
+++ b/mfem/_par/pmesh.i
@@ -41,7 +41,7 @@ import_array();
 
 %import "../common/io_stream_typemap.i"
 OSTREAM_TYPEMAP(std::ostream&)
-
+ISTREAM_TYPEMAP(std::istream&)
 
 %immutable face_nbr_elements;
 %immutable face_nbr_vertices;
@@ -78,17 +78,18 @@ def GroupEdge(self, group, i, *args):
 
 namespace mfem{
 %extend ParMesh{
-ParMesh(MPI_Comm comm, const char *mesh_file){
-    mfem::ParMesh *mesh;
-    std::ifstream imesh(mesh_file);
-    if (!imesh)
-    {
-    std::cerr << "\nCan not open mesh file: " << mesh_file << '\n' << std::endl;
-    return NULL;
-    }
-    mesh = new mfem::ParMesh(comm, imesh);
-    return mesh;
-    }
+     //     
+     //ParMesh(MPI_Comm comm, const char *mesh_file){
+     //mfem::ParMesh *mesh;
+     //std::ifstream imesh(mesh_file);
+     //if (!imesh)
+     //{
+     //std::cerr << "\nCan not open mesh file: " << mesh_file << '\n' << std::endl;
+     //return NULL;
+     //}
+     //mesh = new mfem::ParMesh(comm, imesh);
+     //return mesh;
+     //}
 void ParPrintToFile(const char *mesh_file, const int precision) const
     {
     std::ofstream mesh_ofs(mesh_file);	

--- a/mfem/_par/pmesh.py
+++ b/mfem/_par/pmesh.py
@@ -124,6 +124,15 @@ class ParMesh(mfem._par.mesh.Mesh):
     thisown = property(lambda x: x.this.own(), lambda x, v: x.this.own(v), doc="The membership flag")
     __repr__ = _swig_repr
 
+    def __init__(self, *args):
+        r"""
+        __init__(ParMesh self, ParMesh pmesh, bool copy_nodes=True) -> ParMesh
+        __init__(ParMesh self, MPI_Comm comm, Mesh mesh, int * partitioning_=None, int part_method=1) -> ParMesh
+        __init__(ParMesh self, MPI_Comm comm, std::istream & input, bool refine=True) -> ParMesh
+        __init__(ParMesh self, ParMesh orig_mesh, int ref_factor, int ref_type) -> ParMesh
+        """
+        _pmesh.ParMesh_swiginit(self, _pmesh.new_ParMesh(*args))
+
     def Finalize(self, refine=False, fix_orientation=False):
         r"""Finalize(ParMesh self, bool refine=False, bool fix_orientation=False)"""
         return _pmesh.ParMesh_Finalize(self, refine, fix_orientation)
@@ -339,16 +348,6 @@ class ParMesh(mfem._par.mesh.Mesh):
         return _pmesh.ParMesh_PrintSharedEntities(self, fname_prefix)
     PrintSharedEntities = _swig_new_instance_method(_pmesh.ParMesh_PrintSharedEntities)
     __swig_destroy__ = _pmesh.delete_ParMesh
-
-    def __init__(self, *args):
-        r"""
-        __init__(ParMesh self, ParMesh pmesh, bool copy_nodes=True) -> ParMesh
-        __init__(ParMesh self, MPI_Comm comm, Mesh mesh, int * partitioning_=None, int part_method=1) -> ParMesh
-        __init__(ParMesh self, MPI_Comm comm, std::istream & input, bool refine=True) -> ParMesh
-        __init__(ParMesh self, ParMesh orig_mesh, int ref_factor, int ref_type) -> ParMesh
-        __init__(ParMesh self, MPI_Comm comm, char const * mesh_file) -> ParMesh
-        """
-        _pmesh.ParMesh_swiginit(self, _pmesh.new_ParMesh(*args))
 
     def ParPrintToFile(self, mesh_file, precision):
         r"""ParPrintToFile(ParMesh self, char const * mesh_file, int const precision)"""

--- a/mfem/_par/pmesh_wrap.cxx
+++ b/mfem/_par/pmesh_wrap.cxx
@@ -3102,12 +3102,11 @@ namespace Swig {
 #define SWIGTYPE_p_pri_t swig_types[34]
 #define SWIGTYPE_p_quad_t swig_types[35]
 #define SWIGTYPE_p_seg_t swig_types[36]
-#define SWIGTYPE_p_std__istream swig_types[37]
-#define SWIGTYPE_p_tet_t swig_types[38]
-#define SWIGTYPE_p_tri_t swig_types[39]
-#define SWIGTYPE_p_void swig_types[40]
-static swig_type_info *swig_types[42];
-static swig_module_info swig_module = {swig_types, 41, 0, 0, 0, 0};
+#define SWIGTYPE_p_tet_t swig_types[37]
+#define SWIGTYPE_p_tri_t swig_types[38]
+#define SWIGTYPE_p_void swig_types[39]
+static swig_type_info *swig_types[41];
+static swig_module_info swig_module = {swig_types, 40, 0, 0, 0, 0};
 #define SWIG_TypeQuery(name) SWIG_TypeQueryModule(&swig_module, &swig_module, name)
 #define SWIG_MangledTypeQuery(name) SWIG_MangledTypeQueryModule(&swig_module, &swig_module, name)
 
@@ -3624,17 +3623,6 @@ SWIG_AsVal_int (PyObject * obj, int *val)
 
 
 
-SWIGINTERN mfem::ParMesh *new_mfem_ParMesh__SWIG_6(MPI_Comm comm,char const *mesh_file){
-    mfem::ParMesh *mesh;
-    std::ifstream imesh(mesh_file);
-    if (!imesh)
-    {
-    std::cerr << "\nCan not open mesh file: " << mesh_file << '\n' << std::endl;
-    return NULL;
-    }
-    mesh = new mfem::ParMesh(comm, imesh);
-    return mesh;
-    }
 SWIGINTERN void mfem_ParMesh_ParPrintToFile(mfem::ParMesh const *self,char const *mesh_file,int const precision){
     std::ofstream mesh_ofs(mesh_file);	
     mesh_ofs.precision(precision);
@@ -3836,8 +3824,13 @@ SWIGINTERN PyObject *_wrap_new_ParMesh__SWIG_4(PyObject *SWIGUNUSEDPARM(self), P
   MPI_Comm arg1 ;
   std::istream *arg2 = 0 ;
   bool arg3 = (bool) true ;
-  void *argp2 = 0 ;
-  int res2 = 0 ;
+  PyMFEM::wFILE *temp2 = 0 ;
+  std::ifstream in_txt2 ;
+  mfem::ifgzstream *in_gz2 = 0 ;
+  PyObject *input_str2 = 0 ;
+  std::istringstream *stream2 = 0 ;
+  Py_ssize_t len2 = 0 ;
+  PyObject *ret2 = 0 ;
   bool val3 ;
   int ecode3 = 0 ;
   mfem::ParMesh *result = 0 ;
@@ -3852,14 +3845,64 @@ SWIGINTERN PyObject *_wrap_new_ParMesh__SWIG_4(PyObject *SWIGUNUSEDPARM(self), P
     arg1 = *ptr;
     if (SWIG_IsNewObj(res)) delete ptr;
   }
-  res2 = SWIG_ConvertPtr(swig_obj[1], &argp2, SWIGTYPE_p_std__istream,  0 );
-  if (!SWIG_IsOK(res2)) {
-    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "new_ParMesh" "', argument " "2"" of type '" "std::istream &""'"); 
+  {
+    //  PyMFEM::wFILE or string argument or StringIO
+    if (SWIG_ConvertPtr(swig_obj[1], (void **) &temp2, SWIGTYPE_p_PyMFEM__wFILE, 0 | 0) == -1) {
+      if (!PyString_Check(swig_obj[1]) && !PyUnicode_Check(swig_obj[1])) {
+        // not string, check if it is StringIO
+        PyObject* module = PyImport_ImportModule("io");
+        if (!module){
+          PyErr_SetString(PyExc_RuntimeError, "Can not load io module");
+          return NULL;
+        }      
+        PyObject* cls = PyObject_GetAttrString(module, "StringIO");
+        if (!cls){
+          PyErr_SetString(PyExc_RuntimeError, "Can not load StringIO");
+          return NULL;
+        }      
+        int check = PyObject_IsInstance(swig_obj[1], cls);
+        Py_DECREF(module);
+        if (! check){
+          SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
+          return NULL;
+        }
+        
+        PyObject *input_str2 = PyObject_CallMethod(swig_obj[1], "getvalue", NULL);
+        if (PyErr_Occurred()) {
+          PyErr_SetString(PyExc_RuntimeError, "Can not read from StringIO");
+          return NULL;
+        }
+        
+        char *buf = nullptr;
+        PyObject *str = PyUnicode_AsUTF8String(input_str2);	 
+        PyBytes_AsStringAndSize(str, &buf, &len2);
+        stream2 = new std::istringstream(buf);
+        Py_DECREF(str);
+        Py_DECREF(input_str2);	 
+      } else {
+        // if it is string, extract filename as char*
+        PyObject* str = PyUnicode_AsEncodedString(swig_obj[1], "utf-8", "~E~");	
+        const char* filename = PyBytes_AsString(str);
+        temp2 = new PyMFEM::wFILE(filename, 8, true);
+        Py_DECREF(str);
+      }
+    }
+    if (stream2 == 0){
+      if (temp2->isGZ()){
+        in_gz2 = new mfem::ifgzstream(temp2->getFilename());
+        arg2 = in_gz2;
+      } else {
+        in_txt2.open(temp2->getFilename(), std::ifstream::in);
+        in_txt2.precision(temp2->getPrecision());
+        arg2 = &in_txt2;
+      }
+      if (temp2->isTemporary()){
+        delete temp2;
+      }
+    } else {
+      arg2 = stream2;
+    }
   }
-  if (!argp2) {
-    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "new_ParMesh" "', argument " "2"" of type '" "std::istream &""'"); 
-  }
-  arg2 = reinterpret_cast< std::istream * >(argp2);
   if (swig_obj[2]) {
     ecode3 = SWIG_AsVal_bool(swig_obj[2], &val3);
     if (!SWIG_IsOK(ecode3)) {
@@ -3881,8 +3924,40 @@ SWIGINTERN PyObject *_wrap_new_ParMesh__SWIG_4(PyObject *SWIGUNUSEDPARM(self), P
     //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__ParMesh, SWIG_POINTER_NEW |  0 );
+  {
+    if (stream2) {
+      ret2 = PyLong_FromSsize_t(len2);
+      if (PyErr_Occurred()) {
+        PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
+        return NULL;
+      }
+      delete stream2;    
+      Py_XDECREF(resultobj);   /* Blow away any previous result */
+      resultobj = ret2;    
+    }
+  }
+  {
+    if (!stream2) {
+      if (temp2) {
+        in_txt2.close();
+      }
+      if (in_gz2){
+        delete in_gz2;
+      }
+    }  
+  }
   return resultobj;
 fail:
+  {
+    if (!stream2) {
+      if (temp2) {
+        in_txt2.close();
+      }
+      if (in_gz2){
+        delete in_gz2;
+      }
+    }  
+  }
   return NULL;
 }
 
@@ -3931,6 +4006,153 @@ SWIGINTERN PyObject *_wrap_new_ParMesh__SWIG_5(PyObject *SWIGUNUSEDPARM(self), P
   return resultobj;
 fail:
   return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_new_ParMesh(PyObject *self, PyObject *args) {
+  Py_ssize_t argc;
+  PyObject *argv[5] = {
+    0
+  };
+  
+  if (!(argc = SWIG_Python_UnpackTuple(args, "new_ParMesh", 0, 4, argv))) SWIG_fail;
+  --argc;
+  if ((argc >= 1) && (argc <= 2)) {
+    int _v;
+    int res = SWIG_ConvertPtr(argv[0], 0, SWIGTYPE_p_mfem__ParMesh, SWIG_POINTER_NO_NULL | 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      if (argc <= 1) {
+        return _wrap_new_ParMesh__SWIG_2(self, argc, argv);
+      }
+      {
+        int res = SWIG_AsVal_bool(argv[1], NULL);
+        _v = SWIG_CheckState(res);
+      }
+      if (_v) {
+        return _wrap_new_ParMesh__SWIG_2(self, argc, argv);
+      }
+    }
+  }
+  if ((argc >= 2) && (argc <= 4)) {
+    int _v;
+    int res = SWIG_AsPtr_MPI_Comm(argv[0], (MPI_Comm**)(0));
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      void *vptr = 0;
+      int res = SWIG_ConvertPtr(argv[1], &vptr, SWIGTYPE_p_mfem__Mesh, SWIG_POINTER_NO_NULL);
+      _v = SWIG_CheckState(res);
+      if (_v) {
+        if (argc <= 2) {
+          return _wrap_new_ParMesh__SWIG_3(self, argc, argv);
+        }
+        void *vptr = 0;
+        int res = SWIG_ConvertPtr(argv[2], &vptr, SWIGTYPE_p_int, 0);
+        _v = SWIG_CheckState(res);
+        if (_v) {
+          if (argc <= 3) {
+            return _wrap_new_ParMesh__SWIG_3(self, argc, argv);
+          }
+          {
+            if ((PyArray_PyIntAsInt(argv[3]) == -1) && PyErr_Occurred()) {
+              PyErr_Clear();
+              _v = 0;
+            } else {
+              _v = 1;    
+            }
+          }
+          if (_v) {
+            return _wrap_new_ParMesh__SWIG_3(self, argc, argv);
+          }
+        }
+      }
+    }
+  }
+  if ((argc >= 2) && (argc <= 3)) {
+    int _v;
+    int res = SWIG_AsPtr_MPI_Comm(argv[0], (MPI_Comm**)(0));
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      {
+        void *ptr;
+        //std::string *ptr2 = (std::string *)0;
+        if (SWIG_ConvertPtr(argv[1], (void **) &ptr, SWIGTYPE_p_PyMFEM__wFILE, 0 |0) == -1) {
+          PyErr_Clear();
+          if (!PyString_Check(argv[1]) && !PyUnicode_Check(argv[1])) {
+            // not string
+            _v = 1;	   	
+            PyObject* module = PyImport_ImportModule("io");
+            if (!module){
+              _v = 0;	   
+            }      
+            PyObject* cls = PyObject_GetAttrString(module, "StringIO");
+            if (!cls){
+              _v = 0;	   	   
+            }      
+            int check = PyObject_IsInstance(argv[1], cls);
+            Py_DECREF(module);
+            if (! check){
+              _v = 0;	   	   	   
+            }
+          } else {
+            _v = 1;
+          }
+        } else {
+          _v = 1;
+        }
+      }
+      if (_v) {
+        if (argc <= 2) {
+          return _wrap_new_ParMesh__SWIG_4(self, argc, argv);
+        }
+        {
+          int res = SWIG_AsVal_bool(argv[2], NULL);
+          _v = SWIG_CheckState(res);
+        }
+        if (_v) {
+          return _wrap_new_ParMesh__SWIG_4(self, argc, argv);
+        }
+      }
+    }
+  }
+  if (argc == 3) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_mfem__ParMesh, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      {
+        if ((PyArray_PyIntAsInt(argv[1]) == -1) && PyErr_Occurred()) {
+          PyErr_Clear();
+          _v = 0;
+        } else {
+          _v = 1;    
+        }
+      }
+      if (_v) {
+        {
+          if ((PyArray_PyIntAsInt(argv[2]) == -1) && PyErr_Occurred()) {
+            PyErr_Clear();
+            _v = 0;
+          } else {
+            _v = 1;    
+          }
+        }
+        if (_v) {
+          return _wrap_new_ParMesh__SWIG_5(self, argc, argv);
+        }
+      }
+    }
+  }
+  
+fail:
+  SWIG_Python_RaiseOrModifyTypeError("Wrong number or type of arguments for overloaded function 'new_ParMesh'.\n"
+    "  Possible C/C++ prototypes are:\n"
+    "    mfem::ParMesh::ParMesh(mfem::ParMesh const &,bool)\n"
+    "    mfem::ParMesh::ParMesh(MPI_Comm,mfem::Mesh &,int *,int)\n"
+    "    mfem::ParMesh::ParMesh(MPI_Comm,std::istream &,bool)\n"
+    "    mfem::ParMesh::ParMesh(mfem::ParMesh *,int,int)\n");
+  return 0;
 }
 
 
@@ -5899,10 +6121,10 @@ SWIGINTERN PyObject *_wrap_ParMesh_Print__SWIG_0(PyObject *SWIGUNUSEDPARM(self),
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyMFEM::wFILE *temp2 = 0 ;
-  std::ofstream out2 ;
-  int use_stringio2 = 0 ;
+  std::ofstream out_txt2 ;
+  mfem::ofgzstream *out_gz2 = 0 ;
   PyObject *string_io2 = 0 ;
-  std::ostringstream stream2 ;
+  std::ostringstream *stream2 = 0 ;
   PyObject *ret2 = 0 ;
   
   if ((nobjs < 1) || (nobjs > 2)) SWIG_fail;
@@ -5933,29 +6155,33 @@ SWIGINTERN PyObject *_wrap_ParMesh_Print__SWIG_0(PyObject *SWIGUNUSEDPARM(self),
             SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
             return NULL;
           }
-          use_stringio2=1;
           string_io2=swig_obj[1];
+          stream2 = new std::ostringstream();
         } else {
           // if it is string, extract filename as char*
           PyObject* str = PyUnicode_AsEncodedString(swig_obj[1], "utf-8", "~E~");	
           const char* filename = PyBytes_AsString(str);
-          temp2 = new PyMFEM::wFILE(filename, 8, true);	
+          temp2 = new PyMFEM::wFILE(filename, 8, true);
+          Py_DECREF(str);	 
         }
       }
       
-      if (use_stringio2 == 0){
+      if (stream2 == 0){
         if (temp2->isSTDOUT() == 1) {
           arg2 = &std::cout;
+        } else if (temp2->isGZ()){
+          out_gz2 = new mfem::ofgzstream(temp2->getFilename(), true);
+          arg2 = out_gz2;	     
         } else {
-          out2.open(temp2->getFilename());
-          out2.precision(temp2->getPrecision());
-          if (temp2->isTemporary()){
-            delete temp2;
-          }
-          arg2 = &out2;
+          out_txt2.open(temp2->getFilename());
+          out_txt2.precision(temp2->getPrecision());
+          arg2 = &out_txt2;
+        }
+        if (temp2->isTemporary()){
+          delete temp2;
         }
       } else {
-        arg2 = &stream2;
+        arg2 = stream2;
       }
     }
   }
@@ -5974,8 +6200,8 @@ SWIGINTERN PyObject *_wrap_ParMesh_Print__SWIG_0(PyObject *SWIGUNUSEDPARM(self),
   }
   resultobj = SWIG_Py_Void();
   {
-    if (use_stringio2 == 1) {
-      std::string str =  stream2.str();
+    if (stream2) {
+      std::string str =  stream2->str();
       const char* s = str.c_str();
       const int n = str.length();
       ret2 = PyObject_CallMethod(string_io2, "write", "s#",
@@ -5984,15 +6210,21 @@ SWIGINTERN PyObject *_wrap_ParMesh_Print__SWIG_0(PyObject *SWIGUNUSEDPARM(self),
         PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
         return NULL;
       }
+      delete stream2;
       Py_XDECREF(resultobj);   /* Blow away any previous result */
       resultobj = ret2;    
     }
   }
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -6000,10 +6232,15 @@ SWIGINTERN PyObject *_wrap_ParMesh_Print__SWIG_0(PyObject *SWIGUNUSEDPARM(self),
   return resultobj;
 fail:
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -6020,10 +6257,10 @@ SWIGINTERN PyObject *_wrap_ParMesh_PrintXG__SWIG_0(PyObject *SWIGUNUSEDPARM(self
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyMFEM::wFILE *temp2 = 0 ;
-  std::ofstream out2 ;
-  int use_stringio2 = 0 ;
+  std::ofstream out_txt2 ;
+  mfem::ofgzstream *out_gz2 = 0 ;
   PyObject *string_io2 = 0 ;
-  std::ostringstream stream2 ;
+  std::ostringstream *stream2 = 0 ;
   PyObject *ret2 = 0 ;
   
   if ((nobjs < 1) || (nobjs > 2)) SWIG_fail;
@@ -6054,29 +6291,33 @@ SWIGINTERN PyObject *_wrap_ParMesh_PrintXG__SWIG_0(PyObject *SWIGUNUSEDPARM(self
             SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
             return NULL;
           }
-          use_stringio2=1;
           string_io2=swig_obj[1];
+          stream2 = new std::ostringstream();
         } else {
           // if it is string, extract filename as char*
           PyObject* str = PyUnicode_AsEncodedString(swig_obj[1], "utf-8", "~E~");	
           const char* filename = PyBytes_AsString(str);
-          temp2 = new PyMFEM::wFILE(filename, 8, true);	
+          temp2 = new PyMFEM::wFILE(filename, 8, true);
+          Py_DECREF(str);	 
         }
       }
       
-      if (use_stringio2 == 0){
+      if (stream2 == 0){
         if (temp2->isSTDOUT() == 1) {
           arg2 = &std::cout;
+        } else if (temp2->isGZ()){
+          out_gz2 = new mfem::ofgzstream(temp2->getFilename(), true);
+          arg2 = out_gz2;	     
         } else {
-          out2.open(temp2->getFilename());
-          out2.precision(temp2->getPrecision());
-          if (temp2->isTemporary()){
-            delete temp2;
-          }
-          arg2 = &out2;
+          out_txt2.open(temp2->getFilename());
+          out_txt2.precision(temp2->getPrecision());
+          arg2 = &out_txt2;
+        }
+        if (temp2->isTemporary()){
+          delete temp2;
         }
       } else {
-        arg2 = &stream2;
+        arg2 = stream2;
       }
     }
   }
@@ -6095,8 +6336,8 @@ SWIGINTERN PyObject *_wrap_ParMesh_PrintXG__SWIG_0(PyObject *SWIGUNUSEDPARM(self
   }
   resultobj = SWIG_Py_Void();
   {
-    if (use_stringio2 == 1) {
-      std::string str =  stream2.str();
+    if (stream2) {
+      std::string str =  stream2->str();
       const char* s = str.c_str();
       const int n = str.length();
       ret2 = PyObject_CallMethod(string_io2, "write", "s#",
@@ -6105,15 +6346,21 @@ SWIGINTERN PyObject *_wrap_ParMesh_PrintXG__SWIG_0(PyObject *SWIGUNUSEDPARM(self
         PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
         return NULL;
       }
+      delete stream2;
       Py_XDECREF(resultobj);   /* Blow away any previous result */
       resultobj = ret2;    
     }
   }
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -6121,10 +6368,15 @@ SWIGINTERN PyObject *_wrap_ParMesh_PrintXG__SWIG_0(PyObject *SWIGUNUSEDPARM(self
   return resultobj;
 fail:
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -6141,10 +6393,10 @@ SWIGINTERN PyObject *_wrap_ParMesh_PrintAsOne__SWIG_0(PyObject *SWIGUNUSEDPARM(s
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyMFEM::wFILE *temp2 = 0 ;
-  std::ofstream out2 ;
-  int use_stringio2 = 0 ;
+  std::ofstream out_txt2 ;
+  mfem::ofgzstream *out_gz2 = 0 ;
   PyObject *string_io2 = 0 ;
-  std::ostringstream stream2 ;
+  std::ostringstream *stream2 = 0 ;
   PyObject *ret2 = 0 ;
   
   if ((nobjs < 1) || (nobjs > 2)) SWIG_fail;
@@ -6175,29 +6427,33 @@ SWIGINTERN PyObject *_wrap_ParMesh_PrintAsOne__SWIG_0(PyObject *SWIGUNUSEDPARM(s
             SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
             return NULL;
           }
-          use_stringio2=1;
           string_io2=swig_obj[1];
+          stream2 = new std::ostringstream();
         } else {
           // if it is string, extract filename as char*
           PyObject* str = PyUnicode_AsEncodedString(swig_obj[1], "utf-8", "~E~");	
           const char* filename = PyBytes_AsString(str);
-          temp2 = new PyMFEM::wFILE(filename, 8, true);	
+          temp2 = new PyMFEM::wFILE(filename, 8, true);
+          Py_DECREF(str);	 
         }
       }
       
-      if (use_stringio2 == 0){
+      if (stream2 == 0){
         if (temp2->isSTDOUT() == 1) {
           arg2 = &std::cout;
+        } else if (temp2->isGZ()){
+          out_gz2 = new mfem::ofgzstream(temp2->getFilename(), true);
+          arg2 = out_gz2;	     
         } else {
-          out2.open(temp2->getFilename());
-          out2.precision(temp2->getPrecision());
-          if (temp2->isTemporary()){
-            delete temp2;
-          }
-          arg2 = &out2;
+          out_txt2.open(temp2->getFilename());
+          out_txt2.precision(temp2->getPrecision());
+          arg2 = &out_txt2;
+        }
+        if (temp2->isTemporary()){
+          delete temp2;
         }
       } else {
-        arg2 = &stream2;
+        arg2 = stream2;
       }
     }
   }
@@ -6216,8 +6472,8 @@ SWIGINTERN PyObject *_wrap_ParMesh_PrintAsOne__SWIG_0(PyObject *SWIGUNUSEDPARM(s
   }
   resultobj = SWIG_Py_Void();
   {
-    if (use_stringio2 == 1) {
-      std::string str =  stream2.str();
+    if (stream2) {
+      std::string str =  stream2->str();
       const char* s = str.c_str();
       const int n = str.length();
       ret2 = PyObject_CallMethod(string_io2, "write", "s#",
@@ -6226,15 +6482,21 @@ SWIGINTERN PyObject *_wrap_ParMesh_PrintAsOne__SWIG_0(PyObject *SWIGUNUSEDPARM(s
         PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
         return NULL;
       }
+      delete stream2;
       Py_XDECREF(resultobj);   /* Blow away any previous result */
       resultobj = ret2;    
     }
   }
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -6242,10 +6504,15 @@ SWIGINTERN PyObject *_wrap_ParMesh_PrintAsOne__SWIG_0(PyObject *SWIGUNUSEDPARM(s
   return resultobj;
 fail:
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -6262,10 +6529,10 @@ SWIGINTERN PyObject *_wrap_ParMesh_PrintAsOneXG__SWIG_0(PyObject *SWIGUNUSEDPARM
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyMFEM::wFILE *temp2 = 0 ;
-  std::ofstream out2 ;
-  int use_stringio2 = 0 ;
+  std::ofstream out_txt2 ;
+  mfem::ofgzstream *out_gz2 = 0 ;
   PyObject *string_io2 = 0 ;
-  std::ostringstream stream2 ;
+  std::ostringstream *stream2 = 0 ;
   PyObject *ret2 = 0 ;
   
   if ((nobjs < 1) || (nobjs > 2)) SWIG_fail;
@@ -6296,29 +6563,33 @@ SWIGINTERN PyObject *_wrap_ParMesh_PrintAsOneXG__SWIG_0(PyObject *SWIGUNUSEDPARM
             SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
             return NULL;
           }
-          use_stringio2=1;
           string_io2=swig_obj[1];
+          stream2 = new std::ostringstream();
         } else {
           // if it is string, extract filename as char*
           PyObject* str = PyUnicode_AsEncodedString(swig_obj[1], "utf-8", "~E~");	
           const char* filename = PyBytes_AsString(str);
-          temp2 = new PyMFEM::wFILE(filename, 8, true);	
+          temp2 = new PyMFEM::wFILE(filename, 8, true);
+          Py_DECREF(str);	 
         }
       }
       
-      if (use_stringio2 == 0){
+      if (stream2 == 0){
         if (temp2->isSTDOUT() == 1) {
           arg2 = &std::cout;
+        } else if (temp2->isGZ()){
+          out_gz2 = new mfem::ofgzstream(temp2->getFilename(), true);
+          arg2 = out_gz2;	     
         } else {
-          out2.open(temp2->getFilename());
-          out2.precision(temp2->getPrecision());
-          if (temp2->isTemporary()){
-            delete temp2;
-          }
-          arg2 = &out2;
+          out_txt2.open(temp2->getFilename());
+          out_txt2.precision(temp2->getPrecision());
+          arg2 = &out_txt2;
+        }
+        if (temp2->isTemporary()){
+          delete temp2;
         }
       } else {
-        arg2 = &stream2;
+        arg2 = stream2;
       }
     }
   }
@@ -6337,8 +6608,8 @@ SWIGINTERN PyObject *_wrap_ParMesh_PrintAsOneXG__SWIG_0(PyObject *SWIGUNUSEDPARM
   }
   resultobj = SWIG_Py_Void();
   {
-    if (use_stringio2 == 1) {
-      std::string str =  stream2.str();
+    if (stream2) {
+      std::string str =  stream2->str();
       const char* s = str.c_str();
       const int n = str.length();
       ret2 = PyObject_CallMethod(string_io2, "write", "s#",
@@ -6347,15 +6618,21 @@ SWIGINTERN PyObject *_wrap_ParMesh_PrintAsOneXG__SWIG_0(PyObject *SWIGUNUSEDPARM
         PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
         return NULL;
       }
+      delete stream2;
       Py_XDECREF(resultobj);   /* Blow away any previous result */
       resultobj = ret2;    
     }
   }
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -6363,10 +6640,15 @@ SWIGINTERN PyObject *_wrap_ParMesh_PrintAsOneXG__SWIG_0(PyObject *SWIGUNUSEDPARM
   return resultobj;
 fail:
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -6537,10 +6819,10 @@ SWIGINTERN PyObject *_wrap_ParMesh_PrintInfo__SWIG_0(PyObject *SWIGUNUSEDPARM(se
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyMFEM::wFILE *temp2 = 0 ;
-  std::ofstream out2 ;
-  int use_stringio2 = 0 ;
+  std::ofstream out_txt2 ;
+  mfem::ofgzstream *out_gz2 = 0 ;
   PyObject *string_io2 = 0 ;
-  std::ostringstream stream2 ;
+  std::ostringstream *stream2 = 0 ;
   PyObject *ret2 = 0 ;
   
   if ((nobjs < 1) || (nobjs > 2)) SWIG_fail;
@@ -6571,29 +6853,33 @@ SWIGINTERN PyObject *_wrap_ParMesh_PrintInfo__SWIG_0(PyObject *SWIGUNUSEDPARM(se
             SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
             return NULL;
           }
-          use_stringio2=1;
           string_io2=swig_obj[1];
+          stream2 = new std::ostringstream();
         } else {
           // if it is string, extract filename as char*
           PyObject* str = PyUnicode_AsEncodedString(swig_obj[1], "utf-8", "~E~");	
           const char* filename = PyBytes_AsString(str);
-          temp2 = new PyMFEM::wFILE(filename, 8, true);	
+          temp2 = new PyMFEM::wFILE(filename, 8, true);
+          Py_DECREF(str);	 
         }
       }
       
-      if (use_stringio2 == 0){
+      if (stream2 == 0){
         if (temp2->isSTDOUT() == 1) {
           arg2 = &std::cout;
+        } else if (temp2->isGZ()){
+          out_gz2 = new mfem::ofgzstream(temp2->getFilename(), true);
+          arg2 = out_gz2;	     
         } else {
-          out2.open(temp2->getFilename());
-          out2.precision(temp2->getPrecision());
-          if (temp2->isTemporary()){
-            delete temp2;
-          }
-          arg2 = &out2;
+          out_txt2.open(temp2->getFilename());
+          out_txt2.precision(temp2->getPrecision());
+          arg2 = &out_txt2;
+        }
+        if (temp2->isTemporary()){
+          delete temp2;
         }
       } else {
-        arg2 = &stream2;
+        arg2 = stream2;
       }
     }
   }
@@ -6612,8 +6898,8 @@ SWIGINTERN PyObject *_wrap_ParMesh_PrintInfo__SWIG_0(PyObject *SWIGUNUSEDPARM(se
   }
   resultobj = SWIG_Py_Void();
   {
-    if (use_stringio2 == 1) {
-      std::string str =  stream2.str();
+    if (stream2) {
+      std::string str =  stream2->str();
       const char* s = str.c_str();
       const int n = str.length();
       ret2 = PyObject_CallMethod(string_io2, "write", "s#",
@@ -6622,15 +6908,21 @@ SWIGINTERN PyObject *_wrap_ParMesh_PrintInfo__SWIG_0(PyObject *SWIGUNUSEDPARM(se
         PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
         return NULL;
       }
+      delete stream2;
       Py_XDECREF(resultobj);   /* Blow away any previous result */
       resultobj = ret2;    
     }
   }
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -6638,10 +6930,15 @@ SWIGINTERN PyObject *_wrap_ParMesh_PrintInfo__SWIG_0(PyObject *SWIGUNUSEDPARM(se
   return resultobj;
 fail:
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -6657,10 +6954,10 @@ SWIGINTERN PyObject *_wrap_ParMesh_ParPrint__SWIG_0(PyObject *SWIGUNUSEDPARM(sel
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyMFEM::wFILE *temp2 = 0 ;
-  std::ofstream out2 ;
-  int use_stringio2 = 0 ;
+  std::ofstream out_txt2 ;
+  mfem::ofgzstream *out_gz2 = 0 ;
   PyObject *string_io2 = 0 ;
-  std::ostringstream stream2 ;
+  std::ostringstream *stream2 = 0 ;
   PyObject *ret2 = 0 ;
   
   if ((nobjs < 2) || (nobjs > 2)) SWIG_fail;
@@ -6690,29 +6987,33 @@ SWIGINTERN PyObject *_wrap_ParMesh_ParPrint__SWIG_0(PyObject *SWIGUNUSEDPARM(sel
           SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
           return NULL;
         }
-        use_stringio2=1;
         string_io2=swig_obj[1];
+        stream2 = new std::ostringstream();
       } else {
         // if it is string, extract filename as char*
         PyObject* str = PyUnicode_AsEncodedString(swig_obj[1], "utf-8", "~E~");	
         const char* filename = PyBytes_AsString(str);
-        temp2 = new PyMFEM::wFILE(filename, 8, true);	
+        temp2 = new PyMFEM::wFILE(filename, 8, true);
+        Py_DECREF(str);	 
       }
     }
     
-    if (use_stringio2 == 0){
+    if (stream2 == 0){
       if (temp2->isSTDOUT() == 1) {
         arg2 = &std::cout;
+      } else if (temp2->isGZ()){
+        out_gz2 = new mfem::ofgzstream(temp2->getFilename(), true);
+        arg2 = out_gz2;	     
       } else {
-        out2.open(temp2->getFilename());
-        out2.precision(temp2->getPrecision());
-        if (temp2->isTemporary()){
-          delete temp2;
-        }
-        arg2 = &out2;
+        out_txt2.open(temp2->getFilename());
+        out_txt2.precision(temp2->getPrecision());
+        arg2 = &out_txt2;
+      }
+      if (temp2->isTemporary()){
+        delete temp2;
       }
     } else {
-      arg2 = &stream2;
+      arg2 = stream2;
     }
   }
   {
@@ -6730,8 +7031,8 @@ SWIGINTERN PyObject *_wrap_ParMesh_ParPrint__SWIG_0(PyObject *SWIGUNUSEDPARM(sel
   }
   resultobj = SWIG_Py_Void();
   {
-    if (use_stringio2 == 1) {
-      std::string str =  stream2.str();
+    if (stream2) {
+      std::string str =  stream2->str();
       const char* s = str.c_str();
       const int n = str.length();
       ret2 = PyObject_CallMethod(string_io2, "write", "s#",
@@ -6740,15 +7041,21 @@ SWIGINTERN PyObject *_wrap_ParMesh_ParPrint__SWIG_0(PyObject *SWIGUNUSEDPARM(sel
         PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
         return NULL;
       }
+      delete stream2;
       Py_XDECREF(resultobj);   /* Blow away any previous result */
       resultobj = ret2;    
     }
   }
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -6756,10 +7063,15 @@ SWIGINTERN PyObject *_wrap_ParMesh_ParPrint__SWIG_0(PyObject *SWIGUNUSEDPARM(sel
   return resultobj;
 fail:
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -7035,187 +7347,6 @@ fail:
 }
 
 
-SWIGINTERN PyObject *_wrap_new_ParMesh__SWIG_6(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
-  PyObject *resultobj = 0;
-  MPI_Comm arg1 ;
-  char *arg2 = (char *) 0 ;
-  int res2 ;
-  char *buf2 = 0 ;
-  int alloc2 = 0 ;
-  mfem::ParMesh *result = 0 ;
-  
-  if ((nobjs < 2) || (nobjs > 2)) SWIG_fail;
-  {
-    MPI_Comm *ptr = (MPI_Comm *)0;
-    int res = SWIG_AsPtr_MPI_Comm(swig_obj[0], &ptr);
-    if (!SWIG_IsOK(res) || !ptr) {
-      SWIG_exception_fail(SWIG_ArgError((ptr ? res : SWIG_TypeError)), "in method '" "new_ParMesh" "', argument " "1"" of type '" "MPI_Comm""'"); 
-    }
-    arg1 = *ptr;
-    if (SWIG_IsNewObj(res)) delete ptr;
-  }
-  res2 = SWIG_AsCharPtrAndSize(swig_obj[1], &buf2, NULL, &alloc2);
-  if (!SWIG_IsOK(res2)) {
-    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "new_ParMesh" "', argument " "2"" of type '" "char const *""'");
-  }
-  arg2 = reinterpret_cast< char * >(buf2);
-  {
-    try {
-      result = (mfem::ParMesh *)new_mfem_ParMesh__SWIG_6(arg1,(char const *)arg2); 
-    }
-    catch (Swig::DirectorException &e) {
-      SWIG_fail; 
-    }    
-    //catch (...){
-    //  SWIG_fail;
-    //}
-    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
-    //    catch (std::exception &e) { SWIG_fail; }    
-  }
-  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__ParMesh, SWIG_POINTER_NEW |  0 );
-  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
-  return resultobj;
-fail:
-  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
-  return NULL;
-}
-
-
-SWIGINTERN PyObject *_wrap_new_ParMesh(PyObject *self, PyObject *args) {
-  Py_ssize_t argc;
-  PyObject *argv[5] = {
-    0
-  };
-  
-  if (!(argc = SWIG_Python_UnpackTuple(args, "new_ParMesh", 0, 4, argv))) SWIG_fail;
-  --argc;
-  if ((argc >= 1) && (argc <= 2)) {
-    int _v;
-    int res = SWIG_ConvertPtr(argv[0], 0, SWIGTYPE_p_mfem__ParMesh, SWIG_POINTER_NO_NULL | 0);
-    _v = SWIG_CheckState(res);
-    if (_v) {
-      if (argc <= 1) {
-        return _wrap_new_ParMesh__SWIG_2(self, argc, argv);
-      }
-      {
-        int res = SWIG_AsVal_bool(argv[1], NULL);
-        _v = SWIG_CheckState(res);
-      }
-      if (_v) {
-        return _wrap_new_ParMesh__SWIG_2(self, argc, argv);
-      }
-    }
-  }
-  if ((argc >= 2) && (argc <= 4)) {
-    int _v;
-    int res = SWIG_AsPtr_MPI_Comm(argv[0], (MPI_Comm**)(0));
-    _v = SWIG_CheckState(res);
-    if (_v) {
-      void *vptr = 0;
-      int res = SWIG_ConvertPtr(argv[1], &vptr, SWIGTYPE_p_mfem__Mesh, SWIG_POINTER_NO_NULL);
-      _v = SWIG_CheckState(res);
-      if (_v) {
-        if (argc <= 2) {
-          return _wrap_new_ParMesh__SWIG_3(self, argc, argv);
-        }
-        void *vptr = 0;
-        int res = SWIG_ConvertPtr(argv[2], &vptr, SWIGTYPE_p_int, 0);
-        _v = SWIG_CheckState(res);
-        if (_v) {
-          if (argc <= 3) {
-            return _wrap_new_ParMesh__SWIG_3(self, argc, argv);
-          }
-          {
-            if ((PyArray_PyIntAsInt(argv[3]) == -1) && PyErr_Occurred()) {
-              PyErr_Clear();
-              _v = 0;
-            } else {
-              _v = 1;    
-            }
-          }
-          if (_v) {
-            return _wrap_new_ParMesh__SWIG_3(self, argc, argv);
-          }
-        }
-      }
-    }
-  }
-  if ((argc >= 2) && (argc <= 3)) {
-    int _v;
-    int res = SWIG_AsPtr_MPI_Comm(argv[0], (MPI_Comm**)(0));
-    _v = SWIG_CheckState(res);
-    if (_v) {
-      void *vptr = 0;
-      int res = SWIG_ConvertPtr(argv[1], &vptr, SWIGTYPE_p_std__istream, SWIG_POINTER_NO_NULL);
-      _v = SWIG_CheckState(res);
-      if (_v) {
-        if (argc <= 2) {
-          return _wrap_new_ParMesh__SWIG_4(self, argc, argv);
-        }
-        {
-          int res = SWIG_AsVal_bool(argv[2], NULL);
-          _v = SWIG_CheckState(res);
-        }
-        if (_v) {
-          return _wrap_new_ParMesh__SWIG_4(self, argc, argv);
-        }
-      }
-    }
-  }
-  if (argc == 2) {
-    int _v;
-    int res = SWIG_AsPtr_MPI_Comm(argv[0], (MPI_Comm**)(0));
-    _v = SWIG_CheckState(res);
-    if (_v) {
-      int res = SWIG_AsCharPtrAndSize(argv[1], 0, NULL, 0);
-      _v = SWIG_CheckState(res);
-      if (_v) {
-        return _wrap_new_ParMesh__SWIG_6(self, argc, argv);
-      }
-    }
-  }
-  if (argc == 3) {
-    int _v;
-    void *vptr = 0;
-    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_mfem__ParMesh, 0);
-    _v = SWIG_CheckState(res);
-    if (_v) {
-      {
-        if ((PyArray_PyIntAsInt(argv[1]) == -1) && PyErr_Occurred()) {
-          PyErr_Clear();
-          _v = 0;
-        } else {
-          _v = 1;    
-        }
-      }
-      if (_v) {
-        {
-          if ((PyArray_PyIntAsInt(argv[2]) == -1) && PyErr_Occurred()) {
-            PyErr_Clear();
-            _v = 0;
-          } else {
-            _v = 1;    
-          }
-        }
-        if (_v) {
-          return _wrap_new_ParMesh__SWIG_5(self, argc, argv);
-        }
-      }
-    }
-  }
-  
-fail:
-  SWIG_Python_RaiseOrModifyTypeError("Wrong number or type of arguments for overloaded function 'new_ParMesh'.\n"
-    "  Possible C/C++ prototypes are:\n"
-    "    mfem::ParMesh::ParMesh(mfem::ParMesh const &,bool)\n"
-    "    mfem::ParMesh::ParMesh(MPI_Comm,mfem::Mesh &,int *,int)\n"
-    "    mfem::ParMesh::ParMesh(MPI_Comm,std::istream &,bool)\n"
-    "    mfem::ParMesh::ParMesh(mfem::ParMesh *,int,int)\n"
-    "    mfem::ParMesh::ParMesh(MPI_Comm,char const *)\n");
-  return 0;
-}
-
-
 SWIGINTERN PyObject *_wrap_ParMesh_ParPrintToFile(PyObject *SWIGUNUSEDPARM(self), PyObject *args, PyObject *kwargs) {
   PyObject *resultobj = 0;
   mfem::ParMesh *arg1 = (mfem::ParMesh *) 0 ;
@@ -7363,7 +7494,8 @@ SWIGINTERN PyObject *_wrap_ParMesh_Print(PyObject *self, PyObject *args) {
               _v = 0;	   	   	   
             }
           } else {
-            _v = 0;
+            std::cout << "it is text (out)\n";	
+            _v = 1;
           }
         } else {
           _v = 1;
@@ -7501,7 +7633,8 @@ SWIGINTERN PyObject *_wrap_ParMesh_PrintXG(PyObject *self, PyObject *args) {
               _v = 0;	   	   	   
             }
           } else {
-            _v = 0;
+            std::cout << "it is text (out)\n";	
+            _v = 1;
           }
         } else {
           _v = 1;
@@ -7639,7 +7772,8 @@ SWIGINTERN PyObject *_wrap_ParMesh_PrintAsOne(PyObject *self, PyObject *args) {
               _v = 0;	   	   	   
             }
           } else {
-            _v = 0;
+            std::cout << "it is text (out)\n";	
+            _v = 1;
           }
         } else {
           _v = 1;
@@ -7777,7 +7911,8 @@ SWIGINTERN PyObject *_wrap_ParMesh_PrintAsOneXG(PyObject *self, PyObject *args) 
               _v = 0;	   	   	   
             }
           } else {
-            _v = 0;
+            std::cout << "it is text (out)\n";	
+            _v = 1;
           }
         } else {
           _v = 1;
@@ -7915,7 +8050,8 @@ SWIGINTERN PyObject *_wrap_ParMesh_PrintInfo(PyObject *self, PyObject *args) {
               _v = 0;	   	   	   
             }
           } else {
-            _v = 0;
+            std::cout << "it is text (out)\n";	
+            _v = 1;
           }
         } else {
           _v = 1;
@@ -8117,7 +8253,8 @@ SWIGINTERN PyObject *_wrap_ParMesh_ParPrint(PyObject *self, PyObject *args) {
               _v = 0;	   	   	   
             }
           } else {
-            _v = 0;
+            std::cout << "it is text (out)\n";	
+            _v = 1;
           }
         } else {
           _v = 1;
@@ -8153,6 +8290,12 @@ SWIGINTERN PyObject *ParMesh_swiginit(PyObject *SWIGUNUSEDPARM(self), PyObject *
 static PyMethodDef SwigMethods[] = {
 	 { "SWIG_PyInstanceMethod_New", SWIG_PyInstanceMethod_New, METH_O, NULL},
 	 { "SWIG_PyStaticMethod_New", SWIG_PyStaticMethod_New, METH_O, NULL},
+	 { "new_ParMesh", _wrap_new_ParMesh, METH_VARARGS, "\n"
+		"ParMesh(ParMesh pmesh, bool copy_nodes=True)\n"
+		"ParMesh(MPI_Comm comm, Mesh mesh, int * partitioning_=None, int part_method=1)\n"
+		"ParMesh(MPI_Comm comm, std::istream & input, bool refine=True)\n"
+		"new_ParMesh(ParMesh orig_mesh, int ref_factor, int ref_type) -> ParMesh\n"
+		""},
 	 { "ParMesh_Finalize", (PyCFunction)(void(*)(void))_wrap_ParMesh_Finalize, METH_VARARGS|METH_KEYWORDS, "ParMesh_Finalize(ParMesh self, bool refine=False, bool fix_orientation=False)"},
 	 { "ParMesh_SetAttributes", _wrap_ParMesh_SetAttributes, METH_O, "ParMesh_SetAttributes(ParMesh self)"},
 	 { "ParMesh_GetComm", _wrap_ParMesh_GetComm, METH_O, "ParMesh_GetComm(ParMesh self) -> MPI_Comm"},
@@ -8210,13 +8353,6 @@ static PyMethodDef SwigMethods[] = {
 	 { "ParMesh_FindPoints", (PyCFunction)(void(*)(void))_wrap_ParMesh_FindPoints, METH_VARARGS|METH_KEYWORDS, "ParMesh_FindPoints(ParMesh self, DenseMatrix point_mat, intArray elem_ids, IntegrationPointArray ips, bool warn=True, InverseElementTransformation inv_trans=None) -> int"},
 	 { "ParMesh_PrintSharedEntities", (PyCFunction)(void(*)(void))_wrap_ParMesh_PrintSharedEntities, METH_VARARGS|METH_KEYWORDS, "ParMesh_PrintSharedEntities(ParMesh self, char const * fname_prefix)"},
 	 { "delete_ParMesh", _wrap_delete_ParMesh, METH_O, "delete_ParMesh(ParMesh self)"},
-	 { "new_ParMesh", _wrap_new_ParMesh, METH_VARARGS, "\n"
-		"ParMesh(ParMesh pmesh, bool copy_nodes=True)\n"
-		"ParMesh(MPI_Comm comm, Mesh mesh, int * partitioning_=None, int part_method=1)\n"
-		"ParMesh(MPI_Comm comm, std::istream & input, bool refine=True)\n"
-		"ParMesh(ParMesh orig_mesh, int ref_factor, int ref_type)\n"
-		"new_ParMesh(MPI_Comm comm, char const * mesh_file) -> ParMesh\n"
-		""},
 	 { "ParMesh_ParPrintToFile", (PyCFunction)(void(*)(void))_wrap_ParMesh_ParPrintToFile, METH_VARARGS|METH_KEYWORDS, "ParMesh_ParPrintToFile(ParMesh self, char const * mesh_file, int const precision)"},
 	 { "ParMesh_Print", _wrap_ParMesh_Print, METH_VARARGS, "\n"
 		"ParMesh_Print(ParMesh self, std::ostream & out=out)\n"
@@ -8251,6 +8387,12 @@ static PyMethodDef SwigMethods[] = {
 static PyMethodDef SwigMethods_proxydocs[] = {
 	 { "SWIG_PyInstanceMethod_New", SWIG_PyInstanceMethod_New, METH_O, NULL},
 	 { "SWIG_PyStaticMethod_New", SWIG_PyStaticMethod_New, METH_O, NULL},
+	 { "new_ParMesh", _wrap_new_ParMesh, METH_VARARGS, "\n"
+		"ParMesh(ParMesh pmesh, bool copy_nodes=True)\n"
+		"ParMesh(MPI_Comm comm, Mesh mesh, int * partitioning_=None, int part_method=1)\n"
+		"ParMesh(MPI_Comm comm, std::istream & input, bool refine=True)\n"
+		"new_ParMesh(ParMesh orig_mesh, int ref_factor, int ref_type) -> ParMesh\n"
+		""},
 	 { "ParMesh_Finalize", (PyCFunction)(void(*)(void))_wrap_ParMesh_Finalize, METH_VARARGS|METH_KEYWORDS, "Finalize(ParMesh self, bool refine=False, bool fix_orientation=False)"},
 	 { "ParMesh_SetAttributes", _wrap_ParMesh_SetAttributes, METH_O, "SetAttributes(ParMesh self)"},
 	 { "ParMesh_GetComm", _wrap_ParMesh_GetComm, METH_O, "GetComm(ParMesh self) -> MPI_Comm"},
@@ -8308,13 +8450,6 @@ static PyMethodDef SwigMethods_proxydocs[] = {
 	 { "ParMesh_FindPoints", (PyCFunction)(void(*)(void))_wrap_ParMesh_FindPoints, METH_VARARGS|METH_KEYWORDS, "FindPoints(ParMesh self, DenseMatrix point_mat, intArray elem_ids, IntegrationPointArray ips, bool warn=True, InverseElementTransformation inv_trans=None) -> int"},
 	 { "ParMesh_PrintSharedEntities", (PyCFunction)(void(*)(void))_wrap_ParMesh_PrintSharedEntities, METH_VARARGS|METH_KEYWORDS, "PrintSharedEntities(ParMesh self, char const * fname_prefix)"},
 	 { "delete_ParMesh", _wrap_delete_ParMesh, METH_O, "delete_ParMesh(ParMesh self)"},
-	 { "new_ParMesh", _wrap_new_ParMesh, METH_VARARGS, "\n"
-		"ParMesh(ParMesh pmesh, bool copy_nodes=True)\n"
-		"ParMesh(MPI_Comm comm, Mesh mesh, int * partitioning_=None, int part_method=1)\n"
-		"ParMesh(MPI_Comm comm, std::istream & input, bool refine=True)\n"
-		"ParMesh(ParMesh orig_mesh, int ref_factor, int ref_type)\n"
-		"new_ParMesh(MPI_Comm comm, char const * mesh_file) -> ParMesh\n"
-		""},
 	 { "ParMesh_ParPrintToFile", (PyCFunction)(void(*)(void))_wrap_ParMesh_ParPrintToFile, METH_VARARGS|METH_KEYWORDS, "ParPrintToFile(ParMesh self, char const * mesh_file, int const precision)"},
 	 { "ParMesh_Print", _wrap_ParMesh_Print, METH_VARARGS, "\n"
 		"Print(ParMesh self, std::ostream & out=out)\n"
@@ -8413,7 +8548,6 @@ static swig_type_info _swigt__p_p_mfem__ArrayT_int_t = {"_p_p_mfem__ArrayT_int_t
 static swig_type_info _swigt__p_pri_t = {"_p_pri_t", "pri_t *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_quad_t = {"_p_quad_t", "quad_t *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_seg_t = {"_p_seg_t", "seg_t *", 0, 0, (void*)0, 0};
-static swig_type_info _swigt__p_std__istream = {"_p_std__istream", "std::istream *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_tet_t = {"_p_tet_t", "tet_t *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_tri_t = {"_p_tri_t", "tri_t *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_void = {"_p_void", "void *", 0, 0, (void*)0, 0};
@@ -8456,7 +8590,6 @@ static swig_type_info *swig_type_initial[] = {
   &_swigt__p_pri_t,
   &_swigt__p_quad_t,
   &_swigt__p_seg_t,
-  &_swigt__p_std__istream,
   &_swigt__p_tet_t,
   &_swigt__p_tri_t,
   &_swigt__p_void,
@@ -8499,7 +8632,6 @@ static swig_cast_info _swigc__p_p_mfem__ArrayT_int_t[] = {  {&_swigt__p_p_mfem__
 static swig_cast_info _swigc__p_pri_t[] = {  {&_swigt__p_pri_t, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_quad_t[] = {  {&_swigt__p_quad_t, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_seg_t[] = {  {&_swigt__p_seg_t, 0, 0, 0},{0, 0, 0, 0}};
-static swig_cast_info _swigc__p_std__istream[] = {  {&_swigt__p_std__istream, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_tet_t[] = {  {&_swigt__p_tet_t, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_tri_t[] = {  {&_swigt__p_tri_t, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_void[] = {  {&_swigt__p_void, 0, 0, 0},{0, 0, 0, 0}};
@@ -8542,7 +8674,6 @@ static swig_cast_info *swig_cast_initial[] = {
   _swigc__p_pri_t,
   _swigc__p_quad_t,
   _swigc__p_seg_t,
-  _swigc__p_std__istream,
   _swigc__p_tet_t,
   _swigc__p_tri_t,
   _swigc__p_void,

--- a/mfem/_par/pmesh_wrap.cxx
+++ b/mfem/_par/pmesh_wrap.cxx
@@ -3827,7 +3827,6 @@ SWIGINTERN PyObject *_wrap_new_ParMesh__SWIG_4(PyObject *SWIGUNUSEDPARM(self), P
   PyMFEM::wFILE *temp2 = 0 ;
   std::ifstream in_txt2 ;
   mfem::ifgzstream *in_gz2 = 0 ;
-  PyObject *input_str2 = 0 ;
   std::istringstream *stream2 = 0 ;
   Py_ssize_t len2 = 0 ;
   PyObject *ret2 = 0 ;
@@ -3867,18 +3866,18 @@ SWIGINTERN PyObject *_wrap_new_ParMesh__SWIG_4(PyObject *SWIGUNUSEDPARM(self), P
           return NULL;
         }
         
-        PyObject *input_str2 = PyObject_CallMethod(swig_obj[1], "getvalue", NULL);
+        PyObject *input_str = PyObject_CallMethod(swig_obj[1], "getvalue", NULL);
         if (PyErr_Occurred()) {
           PyErr_SetString(PyExc_RuntimeError, "Can not read from StringIO");
           return NULL;
         }
         
         char *buf = nullptr;
-        PyObject *str = PyUnicode_AsUTF8String(input_str2);	 
+        PyObject *str = PyUnicode_AsUTF8String(input_str);	 
         PyBytes_AsStringAndSize(str, &buf, &len2);
         stream2 = new std::istringstream(buf);
         Py_DECREF(str);
-        Py_DECREF(input_str2);	 
+        Py_DECREF(input_str);	 
       } else {
         // if it is string, extract filename as char*
         PyObject* str = PyUnicode_AsEncodedString(swig_obj[1], "utf-8", "~E~");	
@@ -7494,7 +7493,6 @@ SWIGINTERN PyObject *_wrap_ParMesh_Print(PyObject *self, PyObject *args) {
               _v = 0;	   	   	   
             }
           } else {
-            std::cout << "it is text (out)\n";	
             _v = 1;
           }
         } else {
@@ -7633,7 +7631,6 @@ SWIGINTERN PyObject *_wrap_ParMesh_PrintXG(PyObject *self, PyObject *args) {
               _v = 0;	   	   	   
             }
           } else {
-            std::cout << "it is text (out)\n";	
             _v = 1;
           }
         } else {
@@ -7772,7 +7769,6 @@ SWIGINTERN PyObject *_wrap_ParMesh_PrintAsOne(PyObject *self, PyObject *args) {
               _v = 0;	   	   	   
             }
           } else {
-            std::cout << "it is text (out)\n";	
             _v = 1;
           }
         } else {
@@ -7911,7 +7907,6 @@ SWIGINTERN PyObject *_wrap_ParMesh_PrintAsOneXG(PyObject *self, PyObject *args) 
               _v = 0;	   	   	   
             }
           } else {
-            std::cout << "it is text (out)\n";	
             _v = 1;
           }
         } else {
@@ -8050,7 +8045,6 @@ SWIGINTERN PyObject *_wrap_ParMesh_PrintInfo(PyObject *self, PyObject *args) {
               _v = 0;	   	   	   
             }
           } else {
-            std::cout << "it is text (out)\n";	
             _v = 1;
           }
         } else {
@@ -8253,7 +8247,6 @@ SWIGINTERN PyObject *_wrap_ParMesh_ParPrint(PyObject *self, PyObject *args) {
               _v = 0;	   	   	   
             }
           } else {
-            std::cout << "it is text (out)\n";	
             _v = 1;
           }
         } else {

--- a/mfem/_par/pncmesh.i
+++ b/mfem/_par/pncmesh.i
@@ -32,6 +32,7 @@ import_array();
 
 %import "../common/io_stream_typemap.i"
 OSTREAM_TYPEMAP(std::ostream&)
+ISTREAM_TYPEMAP(std::istream&)
 
 %pointer_class(int, intp);
 

--- a/mfem/_par/pumi_wrap.cxx
+++ b/mfem/_par/pumi_wrap.cxx
@@ -3096,11 +3096,10 @@ namespace Swig {
 #define SWIGTYPE_p_pri_t swig_types[28]
 #define SWIGTYPE_p_quad_t swig_types[29]
 #define SWIGTYPE_p_seg_t swig_types[30]
-#define SWIGTYPE_p_std__istream swig_types[31]
-#define SWIGTYPE_p_tet_t swig_types[32]
-#define SWIGTYPE_p_tri_t swig_types[33]
-static swig_type_info *swig_types[35];
-static swig_module_info swig_module = {swig_types, 34, 0, 0, 0, 0};
+#define SWIGTYPE_p_tet_t swig_types[31]
+#define SWIGTYPE_p_tri_t swig_types[32]
+static swig_type_info *swig_types[34];
+static swig_module_info swig_module = {swig_types, 33, 0, 0, 0, 0};
 #define SWIG_TypeQuery(name) SWIG_TypeQueryModule(&swig_module, &swig_module, name)
 #define SWIG_MangledTypeQuery(name) SWIG_MangledTypeQueryModule(&swig_module, &swig_module, name)
 
@@ -3564,8 +3563,13 @@ SWIGINTERN PyObject *_wrap_PumiMesh_Load__SWIG_0_0(PyObject *SWIGUNUSEDPARM(self
   bool arg5 = (bool) true ;
   void *argp1 = 0 ;
   int res1 = 0 ;
-  void *argp2 = 0 ;
-  int res2 = 0 ;
+  PyMFEM::wFILE *temp2 = 0 ;
+  std::ifstream in_txt2 ;
+  mfem::ifgzstream *in_gz2 = 0 ;
+  PyObject *input_str2 = 0 ;
+  std::istringstream *stream2 = 0 ;
+  Py_ssize_t len2 = 0 ;
+  PyObject *ret2 = 0 ;
   bool val5 ;
   int ecode5 = 0 ;
   
@@ -3575,14 +3579,64 @@ SWIGINTERN PyObject *_wrap_PumiMesh_Load__SWIG_0_0(PyObject *SWIGUNUSEDPARM(self
     SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "PumiMesh_Load" "', argument " "1"" of type '" "mfem::PumiMesh *""'"); 
   }
   arg1 = reinterpret_cast< mfem::PumiMesh * >(argp1);
-  res2 = SWIG_ConvertPtr(swig_obj[1], &argp2, SWIGTYPE_p_std__istream,  0 );
-  if (!SWIG_IsOK(res2)) {
-    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "PumiMesh_Load" "', argument " "2"" of type '" "std::istream &""'"); 
+  {
+    //  PyMFEM::wFILE or string argument or StringIO
+    if (SWIG_ConvertPtr(swig_obj[1], (void **) &temp2, SWIGTYPE_p_PyMFEM__wFILE, 0 | 0) == -1) {
+      if (!PyString_Check(swig_obj[1]) && !PyUnicode_Check(swig_obj[1])) {
+        // not string, check if it is StringIO
+        PyObject* module = PyImport_ImportModule("io");
+        if (!module){
+          PyErr_SetString(PyExc_RuntimeError, "Can not load io module");
+          return NULL;
+        }      
+        PyObject* cls = PyObject_GetAttrString(module, "StringIO");
+        if (!cls){
+          PyErr_SetString(PyExc_RuntimeError, "Can not load StringIO");
+          return NULL;
+        }      
+        int check = PyObject_IsInstance(swig_obj[1], cls);
+        Py_DECREF(module);
+        if (! check){
+          SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
+          return NULL;
+        }
+        
+        PyObject *input_str2 = PyObject_CallMethod(swig_obj[1], "getvalue", NULL);
+        if (PyErr_Occurred()) {
+          PyErr_SetString(PyExc_RuntimeError, "Can not read from StringIO");
+          return NULL;
+        }
+        
+        char *buf = nullptr;
+        PyObject *str = PyUnicode_AsUTF8String(input_str2);	 
+        PyBytes_AsStringAndSize(str, &buf, &len2);
+        stream2 = new std::istringstream(buf);
+        Py_DECREF(str);
+        Py_DECREF(input_str2);	 
+      } else {
+        // if it is string, extract filename as char*
+        PyObject* str = PyUnicode_AsEncodedString(swig_obj[1], "utf-8", "~E~");	
+        const char* filename = PyBytes_AsString(str);
+        temp2 = new PyMFEM::wFILE(filename, 8, true);
+        Py_DECREF(str);
+      }
+    }
+    if (stream2 == 0){
+      if (temp2->isGZ()){
+        in_gz2 = new mfem::ifgzstream(temp2->getFilename());
+        arg2 = in_gz2;
+      } else {
+        in_txt2.open(temp2->getFilename(), std::ifstream::in);
+        in_txt2.precision(temp2->getPrecision());
+        arg2 = &in_txt2;
+      }
+      if (temp2->isTemporary()){
+        delete temp2;
+      }
+    } else {
+      arg2 = stream2;
+    }
   }
-  if (!argp2) {
-    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "PumiMesh_Load" "', argument " "2"" of type '" "std::istream &""'"); 
-  }
-  arg2 = reinterpret_cast< std::istream * >(argp2);
   if (swig_obj[2]) {
     {
       if ((PyArray_PyIntAsInt(swig_obj[2]) == -1) && PyErr_Occurred()) {
@@ -3620,8 +3674,40 @@ SWIGINTERN PyObject *_wrap_PumiMesh_Load__SWIG_0_0(PyObject *SWIGUNUSEDPARM(self
     //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
+  {
+    if (stream2) {
+      ret2 = PyLong_FromSsize_t(len2);
+      if (PyErr_Occurred()) {
+        PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
+        return NULL;
+      }
+      delete stream2;    
+      Py_XDECREF(resultobj);   /* Blow away any previous result */
+      resultobj = ret2;    
+    }
+  }
+  {
+    if (!stream2) {
+      if (temp2) {
+        in_txt2.close();
+      }
+      if (in_gz2){
+        delete in_gz2;
+      }
+    }  
+  }
   return resultobj;
 fail:
+  {
+    if (!stream2) {
+      if (temp2) {
+        in_txt2.close();
+      }
+      if (in_gz2){
+        delete in_gz2;
+      }
+    }  
+  }
   return NULL;
 }
 
@@ -3709,55 +3795,6 @@ SWIGINTERN PyObject *_wrap_PumiMesh_Load(PyObject *self, PyObject *args) {
     _v = SWIG_CheckState(res);
     if (_v) {
       void *vptr = 0;
-      int res = SWIG_ConvertPtr(argv[1], &vptr, SWIGTYPE_p_std__istream, SWIG_POINTER_NO_NULL);
-      _v = SWIG_CheckState(res);
-      if (_v) {
-        if (argc <= 2) {
-          return _wrap_PumiMesh_Load__SWIG_0_0(self, argc, argv);
-        }
-        {
-          if ((PyArray_PyIntAsInt(argv[2]) == -1) && PyErr_Occurred()) {
-            PyErr_Clear();
-            _v = 0;
-          } else {
-            _v = 1;    
-          }
-        }
-        if (_v) {
-          if (argc <= 3) {
-            return _wrap_PumiMesh_Load__SWIG_0_0(self, argc, argv);
-          }
-          {
-            if ((PyArray_PyIntAsInt(argv[3]) == -1) && PyErr_Occurred()) {
-              PyErr_Clear();
-              _v = 0;
-            } else {
-              _v = 1;    
-            }
-          }
-          if (_v) {
-            if (argc <= 4) {
-              return _wrap_PumiMesh_Load__SWIG_0_0(self, argc, argv);
-            }
-            {
-              int res = SWIG_AsVal_bool(argv[4], NULL);
-              _v = SWIG_CheckState(res);
-            }
-            if (_v) {
-              return _wrap_PumiMesh_Load__SWIG_0_0(self, argc, argv);
-            }
-          }
-        }
-      }
-    }
-  }
-  if ((argc >= 2) && (argc <= 5)) {
-    int _v;
-    void *vptr = 0;
-    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_mfem__PumiMesh, 0);
-    _v = SWIG_CheckState(res);
-    if (_v) {
-      void *vptr = 0;
       int res = SWIG_ConvertPtr(argv[1], &vptr, SWIGTYPE_p_apf__Mesh2, 0);
       _v = SWIG_CheckState(res);
       if (_v) {
@@ -3794,6 +3831,80 @@ SWIGINTERN PyObject *_wrap_PumiMesh_Load(PyObject *self, PyObject *args) {
             }
             if (_v) {
               return _wrap_PumiMesh_Load__SWIG_1(self, argc, argv);
+            }
+          }
+        }
+      }
+    }
+  }
+  if ((argc >= 2) && (argc <= 5)) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_mfem__PumiMesh, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      {
+        void *ptr;
+        //std::string *ptr2 = (std::string *)0;
+        if (SWIG_ConvertPtr(argv[1], (void **) &ptr, SWIGTYPE_p_PyMFEM__wFILE, 0 |0) == -1) {
+          PyErr_Clear();
+          if (!PyString_Check(argv[1]) && !PyUnicode_Check(argv[1])) {
+            // not string
+            _v = 1;	   	
+            PyObject* module = PyImport_ImportModule("io");
+            if (!module){
+              _v = 0;	   
+            }      
+            PyObject* cls = PyObject_GetAttrString(module, "StringIO");
+            if (!cls){
+              _v = 0;	   	   
+            }      
+            int check = PyObject_IsInstance(argv[1], cls);
+            Py_DECREF(module);
+            if (! check){
+              _v = 0;	   	   	   
+            }
+          } else {
+            _v = 1;
+          }
+        } else {
+          _v = 1;
+        }
+      }
+      if (_v) {
+        if (argc <= 2) {
+          return _wrap_PumiMesh_Load__SWIG_0_0(self, argc, argv);
+        }
+        {
+          if ((PyArray_PyIntAsInt(argv[2]) == -1) && PyErr_Occurred()) {
+            PyErr_Clear();
+            _v = 0;
+          } else {
+            _v = 1;    
+          }
+        }
+        if (_v) {
+          if (argc <= 3) {
+            return _wrap_PumiMesh_Load__SWIG_0_0(self, argc, argv);
+          }
+          {
+            if ((PyArray_PyIntAsInt(argv[3]) == -1) && PyErr_Occurred()) {
+              PyErr_Clear();
+              _v = 0;
+            } else {
+              _v = 1;    
+            }
+          }
+          if (_v) {
+            if (argc <= 4) {
+              return _wrap_PumiMesh_Load__SWIG_0_0(self, argc, argv);
+            }
+            {
+              int res = SWIG_AsVal_bool(argv[4], NULL);
+              _v = SWIG_CheckState(res);
+            }
+            if (_v) {
+              return _wrap_PumiMesh_Load__SWIG_0_0(self, argc, argv);
             }
           }
         }
@@ -4867,24 +4978,6 @@ static PyMethodDef SwigMethods_proxydocs[] = {
 
 /* -------- TYPE CONVERSION AND EQUIVALENCE RULES (BEGIN) -------- */
 
-static void *_p_mfem__ParMeshTo_p_mfem__Mesh(void *x, int *SWIGUNUSEDPARM(newmemory)) {
-    return (void *)((mfem::Mesh *)  ((mfem::ParMesh *) x));
-}
-static void *_p_mfem__PumiMeshTo_p_mfem__Mesh(void *x, int *SWIGUNUSEDPARM(newmemory)) {
-    return (void *)((mfem::Mesh *)  ((mfem::PumiMesh *) x));
-}
-static void *_p_mfem__ParPumiMeshTo_p_mfem__Mesh(void *x, int *SWIGUNUSEDPARM(newmemory)) {
-    return (void *)((mfem::Mesh *) (mfem::ParMesh *) ((mfem::ParPumiMesh *) x));
-}
-static void *_p_mfem__ParGridFunctionTo_p_mfem__GridFunction(void *x, int *SWIGUNUSEDPARM(newmemory)) {
-    return (void *)((mfem::GridFunction *)  ((mfem::ParGridFunction *) x));
-}
-static void *_p_mfem__GridFunctionPumiTo_p_mfem__GridFunction(void *x, int *SWIGUNUSEDPARM(newmemory)) {
-    return (void *)((mfem::GridFunction *)  ((mfem::GridFunctionPumi *) x));
-}
-static void *_p_mfem__ParPumiMeshTo_p_mfem__ParMesh(void *x, int *SWIGUNUSEDPARM(newmemory)) {
-    return (void *)((mfem::ParMesh *)  ((mfem::ParPumiMesh *) x));
-}
 static void *_p_mfem__HypreParVectorTo_p_mfem__Vector(void *x, int *SWIGUNUSEDPARM(newmemory)) {
     return (void *)((mfem::Vector *)  ((mfem::HypreParVector *) x));
 }
@@ -4902,6 +4995,24 @@ static void *_p_mfem__GridFunctionPumiTo_p_mfem__Vector(void *x, int *SWIGUNUSED
 }
 static void *_p_mfem__LinearFormTo_p_mfem__Vector(void *x, int *SWIGUNUSEDPARM(newmemory)) {
     return (void *)((mfem::Vector *)  ((mfem::LinearForm *) x));
+}
+static void *_p_mfem__ParPumiMeshTo_p_mfem__ParMesh(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::ParMesh *)  ((mfem::ParPumiMesh *) x));
+}
+static void *_p_mfem__ParGridFunctionTo_p_mfem__GridFunction(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::GridFunction *)  ((mfem::ParGridFunction *) x));
+}
+static void *_p_mfem__GridFunctionPumiTo_p_mfem__GridFunction(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::GridFunction *)  ((mfem::GridFunctionPumi *) x));
+}
+static void *_p_mfem__ParMeshTo_p_mfem__Mesh(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::Mesh *)  ((mfem::ParMesh *) x));
+}
+static void *_p_mfem__PumiMeshTo_p_mfem__Mesh(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::Mesh *)  ((mfem::PumiMesh *) x));
+}
+static void *_p_mfem__ParPumiMeshTo_p_mfem__Mesh(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((mfem::Mesh *) (mfem::ParMesh *) ((mfem::ParPumiMesh *) x));
 }
 static swig_type_info _swigt__p_CommGroup = {"_p_CommGroup", "CommGroup *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_GroupId = {"_p_GroupId", "GroupId *", 0, 0, (void*)0, 0};
@@ -4934,7 +5045,6 @@ static swig_type_info _swigt__p_mfem__LinearForm = {"_p_mfem__LinearForm", 0, 0,
 static swig_type_info _swigt__p_pri_t = {"_p_pri_t", "pri_t *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_quad_t = {"_p_quad_t", "quad_t *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_seg_t = {"_p_seg_t", "seg_t *", 0, 0, (void*)0, 0};
-static swig_type_info _swigt__p_std__istream = {"_p_std__istream", "std::istream *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_tet_t = {"_p_tet_t", "tet_t *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_tri_t = {"_p_tri_t", "tri_t *", 0, 0, (void*)0, 0};
 
@@ -4970,7 +5080,6 @@ static swig_type_info *swig_type_initial[] = {
   &_swigt__p_pri_t,
   &_swigt__p_quad_t,
   &_swigt__p_seg_t,
-  &_swigt__p_std__istream,
   &_swigt__p_tet_t,
   &_swigt__p_tri_t,
 };
@@ -5006,7 +5115,6 @@ static swig_cast_info _swigc__p_mfem__Vector[] = {  {&_swigt__p_mfem__HypreParVe
 static swig_cast_info _swigc__p_pri_t[] = {  {&_swigt__p_pri_t, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_quad_t[] = {  {&_swigt__p_quad_t, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_seg_t[] = {  {&_swigt__p_seg_t, 0, 0, 0},{0, 0, 0, 0}};
-static swig_cast_info _swigc__p_std__istream[] = {  {&_swigt__p_std__istream, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_tet_t[] = {  {&_swigt__p_tet_t, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_tri_t[] = {  {&_swigt__p_tri_t, 0, 0, 0},{0, 0, 0, 0}};
 
@@ -5042,7 +5150,6 @@ static swig_cast_info *swig_cast_initial[] = {
   _swigc__p_pri_t,
   _swigc__p_quad_t,
   _swigc__p_seg_t,
-  _swigc__p_std__istream,
   _swigc__p_tet_t,
   _swigc__p_tri_t,
 };

--- a/mfem/_par/pumi_wrap.cxx
+++ b/mfem/_par/pumi_wrap.cxx
@@ -3566,7 +3566,6 @@ SWIGINTERN PyObject *_wrap_PumiMesh_Load__SWIG_0_0(PyObject *SWIGUNUSEDPARM(self
   PyMFEM::wFILE *temp2 = 0 ;
   std::ifstream in_txt2 ;
   mfem::ifgzstream *in_gz2 = 0 ;
-  PyObject *input_str2 = 0 ;
   std::istringstream *stream2 = 0 ;
   Py_ssize_t len2 = 0 ;
   PyObject *ret2 = 0 ;
@@ -3601,18 +3600,18 @@ SWIGINTERN PyObject *_wrap_PumiMesh_Load__SWIG_0_0(PyObject *SWIGUNUSEDPARM(self
           return NULL;
         }
         
-        PyObject *input_str2 = PyObject_CallMethod(swig_obj[1], "getvalue", NULL);
+        PyObject *input_str = PyObject_CallMethod(swig_obj[1], "getvalue", NULL);
         if (PyErr_Occurred()) {
           PyErr_SetString(PyExc_RuntimeError, "Can not read from StringIO");
           return NULL;
         }
         
         char *buf = nullptr;
-        PyObject *str = PyUnicode_AsUTF8String(input_str2);	 
+        PyObject *str = PyUnicode_AsUTF8String(input_str);	 
         PyBytes_AsStringAndSize(str, &buf, &len2);
         stream2 = new std::istringstream(buf);
         Py_DECREF(str);
-        Py_DECREF(input_str2);	 
+        Py_DECREF(input_str);	 
       } else {
         // if it is string, extract filename as char*
         PyObject* str = PyUnicode_AsEncodedString(swig_obj[1], "utf-8", "~E~");	

--- a/mfem/_par/sparsemat.i
+++ b/mfem/_par/sparsemat.i
@@ -6,6 +6,7 @@
 #include <limits>
 #include <cmath>
 #include <cstring>
+#include "general/zstr.hpp"
 #include "linalg/handle.hpp"    
 #include "linalg/sparsemat.hpp"  
 #include "numpy/arrayobject.h"

--- a/mfem/_par/sparsemat_wrap.cxx
+++ b/mfem/_par/sparsemat_wrap.cxx
@@ -3214,6 +3214,7 @@ namespace swig {
 #include <limits>
 #include <cmath>
 #include <cstring>
+#include "general/zstr.hpp"
 #include "linalg/handle.hpp"    
 #include "linalg/sparsemat.hpp"  
 #include "numpy/arrayobject.h"
@@ -11552,10 +11553,10 @@ SWIGINTERN PyObject *_wrap_SparseMatrix_Print__SWIG_0(PyObject *SWIGUNUSEDPARM(s
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyMFEM::wFILE *temp2 = 0 ;
-  std::ofstream out2 ;
-  int use_stringio2 = 0 ;
+  std::ofstream out_txt2 ;
+  mfem::ofgzstream *out_gz2 = 0 ;
   PyObject *string_io2 = 0 ;
-  std::ostringstream stream2 ;
+  std::ostringstream *stream2 = 0 ;
   PyObject *ret2 = 0 ;
   
   if ((nobjs < 1) || (nobjs > 3)) SWIG_fail;
@@ -11586,29 +11587,33 @@ SWIGINTERN PyObject *_wrap_SparseMatrix_Print__SWIG_0(PyObject *SWIGUNUSEDPARM(s
             SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
             return NULL;
           }
-          use_stringio2=1;
           string_io2=swig_obj[1];
+          stream2 = new std::ostringstream();
         } else {
           // if it is string, extract filename as char*
           PyObject* str = PyUnicode_AsEncodedString(swig_obj[1], "utf-8", "~E~");	
           const char* filename = PyBytes_AsString(str);
-          temp2 = new PyMFEM::wFILE(filename, 8, true);	
+          temp2 = new PyMFEM::wFILE(filename, 8, true);
+          Py_DECREF(str);	 
         }
       }
       
-      if (use_stringio2 == 0){
+      if (stream2 == 0){
         if (temp2->isSTDOUT() == 1) {
           arg2 = &std::cout;
+        } else if (temp2->isGZ()){
+          out_gz2 = new mfem::ofgzstream(temp2->getFilename(), true);
+          arg2 = out_gz2;	     
         } else {
-          out2.open(temp2->getFilename());
-          out2.precision(temp2->getPrecision());
-          if (temp2->isTemporary()){
-            delete temp2;
-          }
-          arg2 = &out2;
+          out_txt2.open(temp2->getFilename());
+          out_txt2.precision(temp2->getPrecision());
+          arg2 = &out_txt2;
+        }
+        if (temp2->isTemporary()){
+          delete temp2;
         }
       } else {
-        arg2 = &stream2;
+        arg2 = stream2;
       }
     }
   }
@@ -11635,8 +11640,8 @@ SWIGINTERN PyObject *_wrap_SparseMatrix_Print__SWIG_0(PyObject *SWIGUNUSEDPARM(s
   }
   resultobj = SWIG_Py_Void();
   {
-    if (use_stringio2 == 1) {
-      std::string str =  stream2.str();
+    if (stream2) {
+      std::string str =  stream2->str();
       const char* s = str.c_str();
       const int n = str.length();
       ret2 = PyObject_CallMethod(string_io2, "write", "s#",
@@ -11645,15 +11650,21 @@ SWIGINTERN PyObject *_wrap_SparseMatrix_Print__SWIG_0(PyObject *SWIGUNUSEDPARM(s
         PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
         return NULL;
       }
+      delete stream2;
       Py_XDECREF(resultobj);   /* Blow away any previous result */
       resultobj = ret2;    
     }
   }
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -11661,10 +11672,15 @@ SWIGINTERN PyObject *_wrap_SparseMatrix_Print__SWIG_0(PyObject *SWIGUNUSEDPARM(s
   return resultobj;
 fail:
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -11681,10 +11697,10 @@ SWIGINTERN PyObject *_wrap_SparseMatrix_PrintMatlab__SWIG_0(PyObject *SWIGUNUSED
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyMFEM::wFILE *temp2 = 0 ;
-  std::ofstream out2 ;
-  int use_stringio2 = 0 ;
+  std::ofstream out_txt2 ;
+  mfem::ofgzstream *out_gz2 = 0 ;
   PyObject *string_io2 = 0 ;
-  std::ostringstream stream2 ;
+  std::ostringstream *stream2 = 0 ;
   PyObject *ret2 = 0 ;
   
   if ((nobjs < 1) || (nobjs > 2)) SWIG_fail;
@@ -11715,29 +11731,33 @@ SWIGINTERN PyObject *_wrap_SparseMatrix_PrintMatlab__SWIG_0(PyObject *SWIGUNUSED
             SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
             return NULL;
           }
-          use_stringio2=1;
           string_io2=swig_obj[1];
+          stream2 = new std::ostringstream();
         } else {
           // if it is string, extract filename as char*
           PyObject* str = PyUnicode_AsEncodedString(swig_obj[1], "utf-8", "~E~");	
           const char* filename = PyBytes_AsString(str);
-          temp2 = new PyMFEM::wFILE(filename, 8, true);	
+          temp2 = new PyMFEM::wFILE(filename, 8, true);
+          Py_DECREF(str);	 
         }
       }
       
-      if (use_stringio2 == 0){
+      if (stream2 == 0){
         if (temp2->isSTDOUT() == 1) {
           arg2 = &std::cout;
+        } else if (temp2->isGZ()){
+          out_gz2 = new mfem::ofgzstream(temp2->getFilename(), true);
+          arg2 = out_gz2;	     
         } else {
-          out2.open(temp2->getFilename());
-          out2.precision(temp2->getPrecision());
-          if (temp2->isTemporary()){
-            delete temp2;
-          }
-          arg2 = &out2;
+          out_txt2.open(temp2->getFilename());
+          out_txt2.precision(temp2->getPrecision());
+          arg2 = &out_txt2;
+        }
+        if (temp2->isTemporary()){
+          delete temp2;
         }
       } else {
-        arg2 = &stream2;
+        arg2 = stream2;
       }
     }
   }
@@ -11756,8 +11776,8 @@ SWIGINTERN PyObject *_wrap_SparseMatrix_PrintMatlab__SWIG_0(PyObject *SWIGUNUSED
   }
   resultobj = SWIG_Py_Void();
   {
-    if (use_stringio2 == 1) {
-      std::string str =  stream2.str();
+    if (stream2) {
+      std::string str =  stream2->str();
       const char* s = str.c_str();
       const int n = str.length();
       ret2 = PyObject_CallMethod(string_io2, "write", "s#",
@@ -11766,15 +11786,21 @@ SWIGINTERN PyObject *_wrap_SparseMatrix_PrintMatlab__SWIG_0(PyObject *SWIGUNUSED
         PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
         return NULL;
       }
+      delete stream2;
       Py_XDECREF(resultobj);   /* Blow away any previous result */
       resultobj = ret2;    
     }
   }
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -11782,10 +11808,15 @@ SWIGINTERN PyObject *_wrap_SparseMatrix_PrintMatlab__SWIG_0(PyObject *SWIGUNUSED
   return resultobj;
 fail:
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -11802,10 +11833,10 @@ SWIGINTERN PyObject *_wrap_SparseMatrix_PrintMM__SWIG_0(PyObject *SWIGUNUSEDPARM
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyMFEM::wFILE *temp2 = 0 ;
-  std::ofstream out2 ;
-  int use_stringio2 = 0 ;
+  std::ofstream out_txt2 ;
+  mfem::ofgzstream *out_gz2 = 0 ;
   PyObject *string_io2 = 0 ;
-  std::ostringstream stream2 ;
+  std::ostringstream *stream2 = 0 ;
   PyObject *ret2 = 0 ;
   
   if ((nobjs < 1) || (nobjs > 2)) SWIG_fail;
@@ -11836,29 +11867,33 @@ SWIGINTERN PyObject *_wrap_SparseMatrix_PrintMM__SWIG_0(PyObject *SWIGUNUSEDPARM
             SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
             return NULL;
           }
-          use_stringio2=1;
           string_io2=swig_obj[1];
+          stream2 = new std::ostringstream();
         } else {
           // if it is string, extract filename as char*
           PyObject* str = PyUnicode_AsEncodedString(swig_obj[1], "utf-8", "~E~");	
           const char* filename = PyBytes_AsString(str);
-          temp2 = new PyMFEM::wFILE(filename, 8, true);	
+          temp2 = new PyMFEM::wFILE(filename, 8, true);
+          Py_DECREF(str);	 
         }
       }
       
-      if (use_stringio2 == 0){
+      if (stream2 == 0){
         if (temp2->isSTDOUT() == 1) {
           arg2 = &std::cout;
+        } else if (temp2->isGZ()){
+          out_gz2 = new mfem::ofgzstream(temp2->getFilename(), true);
+          arg2 = out_gz2;	     
         } else {
-          out2.open(temp2->getFilename());
-          out2.precision(temp2->getPrecision());
-          if (temp2->isTemporary()){
-            delete temp2;
-          }
-          arg2 = &out2;
+          out_txt2.open(temp2->getFilename());
+          out_txt2.precision(temp2->getPrecision());
+          arg2 = &out_txt2;
+        }
+        if (temp2->isTemporary()){
+          delete temp2;
         }
       } else {
-        arg2 = &stream2;
+        arg2 = stream2;
       }
     }
   }
@@ -11877,8 +11912,8 @@ SWIGINTERN PyObject *_wrap_SparseMatrix_PrintMM__SWIG_0(PyObject *SWIGUNUSEDPARM
   }
   resultobj = SWIG_Py_Void();
   {
-    if (use_stringio2 == 1) {
-      std::string str =  stream2.str();
+    if (stream2) {
+      std::string str =  stream2->str();
       const char* s = str.c_str();
       const int n = str.length();
       ret2 = PyObject_CallMethod(string_io2, "write", "s#",
@@ -11887,15 +11922,21 @@ SWIGINTERN PyObject *_wrap_SparseMatrix_PrintMM__SWIG_0(PyObject *SWIGUNUSEDPARM
         PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
         return NULL;
       }
+      delete stream2;
       Py_XDECREF(resultobj);   /* Blow away any previous result */
       resultobj = ret2;    
     }
   }
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -11903,10 +11944,15 @@ SWIGINTERN PyObject *_wrap_SparseMatrix_PrintMM__SWIG_0(PyObject *SWIGUNUSEDPARM
   return resultobj;
 fail:
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -11922,10 +11968,10 @@ SWIGINTERN PyObject *_wrap_SparseMatrix_PrintCSR__SWIG_0(PyObject *SWIGUNUSEDPAR
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyMFEM::wFILE *temp2 = 0 ;
-  std::ofstream out2 ;
-  int use_stringio2 = 0 ;
+  std::ofstream out_txt2 ;
+  mfem::ofgzstream *out_gz2 = 0 ;
   PyObject *string_io2 = 0 ;
-  std::ostringstream stream2 ;
+  std::ostringstream *stream2 = 0 ;
   PyObject *ret2 = 0 ;
   
   if ((nobjs < 2) || (nobjs > 2)) SWIG_fail;
@@ -11955,29 +12001,33 @@ SWIGINTERN PyObject *_wrap_SparseMatrix_PrintCSR__SWIG_0(PyObject *SWIGUNUSEDPAR
           SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
           return NULL;
         }
-        use_stringio2=1;
         string_io2=swig_obj[1];
+        stream2 = new std::ostringstream();
       } else {
         // if it is string, extract filename as char*
         PyObject* str = PyUnicode_AsEncodedString(swig_obj[1], "utf-8", "~E~");	
         const char* filename = PyBytes_AsString(str);
-        temp2 = new PyMFEM::wFILE(filename, 8, true);	
+        temp2 = new PyMFEM::wFILE(filename, 8, true);
+        Py_DECREF(str);	 
       }
     }
     
-    if (use_stringio2 == 0){
+    if (stream2 == 0){
       if (temp2->isSTDOUT() == 1) {
         arg2 = &std::cout;
+      } else if (temp2->isGZ()){
+        out_gz2 = new mfem::ofgzstream(temp2->getFilename(), true);
+        arg2 = out_gz2;	     
       } else {
-        out2.open(temp2->getFilename());
-        out2.precision(temp2->getPrecision());
-        if (temp2->isTemporary()){
-          delete temp2;
-        }
-        arg2 = &out2;
+        out_txt2.open(temp2->getFilename());
+        out_txt2.precision(temp2->getPrecision());
+        arg2 = &out_txt2;
+      }
+      if (temp2->isTemporary()){
+        delete temp2;
       }
     } else {
-      arg2 = &stream2;
+      arg2 = stream2;
     }
   }
   {
@@ -11995,8 +12045,8 @@ SWIGINTERN PyObject *_wrap_SparseMatrix_PrintCSR__SWIG_0(PyObject *SWIGUNUSEDPAR
   }
   resultobj = SWIG_Py_Void();
   {
-    if (use_stringio2 == 1) {
-      std::string str =  stream2.str();
+    if (stream2) {
+      std::string str =  stream2->str();
       const char* s = str.c_str();
       const int n = str.length();
       ret2 = PyObject_CallMethod(string_io2, "write", "s#",
@@ -12005,15 +12055,21 @@ SWIGINTERN PyObject *_wrap_SparseMatrix_PrintCSR__SWIG_0(PyObject *SWIGUNUSEDPAR
         PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
         return NULL;
       }
+      delete stream2;
       Py_XDECREF(resultobj);   /* Blow away any previous result */
       resultobj = ret2;    
     }
   }
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -12021,10 +12077,15 @@ SWIGINTERN PyObject *_wrap_SparseMatrix_PrintCSR__SWIG_0(PyObject *SWIGUNUSEDPAR
   return resultobj;
 fail:
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -12040,10 +12101,10 @@ SWIGINTERN PyObject *_wrap_SparseMatrix_PrintCSR2__SWIG_0(PyObject *SWIGUNUSEDPA
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyMFEM::wFILE *temp2 = 0 ;
-  std::ofstream out2 ;
-  int use_stringio2 = 0 ;
+  std::ofstream out_txt2 ;
+  mfem::ofgzstream *out_gz2 = 0 ;
   PyObject *string_io2 = 0 ;
-  std::ostringstream stream2 ;
+  std::ostringstream *stream2 = 0 ;
   PyObject *ret2 = 0 ;
   
   if ((nobjs < 2) || (nobjs > 2)) SWIG_fail;
@@ -12073,29 +12134,33 @@ SWIGINTERN PyObject *_wrap_SparseMatrix_PrintCSR2__SWIG_0(PyObject *SWIGUNUSEDPA
           SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
           return NULL;
         }
-        use_stringio2=1;
         string_io2=swig_obj[1];
+        stream2 = new std::ostringstream();
       } else {
         // if it is string, extract filename as char*
         PyObject* str = PyUnicode_AsEncodedString(swig_obj[1], "utf-8", "~E~");	
         const char* filename = PyBytes_AsString(str);
-        temp2 = new PyMFEM::wFILE(filename, 8, true);	
+        temp2 = new PyMFEM::wFILE(filename, 8, true);
+        Py_DECREF(str);	 
       }
     }
     
-    if (use_stringio2 == 0){
+    if (stream2 == 0){
       if (temp2->isSTDOUT() == 1) {
         arg2 = &std::cout;
+      } else if (temp2->isGZ()){
+        out_gz2 = new mfem::ofgzstream(temp2->getFilename(), true);
+        arg2 = out_gz2;	     
       } else {
-        out2.open(temp2->getFilename());
-        out2.precision(temp2->getPrecision());
-        if (temp2->isTemporary()){
-          delete temp2;
-        }
-        arg2 = &out2;
+        out_txt2.open(temp2->getFilename());
+        out_txt2.precision(temp2->getPrecision());
+        arg2 = &out_txt2;
+      }
+      if (temp2->isTemporary()){
+        delete temp2;
       }
     } else {
-      arg2 = &stream2;
+      arg2 = stream2;
     }
   }
   {
@@ -12113,8 +12178,8 @@ SWIGINTERN PyObject *_wrap_SparseMatrix_PrintCSR2__SWIG_0(PyObject *SWIGUNUSEDPA
   }
   resultobj = SWIG_Py_Void();
   {
-    if (use_stringio2 == 1) {
-      std::string str =  stream2.str();
+    if (stream2) {
+      std::string str =  stream2->str();
       const char* s = str.c_str();
       const int n = str.length();
       ret2 = PyObject_CallMethod(string_io2, "write", "s#",
@@ -12123,15 +12188,21 @@ SWIGINTERN PyObject *_wrap_SparseMatrix_PrintCSR2__SWIG_0(PyObject *SWIGUNUSEDPA
         PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
         return NULL;
       }
+      delete stream2;
       Py_XDECREF(resultobj);   /* Blow away any previous result */
       resultobj = ret2;    
     }
   }
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -12139,10 +12210,15 @@ SWIGINTERN PyObject *_wrap_SparseMatrix_PrintCSR2__SWIG_0(PyObject *SWIGUNUSEDPA
   return resultobj;
 fail:
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -12158,10 +12234,10 @@ SWIGINTERN PyObject *_wrap_SparseMatrix_PrintInfo__SWIG_0(PyObject *SWIGUNUSEDPA
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyMFEM::wFILE *temp2 = 0 ;
-  std::ofstream out2 ;
-  int use_stringio2 = 0 ;
+  std::ofstream out_txt2 ;
+  mfem::ofgzstream *out_gz2 = 0 ;
   PyObject *string_io2 = 0 ;
-  std::ostringstream stream2 ;
+  std::ostringstream *stream2 = 0 ;
   PyObject *ret2 = 0 ;
   
   if ((nobjs < 2) || (nobjs > 2)) SWIG_fail;
@@ -12191,29 +12267,33 @@ SWIGINTERN PyObject *_wrap_SparseMatrix_PrintInfo__SWIG_0(PyObject *SWIGUNUSEDPA
           SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
           return NULL;
         }
-        use_stringio2=1;
         string_io2=swig_obj[1];
+        stream2 = new std::ostringstream();
       } else {
         // if it is string, extract filename as char*
         PyObject* str = PyUnicode_AsEncodedString(swig_obj[1], "utf-8", "~E~");	
         const char* filename = PyBytes_AsString(str);
-        temp2 = new PyMFEM::wFILE(filename, 8, true);	
+        temp2 = new PyMFEM::wFILE(filename, 8, true);
+        Py_DECREF(str);	 
       }
     }
     
-    if (use_stringio2 == 0){
+    if (stream2 == 0){
       if (temp2->isSTDOUT() == 1) {
         arg2 = &std::cout;
+      } else if (temp2->isGZ()){
+        out_gz2 = new mfem::ofgzstream(temp2->getFilename(), true);
+        arg2 = out_gz2;	     
       } else {
-        out2.open(temp2->getFilename());
-        out2.precision(temp2->getPrecision());
-        if (temp2->isTemporary()){
-          delete temp2;
-        }
-        arg2 = &out2;
+        out_txt2.open(temp2->getFilename());
+        out_txt2.precision(temp2->getPrecision());
+        arg2 = &out_txt2;
+      }
+      if (temp2->isTemporary()){
+        delete temp2;
       }
     } else {
-      arg2 = &stream2;
+      arg2 = stream2;
     }
   }
   {
@@ -12231,8 +12311,8 @@ SWIGINTERN PyObject *_wrap_SparseMatrix_PrintInfo__SWIG_0(PyObject *SWIGUNUSEDPA
   }
   resultobj = SWIG_Py_Void();
   {
-    if (use_stringio2 == 1) {
-      std::string str =  stream2.str();
+    if (stream2) {
+      std::string str =  stream2->str();
       const char* s = str.c_str();
       const int n = str.length();
       ret2 = PyObject_CallMethod(string_io2, "write", "s#",
@@ -12241,15 +12321,21 @@ SWIGINTERN PyObject *_wrap_SparseMatrix_PrintInfo__SWIG_0(PyObject *SWIGUNUSEDPA
         PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
         return NULL;
       }
+      delete stream2;
       Py_XDECREF(resultobj);   /* Blow away any previous result */
       resultobj = ret2;    
     }
   }
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -12257,10 +12343,15 @@ SWIGINTERN PyObject *_wrap_SparseMatrix_PrintInfo__SWIG_0(PyObject *SWIGUNUSEDPA
   return resultobj;
 fail:
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -12996,7 +13087,8 @@ SWIGINTERN PyObject *_wrap_SparseMatrix_Print(PyObject *self, PyObject *args) {
               _v = 0;	   	   	   
             }
           } else {
-            _v = 0;
+            std::cout << "it is text (out)\n";	
+            _v = 1;
           }
         } else {
           _v = 1;
@@ -13147,7 +13239,8 @@ SWIGINTERN PyObject *_wrap_SparseMatrix_PrintMatlab(PyObject *self, PyObject *ar
               _v = 0;	   	   	   
             }
           } else {
-            _v = 0;
+            std::cout << "it is text (out)\n";	
+            _v = 1;
           }
         } else {
           _v = 1;
@@ -13285,7 +13378,8 @@ SWIGINTERN PyObject *_wrap_SparseMatrix_PrintMM(PyObject *self, PyObject *args) 
               _v = 0;	   	   	   
             }
           } else {
-            _v = 0;
+            std::cout << "it is text (out)\n";	
+            _v = 1;
           }
         } else {
           _v = 1;
@@ -13487,7 +13581,8 @@ SWIGINTERN PyObject *_wrap_SparseMatrix_PrintCSR(PyObject *self, PyObject *args)
               _v = 0;	   	   	   
             }
           } else {
-            _v = 0;
+            std::cout << "it is text (out)\n";	
+            _v = 1;
           }
         } else {
           _v = 1;
@@ -13664,7 +13759,8 @@ SWIGINTERN PyObject *_wrap_SparseMatrix_PrintCSR2(PyObject *self, PyObject *args
               _v = 0;	   	   	   
             }
           } else {
-            _v = 0;
+            std::cout << "it is text (out)\n";	
+            _v = 1;
           }
         } else {
           _v = 1;
@@ -13841,7 +13937,8 @@ SWIGINTERN PyObject *_wrap_SparseMatrix_PrintInfo(PyObject *self, PyObject *args
               _v = 0;	   	   	   
             }
           } else {
-            _v = 0;
+            std::cout << "it is text (out)\n";	
+            _v = 1;
           }
         } else {
           _v = 1;
@@ -13879,10 +13976,10 @@ SWIGINTERN PyObject *_wrap___lshift__(PyObject *SWIGUNUSEDPARM(self), PyObject *
   std::ostream *arg1 = 0 ;
   mfem::SparseMatrix *arg2 = 0 ;
   PyMFEM::wFILE *temp1 = 0 ;
-  std::ofstream out1 ;
-  int use_stringio1 = 0 ;
+  std::ofstream out_txt1 ;
+  mfem::ofgzstream *out_gz1 = 0 ;
   PyObject *string_io1 = 0 ;
-  std::ostringstream stream1 ;
+  std::ostringstream *stream1 = 0 ;
   PyObject *ret1 = 0 ;
   void *argp2 = 0 ;
   int res2 = 0 ;
@@ -13915,29 +14012,33 @@ SWIGINTERN PyObject *_wrap___lshift__(PyObject *SWIGUNUSEDPARM(self), PyObject *
           SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
           return NULL;
         }
-        use_stringio1=1;
         string_io1=obj0;
+        stream1 = new std::ostringstream();
       } else {
         // if it is string, extract filename as char*
         PyObject* str = PyUnicode_AsEncodedString(obj0, "utf-8", "~E~");	
         const char* filename = PyBytes_AsString(str);
-        temp1 = new PyMFEM::wFILE(filename, 8, true);	
+        temp1 = new PyMFEM::wFILE(filename, 8, true);
+        Py_DECREF(str);	 
       }
     }
     
-    if (use_stringio1 == 0){
+    if (stream1 == 0){
       if (temp1->isSTDOUT() == 1) {
         arg1 = &std::cout;
+      } else if (temp1->isGZ()){
+        out_gz1 = new mfem::ofgzstream(temp1->getFilename(), true);
+        arg1 = out_gz1;	     
       } else {
-        out1.open(temp1->getFilename());
-        out1.precision(temp1->getPrecision());
-        if (temp1->isTemporary()){
-          delete temp1;
-        }
-        arg1 = &out1;
+        out_txt1.open(temp1->getFilename());
+        out_txt1.precision(temp1->getPrecision());
+        arg1 = &out_txt1;
+      }
+      if (temp1->isTemporary()){
+        delete temp1;
       }
     } else {
-      arg1 = &stream1;
+      arg1 = stream1;
     }
   }
   res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_mfem__SparseMatrix,  0  | 0);
@@ -13963,8 +14064,8 @@ SWIGINTERN PyObject *_wrap___lshift__(PyObject *SWIGUNUSEDPARM(self), PyObject *
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_std__ostream, 0 |  0 );
   {
-    if (use_stringio1 == 1) {
-      std::string str =  stream1.str();
+    if (stream1) {
+      std::string str =  stream1->str();
       const char* s = str.c_str();
       const int n = str.length();
       ret1 = PyObject_CallMethod(string_io1, "write", "s#",
@@ -13973,15 +14074,21 @@ SWIGINTERN PyObject *_wrap___lshift__(PyObject *SWIGUNUSEDPARM(self), PyObject *
         PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
         return NULL;
       }
+      delete stream1;
       Py_XDECREF(resultobj);   /* Blow away any previous result */
       resultobj = ret1;    
     }
   }
   {
-    if (use_stringio1 == 0) {
+    if (!stream1) {
       if (temp1) {
         if (temp1->isSTDOUT() != 1) {
-          out1.close();
+          if (out_txt1.is_open()){
+            out_txt1.close();
+          }
+          if (out_gz1){
+            delete out_gz1;
+          }
         }
       }
     }
@@ -13989,10 +14096,15 @@ SWIGINTERN PyObject *_wrap___lshift__(PyObject *SWIGUNUSEDPARM(self), PyObject *
   return resultobj;
 fail:
   {
-    if (use_stringio1 == 0) {
+    if (!stream1) {
       if (temp1) {
         if (temp1->isSTDOUT() != 1) {
-          out1.close();
+          if (out_txt1.is_open()){
+            out_txt1.close();
+          }
+          if (out_gz1){
+            delete out_gz1;
+          }
         }
       }
     }

--- a/mfem/_par/sparsemat_wrap.cxx
+++ b/mfem/_par/sparsemat_wrap.cxx
@@ -13087,7 +13087,6 @@ SWIGINTERN PyObject *_wrap_SparseMatrix_Print(PyObject *self, PyObject *args) {
               _v = 0;	   	   	   
             }
           } else {
-            std::cout << "it is text (out)\n";	
             _v = 1;
           }
         } else {
@@ -13239,7 +13238,6 @@ SWIGINTERN PyObject *_wrap_SparseMatrix_PrintMatlab(PyObject *self, PyObject *ar
               _v = 0;	   	   	   
             }
           } else {
-            std::cout << "it is text (out)\n";	
             _v = 1;
           }
         } else {
@@ -13378,7 +13376,6 @@ SWIGINTERN PyObject *_wrap_SparseMatrix_PrintMM(PyObject *self, PyObject *args) 
               _v = 0;	   	   	   
             }
           } else {
-            std::cout << "it is text (out)\n";	
             _v = 1;
           }
         } else {
@@ -13581,7 +13578,6 @@ SWIGINTERN PyObject *_wrap_SparseMatrix_PrintCSR(PyObject *self, PyObject *args)
               _v = 0;	   	   	   
             }
           } else {
-            std::cout << "it is text (out)\n";	
             _v = 1;
           }
         } else {
@@ -13759,7 +13755,6 @@ SWIGINTERN PyObject *_wrap_SparseMatrix_PrintCSR2(PyObject *self, PyObject *args
               _v = 0;	   	   	   
             }
           } else {
-            std::cout << "it is text (out)\n";	
             _v = 1;
           }
         } else {
@@ -13937,7 +13932,6 @@ SWIGINTERN PyObject *_wrap_SparseMatrix_PrintInfo(PyObject *self, PyObject *args
               _v = 0;	   	   	   
             }
           } else {
-            std::cout << "it is text (out)\n";	
             _v = 1;
           }
         } else {

--- a/mfem/_par/stable3d_wrap.cxx
+++ b/mfem/_par/stable3d_wrap.cxx
@@ -4354,7 +4354,6 @@ SWIGINTERN PyObject *_wrap_STable3D_Print(PyObject *self, PyObject *args) {
               _v = 0;	   	   	   
             }
           } else {
-            std::cout << "it is text (out)\n";	
             _v = 1;
           }
         } else {

--- a/mfem/_par/stable3d_wrap.cxx
+++ b/mfem/_par/stable3d_wrap.cxx
@@ -4101,10 +4101,10 @@ SWIGINTERN PyObject *_wrap_STable3D_Print__SWIG_0(PyObject *SWIGUNUSEDPARM(self)
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyMFEM::wFILE *temp2 = 0 ;
-  std::ofstream out2 ;
-  int use_stringio2 = 0 ;
+  std::ofstream out_txt2 ;
+  mfem::ofgzstream *out_gz2 = 0 ;
   PyObject *string_io2 = 0 ;
-  std::ostringstream stream2 ;
+  std::ostringstream *stream2 = 0 ;
   PyObject *ret2 = 0 ;
   
   if ((nobjs < 1) || (nobjs > 2)) SWIG_fail;
@@ -4135,29 +4135,33 @@ SWIGINTERN PyObject *_wrap_STable3D_Print__SWIG_0(PyObject *SWIGUNUSEDPARM(self)
             SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
             return NULL;
           }
-          use_stringio2=1;
           string_io2=swig_obj[1];
+          stream2 = new std::ostringstream();
         } else {
           // if it is string, extract filename as char*
           PyObject* str = PyUnicode_AsEncodedString(swig_obj[1], "utf-8", "~E~");	
           const char* filename = PyBytes_AsString(str);
-          temp2 = new PyMFEM::wFILE(filename, 8, true);	
+          temp2 = new PyMFEM::wFILE(filename, 8, true);
+          Py_DECREF(str);	 
         }
       }
       
-      if (use_stringio2 == 0){
+      if (stream2 == 0){
         if (temp2->isSTDOUT() == 1) {
           arg2 = &std::cout;
+        } else if (temp2->isGZ()){
+          out_gz2 = new mfem::ofgzstream(temp2->getFilename(), true);
+          arg2 = out_gz2;	     
         } else {
-          out2.open(temp2->getFilename());
-          out2.precision(temp2->getPrecision());
-          if (temp2->isTemporary()){
-            delete temp2;
-          }
-          arg2 = &out2;
+          out_txt2.open(temp2->getFilename());
+          out_txt2.precision(temp2->getPrecision());
+          arg2 = &out_txt2;
+        }
+        if (temp2->isTemporary()){
+          delete temp2;
         }
       } else {
-        arg2 = &stream2;
+        arg2 = stream2;
       }
     }
   }
@@ -4176,8 +4180,8 @@ SWIGINTERN PyObject *_wrap_STable3D_Print__SWIG_0(PyObject *SWIGUNUSEDPARM(self)
   }
   resultobj = SWIG_Py_Void();
   {
-    if (use_stringio2 == 1) {
-      std::string str =  stream2.str();
+    if (stream2) {
+      std::string str =  stream2->str();
       const char* s = str.c_str();
       const int n = str.length();
       ret2 = PyObject_CallMethod(string_io2, "write", "s#",
@@ -4186,15 +4190,21 @@ SWIGINTERN PyObject *_wrap_STable3D_Print__SWIG_0(PyObject *SWIGUNUSEDPARM(self)
         PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
         return NULL;
       }
+      delete stream2;
       Py_XDECREF(resultobj);   /* Blow away any previous result */
       resultobj = ret2;    
     }
   }
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -4202,10 +4212,15 @@ SWIGINTERN PyObject *_wrap_STable3D_Print__SWIG_0(PyObject *SWIGUNUSEDPARM(self)
   return resultobj;
 fail:
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -4339,7 +4354,8 @@ SWIGINTERN PyObject *_wrap_STable3D_Print(PyObject *self, PyObject *args) {
               _v = 0;	   	   	   
             }
           } else {
-            _v = 0;
+            std::cout << "it is text (out)\n";	
+            _v = 1;
           }
         } else {
           _v = 1;

--- a/mfem/_par/table.i
+++ b/mfem/_par/table.i
@@ -5,6 +5,7 @@
 %{
 #include <fstream>  
 #include <iostream>
+#include "general/zstr.hpp"  
 #include "numpy/arrayobject.h"      
 #include "../common/io_stream.hpp"
 #include "general/table.hpp"

--- a/mfem/_par/table_wrap.cxx
+++ b/mfem/_par/table_wrap.cxx
@@ -2670,10 +2670,9 @@ SWIGINTERN PyObject *SWIG_PyStaticMethod_New(PyObject *SWIGUNUSEDPARM(self), PyO
 #define SWIGTYPE_p_mfem__MemoryT_int_t swig_types[7]
 #define SWIGTYPE_p_mfem__STable swig_types[8]
 #define SWIGTYPE_p_mfem__Table swig_types[9]
-#define SWIGTYPE_p_std__istream swig_types[10]
-#define SWIGTYPE_p_void swig_types[11]
-static swig_type_info *swig_types[13];
-static swig_module_info swig_module = {swig_types, 12, 0, 0, 0, 0};
+#define SWIGTYPE_p_void swig_types[10]
+static swig_type_info *swig_types[12];
+static swig_module_info swig_module = {swig_types, 11, 0, 0, 0, 0};
 #define SWIG_TypeQuery(name) SWIG_TypeQueryModule(&swig_module, &swig_module, name)
 #define SWIG_MangledTypeQuery(name) SWIG_MangledTypeQueryModule(&swig_module, &swig_module, name)
 
@@ -2779,6 +2778,7 @@ namespace swig {
 
 #include <fstream>  
 #include <iostream>
+#include "general/zstr.hpp"  
 #include "numpy/arrayobject.h"      
 #include "../common/io_stream.hpp"
 #include "general/table.hpp"
@@ -5267,10 +5267,10 @@ SWIGINTERN PyObject *_wrap_Table_Print__SWIG_0(PyObject *SWIGUNUSEDPARM(self), P
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyMFEM::wFILE *temp2 = 0 ;
-  std::ofstream out2 ;
-  int use_stringio2 = 0 ;
+  std::ofstream out_txt2 ;
+  mfem::ofgzstream *out_gz2 = 0 ;
   PyObject *string_io2 = 0 ;
-  std::ostringstream stream2 ;
+  std::ostringstream *stream2 = 0 ;
   PyObject *ret2 = 0 ;
   
   if ((nobjs < 1) || (nobjs > 3)) SWIG_fail;
@@ -5301,29 +5301,33 @@ SWIGINTERN PyObject *_wrap_Table_Print__SWIG_0(PyObject *SWIGUNUSEDPARM(self), P
             SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
             return NULL;
           }
-          use_stringio2=1;
           string_io2=swig_obj[1];
+          stream2 = new std::ostringstream();
         } else {
           // if it is string, extract filename as char*
           PyObject* str = PyUnicode_AsEncodedString(swig_obj[1], "utf-8", "~E~");	
           const char* filename = PyBytes_AsString(str);
-          temp2 = new PyMFEM::wFILE(filename, 8, true);	
+          temp2 = new PyMFEM::wFILE(filename, 8, true);
+          Py_DECREF(str);	 
         }
       }
       
-      if (use_stringio2 == 0){
+      if (stream2 == 0){
         if (temp2->isSTDOUT() == 1) {
           arg2 = &std::cout;
+        } else if (temp2->isGZ()){
+          out_gz2 = new mfem::ofgzstream(temp2->getFilename(), true);
+          arg2 = out_gz2;	     
         } else {
-          out2.open(temp2->getFilename());
-          out2.precision(temp2->getPrecision());
-          if (temp2->isTemporary()){
-            delete temp2;
-          }
-          arg2 = &out2;
+          out_txt2.open(temp2->getFilename());
+          out_txt2.precision(temp2->getPrecision());
+          arg2 = &out_txt2;
+        }
+        if (temp2->isTemporary()){
+          delete temp2;
         }
       } else {
-        arg2 = &stream2;
+        arg2 = stream2;
       }
     }
   }
@@ -5353,8 +5357,8 @@ SWIGINTERN PyObject *_wrap_Table_Print__SWIG_0(PyObject *SWIGUNUSEDPARM(self), P
   }
   resultobj = SWIG_Py_Void();
   {
-    if (use_stringio2 == 1) {
-      std::string str =  stream2.str();
+    if (stream2) {
+      std::string str =  stream2->str();
       const char* s = str.c_str();
       const int n = str.length();
       ret2 = PyObject_CallMethod(string_io2, "write", "s#",
@@ -5363,15 +5367,21 @@ SWIGINTERN PyObject *_wrap_Table_Print__SWIG_0(PyObject *SWIGUNUSEDPARM(self), P
         PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
         return NULL;
       }
+      delete stream2;
       Py_XDECREF(resultobj);   /* Blow away any previous result */
       resultobj = ret2;    
     }
   }
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -5379,10 +5389,15 @@ SWIGINTERN PyObject *_wrap_Table_Print__SWIG_0(PyObject *SWIGUNUSEDPARM(self), P
   return resultobj;
 fail:
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -5398,10 +5413,10 @@ SWIGINTERN PyObject *_wrap_Table_PrintMatlab__SWIG_0(PyObject *SWIGUNUSEDPARM(se
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyMFEM::wFILE *temp2 = 0 ;
-  std::ofstream out2 ;
-  int use_stringio2 = 0 ;
+  std::ofstream out_txt2 ;
+  mfem::ofgzstream *out_gz2 = 0 ;
   PyObject *string_io2 = 0 ;
-  std::ostringstream stream2 ;
+  std::ostringstream *stream2 = 0 ;
   PyObject *ret2 = 0 ;
   
   if ((nobjs < 2) || (nobjs > 2)) SWIG_fail;
@@ -5431,29 +5446,33 @@ SWIGINTERN PyObject *_wrap_Table_PrintMatlab__SWIG_0(PyObject *SWIGUNUSEDPARM(se
           SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
           return NULL;
         }
-        use_stringio2=1;
         string_io2=swig_obj[1];
+        stream2 = new std::ostringstream();
       } else {
         // if it is string, extract filename as char*
         PyObject* str = PyUnicode_AsEncodedString(swig_obj[1], "utf-8", "~E~");	
         const char* filename = PyBytes_AsString(str);
-        temp2 = new PyMFEM::wFILE(filename, 8, true);	
+        temp2 = new PyMFEM::wFILE(filename, 8, true);
+        Py_DECREF(str);	 
       }
     }
     
-    if (use_stringio2 == 0){
+    if (stream2 == 0){
       if (temp2->isSTDOUT() == 1) {
         arg2 = &std::cout;
+      } else if (temp2->isGZ()){
+        out_gz2 = new mfem::ofgzstream(temp2->getFilename(), true);
+        arg2 = out_gz2;	     
       } else {
-        out2.open(temp2->getFilename());
-        out2.precision(temp2->getPrecision());
-        if (temp2->isTemporary()){
-          delete temp2;
-        }
-        arg2 = &out2;
+        out_txt2.open(temp2->getFilename());
+        out_txt2.precision(temp2->getPrecision());
+        arg2 = &out_txt2;
+      }
+      if (temp2->isTemporary()){
+        delete temp2;
       }
     } else {
-      arg2 = &stream2;
+      arg2 = stream2;
     }
   }
   {
@@ -5474,8 +5493,8 @@ SWIGINTERN PyObject *_wrap_Table_PrintMatlab__SWIG_0(PyObject *SWIGUNUSEDPARM(se
   }
   resultobj = SWIG_Py_Void();
   {
-    if (use_stringio2 == 1) {
-      std::string str =  stream2.str();
+    if (stream2) {
+      std::string str =  stream2->str();
       const char* s = str.c_str();
       const int n = str.length();
       ret2 = PyObject_CallMethod(string_io2, "write", "s#",
@@ -5484,15 +5503,21 @@ SWIGINTERN PyObject *_wrap_Table_PrintMatlab__SWIG_0(PyObject *SWIGUNUSEDPARM(se
         PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
         return NULL;
       }
+      delete stream2;
       Py_XDECREF(resultobj);   /* Blow away any previous result */
       resultobj = ret2;    
     }
   }
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -5500,10 +5525,15 @@ SWIGINTERN PyObject *_wrap_Table_PrintMatlab__SWIG_0(PyObject *SWIGUNUSEDPARM(se
   return resultobj;
 fail:
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -5519,10 +5549,10 @@ SWIGINTERN PyObject *_wrap_Table_Save__SWIG_0(PyObject *SWIGUNUSEDPARM(self), Py
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyMFEM::wFILE *temp2 = 0 ;
-  std::ofstream out2 ;
-  int use_stringio2 = 0 ;
+  std::ofstream out_txt2 ;
+  mfem::ofgzstream *out_gz2 = 0 ;
   PyObject *string_io2 = 0 ;
-  std::ostringstream stream2 ;
+  std::ostringstream *stream2 = 0 ;
   PyObject *ret2 = 0 ;
   
   if ((nobjs < 2) || (nobjs > 2)) SWIG_fail;
@@ -5552,29 +5582,33 @@ SWIGINTERN PyObject *_wrap_Table_Save__SWIG_0(PyObject *SWIGUNUSEDPARM(self), Py
           SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
           return NULL;
         }
-        use_stringio2=1;
         string_io2=swig_obj[1];
+        stream2 = new std::ostringstream();
       } else {
         // if it is string, extract filename as char*
         PyObject* str = PyUnicode_AsEncodedString(swig_obj[1], "utf-8", "~E~");	
         const char* filename = PyBytes_AsString(str);
-        temp2 = new PyMFEM::wFILE(filename, 8, true);	
+        temp2 = new PyMFEM::wFILE(filename, 8, true);
+        Py_DECREF(str);	 
       }
     }
     
-    if (use_stringio2 == 0){
+    if (stream2 == 0){
       if (temp2->isSTDOUT() == 1) {
         arg2 = &std::cout;
+      } else if (temp2->isGZ()){
+        out_gz2 = new mfem::ofgzstream(temp2->getFilename(), true);
+        arg2 = out_gz2;	     
       } else {
-        out2.open(temp2->getFilename());
-        out2.precision(temp2->getPrecision());
-        if (temp2->isTemporary()){
-          delete temp2;
-        }
-        arg2 = &out2;
+        out_txt2.open(temp2->getFilename());
+        out_txt2.precision(temp2->getPrecision());
+        arg2 = &out_txt2;
+      }
+      if (temp2->isTemporary()){
+        delete temp2;
       }
     } else {
-      arg2 = &stream2;
+      arg2 = stream2;
     }
   }
   {
@@ -5595,8 +5629,8 @@ SWIGINTERN PyObject *_wrap_Table_Save__SWIG_0(PyObject *SWIGUNUSEDPARM(self), Py
   }
   resultobj = SWIG_Py_Void();
   {
-    if (use_stringio2 == 1) {
-      std::string str =  stream2.str();
+    if (stream2) {
+      std::string str =  stream2->str();
       const char* s = str.c_str();
       const int n = str.length();
       ret2 = PyObject_CallMethod(string_io2, "write", "s#",
@@ -5605,15 +5639,21 @@ SWIGINTERN PyObject *_wrap_Table_Save__SWIG_0(PyObject *SWIGUNUSEDPARM(self), Py
         PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
         return NULL;
       }
+      delete stream2;
       Py_XDECREF(resultobj);   /* Blow away any previous result */
       resultobj = ret2;    
     }
   }
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -5621,10 +5661,15 @@ SWIGINTERN PyObject *_wrap_Table_Save__SWIG_0(PyObject *SWIGUNUSEDPARM(self), Py
   return resultobj;
 fail:
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -5639,8 +5684,13 @@ SWIGINTERN PyObject *_wrap_Table_Load(PyObject *SWIGUNUSEDPARM(self), PyObject *
   std::istream *arg2 = 0 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
-  void *argp2 = 0 ;
-  int res2 = 0 ;
+  PyMFEM::wFILE *temp2 = 0 ;
+  std::ifstream in_txt2 ;
+  mfem::ifgzstream *in_gz2 = 0 ;
+  PyObject *input_str2 = 0 ;
+  std::istringstream *stream2 = 0 ;
+  Py_ssize_t len2 = 0 ;
+  PyObject *ret2 = 0 ;
   PyObject * obj0 = 0 ;
   PyObject * obj1 = 0 ;
   char * kwnames[] = {
@@ -5653,14 +5703,64 @@ SWIGINTERN PyObject *_wrap_Table_Load(PyObject *SWIGUNUSEDPARM(self), PyObject *
     SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "Table_Load" "', argument " "1"" of type '" "mfem::Table *""'"); 
   }
   arg1 = reinterpret_cast< mfem::Table * >(argp1);
-  res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_std__istream,  0 );
-  if (!SWIG_IsOK(res2)) {
-    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "Table_Load" "', argument " "2"" of type '" "std::istream &""'"); 
+  {
+    //  PyMFEM::wFILE or string argument or StringIO
+    if (SWIG_ConvertPtr(obj1, (void **) &temp2, SWIGTYPE_p_PyMFEM__wFILE, 0 | 0) == -1) {
+      if (!PyString_Check(obj1) && !PyUnicode_Check(obj1)) {
+        // not string, check if it is StringIO
+        PyObject* module = PyImport_ImportModule("io");
+        if (!module){
+          PyErr_SetString(PyExc_RuntimeError, "Can not load io module");
+          return NULL;
+        }      
+        PyObject* cls = PyObject_GetAttrString(module, "StringIO");
+        if (!cls){
+          PyErr_SetString(PyExc_RuntimeError, "Can not load StringIO");
+          return NULL;
+        }      
+        int check = PyObject_IsInstance(obj1, cls);
+        Py_DECREF(module);
+        if (! check){
+          SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
+          return NULL;
+        }
+        
+        PyObject *input_str2 = PyObject_CallMethod(obj1, "getvalue", NULL);
+        if (PyErr_Occurred()) {
+          PyErr_SetString(PyExc_RuntimeError, "Can not read from StringIO");
+          return NULL;
+        }
+        
+        char *buf = nullptr;
+        PyObject *str = PyUnicode_AsUTF8String(input_str2);	 
+        PyBytes_AsStringAndSize(str, &buf, &len2);
+        stream2 = new std::istringstream(buf);
+        Py_DECREF(str);
+        Py_DECREF(input_str2);	 
+      } else {
+        // if it is string, extract filename as char*
+        PyObject* str = PyUnicode_AsEncodedString(obj1, "utf-8", "~E~");	
+        const char* filename = PyBytes_AsString(str);
+        temp2 = new PyMFEM::wFILE(filename, 8, true);
+        Py_DECREF(str);
+      }
+    }
+    if (stream2 == 0){
+      if (temp2->isGZ()){
+        in_gz2 = new mfem::ifgzstream(temp2->getFilename());
+        arg2 = in_gz2;
+      } else {
+        in_txt2.open(temp2->getFilename(), std::ifstream::in);
+        in_txt2.precision(temp2->getPrecision());
+        arg2 = &in_txt2;
+      }
+      if (temp2->isTemporary()){
+        delete temp2;
+      }
+    } else {
+      arg2 = stream2;
+    }
   }
-  if (!argp2) {
-    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "Table_Load" "', argument " "2"" of type '" "std::istream &""'"); 
-  }
-  arg2 = reinterpret_cast< std::istream * >(argp2);
   {
     try {
       (arg1)->Load(*arg2);
@@ -5678,8 +5778,40 @@ SWIGINTERN PyObject *_wrap_Table_Load(PyObject *SWIGUNUSEDPARM(self), PyObject *
     }	 
   }
   resultobj = SWIG_Py_Void();
+  {
+    if (stream2) {
+      ret2 = PyLong_FromSsize_t(len2);
+      if (PyErr_Occurred()) {
+        PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
+        return NULL;
+      }
+      delete stream2;    
+      Py_XDECREF(resultobj);   /* Blow away any previous result */
+      resultobj = ret2;    
+    }
+  }
+  {
+    if (!stream2) {
+      if (temp2) {
+        in_txt2.close();
+      }
+      if (in_gz2){
+        delete in_gz2;
+      }
+    }  
+  }
   return resultobj;
 fail:
+  {
+    if (!stream2) {
+      if (temp2) {
+        in_txt2.close();
+      }
+      if (in_gz2){
+        delete in_gz2;
+      }
+    }  
+  }
   return NULL;
 }
 
@@ -6040,7 +6172,8 @@ SWIGINTERN PyObject *_wrap_Table_Print(PyObject *self, PyObject *args) {
               _v = 0;	   	   	   
             }
           } else {
-            _v = 0;
+            std::cout << "it is text (out)\n";	
+            _v = 1;
           }
         } else {
           _v = 1;
@@ -6217,7 +6350,8 @@ SWIGINTERN PyObject *_wrap_Table_PrintMatlab(PyObject *self, PyObject *args) {
               _v = 0;	   	   	   
             }
           } else {
-            _v = 0;
+            std::cout << "it is text (out)\n";	
+            _v = 1;
           }
         } else {
           _v = 1;
@@ -6399,7 +6533,8 @@ SWIGINTERN PyObject *_wrap_Table_Save(PyObject *self, PyObject *args) {
               _v = 0;	   	   	   
             }
           } else {
-            _v = 0;
+            std::cout << "it is text (out)\n";	
+            _v = 1;
           }
         } else {
           _v = 1;
@@ -7138,7 +7273,6 @@ static swig_type_info _swigt__p_mfem__DSTable = {"_p_mfem__DSTable", "mfem::DSTa
 static swig_type_info _swigt__p_mfem__MemoryT_int_t = {"_p_mfem__MemoryT_int_t", "mfem::Memory< int > *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_mfem__STable = {"_p_mfem__STable", "mfem::STable *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_mfem__Table = {"_p_mfem__Table", "mfem::Table *", 0, 0, (void*)0, 0};
-static swig_type_info _swigt__p_std__istream = {"_p_std__istream", "std::istream *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_void = {"_p_void", "void *", 0, 0, (void*)0, 0};
 
 static swig_type_info *swig_type_initial[] = {
@@ -7152,7 +7286,6 @@ static swig_type_info *swig_type_initial[] = {
   &_swigt__p_mfem__MemoryT_int_t,
   &_swigt__p_mfem__STable,
   &_swigt__p_mfem__Table,
-  &_swigt__p_std__istream,
   &_swigt__p_void,
 };
 
@@ -7166,7 +7299,6 @@ static swig_cast_info _swigc__p_mfem__DSTable[] = {  {&_swigt__p_mfem__DSTable, 
 static swig_cast_info _swigc__p_mfem__MemoryT_int_t[] = {  {&_swigt__p_mfem__MemoryT_int_t, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_mfem__STable[] = {  {&_swigt__p_mfem__STable, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_mfem__Table[] = {  {&_swigt__p_mfem__STable, _p_mfem__STableTo_p_mfem__Table, 0, 0},  {&_swigt__p_mfem__Table, 0, 0, 0},{0, 0, 0, 0}};
-static swig_cast_info _swigc__p_std__istream[] = {  {&_swigt__p_std__istream, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_void[] = {  {&_swigt__p_void, 0, 0, 0},{0, 0, 0, 0}};
 
 static swig_cast_info *swig_cast_initial[] = {
@@ -7180,7 +7312,6 @@ static swig_cast_info *swig_cast_initial[] = {
   _swigc__p_mfem__MemoryT_int_t,
   _swigc__p_mfem__STable,
   _swigc__p_mfem__Table,
-  _swigc__p_std__istream,
   _swigc__p_void,
 };
 

--- a/mfem/_par/table_wrap.cxx
+++ b/mfem/_par/table_wrap.cxx
@@ -5687,7 +5687,6 @@ SWIGINTERN PyObject *_wrap_Table_Load(PyObject *SWIGUNUSEDPARM(self), PyObject *
   PyMFEM::wFILE *temp2 = 0 ;
   std::ifstream in_txt2 ;
   mfem::ifgzstream *in_gz2 = 0 ;
-  PyObject *input_str2 = 0 ;
   std::istringstream *stream2 = 0 ;
   Py_ssize_t len2 = 0 ;
   PyObject *ret2 = 0 ;
@@ -5725,18 +5724,18 @@ SWIGINTERN PyObject *_wrap_Table_Load(PyObject *SWIGUNUSEDPARM(self), PyObject *
           return NULL;
         }
         
-        PyObject *input_str2 = PyObject_CallMethod(obj1, "getvalue", NULL);
+        PyObject *input_str = PyObject_CallMethod(obj1, "getvalue", NULL);
         if (PyErr_Occurred()) {
           PyErr_SetString(PyExc_RuntimeError, "Can not read from StringIO");
           return NULL;
         }
         
         char *buf = nullptr;
-        PyObject *str = PyUnicode_AsUTF8String(input_str2);	 
+        PyObject *str = PyUnicode_AsUTF8String(input_str);	 
         PyBytes_AsStringAndSize(str, &buf, &len2);
         stream2 = new std::istringstream(buf);
         Py_DECREF(str);
-        Py_DECREF(input_str2);	 
+        Py_DECREF(input_str);	 
       } else {
         // if it is string, extract filename as char*
         PyObject* str = PyUnicode_AsEncodedString(obj1, "utf-8", "~E~");	
@@ -6172,7 +6171,6 @@ SWIGINTERN PyObject *_wrap_Table_Print(PyObject *self, PyObject *args) {
               _v = 0;	   	   	   
             }
           } else {
-            std::cout << "it is text (out)\n";	
             _v = 1;
           }
         } else {
@@ -6350,7 +6348,6 @@ SWIGINTERN PyObject *_wrap_Table_PrintMatlab(PyObject *self, PyObject *args) {
               _v = 0;	   	   	   
             }
           } else {
-            std::cout << "it is text (out)\n";	
             _v = 1;
           }
         } else {
@@ -6533,7 +6530,6 @@ SWIGINTERN PyObject *_wrap_Table_Save(PyObject *self, PyObject *args) {
               _v = 0;	   	   	   
             }
           } else {
-            std::cout << "it is text (out)\n";	
             _v = 1;
           }
         } else {

--- a/mfem/_par/vector.i
+++ b/mfem/_par/vector.i
@@ -12,7 +12,8 @@
 #include <cmath>
 #include <cstring>
 #include <ctime>
-#include "../common/io_stream.hpp"             
+#include "../common/io_stream.hpp"
+#include "general/zstr.hpp"  
 #include "numpy/arrayobject.h"
 #include "linalg/vector.hpp"  
 %}

--- a/mfem/_par/vector.i
+++ b/mfem/_par/vector.i
@@ -36,6 +36,7 @@ import_array();
 
 %import "../common/io_stream_typemap.i"
 OSTREAM_TYPEMAP(std::ostream&)
+ISTREAM_TYPEMAP(std::istream&)
 
 ARRAY_TO_DOUBLEARRAY_IN(double *_data)
 

--- a/mfem/_par/vector_wrap.cxx
+++ b/mfem/_par/vector_wrap.cxx
@@ -2672,10 +2672,9 @@ SWIGINTERN PyObject *SWIG_PyStaticMethod_New(PyObject *SWIGUNUSEDPARM(self), PyO
 #define SWIGTYPE_p_mfem__Vector swig_types[6]
 #define SWIGTYPE_p_p_double swig_types[7]
 #define SWIGTYPE_p_p_std__istream swig_types[8]
-#define SWIGTYPE_p_std__istream swig_types[9]
-#define SWIGTYPE_p_void swig_types[10]
-static swig_type_info *swig_types[12];
-static swig_module_info swig_module = {swig_types, 11, 0, 0, 0, 0};
+#define SWIGTYPE_p_void swig_types[9]
+static swig_type_info *swig_types[11];
+static swig_module_info swig_module = {swig_types, 10, 0, 0, 0, 0};
 #define SWIG_TypeQuery(name) SWIG_TypeQueryModule(&swig_module, &swig_module, name)
 #define SWIG_MangledTypeQuery(name) SWIG_MangledTypeQueryModule(&swig_module, &swig_module, name)
 
@@ -4316,8 +4315,13 @@ SWIGINTERN PyObject *_wrap_Vector_Load__SWIG_1(PyObject *SWIGUNUSEDPARM(self), P
   int arg3 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
-  void *argp2 = 0 ;
-  int res2 = 0 ;
+  PyMFEM::wFILE *temp2 = 0 ;
+  std::ifstream in_txt2 ;
+  mfem::ifgzstream *in_gz2 = 0 ;
+  PyObject *input_str2 = 0 ;
+  std::istringstream *stream2 = 0 ;
+  Py_ssize_t len2 = 0 ;
+  PyObject *ret2 = 0 ;
   
   if ((nobjs < 3) || (nobjs > 3)) SWIG_fail;
   res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_mfem__Vector, 0 |  0 );
@@ -4325,14 +4329,64 @@ SWIGINTERN PyObject *_wrap_Vector_Load__SWIG_1(PyObject *SWIGUNUSEDPARM(self), P
     SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "Vector_Load" "', argument " "1"" of type '" "mfem::Vector *""'"); 
   }
   arg1 = reinterpret_cast< mfem::Vector * >(argp1);
-  res2 = SWIG_ConvertPtr(swig_obj[1], &argp2, SWIGTYPE_p_std__istream,  0 );
-  if (!SWIG_IsOK(res2)) {
-    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "Vector_Load" "', argument " "2"" of type '" "std::istream &""'"); 
+  {
+    //  PyMFEM::wFILE or string argument or StringIO
+    if (SWIG_ConvertPtr(swig_obj[1], (void **) &temp2, SWIGTYPE_p_PyMFEM__wFILE, 0 | 0) == -1) {
+      if (!PyString_Check(swig_obj[1]) && !PyUnicode_Check(swig_obj[1])) {
+        // not string, check if it is StringIO
+        PyObject* module = PyImport_ImportModule("io");
+        if (!module){
+          PyErr_SetString(PyExc_RuntimeError, "Can not load io module");
+          return NULL;
+        }      
+        PyObject* cls = PyObject_GetAttrString(module, "StringIO");
+        if (!cls){
+          PyErr_SetString(PyExc_RuntimeError, "Can not load StringIO");
+          return NULL;
+        }      
+        int check = PyObject_IsInstance(swig_obj[1], cls);
+        Py_DECREF(module);
+        if (! check){
+          SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
+          return NULL;
+        }
+        
+        PyObject *input_str2 = PyObject_CallMethod(swig_obj[1], "getvalue", NULL);
+        if (PyErr_Occurred()) {
+          PyErr_SetString(PyExc_RuntimeError, "Can not read from StringIO");
+          return NULL;
+        }
+        
+        char *buf = nullptr;
+        PyObject *str = PyUnicode_AsUTF8String(input_str2);	 
+        PyBytes_AsStringAndSize(str, &buf, &len2);
+        stream2 = new std::istringstream(buf);
+        Py_DECREF(str);
+        Py_DECREF(input_str2);	 
+      } else {
+        // if it is string, extract filename as char*
+        PyObject* str = PyUnicode_AsEncodedString(swig_obj[1], "utf-8", "~E~");	
+        const char* filename = PyBytes_AsString(str);
+        temp2 = new PyMFEM::wFILE(filename, 8, true);
+        Py_DECREF(str);
+      }
+    }
+    if (stream2 == 0){
+      if (temp2->isGZ()){
+        in_gz2 = new mfem::ifgzstream(temp2->getFilename());
+        arg2 = in_gz2;
+      } else {
+        in_txt2.open(temp2->getFilename(), std::ifstream::in);
+        in_txt2.precision(temp2->getPrecision());
+        arg2 = &in_txt2;
+      }
+      if (temp2->isTemporary()){
+        delete temp2;
+      }
+    } else {
+      arg2 = stream2;
+    }
   }
-  if (!argp2) {
-    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "Vector_Load" "', argument " "2"" of type '" "std::istream &""'"); 
-  }
-  arg2 = reinterpret_cast< std::istream * >(argp2);
   {
     if ((PyArray_PyIntAsInt(swig_obj[2]) == -1) && PyErr_Occurred()) {
       SWIG_exception_fail(SWIG_TypeError, "Input must be integer");
@@ -4356,8 +4410,40 @@ SWIGINTERN PyObject *_wrap_Vector_Load__SWIG_1(PyObject *SWIGUNUSEDPARM(self), P
     }	 
   }
   resultobj = SWIG_Py_Void();
+  {
+    if (stream2) {
+      ret2 = PyLong_FromSsize_t(len2);
+      if (PyErr_Occurred()) {
+        PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
+        return NULL;
+      }
+      delete stream2;    
+      Py_XDECREF(resultobj);   /* Blow away any previous result */
+      resultobj = ret2;    
+    }
+  }
+  {
+    if (!stream2) {
+      if (temp2) {
+        in_txt2.close();
+      }
+      if (in_gz2){
+        delete in_gz2;
+      }
+    }  
+  }
   return resultobj;
 fail:
+  {
+    if (!stream2) {
+      if (temp2) {
+        in_txt2.close();
+      }
+      if (in_gz2){
+        delete in_gz2;
+      }
+    }  
+  }
   return NULL;
 }
 
@@ -4368,8 +4454,13 @@ SWIGINTERN PyObject *_wrap_Vector_Load__SWIG_2(PyObject *SWIGUNUSEDPARM(self), P
   std::istream *arg2 = 0 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
-  void *argp2 = 0 ;
-  int res2 = 0 ;
+  PyMFEM::wFILE *temp2 = 0 ;
+  std::ifstream in_txt2 ;
+  mfem::ifgzstream *in_gz2 = 0 ;
+  PyObject *input_str2 = 0 ;
+  std::istringstream *stream2 = 0 ;
+  Py_ssize_t len2 = 0 ;
+  PyObject *ret2 = 0 ;
   
   if ((nobjs < 2) || (nobjs > 2)) SWIG_fail;
   res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_mfem__Vector, 0 |  0 );
@@ -4377,14 +4468,64 @@ SWIGINTERN PyObject *_wrap_Vector_Load__SWIG_2(PyObject *SWIGUNUSEDPARM(self), P
     SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "Vector_Load" "', argument " "1"" of type '" "mfem::Vector *""'"); 
   }
   arg1 = reinterpret_cast< mfem::Vector * >(argp1);
-  res2 = SWIG_ConvertPtr(swig_obj[1], &argp2, SWIGTYPE_p_std__istream,  0 );
-  if (!SWIG_IsOK(res2)) {
-    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "Vector_Load" "', argument " "2"" of type '" "std::istream &""'"); 
+  {
+    //  PyMFEM::wFILE or string argument or StringIO
+    if (SWIG_ConvertPtr(swig_obj[1], (void **) &temp2, SWIGTYPE_p_PyMFEM__wFILE, 0 | 0) == -1) {
+      if (!PyString_Check(swig_obj[1]) && !PyUnicode_Check(swig_obj[1])) {
+        // not string, check if it is StringIO
+        PyObject* module = PyImport_ImportModule("io");
+        if (!module){
+          PyErr_SetString(PyExc_RuntimeError, "Can not load io module");
+          return NULL;
+        }      
+        PyObject* cls = PyObject_GetAttrString(module, "StringIO");
+        if (!cls){
+          PyErr_SetString(PyExc_RuntimeError, "Can not load StringIO");
+          return NULL;
+        }      
+        int check = PyObject_IsInstance(swig_obj[1], cls);
+        Py_DECREF(module);
+        if (! check){
+          SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
+          return NULL;
+        }
+        
+        PyObject *input_str2 = PyObject_CallMethod(swig_obj[1], "getvalue", NULL);
+        if (PyErr_Occurred()) {
+          PyErr_SetString(PyExc_RuntimeError, "Can not read from StringIO");
+          return NULL;
+        }
+        
+        char *buf = nullptr;
+        PyObject *str = PyUnicode_AsUTF8String(input_str2);	 
+        PyBytes_AsStringAndSize(str, &buf, &len2);
+        stream2 = new std::istringstream(buf);
+        Py_DECREF(str);
+        Py_DECREF(input_str2);	 
+      } else {
+        // if it is string, extract filename as char*
+        PyObject* str = PyUnicode_AsEncodedString(swig_obj[1], "utf-8", "~E~");	
+        const char* filename = PyBytes_AsString(str);
+        temp2 = new PyMFEM::wFILE(filename, 8, true);
+        Py_DECREF(str);
+      }
+    }
+    if (stream2 == 0){
+      if (temp2->isGZ()){
+        in_gz2 = new mfem::ifgzstream(temp2->getFilename());
+        arg2 = in_gz2;
+      } else {
+        in_txt2.open(temp2->getFilename(), std::ifstream::in);
+        in_txt2.precision(temp2->getPrecision());
+        arg2 = &in_txt2;
+      }
+      if (temp2->isTemporary()){
+        delete temp2;
+      }
+    } else {
+      arg2 = stream2;
+    }
   }
-  if (!argp2) {
-    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "Vector_Load" "', argument " "2"" of type '" "std::istream &""'"); 
-  }
-  arg2 = reinterpret_cast< std::istream * >(argp2);
   {
     try {
       (arg1)->Load(*arg2);
@@ -4402,8 +4543,40 @@ SWIGINTERN PyObject *_wrap_Vector_Load__SWIG_2(PyObject *SWIGUNUSEDPARM(self), P
     }	 
   }
   resultobj = SWIG_Py_Void();
+  {
+    if (stream2) {
+      ret2 = PyLong_FromSsize_t(len2);
+      if (PyErr_Occurred()) {
+        PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
+        return NULL;
+      }
+      delete stream2;    
+      Py_XDECREF(resultobj);   /* Blow away any previous result */
+      resultobj = ret2;    
+    }
+  }
+  {
+    if (!stream2) {
+      if (temp2) {
+        in_txt2.close();
+      }
+      if (in_gz2){
+        delete in_gz2;
+      }
+    }  
+  }
   return resultobj;
 fail:
+  {
+    if (!stream2) {
+      if (temp2) {
+        in_txt2.close();
+      }
+      if (in_gz2){
+        delete in_gz2;
+      }
+    }  
+  }
   return NULL;
 }
 
@@ -4422,9 +4595,34 @@ SWIGINTERN PyObject *_wrap_Vector_Load(PyObject *self, PyObject *args) {
     int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_mfem__Vector, 0);
     _v = SWIG_CheckState(res);
     if (_v) {
-      void *vptr = 0;
-      int res = SWIG_ConvertPtr(argv[1], &vptr, SWIGTYPE_p_std__istream, SWIG_POINTER_NO_NULL);
-      _v = SWIG_CheckState(res);
+      {
+        void *ptr;
+        //std::string *ptr2 = (std::string *)0;
+        if (SWIG_ConvertPtr(argv[1], (void **) &ptr, SWIGTYPE_p_PyMFEM__wFILE, 0 |0) == -1) {
+          PyErr_Clear();
+          if (!PyString_Check(argv[1]) && !PyUnicode_Check(argv[1])) {
+            // not string
+            _v = 1;	   	
+            PyObject* module = PyImport_ImportModule("io");
+            if (!module){
+              _v = 0;	   
+            }      
+            PyObject* cls = PyObject_GetAttrString(module, "StringIO");
+            if (!cls){
+              _v = 0;	   	   
+            }      
+            int check = PyObject_IsInstance(argv[1], cls);
+            Py_DECREF(module);
+            if (! check){
+              _v = 0;	   	   	   
+            }
+          } else {
+            _v = 1;
+          }
+        } else {
+          _v = 1;
+        }
+      }
       if (_v) {
         return _wrap_Vector_Load__SWIG_2(self, argc, argv);
       }
@@ -4436,9 +4634,34 @@ SWIGINTERN PyObject *_wrap_Vector_Load(PyObject *self, PyObject *args) {
     int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_mfem__Vector, 0);
     _v = SWIG_CheckState(res);
     if (_v) {
-      void *vptr = 0;
-      int res = SWIG_ConvertPtr(argv[1], &vptr, SWIGTYPE_p_std__istream, SWIG_POINTER_NO_NULL);
-      _v = SWIG_CheckState(res);
+      {
+        void *ptr;
+        //std::string *ptr2 = (std::string *)0;
+        if (SWIG_ConvertPtr(argv[1], (void **) &ptr, SWIGTYPE_p_PyMFEM__wFILE, 0 |0) == -1) {
+          PyErr_Clear();
+          if (!PyString_Check(argv[1]) && !PyUnicode_Check(argv[1])) {
+            // not string
+            _v = 1;	   	
+            PyObject* module = PyImport_ImportModule("io");
+            if (!module){
+              _v = 0;	   
+            }      
+            PyObject* cls = PyObject_GetAttrString(module, "StringIO");
+            if (!cls){
+              _v = 0;	   	   
+            }      
+            int check = PyObject_IsInstance(argv[1], cls);
+            Py_DECREF(module);
+            if (! check){
+              _v = 0;	   	   	   
+            }
+          } else {
+            _v = 1;
+          }
+        } else {
+          _v = 1;
+        }
+      }
       if (_v) {
         {
           if ((PyArray_PyIntAsInt(argv[2]) == -1) && PyErr_Occurred()) {
@@ -7549,10 +7772,10 @@ SWIGINTERN PyObject *_wrap_Vector_Print__SWIG_0(PyObject *SWIGUNUSEDPARM(self), 
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyMFEM::wFILE *temp2 = 0 ;
-  std::ofstream out2 ;
-  int use_stringio2 = 0 ;
+  std::ofstream out_txt2 ;
+  mfem::ofgzstream *out_gz2 = 0 ;
   PyObject *string_io2 = 0 ;
-  std::ostringstream stream2 ;
+  std::ostringstream *stream2 = 0 ;
   PyObject *ret2 = 0 ;
   
   if ((nobjs < 1) || (nobjs > 3)) SWIG_fail;
@@ -7583,29 +7806,33 @@ SWIGINTERN PyObject *_wrap_Vector_Print__SWIG_0(PyObject *SWIGUNUSEDPARM(self), 
             SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
             return NULL;
           }
-          use_stringio2=1;
           string_io2=swig_obj[1];
+          stream2 = new std::ostringstream();
         } else {
           // if it is string, extract filename as char*
           PyObject* str = PyUnicode_AsEncodedString(swig_obj[1], "utf-8", "~E~");	
           const char* filename = PyBytes_AsString(str);
-          temp2 = new PyMFEM::wFILE(filename, 8, true);	
+          temp2 = new PyMFEM::wFILE(filename, 8, true);
+          Py_DECREF(str);	 
         }
       }
       
-      if (use_stringio2 == 0){
+      if (stream2 == 0){
         if (temp2->isSTDOUT() == 1) {
           arg2 = &std::cout;
+        } else if (temp2->isGZ()){
+          out_gz2 = new mfem::ofgzstream(temp2->getFilename(), true);
+          arg2 = out_gz2;	     
         } else {
-          out2.open(temp2->getFilename());
-          out2.precision(temp2->getPrecision());
-          if (temp2->isTemporary()){
-            delete temp2;
-          }
-          arg2 = &out2;
+          out_txt2.open(temp2->getFilename());
+          out_txt2.precision(temp2->getPrecision());
+          arg2 = &out_txt2;
+        }
+        if (temp2->isTemporary()){
+          delete temp2;
         }
       } else {
-        arg2 = &stream2;
+        arg2 = stream2;
       }
     }
   }
@@ -7635,8 +7862,8 @@ SWIGINTERN PyObject *_wrap_Vector_Print__SWIG_0(PyObject *SWIGUNUSEDPARM(self), 
   }
   resultobj = SWIG_Py_Void();
   {
-    if (use_stringio2 == 1) {
-      std::string str =  stream2.str();
+    if (stream2) {
+      std::string str =  stream2->str();
       const char* s = str.c_str();
       const int n = str.length();
       ret2 = PyObject_CallMethod(string_io2, "write", "s#",
@@ -7645,15 +7872,21 @@ SWIGINTERN PyObject *_wrap_Vector_Print__SWIG_0(PyObject *SWIGUNUSEDPARM(self), 
         PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
         return NULL;
       }
+      delete stream2;
       Py_XDECREF(resultobj);   /* Blow away any previous result */
       resultobj = ret2;    
     }
   }
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -7661,10 +7894,15 @@ SWIGINTERN PyObject *_wrap_Vector_Print__SWIG_0(PyObject *SWIGUNUSEDPARM(self), 
   return resultobj;
 fail:
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -7680,10 +7918,10 @@ SWIGINTERN PyObject *_wrap_Vector_Print_HYPRE__SWIG_0(PyObject *SWIGUNUSEDPARM(s
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyMFEM::wFILE *temp2 = 0 ;
-  std::ofstream out2 ;
-  int use_stringio2 = 0 ;
+  std::ofstream out_txt2 ;
+  mfem::ofgzstream *out_gz2 = 0 ;
   PyObject *string_io2 = 0 ;
-  std::ostringstream stream2 ;
+  std::ostringstream *stream2 = 0 ;
   PyObject *ret2 = 0 ;
   
   if ((nobjs < 2) || (nobjs > 2)) SWIG_fail;
@@ -7713,29 +7951,33 @@ SWIGINTERN PyObject *_wrap_Vector_Print_HYPRE__SWIG_0(PyObject *SWIGUNUSEDPARM(s
           SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
           return NULL;
         }
-        use_stringio2=1;
         string_io2=swig_obj[1];
+        stream2 = new std::ostringstream();
       } else {
         // if it is string, extract filename as char*
         PyObject* str = PyUnicode_AsEncodedString(swig_obj[1], "utf-8", "~E~");	
         const char* filename = PyBytes_AsString(str);
-        temp2 = new PyMFEM::wFILE(filename, 8, true);	
+        temp2 = new PyMFEM::wFILE(filename, 8, true);
+        Py_DECREF(str);	 
       }
     }
     
-    if (use_stringio2 == 0){
+    if (stream2 == 0){
       if (temp2->isSTDOUT() == 1) {
         arg2 = &std::cout;
+      } else if (temp2->isGZ()){
+        out_gz2 = new mfem::ofgzstream(temp2->getFilename(), true);
+        arg2 = out_gz2;	     
       } else {
-        out2.open(temp2->getFilename());
-        out2.precision(temp2->getPrecision());
-        if (temp2->isTemporary()){
-          delete temp2;
-        }
-        arg2 = &out2;
+        out_txt2.open(temp2->getFilename());
+        out_txt2.precision(temp2->getPrecision());
+        arg2 = &out_txt2;
+      }
+      if (temp2->isTemporary()){
+        delete temp2;
       }
     } else {
-      arg2 = &stream2;
+      arg2 = stream2;
     }
   }
   {
@@ -7756,8 +7998,8 @@ SWIGINTERN PyObject *_wrap_Vector_Print_HYPRE__SWIG_0(PyObject *SWIGUNUSEDPARM(s
   }
   resultobj = SWIG_Py_Void();
   {
-    if (use_stringio2 == 1) {
-      std::string str =  stream2.str();
+    if (stream2) {
+      std::string str =  stream2->str();
       const char* s = str.c_str();
       const int n = str.length();
       ret2 = PyObject_CallMethod(string_io2, "write", "s#",
@@ -7766,15 +8008,21 @@ SWIGINTERN PyObject *_wrap_Vector_Print_HYPRE__SWIG_0(PyObject *SWIGUNUSEDPARM(s
         PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
         return NULL;
       }
+      delete stream2;
       Py_XDECREF(resultobj);   /* Blow away any previous result */
       resultobj = ret2;    
     }
   }
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -7782,10 +8030,15 @@ SWIGINTERN PyObject *_wrap_Vector_Print_HYPRE__SWIG_0(PyObject *SWIGUNUSEDPARM(s
   return resultobj;
 fail:
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -9147,7 +9400,8 @@ SWIGINTERN PyObject *_wrap_Vector_Print(PyObject *self, PyObject *args) {
               _v = 0;	   	   	   
             }
           } else {
-            _v = 0;
+            std::cout << "it is text (out)\n";	
+            _v = 1;
           }
         } else {
           _v = 1;
@@ -9368,7 +9622,8 @@ SWIGINTERN PyObject *_wrap_Vector_Print_HYPRE(PyObject *self, PyObject *args) {
               _v = 0;	   	   	   
             }
           } else {
-            _v = 0;
+            std::cout << "it is text (out)\n";	
+            _v = 1;
           }
         } else {
           _v = 1;
@@ -9863,7 +10118,6 @@ static swig_type_info _swigt__p_mfem__MemoryT_double_t = {"_p_mfem__MemoryT_doub
 static swig_type_info _swigt__p_mfem__Vector = {"_p_mfem__Vector", "mfem::Vector *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_p_double = {"_p_p_double", "double **", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_p_std__istream = {"_p_p_std__istream", "std::istream **", 0, 0, (void*)0, 0};
-static swig_type_info _swigt__p_std__istream = {"_p_std__istream", "std::istream *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_void = {"_p_void", "void *", 0, 0, (void*)0, 0};
 
 static swig_type_info *swig_type_initial[] = {
@@ -9876,7 +10130,6 @@ static swig_type_info *swig_type_initial[] = {
   &_swigt__p_mfem__Vector,
   &_swigt__p_p_double,
   &_swigt__p_p_std__istream,
-  &_swigt__p_std__istream,
   &_swigt__p_void,
 };
 
@@ -9889,7 +10142,6 @@ static swig_cast_info _swigc__p_mfem__MemoryT_double_t[] = {  {&_swigt__p_mfem__
 static swig_cast_info _swigc__p_mfem__Vector[] = {  {&_swigt__p_mfem__Vector, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_p_double[] = {  {&_swigt__p_p_double, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_p_std__istream[] = {  {&_swigt__p_p_std__istream, 0, 0, 0},{0, 0, 0, 0}};
-static swig_cast_info _swigc__p_std__istream[] = {  {&_swigt__p_std__istream, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_void[] = {  {&_swigt__p_void, 0, 0, 0},{0, 0, 0, 0}};
 
 static swig_cast_info *swig_cast_initial[] = {
@@ -9902,7 +10154,6 @@ static swig_cast_info *swig_cast_initial[] = {
   _swigc__p_mfem__Vector,
   _swigc__p_p_double,
   _swigc__p_p_std__istream,
-  _swigc__p_std__istream,
   _swigc__p_void,
 };
 

--- a/mfem/_par/vector_wrap.cxx
+++ b/mfem/_par/vector_wrap.cxx
@@ -2784,7 +2784,8 @@ namespace swig {
 #include <cmath>
 #include <cstring>
 #include <ctime>
-#include "../common/io_stream.hpp"             
+#include "../common/io_stream.hpp"
+#include "general/zstr.hpp"  
 #include "numpy/arrayobject.h"
 #include "linalg/vector.hpp"  
 
@@ -4318,7 +4319,6 @@ SWIGINTERN PyObject *_wrap_Vector_Load__SWIG_1(PyObject *SWIGUNUSEDPARM(self), P
   PyMFEM::wFILE *temp2 = 0 ;
   std::ifstream in_txt2 ;
   mfem::ifgzstream *in_gz2 = 0 ;
-  PyObject *input_str2 = 0 ;
   std::istringstream *stream2 = 0 ;
   Py_ssize_t len2 = 0 ;
   PyObject *ret2 = 0 ;
@@ -4351,18 +4351,18 @@ SWIGINTERN PyObject *_wrap_Vector_Load__SWIG_1(PyObject *SWIGUNUSEDPARM(self), P
           return NULL;
         }
         
-        PyObject *input_str2 = PyObject_CallMethod(swig_obj[1], "getvalue", NULL);
+        PyObject *input_str = PyObject_CallMethod(swig_obj[1], "getvalue", NULL);
         if (PyErr_Occurred()) {
           PyErr_SetString(PyExc_RuntimeError, "Can not read from StringIO");
           return NULL;
         }
         
         char *buf = nullptr;
-        PyObject *str = PyUnicode_AsUTF8String(input_str2);	 
+        PyObject *str = PyUnicode_AsUTF8String(input_str);	 
         PyBytes_AsStringAndSize(str, &buf, &len2);
         stream2 = new std::istringstream(buf);
         Py_DECREF(str);
-        Py_DECREF(input_str2);	 
+        Py_DECREF(input_str);	 
       } else {
         // if it is string, extract filename as char*
         PyObject* str = PyUnicode_AsEncodedString(swig_obj[1], "utf-8", "~E~");	
@@ -4457,7 +4457,6 @@ SWIGINTERN PyObject *_wrap_Vector_Load__SWIG_2(PyObject *SWIGUNUSEDPARM(self), P
   PyMFEM::wFILE *temp2 = 0 ;
   std::ifstream in_txt2 ;
   mfem::ifgzstream *in_gz2 = 0 ;
-  PyObject *input_str2 = 0 ;
   std::istringstream *stream2 = 0 ;
   Py_ssize_t len2 = 0 ;
   PyObject *ret2 = 0 ;
@@ -4490,18 +4489,18 @@ SWIGINTERN PyObject *_wrap_Vector_Load__SWIG_2(PyObject *SWIGUNUSEDPARM(self), P
           return NULL;
         }
         
-        PyObject *input_str2 = PyObject_CallMethod(swig_obj[1], "getvalue", NULL);
+        PyObject *input_str = PyObject_CallMethod(swig_obj[1], "getvalue", NULL);
         if (PyErr_Occurred()) {
           PyErr_SetString(PyExc_RuntimeError, "Can not read from StringIO");
           return NULL;
         }
         
         char *buf = nullptr;
-        PyObject *str = PyUnicode_AsUTF8String(input_str2);	 
+        PyObject *str = PyUnicode_AsUTF8String(input_str);	 
         PyBytes_AsStringAndSize(str, &buf, &len2);
         stream2 = new std::istringstream(buf);
         Py_DECREF(str);
-        Py_DECREF(input_str2);	 
+        Py_DECREF(input_str);	 
       } else {
         // if it is string, extract filename as char*
         PyObject* str = PyUnicode_AsEncodedString(swig_obj[1], "utf-8", "~E~");	
@@ -9400,7 +9399,6 @@ SWIGINTERN PyObject *_wrap_Vector_Print(PyObject *self, PyObject *args) {
               _v = 0;	   	   	   
             }
           } else {
-            std::cout << "it is text (out)\n";	
             _v = 1;
           }
         } else {
@@ -9622,7 +9620,6 @@ SWIGINTERN PyObject *_wrap_Vector_Print_HYPRE(PyObject *self, PyObject *args) {
               _v = 0;	   	   	   
             }
           } else {
-            std::cout << "it is text (out)\n";	
             _v = 1;
           }
         } else {

--- a/mfem/_ser/array.i
+++ b/mfem/_ser/array.i
@@ -7,7 +7,8 @@
 #include <fstream>  
 #include <iostream>
 #include <stdio.h>
-#include "../common/io_stream.hpp"    
+#include "../common/io_stream.hpp"
+#include "general/zstr.hpp"
 #include "general/array.hpp"  
 #include "numpy/arrayobject.h"    
 %}
@@ -24,6 +25,7 @@ import_array();
 
 %import "../common/io_stream_typemap.i"
 OSTREAM_TYPEMAP(std::ostream&)
+ISTREAM_TYPEMAP(std::istream&)
 
 %import "mem_manager.i"
 

--- a/mfem/_ser/array_wrap.cxx
+++ b/mfem/_ser/array_wrap.cxx
@@ -2675,9 +2675,8 @@ SWIGINTERN PyObject *SWIG_PyStaticMethod_New(PyObject *SWIGUNUSEDPARM(self), PyO
 #define SWIGTYPE_p_mfem__MemoryT_int_t swig_types[9]
 #define SWIGTYPE_p_p_double swig_types[10]
 #define SWIGTYPE_p_p_int swig_types[11]
-#define SWIGTYPE_p_std__istream swig_types[12]
-static swig_type_info *swig_types[14];
-static swig_module_info swig_module = {swig_types, 13, 0, 0, 0, 0};
+static swig_type_info *swig_types[13];
+static swig_module_info swig_module = {swig_types, 12, 0, 0, 0, 0};
 #define SWIG_TypeQuery(name) SWIG_TypeQueryModule(&swig_module, &swig_module, name)
 #define SWIG_MangledTypeQuery(name) SWIG_MangledTypeQueryModule(&swig_module, &swig_module, name)
 
@@ -2784,7 +2783,8 @@ namespace swig {
 #include <fstream>  
 #include <iostream>
 #include <stdio.h>
-#include "../common/io_stream.hpp"    
+#include "../common/io_stream.hpp"
+#include "general/zstr.hpp"
 #include "general/array.hpp"  
 #include "numpy/arrayobject.h"    
 
@@ -5146,10 +5146,10 @@ SWIGINTERN PyObject *_wrap_intArray_Print__SWIG_0(PyObject *SWIGUNUSEDPARM(self)
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyMFEM::wFILE *temp2 = 0 ;
-  std::ofstream out2 ;
-  int use_stringio2 = 0 ;
+  std::ofstream out_txt2 ;
+  mfem::ofgzstream *out_gz2 = 0 ;
   PyObject *string_io2 = 0 ;
-  std::ostringstream stream2 ;
+  std::ostringstream *stream2 = 0 ;
   PyObject *ret2 = 0 ;
   int val3 ;
   int ecode3 = 0 ;
@@ -5182,29 +5182,33 @@ SWIGINTERN PyObject *_wrap_intArray_Print__SWIG_0(PyObject *SWIGUNUSEDPARM(self)
             SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
             return NULL;
           }
-          use_stringio2=1;
           string_io2=swig_obj[1];
+          stream2 = new std::ostringstream();
         } else {
           // if it is string, extract filename as char*
           PyObject* str = PyUnicode_AsEncodedString(swig_obj[1], "utf-8", "~E~");	
           const char* filename = PyBytes_AsString(str);
-          temp2 = new PyMFEM::wFILE(filename, 8, true);	
+          temp2 = new PyMFEM::wFILE(filename, 8, true);
+          Py_DECREF(str);	 
         }
       }
       
-      if (use_stringio2 == 0){
+      if (stream2 == 0){
         if (temp2->isSTDOUT() == 1) {
           arg2 = &std::cout;
+        } else if (temp2->isGZ()){
+          out_gz2 = new mfem::ofgzstream(temp2->getFilename(), true);
+          arg2 = out_gz2;	     
         } else {
-          out2.open(temp2->getFilename());
-          out2.precision(temp2->getPrecision());
-          if (temp2->isTemporary()){
-            delete temp2;
-          }
-          arg2 = &out2;
+          out_txt2.open(temp2->getFilename());
+          out_txt2.precision(temp2->getPrecision());
+          arg2 = &out_txt2;
+        }
+        if (temp2->isTemporary()){
+          delete temp2;
         }
       } else {
-        arg2 = &stream2;
+        arg2 = stream2;
       }
     }
   }
@@ -5233,8 +5237,8 @@ SWIGINTERN PyObject *_wrap_intArray_Print__SWIG_0(PyObject *SWIGUNUSEDPARM(self)
   }
   resultobj = SWIG_Py_Void();
   {
-    if (use_stringio2 == 1) {
-      std::string str =  stream2.str();
+    if (stream2) {
+      std::string str =  stream2->str();
       const char* s = str.c_str();
       const int n = str.length();
       ret2 = PyObject_CallMethod(string_io2, "write", "s#",
@@ -5243,15 +5247,21 @@ SWIGINTERN PyObject *_wrap_intArray_Print__SWIG_0(PyObject *SWIGUNUSEDPARM(self)
         PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
         return NULL;
       }
+      delete stream2;
       Py_XDECREF(resultobj);   /* Blow away any previous result */
       resultobj = ret2;    
     }
   }
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -5259,10 +5269,15 @@ SWIGINTERN PyObject *_wrap_intArray_Print__SWIG_0(PyObject *SWIGUNUSEDPARM(self)
   return resultobj;
 fail:
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -5279,10 +5294,10 @@ SWIGINTERN PyObject *_wrap_intArray_Save__SWIG_0(PyObject *SWIGUNUSEDPARM(self),
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyMFEM::wFILE *temp2 = 0 ;
-  std::ofstream out2 ;
-  int use_stringio2 = 0 ;
+  std::ofstream out_txt2 ;
+  mfem::ofgzstream *out_gz2 = 0 ;
   PyObject *string_io2 = 0 ;
-  std::ostringstream stream2 ;
+  std::ostringstream *stream2 = 0 ;
   PyObject *ret2 = 0 ;
   int val3 ;
   int ecode3 = 0 ;
@@ -5314,29 +5329,33 @@ SWIGINTERN PyObject *_wrap_intArray_Save__SWIG_0(PyObject *SWIGUNUSEDPARM(self),
           SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
           return NULL;
         }
-        use_stringio2=1;
         string_io2=swig_obj[1];
+        stream2 = new std::ostringstream();
       } else {
         // if it is string, extract filename as char*
         PyObject* str = PyUnicode_AsEncodedString(swig_obj[1], "utf-8", "~E~");	
         const char* filename = PyBytes_AsString(str);
-        temp2 = new PyMFEM::wFILE(filename, 8, true);	
+        temp2 = new PyMFEM::wFILE(filename, 8, true);
+        Py_DECREF(str);	 
       }
     }
     
-    if (use_stringio2 == 0){
+    if (stream2 == 0){
       if (temp2->isSTDOUT() == 1) {
         arg2 = &std::cout;
+      } else if (temp2->isGZ()){
+        out_gz2 = new mfem::ofgzstream(temp2->getFilename(), true);
+        arg2 = out_gz2;	     
       } else {
-        out2.open(temp2->getFilename());
-        out2.precision(temp2->getPrecision());
-        if (temp2->isTemporary()){
-          delete temp2;
-        }
-        arg2 = &out2;
+        out_txt2.open(temp2->getFilename());
+        out_txt2.precision(temp2->getPrecision());
+        arg2 = &out_txt2;
+      }
+      if (temp2->isTemporary()){
+        delete temp2;
       }
     } else {
-      arg2 = &stream2;
+      arg2 = stream2;
     }
   }
   if (swig_obj[2]) {
@@ -5364,8 +5383,8 @@ SWIGINTERN PyObject *_wrap_intArray_Save__SWIG_0(PyObject *SWIGUNUSEDPARM(self),
   }
   resultobj = SWIG_Py_Void();
   {
-    if (use_stringio2 == 1) {
-      std::string str =  stream2.str();
+    if (stream2) {
+      std::string str =  stream2->str();
       const char* s = str.c_str();
       const int n = str.length();
       ret2 = PyObject_CallMethod(string_io2, "write", "s#",
@@ -5374,15 +5393,21 @@ SWIGINTERN PyObject *_wrap_intArray_Save__SWIG_0(PyObject *SWIGUNUSEDPARM(self),
         PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
         return NULL;
       }
+      delete stream2;
       Py_XDECREF(resultobj);   /* Blow away any previous result */
       resultobj = ret2;    
     }
   }
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -5390,10 +5415,15 @@ SWIGINTERN PyObject *_wrap_intArray_Save__SWIG_0(PyObject *SWIGUNUSEDPARM(self),
   return resultobj;
 fail:
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -5409,8 +5439,13 @@ SWIGINTERN PyObject *_wrap_intArray_Load__SWIG_0(PyObject *SWIGUNUSEDPARM(self),
   int arg3 = (int) 0 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
-  void *argp2 = 0 ;
-  int res2 = 0 ;
+  PyMFEM::wFILE *temp2 = 0 ;
+  std::ifstream in_txt2 ;
+  mfem::ifgzstream *in_gz2 = 0 ;
+  PyObject *input_str2 = 0 ;
+  std::istringstream *stream2 = 0 ;
+  Py_ssize_t len2 = 0 ;
+  PyObject *ret2 = 0 ;
   int val3 ;
   int ecode3 = 0 ;
   
@@ -5420,14 +5455,64 @@ SWIGINTERN PyObject *_wrap_intArray_Load__SWIG_0(PyObject *SWIGUNUSEDPARM(self),
     SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "intArray_Load" "', argument " "1"" of type '" "mfem::Array< int > *""'"); 
   }
   arg1 = reinterpret_cast< mfem::Array< int > * >(argp1);
-  res2 = SWIG_ConvertPtr(swig_obj[1], &argp2, SWIGTYPE_p_std__istream,  0 );
-  if (!SWIG_IsOK(res2)) {
-    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "intArray_Load" "', argument " "2"" of type '" "std::istream &""'"); 
+  {
+    //  PyMFEM::wFILE or string argument or StringIO
+    if (SWIG_ConvertPtr(swig_obj[1], (void **) &temp2, SWIGTYPE_p_PyMFEM__wFILE, 0 | 0) == -1) {
+      if (!PyString_Check(swig_obj[1]) && !PyUnicode_Check(swig_obj[1])) {
+        // not string, check if it is StringIO
+        PyObject* module = PyImport_ImportModule("io");
+        if (!module){
+          PyErr_SetString(PyExc_RuntimeError, "Can not load io module");
+          return NULL;
+        }      
+        PyObject* cls = PyObject_GetAttrString(module, "StringIO");
+        if (!cls){
+          PyErr_SetString(PyExc_RuntimeError, "Can not load StringIO");
+          return NULL;
+        }      
+        int check = PyObject_IsInstance(swig_obj[1], cls);
+        Py_DECREF(module);
+        if (! check){
+          SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
+          return NULL;
+        }
+        
+        PyObject *input_str2 = PyObject_CallMethod(swig_obj[1], "getvalue", NULL);
+        if (PyErr_Occurred()) {
+          PyErr_SetString(PyExc_RuntimeError, "Can not read from StringIO");
+          return NULL;
+        }
+        
+        char *buf = nullptr;
+        PyObject *str = PyUnicode_AsUTF8String(input_str2);	 
+        PyBytes_AsStringAndSize(str, &buf, &len2);
+        stream2 = new std::istringstream(buf);
+        Py_DECREF(str);
+        Py_DECREF(input_str2);	 
+      } else {
+        // if it is string, extract filename as char*
+        PyObject* str = PyUnicode_AsEncodedString(swig_obj[1], "utf-8", "~E~");	
+        const char* filename = PyBytes_AsString(str);
+        temp2 = new PyMFEM::wFILE(filename, 8, true);
+        Py_DECREF(str);
+      }
+    }
+    if (stream2 == 0){
+      if (temp2->isGZ()){
+        in_gz2 = new mfem::ifgzstream(temp2->getFilename());
+        arg2 = in_gz2;
+      } else {
+        in_txt2.open(temp2->getFilename(), std::ifstream::in);
+        in_txt2.precision(temp2->getPrecision());
+        arg2 = &in_txt2;
+      }
+      if (temp2->isTemporary()){
+        delete temp2;
+      }
+    } else {
+      arg2 = stream2;
+    }
   }
-  if (!argp2) {
-    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "intArray_Load" "', argument " "2"" of type '" "std::istream &""'"); 
-  }
-  arg2 = reinterpret_cast< std::istream * >(argp2);
   if (swig_obj[2]) {
     ecode3 = SWIG_AsVal_int(swig_obj[2], &val3);
     if (!SWIG_IsOK(ecode3)) {
@@ -5452,8 +5537,40 @@ SWIGINTERN PyObject *_wrap_intArray_Load__SWIG_0(PyObject *SWIGUNUSEDPARM(self),
     }	 
   }
   resultobj = SWIG_Py_Void();
+  {
+    if (stream2) {
+      ret2 = PyLong_FromSsize_t(len2);
+      if (PyErr_Occurred()) {
+        PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
+        return NULL;
+      }
+      delete stream2;    
+      Py_XDECREF(resultobj);   /* Blow away any previous result */
+      resultobj = ret2;    
+    }
+  }
+  {
+    if (!stream2) {
+      if (temp2) {
+        in_txt2.close();
+      }
+      if (in_gz2){
+        delete in_gz2;
+      }
+    }  
+  }
   return resultobj;
 fail:
+  {
+    if (!stream2) {
+      if (temp2) {
+        in_txt2.close();
+      }
+      if (in_gz2){
+        delete in_gz2;
+      }
+    }  
+  }
   return NULL;
 }
 
@@ -5467,8 +5584,13 @@ SWIGINTERN PyObject *_wrap_intArray_Load__SWIG_1(PyObject *SWIGUNUSEDPARM(self),
   int res1 = 0 ;
   int val2 ;
   int ecode2 = 0 ;
-  void *argp3 = 0 ;
-  int res3 = 0 ;
+  PyMFEM::wFILE *temp3 = 0 ;
+  std::ifstream in_txt3 ;
+  mfem::ifgzstream *in_gz3 = 0 ;
+  PyObject *input_str3 = 0 ;
+  std::istringstream *stream3 = 0 ;
+  Py_ssize_t len3 = 0 ;
+  PyObject *ret3 = 0 ;
   
   if ((nobjs < 3) || (nobjs > 3)) SWIG_fail;
   res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_mfem__ArrayT_int_t, 0 |  0 );
@@ -5481,14 +5603,64 @@ SWIGINTERN PyObject *_wrap_intArray_Load__SWIG_1(PyObject *SWIGUNUSEDPARM(self),
     SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "intArray_Load" "', argument " "2"" of type '" "int""'");
   } 
   arg2 = static_cast< int >(val2);
-  res3 = SWIG_ConvertPtr(swig_obj[2], &argp3, SWIGTYPE_p_std__istream,  0 );
-  if (!SWIG_IsOK(res3)) {
-    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "intArray_Load" "', argument " "3"" of type '" "std::istream &""'"); 
+  {
+    //  PyMFEM::wFILE or string argument or StringIO
+    if (SWIG_ConvertPtr(swig_obj[2], (void **) &temp3, SWIGTYPE_p_PyMFEM__wFILE, 0 | 0) == -1) {
+      if (!PyString_Check(swig_obj[2]) && !PyUnicode_Check(swig_obj[2])) {
+        // not string, check if it is StringIO
+        PyObject* module = PyImport_ImportModule("io");
+        if (!module){
+          PyErr_SetString(PyExc_RuntimeError, "Can not load io module");
+          return NULL;
+        }      
+        PyObject* cls = PyObject_GetAttrString(module, "StringIO");
+        if (!cls){
+          PyErr_SetString(PyExc_RuntimeError, "Can not load StringIO");
+          return NULL;
+        }      
+        int check = PyObject_IsInstance(swig_obj[2], cls);
+        Py_DECREF(module);
+        if (! check){
+          SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
+          return NULL;
+        }
+        
+        PyObject *input_str3 = PyObject_CallMethod(swig_obj[2], "getvalue", NULL);
+        if (PyErr_Occurred()) {
+          PyErr_SetString(PyExc_RuntimeError, "Can not read from StringIO");
+          return NULL;
+        }
+        
+        char *buf = nullptr;
+        PyObject *str = PyUnicode_AsUTF8String(input_str3);	 
+        PyBytes_AsStringAndSize(str, &buf, &len3);
+        stream3 = new std::istringstream(buf);
+        Py_DECREF(str);
+        Py_DECREF(input_str3);	 
+      } else {
+        // if it is string, extract filename as char*
+        PyObject* str = PyUnicode_AsEncodedString(swig_obj[2], "utf-8", "~E~");	
+        const char* filename = PyBytes_AsString(str);
+        temp3 = new PyMFEM::wFILE(filename, 8, true);
+        Py_DECREF(str);
+      }
+    }
+    if (stream3 == 0){
+      if (temp3->isGZ()){
+        in_gz3 = new mfem::ifgzstream(temp3->getFilename());
+        arg3 = in_gz3;
+      } else {
+        in_txt3.open(temp3->getFilename(), std::ifstream::in);
+        in_txt3.precision(temp3->getPrecision());
+        arg3 = &in_txt3;
+      }
+      if (temp3->isTemporary()){
+        delete temp3;
+      }
+    } else {
+      arg3 = stream3;
+    }
   }
-  if (!argp3) {
-    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "intArray_Load" "', argument " "3"" of type '" "std::istream &""'"); 
-  }
-  arg3 = reinterpret_cast< std::istream * >(argp3);
   {
     try {
       (arg1)->Load(arg2,*arg3);
@@ -5506,8 +5678,40 @@ SWIGINTERN PyObject *_wrap_intArray_Load__SWIG_1(PyObject *SWIGUNUSEDPARM(self),
     }	 
   }
   resultobj = SWIG_Py_Void();
+  {
+    if (stream3) {
+      ret3 = PyLong_FromSsize_t(len3);
+      if (PyErr_Occurred()) {
+        PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
+        return NULL;
+      }
+      delete stream3;    
+      Py_XDECREF(resultobj);   /* Blow away any previous result */
+      resultobj = ret3;    
+    }
+  }
+  {
+    if (!stream3) {
+      if (temp3) {
+        in_txt3.close();
+      }
+      if (in_gz3){
+        delete in_gz3;
+      }
+    }  
+  }
   return resultobj;
 fail:
+  {
+    if (!stream3) {
+      if (temp3) {
+        in_txt3.close();
+      }
+      if (in_gz3){
+        delete in_gz3;
+      }
+    }  
+  }
   return NULL;
 }
 
@@ -5526,9 +5730,34 @@ SWIGINTERN PyObject *_wrap_intArray_Load(PyObject *self, PyObject *args) {
     int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_mfem__ArrayT_int_t, 0);
     _v = SWIG_CheckState(res);
     if (_v) {
-      void *vptr = 0;
-      int res = SWIG_ConvertPtr(argv[1], &vptr, SWIGTYPE_p_std__istream, SWIG_POINTER_NO_NULL);
-      _v = SWIG_CheckState(res);
+      {
+        void *ptr;
+        //std::string *ptr2 = (std::string *)0;
+        if (SWIG_ConvertPtr(argv[1], (void **) &ptr, SWIGTYPE_p_PyMFEM__wFILE, 0 |0) == -1) {
+          PyErr_Clear();
+          if (!PyString_Check(argv[1]) && !PyUnicode_Check(argv[1])) {
+            // not string
+            _v = 1;	   	
+            PyObject* module = PyImport_ImportModule("io");
+            if (!module){
+              _v = 0;	   
+            }      
+            PyObject* cls = PyObject_GetAttrString(module, "StringIO");
+            if (!cls){
+              _v = 0;	   	   
+            }      
+            int check = PyObject_IsInstance(argv[1], cls);
+            Py_DECREF(module);
+            if (! check){
+              _v = 0;	   	   	   
+            }
+          } else {
+            _v = 1;
+          }
+        } else {
+          _v = 1;
+        }
+      }
       if (_v) {
         if (argc <= 2) {
           return _wrap_intArray_Load__SWIG_0(self, argc, argv);
@@ -5554,9 +5783,34 @@ SWIGINTERN PyObject *_wrap_intArray_Load(PyObject *self, PyObject *args) {
         _v = SWIG_CheckState(res);
       }
       if (_v) {
-        void *vptr = 0;
-        int res = SWIG_ConvertPtr(argv[2], &vptr, SWIGTYPE_p_std__istream, SWIG_POINTER_NO_NULL);
-        _v = SWIG_CheckState(res);
+        {
+          void *ptr;
+          //std::string *ptr2 = (std::string *)0;
+          if (SWIG_ConvertPtr(argv[2], (void **) &ptr, SWIGTYPE_p_PyMFEM__wFILE, 0 |0) == -1) {
+            PyErr_Clear();
+            if (!PyString_Check(argv[2]) && !PyUnicode_Check(argv[2])) {
+              // not string
+              _v = 1;	   	
+              PyObject* module = PyImport_ImportModule("io");
+              if (!module){
+                _v = 0;	   
+              }      
+              PyObject* cls = PyObject_GetAttrString(module, "StringIO");
+              if (!cls){
+                _v = 0;	   	   
+              }      
+              int check = PyObject_IsInstance(argv[2], cls);
+              Py_DECREF(module);
+              if (! check){
+                _v = 0;	   	   	   
+              }
+            } else {
+              _v = 1;
+            }
+          } else {
+            _v = 1;
+          }
+        }
         if (_v) {
           return _wrap_intArray_Load__SWIG_1(self, argc, argv);
         }
@@ -6730,7 +6984,8 @@ SWIGINTERN PyObject *_wrap_intArray_Print(PyObject *self, PyObject *args) {
               _v = 0;	   	   	   
             }
           } else {
-            _v = 0;
+            std::cout << "it is text (out)\n";	
+            _v = 1;
           }
         } else {
           _v = 1;
@@ -6940,7 +7195,8 @@ SWIGINTERN PyObject *_wrap_intArray_Save(PyObject *self, PyObject *args) {
               _v = 0;	   	   	   
             }
           } else {
-            _v = 0;
+            std::cout << "it is text (out)\n";	
+            _v = 1;
           }
         } else {
           _v = 1;
@@ -8959,10 +9215,10 @@ SWIGINTERN PyObject *_wrap_doubleArray_Print__SWIG_0(PyObject *SWIGUNUSEDPARM(se
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyMFEM::wFILE *temp2 = 0 ;
-  std::ofstream out2 ;
-  int use_stringio2 = 0 ;
+  std::ofstream out_txt2 ;
+  mfem::ofgzstream *out_gz2 = 0 ;
   PyObject *string_io2 = 0 ;
-  std::ostringstream stream2 ;
+  std::ostringstream *stream2 = 0 ;
   PyObject *ret2 = 0 ;
   int val3 ;
   int ecode3 = 0 ;
@@ -8995,29 +9251,33 @@ SWIGINTERN PyObject *_wrap_doubleArray_Print__SWIG_0(PyObject *SWIGUNUSEDPARM(se
             SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
             return NULL;
           }
-          use_stringio2=1;
           string_io2=swig_obj[1];
+          stream2 = new std::ostringstream();
         } else {
           // if it is string, extract filename as char*
           PyObject* str = PyUnicode_AsEncodedString(swig_obj[1], "utf-8", "~E~");	
           const char* filename = PyBytes_AsString(str);
-          temp2 = new PyMFEM::wFILE(filename, 8, true);	
+          temp2 = new PyMFEM::wFILE(filename, 8, true);
+          Py_DECREF(str);	 
         }
       }
       
-      if (use_stringio2 == 0){
+      if (stream2 == 0){
         if (temp2->isSTDOUT() == 1) {
           arg2 = &std::cout;
+        } else if (temp2->isGZ()){
+          out_gz2 = new mfem::ofgzstream(temp2->getFilename(), true);
+          arg2 = out_gz2;	     
         } else {
-          out2.open(temp2->getFilename());
-          out2.precision(temp2->getPrecision());
-          if (temp2->isTemporary()){
-            delete temp2;
-          }
-          arg2 = &out2;
+          out_txt2.open(temp2->getFilename());
+          out_txt2.precision(temp2->getPrecision());
+          arg2 = &out_txt2;
+        }
+        if (temp2->isTemporary()){
+          delete temp2;
         }
       } else {
-        arg2 = &stream2;
+        arg2 = stream2;
       }
     }
   }
@@ -9046,8 +9306,8 @@ SWIGINTERN PyObject *_wrap_doubleArray_Print__SWIG_0(PyObject *SWIGUNUSEDPARM(se
   }
   resultobj = SWIG_Py_Void();
   {
-    if (use_stringio2 == 1) {
-      std::string str =  stream2.str();
+    if (stream2) {
+      std::string str =  stream2->str();
       const char* s = str.c_str();
       const int n = str.length();
       ret2 = PyObject_CallMethod(string_io2, "write", "s#",
@@ -9056,15 +9316,21 @@ SWIGINTERN PyObject *_wrap_doubleArray_Print__SWIG_0(PyObject *SWIGUNUSEDPARM(se
         PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
         return NULL;
       }
+      delete stream2;
       Py_XDECREF(resultobj);   /* Blow away any previous result */
       resultobj = ret2;    
     }
   }
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -9072,10 +9338,15 @@ SWIGINTERN PyObject *_wrap_doubleArray_Print__SWIG_0(PyObject *SWIGUNUSEDPARM(se
   return resultobj;
 fail:
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -9092,10 +9363,10 @@ SWIGINTERN PyObject *_wrap_doubleArray_Save__SWIG_0(PyObject *SWIGUNUSEDPARM(sel
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyMFEM::wFILE *temp2 = 0 ;
-  std::ofstream out2 ;
-  int use_stringio2 = 0 ;
+  std::ofstream out_txt2 ;
+  mfem::ofgzstream *out_gz2 = 0 ;
   PyObject *string_io2 = 0 ;
-  std::ostringstream stream2 ;
+  std::ostringstream *stream2 = 0 ;
   PyObject *ret2 = 0 ;
   int val3 ;
   int ecode3 = 0 ;
@@ -9127,29 +9398,33 @@ SWIGINTERN PyObject *_wrap_doubleArray_Save__SWIG_0(PyObject *SWIGUNUSEDPARM(sel
           SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
           return NULL;
         }
-        use_stringio2=1;
         string_io2=swig_obj[1];
+        stream2 = new std::ostringstream();
       } else {
         // if it is string, extract filename as char*
         PyObject* str = PyUnicode_AsEncodedString(swig_obj[1], "utf-8", "~E~");	
         const char* filename = PyBytes_AsString(str);
-        temp2 = new PyMFEM::wFILE(filename, 8, true);	
+        temp2 = new PyMFEM::wFILE(filename, 8, true);
+        Py_DECREF(str);	 
       }
     }
     
-    if (use_stringio2 == 0){
+    if (stream2 == 0){
       if (temp2->isSTDOUT() == 1) {
         arg2 = &std::cout;
+      } else if (temp2->isGZ()){
+        out_gz2 = new mfem::ofgzstream(temp2->getFilename(), true);
+        arg2 = out_gz2;	     
       } else {
-        out2.open(temp2->getFilename());
-        out2.precision(temp2->getPrecision());
-        if (temp2->isTemporary()){
-          delete temp2;
-        }
-        arg2 = &out2;
+        out_txt2.open(temp2->getFilename());
+        out_txt2.precision(temp2->getPrecision());
+        arg2 = &out_txt2;
+      }
+      if (temp2->isTemporary()){
+        delete temp2;
       }
     } else {
-      arg2 = &stream2;
+      arg2 = stream2;
     }
   }
   if (swig_obj[2]) {
@@ -9177,8 +9452,8 @@ SWIGINTERN PyObject *_wrap_doubleArray_Save__SWIG_0(PyObject *SWIGUNUSEDPARM(sel
   }
   resultobj = SWIG_Py_Void();
   {
-    if (use_stringio2 == 1) {
-      std::string str =  stream2.str();
+    if (stream2) {
+      std::string str =  stream2->str();
       const char* s = str.c_str();
       const int n = str.length();
       ret2 = PyObject_CallMethod(string_io2, "write", "s#",
@@ -9187,15 +9462,21 @@ SWIGINTERN PyObject *_wrap_doubleArray_Save__SWIG_0(PyObject *SWIGUNUSEDPARM(sel
         PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
         return NULL;
       }
+      delete stream2;
       Py_XDECREF(resultobj);   /* Blow away any previous result */
       resultobj = ret2;    
     }
   }
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -9203,10 +9484,15 @@ SWIGINTERN PyObject *_wrap_doubleArray_Save__SWIG_0(PyObject *SWIGUNUSEDPARM(sel
   return resultobj;
 fail:
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -9222,8 +9508,13 @@ SWIGINTERN PyObject *_wrap_doubleArray_Load__SWIG_0(PyObject *SWIGUNUSEDPARM(sel
   int arg3 = (int) 0 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
-  void *argp2 = 0 ;
-  int res2 = 0 ;
+  PyMFEM::wFILE *temp2 = 0 ;
+  std::ifstream in_txt2 ;
+  mfem::ifgzstream *in_gz2 = 0 ;
+  PyObject *input_str2 = 0 ;
+  std::istringstream *stream2 = 0 ;
+  Py_ssize_t len2 = 0 ;
+  PyObject *ret2 = 0 ;
   int val3 ;
   int ecode3 = 0 ;
   
@@ -9233,14 +9524,64 @@ SWIGINTERN PyObject *_wrap_doubleArray_Load__SWIG_0(PyObject *SWIGUNUSEDPARM(sel
     SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "doubleArray_Load" "', argument " "1"" of type '" "mfem::Array< double > *""'"); 
   }
   arg1 = reinterpret_cast< mfem::Array< double > * >(argp1);
-  res2 = SWIG_ConvertPtr(swig_obj[1], &argp2, SWIGTYPE_p_std__istream,  0 );
-  if (!SWIG_IsOK(res2)) {
-    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "doubleArray_Load" "', argument " "2"" of type '" "std::istream &""'"); 
+  {
+    //  PyMFEM::wFILE or string argument or StringIO
+    if (SWIG_ConvertPtr(swig_obj[1], (void **) &temp2, SWIGTYPE_p_PyMFEM__wFILE, 0 | 0) == -1) {
+      if (!PyString_Check(swig_obj[1]) && !PyUnicode_Check(swig_obj[1])) {
+        // not string, check if it is StringIO
+        PyObject* module = PyImport_ImportModule("io");
+        if (!module){
+          PyErr_SetString(PyExc_RuntimeError, "Can not load io module");
+          return NULL;
+        }      
+        PyObject* cls = PyObject_GetAttrString(module, "StringIO");
+        if (!cls){
+          PyErr_SetString(PyExc_RuntimeError, "Can not load StringIO");
+          return NULL;
+        }      
+        int check = PyObject_IsInstance(swig_obj[1], cls);
+        Py_DECREF(module);
+        if (! check){
+          SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
+          return NULL;
+        }
+        
+        PyObject *input_str2 = PyObject_CallMethod(swig_obj[1], "getvalue", NULL);
+        if (PyErr_Occurred()) {
+          PyErr_SetString(PyExc_RuntimeError, "Can not read from StringIO");
+          return NULL;
+        }
+        
+        char *buf = nullptr;
+        PyObject *str = PyUnicode_AsUTF8String(input_str2);	 
+        PyBytes_AsStringAndSize(str, &buf, &len2);
+        stream2 = new std::istringstream(buf);
+        Py_DECREF(str);
+        Py_DECREF(input_str2);	 
+      } else {
+        // if it is string, extract filename as char*
+        PyObject* str = PyUnicode_AsEncodedString(swig_obj[1], "utf-8", "~E~");	
+        const char* filename = PyBytes_AsString(str);
+        temp2 = new PyMFEM::wFILE(filename, 8, true);
+        Py_DECREF(str);
+      }
+    }
+    if (stream2 == 0){
+      if (temp2->isGZ()){
+        in_gz2 = new mfem::ifgzstream(temp2->getFilename());
+        arg2 = in_gz2;
+      } else {
+        in_txt2.open(temp2->getFilename(), std::ifstream::in);
+        in_txt2.precision(temp2->getPrecision());
+        arg2 = &in_txt2;
+      }
+      if (temp2->isTemporary()){
+        delete temp2;
+      }
+    } else {
+      arg2 = stream2;
+    }
   }
-  if (!argp2) {
-    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "doubleArray_Load" "', argument " "2"" of type '" "std::istream &""'"); 
-  }
-  arg2 = reinterpret_cast< std::istream * >(argp2);
   if (swig_obj[2]) {
     ecode3 = SWIG_AsVal_int(swig_obj[2], &val3);
     if (!SWIG_IsOK(ecode3)) {
@@ -9265,8 +9606,40 @@ SWIGINTERN PyObject *_wrap_doubleArray_Load__SWIG_0(PyObject *SWIGUNUSEDPARM(sel
     }	 
   }
   resultobj = SWIG_Py_Void();
+  {
+    if (stream2) {
+      ret2 = PyLong_FromSsize_t(len2);
+      if (PyErr_Occurred()) {
+        PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
+        return NULL;
+      }
+      delete stream2;    
+      Py_XDECREF(resultobj);   /* Blow away any previous result */
+      resultobj = ret2;    
+    }
+  }
+  {
+    if (!stream2) {
+      if (temp2) {
+        in_txt2.close();
+      }
+      if (in_gz2){
+        delete in_gz2;
+      }
+    }  
+  }
   return resultobj;
 fail:
+  {
+    if (!stream2) {
+      if (temp2) {
+        in_txt2.close();
+      }
+      if (in_gz2){
+        delete in_gz2;
+      }
+    }  
+  }
   return NULL;
 }
 
@@ -9280,8 +9653,13 @@ SWIGINTERN PyObject *_wrap_doubleArray_Load__SWIG_1(PyObject *SWIGUNUSEDPARM(sel
   int res1 = 0 ;
   int val2 ;
   int ecode2 = 0 ;
-  void *argp3 = 0 ;
-  int res3 = 0 ;
+  PyMFEM::wFILE *temp3 = 0 ;
+  std::ifstream in_txt3 ;
+  mfem::ifgzstream *in_gz3 = 0 ;
+  PyObject *input_str3 = 0 ;
+  std::istringstream *stream3 = 0 ;
+  Py_ssize_t len3 = 0 ;
+  PyObject *ret3 = 0 ;
   
   if ((nobjs < 3) || (nobjs > 3)) SWIG_fail;
   res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_mfem__ArrayT_double_t, 0 |  0 );
@@ -9294,14 +9672,64 @@ SWIGINTERN PyObject *_wrap_doubleArray_Load__SWIG_1(PyObject *SWIGUNUSEDPARM(sel
     SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "doubleArray_Load" "', argument " "2"" of type '" "int""'");
   } 
   arg2 = static_cast< int >(val2);
-  res3 = SWIG_ConvertPtr(swig_obj[2], &argp3, SWIGTYPE_p_std__istream,  0 );
-  if (!SWIG_IsOK(res3)) {
-    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "doubleArray_Load" "', argument " "3"" of type '" "std::istream &""'"); 
+  {
+    //  PyMFEM::wFILE or string argument or StringIO
+    if (SWIG_ConvertPtr(swig_obj[2], (void **) &temp3, SWIGTYPE_p_PyMFEM__wFILE, 0 | 0) == -1) {
+      if (!PyString_Check(swig_obj[2]) && !PyUnicode_Check(swig_obj[2])) {
+        // not string, check if it is StringIO
+        PyObject* module = PyImport_ImportModule("io");
+        if (!module){
+          PyErr_SetString(PyExc_RuntimeError, "Can not load io module");
+          return NULL;
+        }      
+        PyObject* cls = PyObject_GetAttrString(module, "StringIO");
+        if (!cls){
+          PyErr_SetString(PyExc_RuntimeError, "Can not load StringIO");
+          return NULL;
+        }      
+        int check = PyObject_IsInstance(swig_obj[2], cls);
+        Py_DECREF(module);
+        if (! check){
+          SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
+          return NULL;
+        }
+        
+        PyObject *input_str3 = PyObject_CallMethod(swig_obj[2], "getvalue", NULL);
+        if (PyErr_Occurred()) {
+          PyErr_SetString(PyExc_RuntimeError, "Can not read from StringIO");
+          return NULL;
+        }
+        
+        char *buf = nullptr;
+        PyObject *str = PyUnicode_AsUTF8String(input_str3);	 
+        PyBytes_AsStringAndSize(str, &buf, &len3);
+        stream3 = new std::istringstream(buf);
+        Py_DECREF(str);
+        Py_DECREF(input_str3);	 
+      } else {
+        // if it is string, extract filename as char*
+        PyObject* str = PyUnicode_AsEncodedString(swig_obj[2], "utf-8", "~E~");	
+        const char* filename = PyBytes_AsString(str);
+        temp3 = new PyMFEM::wFILE(filename, 8, true);
+        Py_DECREF(str);
+      }
+    }
+    if (stream3 == 0){
+      if (temp3->isGZ()){
+        in_gz3 = new mfem::ifgzstream(temp3->getFilename());
+        arg3 = in_gz3;
+      } else {
+        in_txt3.open(temp3->getFilename(), std::ifstream::in);
+        in_txt3.precision(temp3->getPrecision());
+        arg3 = &in_txt3;
+      }
+      if (temp3->isTemporary()){
+        delete temp3;
+      }
+    } else {
+      arg3 = stream3;
+    }
   }
-  if (!argp3) {
-    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "doubleArray_Load" "', argument " "3"" of type '" "std::istream &""'"); 
-  }
-  arg3 = reinterpret_cast< std::istream * >(argp3);
   {
     try {
       (arg1)->Load(arg2,*arg3);
@@ -9319,8 +9747,40 @@ SWIGINTERN PyObject *_wrap_doubleArray_Load__SWIG_1(PyObject *SWIGUNUSEDPARM(sel
     }	 
   }
   resultobj = SWIG_Py_Void();
+  {
+    if (stream3) {
+      ret3 = PyLong_FromSsize_t(len3);
+      if (PyErr_Occurred()) {
+        PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
+        return NULL;
+      }
+      delete stream3;    
+      Py_XDECREF(resultobj);   /* Blow away any previous result */
+      resultobj = ret3;    
+    }
+  }
+  {
+    if (!stream3) {
+      if (temp3) {
+        in_txt3.close();
+      }
+      if (in_gz3){
+        delete in_gz3;
+      }
+    }  
+  }
   return resultobj;
 fail:
+  {
+    if (!stream3) {
+      if (temp3) {
+        in_txt3.close();
+      }
+      if (in_gz3){
+        delete in_gz3;
+      }
+    }  
+  }
   return NULL;
 }
 
@@ -9339,9 +9799,34 @@ SWIGINTERN PyObject *_wrap_doubleArray_Load(PyObject *self, PyObject *args) {
     int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_mfem__ArrayT_double_t, 0);
     _v = SWIG_CheckState(res);
     if (_v) {
-      void *vptr = 0;
-      int res = SWIG_ConvertPtr(argv[1], &vptr, SWIGTYPE_p_std__istream, SWIG_POINTER_NO_NULL);
-      _v = SWIG_CheckState(res);
+      {
+        void *ptr;
+        //std::string *ptr2 = (std::string *)0;
+        if (SWIG_ConvertPtr(argv[1], (void **) &ptr, SWIGTYPE_p_PyMFEM__wFILE, 0 |0) == -1) {
+          PyErr_Clear();
+          if (!PyString_Check(argv[1]) && !PyUnicode_Check(argv[1])) {
+            // not string
+            _v = 1;	   	
+            PyObject* module = PyImport_ImportModule("io");
+            if (!module){
+              _v = 0;	   
+            }      
+            PyObject* cls = PyObject_GetAttrString(module, "StringIO");
+            if (!cls){
+              _v = 0;	   	   
+            }      
+            int check = PyObject_IsInstance(argv[1], cls);
+            Py_DECREF(module);
+            if (! check){
+              _v = 0;	   	   	   
+            }
+          } else {
+            _v = 1;
+          }
+        } else {
+          _v = 1;
+        }
+      }
       if (_v) {
         if (argc <= 2) {
           return _wrap_doubleArray_Load__SWIG_0(self, argc, argv);
@@ -9367,9 +9852,34 @@ SWIGINTERN PyObject *_wrap_doubleArray_Load(PyObject *self, PyObject *args) {
         _v = SWIG_CheckState(res);
       }
       if (_v) {
-        void *vptr = 0;
-        int res = SWIG_ConvertPtr(argv[2], &vptr, SWIGTYPE_p_std__istream, SWIG_POINTER_NO_NULL);
-        _v = SWIG_CheckState(res);
+        {
+          void *ptr;
+          //std::string *ptr2 = (std::string *)0;
+          if (SWIG_ConvertPtr(argv[2], (void **) &ptr, SWIGTYPE_p_PyMFEM__wFILE, 0 |0) == -1) {
+            PyErr_Clear();
+            if (!PyString_Check(argv[2]) && !PyUnicode_Check(argv[2])) {
+              // not string
+              _v = 1;	   	
+              PyObject* module = PyImport_ImportModule("io");
+              if (!module){
+                _v = 0;	   
+              }      
+              PyObject* cls = PyObject_GetAttrString(module, "StringIO");
+              if (!cls){
+                _v = 0;	   	   
+              }      
+              int check = PyObject_IsInstance(argv[2], cls);
+              Py_DECREF(module);
+              if (! check){
+                _v = 0;	   	   	   
+              }
+            } else {
+              _v = 1;
+            }
+          } else {
+            _v = 1;
+          }
+        }
         if (_v) {
           return _wrap_doubleArray_Load__SWIG_1(self, argc, argv);
         }
@@ -10543,7 +11053,8 @@ SWIGINTERN PyObject *_wrap_doubleArray_Print(PyObject *self, PyObject *args) {
               _v = 0;	   	   	   
             }
           } else {
-            _v = 0;
+            std::cout << "it is text (out)\n";	
+            _v = 1;
           }
         } else {
           _v = 1;
@@ -10753,7 +11264,8 @@ SWIGINTERN PyObject *_wrap_doubleArray_Save(PyObject *self, PyObject *args) {
               _v = 0;	   	   	   
             }
           } else {
-            _v = 0;
+            std::cout << "it is text (out)\n";	
+            _v = 1;
           }
         } else {
           _v = 1;
@@ -11638,7 +12150,6 @@ static swig_type_info _swigt__p_mfem__MemoryT_double_t = {"_p_mfem__MemoryT_doub
 static swig_type_info _swigt__p_mfem__MemoryT_int_t = {"_p_mfem__MemoryT_int_t", "mfem::Memory< int > *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_p_double = {"_p_p_double", "double **", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_p_int = {"_p_p_int", "int **", 0, 0, (void*)0, 0};
-static swig_type_info _swigt__p_std__istream = {"_p_std__istream", "std::istream *", 0, 0, (void*)0, 0};
 
 static swig_type_info *swig_type_initial[] = {
   &_swigt__p_PyMFEM__wFILE,
@@ -11653,7 +12164,6 @@ static swig_type_info *swig_type_initial[] = {
   &_swigt__p_mfem__MemoryT_int_t,
   &_swigt__p_p_double,
   &_swigt__p_p_int,
-  &_swigt__p_std__istream,
 };
 
 static swig_cast_info _swigc__p_PyMFEM__wFILE[] = {  {&_swigt__p_PyMFEM__wFILE, 0, 0, 0},{0, 0, 0, 0}};
@@ -11668,7 +12178,6 @@ static swig_cast_info _swigc__p_mfem__MemoryT_double_t[] = {  {&_swigt__p_mfem__
 static swig_cast_info _swigc__p_mfem__MemoryT_int_t[] = {  {&_swigt__p_mfem__MemoryT_int_t, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_p_double[] = {  {&_swigt__p_p_double, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_p_int[] = {  {&_swigt__p_p_int, 0, 0, 0},{0, 0, 0, 0}};
-static swig_cast_info _swigc__p_std__istream[] = {  {&_swigt__p_std__istream, 0, 0, 0},{0, 0, 0, 0}};
 
 static swig_cast_info *swig_cast_initial[] = {
   _swigc__p_PyMFEM__wFILE,
@@ -11683,7 +12192,6 @@ static swig_cast_info *swig_cast_initial[] = {
   _swigc__p_mfem__MemoryT_int_t,
   _swigc__p_p_double,
   _swigc__p_p_int,
-  _swigc__p_std__istream,
 };
 
 

--- a/mfem/_ser/array_wrap.cxx
+++ b/mfem/_ser/array_wrap.cxx
@@ -5442,7 +5442,6 @@ SWIGINTERN PyObject *_wrap_intArray_Load__SWIG_0(PyObject *SWIGUNUSEDPARM(self),
   PyMFEM::wFILE *temp2 = 0 ;
   std::ifstream in_txt2 ;
   mfem::ifgzstream *in_gz2 = 0 ;
-  PyObject *input_str2 = 0 ;
   std::istringstream *stream2 = 0 ;
   Py_ssize_t len2 = 0 ;
   PyObject *ret2 = 0 ;
@@ -5477,18 +5476,18 @@ SWIGINTERN PyObject *_wrap_intArray_Load__SWIG_0(PyObject *SWIGUNUSEDPARM(self),
           return NULL;
         }
         
-        PyObject *input_str2 = PyObject_CallMethod(swig_obj[1], "getvalue", NULL);
+        PyObject *input_str = PyObject_CallMethod(swig_obj[1], "getvalue", NULL);
         if (PyErr_Occurred()) {
           PyErr_SetString(PyExc_RuntimeError, "Can not read from StringIO");
           return NULL;
         }
         
         char *buf = nullptr;
-        PyObject *str = PyUnicode_AsUTF8String(input_str2);	 
+        PyObject *str = PyUnicode_AsUTF8String(input_str);	 
         PyBytes_AsStringAndSize(str, &buf, &len2);
         stream2 = new std::istringstream(buf);
         Py_DECREF(str);
-        Py_DECREF(input_str2);	 
+        Py_DECREF(input_str);	 
       } else {
         // if it is string, extract filename as char*
         PyObject* str = PyUnicode_AsEncodedString(swig_obj[1], "utf-8", "~E~");	
@@ -5587,7 +5586,6 @@ SWIGINTERN PyObject *_wrap_intArray_Load__SWIG_1(PyObject *SWIGUNUSEDPARM(self),
   PyMFEM::wFILE *temp3 = 0 ;
   std::ifstream in_txt3 ;
   mfem::ifgzstream *in_gz3 = 0 ;
-  PyObject *input_str3 = 0 ;
   std::istringstream *stream3 = 0 ;
   Py_ssize_t len3 = 0 ;
   PyObject *ret3 = 0 ;
@@ -5625,18 +5623,18 @@ SWIGINTERN PyObject *_wrap_intArray_Load__SWIG_1(PyObject *SWIGUNUSEDPARM(self),
           return NULL;
         }
         
-        PyObject *input_str3 = PyObject_CallMethod(swig_obj[2], "getvalue", NULL);
+        PyObject *input_str = PyObject_CallMethod(swig_obj[2], "getvalue", NULL);
         if (PyErr_Occurred()) {
           PyErr_SetString(PyExc_RuntimeError, "Can not read from StringIO");
           return NULL;
         }
         
         char *buf = nullptr;
-        PyObject *str = PyUnicode_AsUTF8String(input_str3);	 
+        PyObject *str = PyUnicode_AsUTF8String(input_str);	 
         PyBytes_AsStringAndSize(str, &buf, &len3);
         stream3 = new std::istringstream(buf);
         Py_DECREF(str);
-        Py_DECREF(input_str3);	 
+        Py_DECREF(input_str);	 
       } else {
         // if it is string, extract filename as char*
         PyObject* str = PyUnicode_AsEncodedString(swig_obj[2], "utf-8", "~E~");	
@@ -6984,7 +6982,6 @@ SWIGINTERN PyObject *_wrap_intArray_Print(PyObject *self, PyObject *args) {
               _v = 0;	   	   	   
             }
           } else {
-            std::cout << "it is text (out)\n";	
             _v = 1;
           }
         } else {
@@ -7195,7 +7192,6 @@ SWIGINTERN PyObject *_wrap_intArray_Save(PyObject *self, PyObject *args) {
               _v = 0;	   	   	   
             }
           } else {
-            std::cout << "it is text (out)\n";	
             _v = 1;
           }
         } else {
@@ -9511,7 +9507,6 @@ SWIGINTERN PyObject *_wrap_doubleArray_Load__SWIG_0(PyObject *SWIGUNUSEDPARM(sel
   PyMFEM::wFILE *temp2 = 0 ;
   std::ifstream in_txt2 ;
   mfem::ifgzstream *in_gz2 = 0 ;
-  PyObject *input_str2 = 0 ;
   std::istringstream *stream2 = 0 ;
   Py_ssize_t len2 = 0 ;
   PyObject *ret2 = 0 ;
@@ -9546,18 +9541,18 @@ SWIGINTERN PyObject *_wrap_doubleArray_Load__SWIG_0(PyObject *SWIGUNUSEDPARM(sel
           return NULL;
         }
         
-        PyObject *input_str2 = PyObject_CallMethod(swig_obj[1], "getvalue", NULL);
+        PyObject *input_str = PyObject_CallMethod(swig_obj[1], "getvalue", NULL);
         if (PyErr_Occurred()) {
           PyErr_SetString(PyExc_RuntimeError, "Can not read from StringIO");
           return NULL;
         }
         
         char *buf = nullptr;
-        PyObject *str = PyUnicode_AsUTF8String(input_str2);	 
+        PyObject *str = PyUnicode_AsUTF8String(input_str);	 
         PyBytes_AsStringAndSize(str, &buf, &len2);
         stream2 = new std::istringstream(buf);
         Py_DECREF(str);
-        Py_DECREF(input_str2);	 
+        Py_DECREF(input_str);	 
       } else {
         // if it is string, extract filename as char*
         PyObject* str = PyUnicode_AsEncodedString(swig_obj[1], "utf-8", "~E~");	
@@ -9656,7 +9651,6 @@ SWIGINTERN PyObject *_wrap_doubleArray_Load__SWIG_1(PyObject *SWIGUNUSEDPARM(sel
   PyMFEM::wFILE *temp3 = 0 ;
   std::ifstream in_txt3 ;
   mfem::ifgzstream *in_gz3 = 0 ;
-  PyObject *input_str3 = 0 ;
   std::istringstream *stream3 = 0 ;
   Py_ssize_t len3 = 0 ;
   PyObject *ret3 = 0 ;
@@ -9694,18 +9688,18 @@ SWIGINTERN PyObject *_wrap_doubleArray_Load__SWIG_1(PyObject *SWIGUNUSEDPARM(sel
           return NULL;
         }
         
-        PyObject *input_str3 = PyObject_CallMethod(swig_obj[2], "getvalue", NULL);
+        PyObject *input_str = PyObject_CallMethod(swig_obj[2], "getvalue", NULL);
         if (PyErr_Occurred()) {
           PyErr_SetString(PyExc_RuntimeError, "Can not read from StringIO");
           return NULL;
         }
         
         char *buf = nullptr;
-        PyObject *str = PyUnicode_AsUTF8String(input_str3);	 
+        PyObject *str = PyUnicode_AsUTF8String(input_str);	 
         PyBytes_AsStringAndSize(str, &buf, &len3);
         stream3 = new std::istringstream(buf);
         Py_DECREF(str);
-        Py_DECREF(input_str3);	 
+        Py_DECREF(input_str);	 
       } else {
         // if it is string, extract filename as char*
         PyObject* str = PyUnicode_AsEncodedString(swig_obj[2], "utf-8", "~E~");	
@@ -11053,7 +11047,6 @@ SWIGINTERN PyObject *_wrap_doubleArray_Print(PyObject *self, PyObject *args) {
               _v = 0;	   	   	   
             }
           } else {
-            std::cout << "it is text (out)\n";	
             _v = 1;
           }
         } else {
@@ -11264,7 +11257,6 @@ SWIGINTERN PyObject *_wrap_doubleArray_Save(PyObject *self, PyObject *args) {
               _v = 0;	   	   	   
             }
           } else {
-            std::cout << "it is text (out)\n";	
             _v = 1;
           }
         } else {

--- a/mfem/_ser/blockmatrix.i
+++ b/mfem/_ser/blockmatrix.i
@@ -3,6 +3,7 @@
 %{
 #include <fstream>  
 #include <iostream>
+#include "general/zstr.hpp"      
 #include "linalg/blockmatrix.hpp"
 #include "numpy/arrayobject.h"
 #include "pyoperator.hpp"

--- a/mfem/_ser/blockmatrix_wrap.cxx
+++ b/mfem/_ser/blockmatrix_wrap.cxx
@@ -5737,7 +5737,6 @@ SWIGINTERN PyObject *_wrap_BlockMatrix_PrintMatlab(PyObject *self, PyObject *arg
               _v = 0;	   	   	   
             }
           } else {
-            std::cout << "it is text (out)\n";	
             _v = 1;
           }
         } else {

--- a/mfem/_ser/blockmatrix_wrap.cxx
+++ b/mfem/_ser/blockmatrix_wrap.cxx
@@ -3199,6 +3199,7 @@ namespace swig {
 
 #include <fstream>  
 #include <iostream>
+#include "general/zstr.hpp"      
 #include "linalg/blockmatrix.hpp"
 #include "numpy/arrayobject.h"
 #include "pyoperator.hpp"
@@ -4736,10 +4737,10 @@ SWIGINTERN PyObject *_wrap_BlockMatrix_PrintMatlab__SWIG_0(PyObject *SWIGUNUSEDP
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyMFEM::wFILE *temp2 = 0 ;
-  std::ofstream out2 ;
-  int use_stringio2 = 0 ;
+  std::ofstream out_txt2 ;
+  mfem::ofgzstream *out_gz2 = 0 ;
   PyObject *string_io2 = 0 ;
-  std::ostringstream stream2 ;
+  std::ostringstream *stream2 = 0 ;
   PyObject *ret2 = 0 ;
   
   if ((nobjs < 1) || (nobjs > 2)) SWIG_fail;
@@ -4770,29 +4771,33 @@ SWIGINTERN PyObject *_wrap_BlockMatrix_PrintMatlab__SWIG_0(PyObject *SWIGUNUSEDP
             SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
             return NULL;
           }
-          use_stringio2=1;
           string_io2=swig_obj[1];
+          stream2 = new std::ostringstream();
         } else {
           // if it is string, extract filename as char*
           PyObject* str = PyUnicode_AsEncodedString(swig_obj[1], "utf-8", "~E~");	
           const char* filename = PyBytes_AsString(str);
-          temp2 = new PyMFEM::wFILE(filename, 8, true);	
+          temp2 = new PyMFEM::wFILE(filename, 8, true);
+          Py_DECREF(str);	 
         }
       }
       
-      if (use_stringio2 == 0){
+      if (stream2 == 0){
         if (temp2->isSTDOUT() == 1) {
           arg2 = &std::cout;
+        } else if (temp2->isGZ()){
+          out_gz2 = new mfem::ofgzstream(temp2->getFilename(), true);
+          arg2 = out_gz2;	     
         } else {
-          out2.open(temp2->getFilename());
-          out2.precision(temp2->getPrecision());
-          if (temp2->isTemporary()){
-            delete temp2;
-          }
-          arg2 = &out2;
+          out_txt2.open(temp2->getFilename());
+          out_txt2.precision(temp2->getPrecision());
+          arg2 = &out_txt2;
+        }
+        if (temp2->isTemporary()){
+          delete temp2;
         }
       } else {
-        arg2 = &stream2;
+        arg2 = stream2;
       }
     }
   }
@@ -4817,8 +4822,8 @@ SWIGINTERN PyObject *_wrap_BlockMatrix_PrintMatlab__SWIG_0(PyObject *SWIGUNUSEDP
   }
   resultobj = SWIG_Py_Void();
   {
-    if (use_stringio2 == 1) {
-      std::string str =  stream2.str();
+    if (stream2) {
+      std::string str =  stream2->str();
       const char* s = str.c_str();
       const int n = str.length();
       ret2 = PyObject_CallMethod(string_io2, "write", "s#",
@@ -4827,15 +4832,21 @@ SWIGINTERN PyObject *_wrap_BlockMatrix_PrintMatlab__SWIG_0(PyObject *SWIGUNUSEDP
         PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
         return NULL;
       }
+      delete stream2;
       Py_XDECREF(resultobj);   /* Blow away any previous result */
       resultobj = ret2;    
     }
   }
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -4843,10 +4854,15 @@ SWIGINTERN PyObject *_wrap_BlockMatrix_PrintMatlab__SWIG_0(PyObject *SWIGUNUSEDP
   return resultobj;
 fail:
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -5721,7 +5737,8 @@ SWIGINTERN PyObject *_wrap_BlockMatrix_PrintMatlab(PyObject *self, PyObject *arg
               _v = 0;	   	   	   
             }
           } else {
-            _v = 0;
+            std::cout << "it is text (out)\n";	
+            _v = 1;
           }
         } else {
           _v = 1;

--- a/mfem/_ser/common_functions.i
+++ b/mfem/_ser/common_functions.i
@@ -3,6 +3,7 @@
 %{
 #include <iostream>
 #include <fstream>
+#include "general/zstr.hpp"  
 #include "../common/io_stream.hpp"          
 #include "linalg/sparsemat.hpp"
 #include "linalg/densemat.hpp"

--- a/mfem/_ser/common_functions_wrap.cxx
+++ b/mfem/_ser/common_functions_wrap.cxx
@@ -2779,6 +2779,7 @@ namespace swig {
 
 #include <iostream>
 #include <fstream>
+#include "general/zstr.hpp"  
 #include "../common/io_stream.hpp"          
 #include "linalg/sparsemat.hpp"
 #include "linalg/densemat.hpp"
@@ -3544,10 +3545,10 @@ SWIGINTERN PyObject *_wrap___lshift__(PyObject *SWIGUNUSEDPARM(self), PyObject *
   std::ostream *arg1 = 0 ;
   mfem::SparseMatrix *arg2 = 0 ;
   PyMFEM::wFILE *temp1 = 0 ;
-  std::ofstream out1 ;
-  int use_stringio1 = 0 ;
+  std::ofstream out_txt1 ;
+  mfem::ofgzstream *out_gz1 = 0 ;
   PyObject *string_io1 = 0 ;
-  std::ostringstream stream1 ;
+  std::ostringstream *stream1 = 0 ;
   PyObject *ret1 = 0 ;
   void *argp2 = 0 ;
   int res2 = 0 ;
@@ -3580,29 +3581,33 @@ SWIGINTERN PyObject *_wrap___lshift__(PyObject *SWIGUNUSEDPARM(self), PyObject *
           SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
           return NULL;
         }
-        use_stringio1=1;
         string_io1=obj0;
+        stream1 = new std::ostringstream();
       } else {
         // if it is string, extract filename as char*
         PyObject* str = PyUnicode_AsEncodedString(obj0, "utf-8", "~E~");	
         const char* filename = PyBytes_AsString(str);
-        temp1 = new PyMFEM::wFILE(filename, 8, true);	
+        temp1 = new PyMFEM::wFILE(filename, 8, true);
+        Py_DECREF(str);	 
       }
     }
     
-    if (use_stringio1 == 0){
+    if (stream1 == 0){
       if (temp1->isSTDOUT() == 1) {
         arg1 = &std::cout;
+      } else if (temp1->isGZ()){
+        out_gz1 = new mfem::ofgzstream(temp1->getFilename(), true);
+        arg1 = out_gz1;	     
       } else {
-        out1.open(temp1->getFilename());
-        out1.precision(temp1->getPrecision());
-        if (temp1->isTemporary()){
-          delete temp1;
-        }
-        arg1 = &out1;
+        out_txt1.open(temp1->getFilename());
+        out_txt1.precision(temp1->getPrecision());
+        arg1 = &out_txt1;
+      }
+      if (temp1->isTemporary()){
+        delete temp1;
       }
     } else {
-      arg1 = &stream1;
+      arg1 = stream1;
     }
   }
   res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_mfem__SparseMatrix,  0  | 0);
@@ -3631,8 +3636,8 @@ SWIGINTERN PyObject *_wrap___lshift__(PyObject *SWIGUNUSEDPARM(self), PyObject *
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_std__ostream, 0 |  0 );
   {
-    if (use_stringio1 == 1) {
-      std::string str =  stream1.str();
+    if (stream1) {
+      std::string str =  stream1->str();
       const char* s = str.c_str();
       const int n = str.length();
       ret1 = PyObject_CallMethod(string_io1, "write", "s#",
@@ -3641,15 +3646,21 @@ SWIGINTERN PyObject *_wrap___lshift__(PyObject *SWIGUNUSEDPARM(self), PyObject *
         PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
         return NULL;
       }
+      delete stream1;
       Py_XDECREF(resultobj);   /* Blow away any previous result */
       resultobj = ret1;    
     }
   }
   {
-    if (use_stringio1 == 0) {
+    if (!stream1) {
       if (temp1) {
         if (temp1->isSTDOUT() != 1) {
-          out1.close();
+          if (out_txt1.is_open()){
+            out_txt1.close();
+          }
+          if (out_gz1){
+            delete out_gz1;
+          }
         }
       }
     }
@@ -3657,10 +3668,15 @@ SWIGINTERN PyObject *_wrap___lshift__(PyObject *SWIGUNUSEDPARM(self), PyObject *
   return resultobj;
 fail:
   {
-    if (use_stringio1 == 0) {
+    if (!stream1) {
       if (temp1) {
         if (temp1->isSTDOUT() != 1) {
-          out1.close();
+          if (out_txt1.is_open()){
+            out_txt1.close();
+          }
+          if (out_gz1){
+            delete out_gz1;
+          }
         }
       }
     }

--- a/mfem/_ser/densemat.i
+++ b/mfem/_ser/densemat.i
@@ -8,7 +8,8 @@
 %feature("autodoc", "1");
 %{
 #include <fstream>
-#include <iostream>      
+#include <iostream>
+#include "general/zstr.hpp"
 #include "linalg/sparsemat.hpp"
 #include "numpy/arrayobject.h"
 #include "pyoperator.hpp"

--- a/mfem/_ser/densemat_wrap.cxx
+++ b/mfem/_ser/densemat_wrap.cxx
@@ -3204,7 +3204,8 @@ namespace swig {
 
 
 #include <fstream>
-#include <iostream>      
+#include <iostream>
+#include "general/zstr.hpp"
 #include "linalg/sparsemat.hpp"
 #include "numpy/arrayobject.h"
 #include "pyoperator.hpp"
@@ -10845,10 +10846,10 @@ SWIGINTERN PyObject *_wrap_DenseMatrix_Print__SWIG_0(PyObject *SWIGUNUSEDPARM(se
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyMFEM::wFILE *temp2 = 0 ;
-  std::ofstream out2 ;
-  int use_stringio2 = 0 ;
+  std::ofstream out_txt2 ;
+  mfem::ofgzstream *out_gz2 = 0 ;
   PyObject *string_io2 = 0 ;
-  std::ostringstream stream2 ;
+  std::ostringstream *stream2 = 0 ;
   PyObject *ret2 = 0 ;
   
   if ((nobjs < 1) || (nobjs > 3)) SWIG_fail;
@@ -10879,29 +10880,33 @@ SWIGINTERN PyObject *_wrap_DenseMatrix_Print__SWIG_0(PyObject *SWIGUNUSEDPARM(se
             SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
             return NULL;
           }
-          use_stringio2=1;
           string_io2=swig_obj[1];
+          stream2 = new std::ostringstream();
         } else {
           // if it is string, extract filename as char*
           PyObject* str = PyUnicode_AsEncodedString(swig_obj[1], "utf-8", "~E~");	
           const char* filename = PyBytes_AsString(str);
-          temp2 = new PyMFEM::wFILE(filename, 8, true);	
+          temp2 = new PyMFEM::wFILE(filename, 8, true);
+          Py_DECREF(str);	 
         }
       }
       
-      if (use_stringio2 == 0){
+      if (stream2 == 0){
         if (temp2->isSTDOUT() == 1) {
           arg2 = &std::cout;
+        } else if (temp2->isGZ()){
+          out_gz2 = new mfem::ofgzstream(temp2->getFilename(), true);
+          arg2 = out_gz2;	     
         } else {
-          out2.open(temp2->getFilename());
-          out2.precision(temp2->getPrecision());
-          if (temp2->isTemporary()){
-            delete temp2;
-          }
-          arg2 = &out2;
+          out_txt2.open(temp2->getFilename());
+          out_txt2.precision(temp2->getPrecision());
+          arg2 = &out_txt2;
+        }
+        if (temp2->isTemporary()){
+          delete temp2;
         }
       } else {
-        arg2 = &stream2;
+        arg2 = stream2;
       }
     }
   }
@@ -10934,8 +10939,8 @@ SWIGINTERN PyObject *_wrap_DenseMatrix_Print__SWIG_0(PyObject *SWIGUNUSEDPARM(se
   }
   resultobj = SWIG_Py_Void();
   {
-    if (use_stringio2 == 1) {
-      std::string str =  stream2.str();
+    if (stream2) {
+      std::string str =  stream2->str();
       const char* s = str.c_str();
       const int n = str.length();
       ret2 = PyObject_CallMethod(string_io2, "write", "s#",
@@ -10944,15 +10949,21 @@ SWIGINTERN PyObject *_wrap_DenseMatrix_Print__SWIG_0(PyObject *SWIGUNUSEDPARM(se
         PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
         return NULL;
       }
+      delete stream2;
       Py_XDECREF(resultobj);   /* Blow away any previous result */
       resultobj = ret2;    
     }
   }
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -10960,10 +10971,15 @@ SWIGINTERN PyObject *_wrap_DenseMatrix_Print__SWIG_0(PyObject *SWIGUNUSEDPARM(se
   return resultobj;
 fail:
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -10980,10 +10996,10 @@ SWIGINTERN PyObject *_wrap_DenseMatrix_PrintMatlab__SWIG_0(PyObject *SWIGUNUSEDP
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyMFEM::wFILE *temp2 = 0 ;
-  std::ofstream out2 ;
-  int use_stringio2 = 0 ;
+  std::ofstream out_txt2 ;
+  mfem::ofgzstream *out_gz2 = 0 ;
   PyObject *string_io2 = 0 ;
-  std::ostringstream stream2 ;
+  std::ostringstream *stream2 = 0 ;
   PyObject *ret2 = 0 ;
   
   if ((nobjs < 1) || (nobjs > 2)) SWIG_fail;
@@ -11014,29 +11030,33 @@ SWIGINTERN PyObject *_wrap_DenseMatrix_PrintMatlab__SWIG_0(PyObject *SWIGUNUSEDP
             SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
             return NULL;
           }
-          use_stringio2=1;
           string_io2=swig_obj[1];
+          stream2 = new std::ostringstream();
         } else {
           // if it is string, extract filename as char*
           PyObject* str = PyUnicode_AsEncodedString(swig_obj[1], "utf-8", "~E~");	
           const char* filename = PyBytes_AsString(str);
-          temp2 = new PyMFEM::wFILE(filename, 8, true);	
+          temp2 = new PyMFEM::wFILE(filename, 8, true);
+          Py_DECREF(str);	 
         }
       }
       
-      if (use_stringio2 == 0){
+      if (stream2 == 0){
         if (temp2->isSTDOUT() == 1) {
           arg2 = &std::cout;
+        } else if (temp2->isGZ()){
+          out_gz2 = new mfem::ofgzstream(temp2->getFilename(), true);
+          arg2 = out_gz2;	     
         } else {
-          out2.open(temp2->getFilename());
-          out2.precision(temp2->getPrecision());
-          if (temp2->isTemporary()){
-            delete temp2;
-          }
-          arg2 = &out2;
+          out_txt2.open(temp2->getFilename());
+          out_txt2.precision(temp2->getPrecision());
+          arg2 = &out_txt2;
+        }
+        if (temp2->isTemporary()){
+          delete temp2;
         }
       } else {
-        arg2 = &stream2;
+        arg2 = stream2;
       }
     }
   }
@@ -11061,8 +11081,8 @@ SWIGINTERN PyObject *_wrap_DenseMatrix_PrintMatlab__SWIG_0(PyObject *SWIGUNUSEDP
   }
   resultobj = SWIG_Py_Void();
   {
-    if (use_stringio2 == 1) {
-      std::string str =  stream2.str();
+    if (stream2) {
+      std::string str =  stream2->str();
       const char* s = str.c_str();
       const int n = str.length();
       ret2 = PyObject_CallMethod(string_io2, "write", "s#",
@@ -11071,15 +11091,21 @@ SWIGINTERN PyObject *_wrap_DenseMatrix_PrintMatlab__SWIG_0(PyObject *SWIGUNUSEDP
         PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
         return NULL;
       }
+      delete stream2;
       Py_XDECREF(resultobj);   /* Blow away any previous result */
       resultobj = ret2;    
     }
   }
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -11087,10 +11113,15 @@ SWIGINTERN PyObject *_wrap_DenseMatrix_PrintMatlab__SWIG_0(PyObject *SWIGUNUSEDP
   return resultobj;
 fail:
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -11108,10 +11139,10 @@ SWIGINTERN PyObject *_wrap_DenseMatrix_PrintT__SWIG_0(PyObject *SWIGUNUSEDPARM(s
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyMFEM::wFILE *temp2 = 0 ;
-  std::ofstream out2 ;
-  int use_stringio2 = 0 ;
+  std::ofstream out_txt2 ;
+  mfem::ofgzstream *out_gz2 = 0 ;
   PyObject *string_io2 = 0 ;
-  std::ostringstream stream2 ;
+  std::ostringstream *stream2 = 0 ;
   PyObject *ret2 = 0 ;
   
   if ((nobjs < 1) || (nobjs > 3)) SWIG_fail;
@@ -11142,29 +11173,33 @@ SWIGINTERN PyObject *_wrap_DenseMatrix_PrintT__SWIG_0(PyObject *SWIGUNUSEDPARM(s
             SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
             return NULL;
           }
-          use_stringio2=1;
           string_io2=swig_obj[1];
+          stream2 = new std::ostringstream();
         } else {
           // if it is string, extract filename as char*
           PyObject* str = PyUnicode_AsEncodedString(swig_obj[1], "utf-8", "~E~");	
           const char* filename = PyBytes_AsString(str);
-          temp2 = new PyMFEM::wFILE(filename, 8, true);	
+          temp2 = new PyMFEM::wFILE(filename, 8, true);
+          Py_DECREF(str);	 
         }
       }
       
-      if (use_stringio2 == 0){
+      if (stream2 == 0){
         if (temp2->isSTDOUT() == 1) {
           arg2 = &std::cout;
+        } else if (temp2->isGZ()){
+          out_gz2 = new mfem::ofgzstream(temp2->getFilename(), true);
+          arg2 = out_gz2;	     
         } else {
-          out2.open(temp2->getFilename());
-          out2.precision(temp2->getPrecision());
-          if (temp2->isTemporary()){
-            delete temp2;
-          }
-          arg2 = &out2;
+          out_txt2.open(temp2->getFilename());
+          out_txt2.precision(temp2->getPrecision());
+          arg2 = &out_txt2;
+        }
+        if (temp2->isTemporary()){
+          delete temp2;
         }
       } else {
-        arg2 = &stream2;
+        arg2 = stream2;
       }
     }
   }
@@ -11197,8 +11232,8 @@ SWIGINTERN PyObject *_wrap_DenseMatrix_PrintT__SWIG_0(PyObject *SWIGUNUSEDPARM(s
   }
   resultobj = SWIG_Py_Void();
   {
-    if (use_stringio2 == 1) {
-      std::string str =  stream2.str();
+    if (stream2) {
+      std::string str =  stream2->str();
       const char* s = str.c_str();
       const int n = str.length();
       ret2 = PyObject_CallMethod(string_io2, "write", "s#",
@@ -11207,15 +11242,21 @@ SWIGINTERN PyObject *_wrap_DenseMatrix_PrintT__SWIG_0(PyObject *SWIGUNUSEDPARM(s
         PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
         return NULL;
       }
+      delete stream2;
       Py_XDECREF(resultobj);   /* Blow away any previous result */
       resultobj = ret2;    
     }
   }
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -11223,10 +11264,15 @@ SWIGINTERN PyObject *_wrap_DenseMatrix_PrintT__SWIG_0(PyObject *SWIGUNUSEDPARM(s
   return resultobj;
 fail:
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -12099,7 +12145,8 @@ SWIGINTERN PyObject *_wrap_DenseMatrix_Print(PyObject *self, PyObject *args) {
               _v = 0;	   	   	   
             }
           } else {
-            _v = 0;
+            std::cout << "it is text (out)\n";	
+            _v = 1;
           }
         } else {
           _v = 1;
@@ -12256,7 +12303,8 @@ SWIGINTERN PyObject *_wrap_DenseMatrix_PrintT(PyObject *self, PyObject *args) {
               _v = 0;	   	   	   
             }
           } else {
-            _v = 0;
+            std::cout << "it is text (out)\n";	
+            _v = 1;
           }
         } else {
           _v = 1;
@@ -12413,7 +12461,8 @@ SWIGINTERN PyObject *_wrap_DenseMatrix_PrintMatlab(PyObject *self, PyObject *arg
               _v = 0;	   	   	   
             }
           } else {
-            _v = 0;
+            std::cout << "it is text (out)\n";	
+            _v = 1;
           }
         } else {
           _v = 1;

--- a/mfem/_ser/densemat_wrap.cxx
+++ b/mfem/_ser/densemat_wrap.cxx
@@ -12145,7 +12145,6 @@ SWIGINTERN PyObject *_wrap_DenseMatrix_Print(PyObject *self, PyObject *args) {
               _v = 0;	   	   	   
             }
           } else {
-            std::cout << "it is text (out)\n";	
             _v = 1;
           }
         } else {
@@ -12303,7 +12302,6 @@ SWIGINTERN PyObject *_wrap_DenseMatrix_PrintT(PyObject *self, PyObject *args) {
               _v = 0;	   	   	   
             }
           } else {
-            std::cout << "it is text (out)\n";	
             _v = 1;
           }
         } else {
@@ -12461,7 +12459,6 @@ SWIGINTERN PyObject *_wrap_DenseMatrix_PrintMatlab(PyObject *self, PyObject *arg
               _v = 0;	   	   	   
             }
           } else {
-            std::cout << "it is text (out)\n";	
             _v = 1;
           }
         } else {

--- a/mfem/_ser/fespace.i
+++ b/mfem/_ser/fespace.i
@@ -44,6 +44,7 @@ import_array();
 
 %import "../common/io_stream_typemap.i"
 OSTREAM_TYPEMAP(std::ostream&)
+ISTREAM_TYPEMAP(std::istream&)
 
 // default number is -1, which conflict with error code of PyArray_PyIntAsInt...
 %typemap(typecheck) (int ndofs = -1) {

--- a/mfem/_ser/fespace_wrap.cxx
+++ b/mfem/_ser/fespace_wrap.cxx
@@ -3332,12 +3332,11 @@ namespace Swig {
 #define SWIGTYPE_p_pri_t swig_types[264]
 #define SWIGTYPE_p_quad_t swig_types[265]
 #define SWIGTYPE_p_seg_t swig_types[266]
-#define SWIGTYPE_p_std__istream swig_types[267]
-#define SWIGTYPE_p_tet_t swig_types[268]
-#define SWIGTYPE_p_tri_t swig_types[269]
-#define SWIGTYPE_p_void swig_types[270]
-static swig_type_info *swig_types[272];
-static swig_module_info swig_module = {swig_types, 271, 0, 0, 0, 0};
+#define SWIGTYPE_p_tet_t swig_types[267]
+#define SWIGTYPE_p_tri_t swig_types[268]
+#define SWIGTYPE_p_void swig_types[269]
+static swig_type_info *swig_types[271];
+static swig_module_info swig_module = {swig_types, 270, 0, 0, 0, 0};
 #define SWIG_TypeQuery(name) SWIG_TypeQueryModule(&swig_module, &swig_module, name)
 #define SWIG_MangledTypeQuery(name) SWIG_MangledTypeQueryModule(&swig_module, &swig_module, name)
 
@@ -9336,10 +9335,10 @@ SWIGINTERN PyObject *_wrap_FiniteElementSpace_Save__SWIG_0(PyObject *SWIGUNUSEDP
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyMFEM::wFILE *temp2 = 0 ;
-  std::ofstream out2 ;
-  int use_stringio2 = 0 ;
+  std::ofstream out_txt2 ;
+  mfem::ofgzstream *out_gz2 = 0 ;
   PyObject *string_io2 = 0 ;
-  std::ostringstream stream2 ;
+  std::ostringstream *stream2 = 0 ;
   PyObject *ret2 = 0 ;
   
   if ((nobjs < 2) || (nobjs > 2)) SWIG_fail;
@@ -9369,29 +9368,33 @@ SWIGINTERN PyObject *_wrap_FiniteElementSpace_Save__SWIG_0(PyObject *SWIGUNUSEDP
           SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
           return NULL;
         }
-        use_stringio2=1;
         string_io2=swig_obj[1];
+        stream2 = new std::ostringstream();
       } else {
         // if it is string, extract filename as char*
         PyObject* str = PyUnicode_AsEncodedString(swig_obj[1], "utf-8", "~E~");	
         const char* filename = PyBytes_AsString(str);
-        temp2 = new PyMFEM::wFILE(filename, 8, true);	
+        temp2 = new PyMFEM::wFILE(filename, 8, true);
+        Py_DECREF(str);	 
       }
     }
     
-    if (use_stringio2 == 0){
+    if (stream2 == 0){
       if (temp2->isSTDOUT() == 1) {
         arg2 = &std::cout;
+      } else if (temp2->isGZ()){
+        out_gz2 = new mfem::ofgzstream(temp2->getFilename(), true);
+        arg2 = out_gz2;	     
       } else {
-        out2.open(temp2->getFilename());
-        out2.precision(temp2->getPrecision());
-        if (temp2->isTemporary()){
-          delete temp2;
-        }
-        arg2 = &out2;
+        out_txt2.open(temp2->getFilename());
+        out_txt2.precision(temp2->getPrecision());
+        arg2 = &out_txt2;
+      }
+      if (temp2->isTemporary()){
+        delete temp2;
       }
     } else {
-      arg2 = &stream2;
+      arg2 = stream2;
     }
   }
   {
@@ -9415,8 +9418,8 @@ SWIGINTERN PyObject *_wrap_FiniteElementSpace_Save__SWIG_0(PyObject *SWIGUNUSEDP
   }
   resultobj = SWIG_Py_Void();
   {
-    if (use_stringio2 == 1) {
-      std::string str =  stream2.str();
+    if (stream2) {
+      std::string str =  stream2->str();
       const char* s = str.c_str();
       const int n = str.length();
       ret2 = PyObject_CallMethod(string_io2, "write", "s#",
@@ -9425,15 +9428,21 @@ SWIGINTERN PyObject *_wrap_FiniteElementSpace_Save__SWIG_0(PyObject *SWIGUNUSEDP
         PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
         return NULL;
       }
+      delete stream2;
       Py_XDECREF(resultobj);   /* Blow away any previous result */
       resultobj = ret2;    
     }
   }
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -9441,10 +9450,15 @@ SWIGINTERN PyObject *_wrap_FiniteElementSpace_Save__SWIG_0(PyObject *SWIGUNUSEDP
   return resultobj;
 fail:
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -9462,8 +9476,13 @@ SWIGINTERN PyObject *_wrap_FiniteElementSpace_Load(PyObject *SWIGUNUSEDPARM(self
   int res1 = 0 ;
   void *argp2 = 0 ;
   int res2 = 0 ;
-  void *argp3 = 0 ;
-  int res3 = 0 ;
+  PyMFEM::wFILE *temp3 = 0 ;
+  std::ifstream in_txt3 ;
+  mfem::ifgzstream *in_gz3 = 0 ;
+  PyObject *input_str3 = 0 ;
+  std::istringstream *stream3 = 0 ;
+  Py_ssize_t len3 = 0 ;
+  PyObject *ret3 = 0 ;
   PyObject * obj0 = 0 ;
   PyObject * obj1 = 0 ;
   PyObject * obj2 = 0 ;
@@ -9483,14 +9502,64 @@ SWIGINTERN PyObject *_wrap_FiniteElementSpace_Load(PyObject *SWIGUNUSEDPARM(self
     SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "FiniteElementSpace_Load" "', argument " "2"" of type '" "mfem::Mesh *""'"); 
   }
   arg2 = reinterpret_cast< mfem::Mesh * >(argp2);
-  res3 = SWIG_ConvertPtr(obj2, &argp3, SWIGTYPE_p_std__istream,  0 );
-  if (!SWIG_IsOK(res3)) {
-    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "FiniteElementSpace_Load" "', argument " "3"" of type '" "std::istream &""'"); 
+  {
+    //  PyMFEM::wFILE or string argument or StringIO
+    if (SWIG_ConvertPtr(obj2, (void **) &temp3, SWIGTYPE_p_PyMFEM__wFILE, 0 | 0) == -1) {
+      if (!PyString_Check(obj2) && !PyUnicode_Check(obj2)) {
+        // not string, check if it is StringIO
+        PyObject* module = PyImport_ImportModule("io");
+        if (!module){
+          PyErr_SetString(PyExc_RuntimeError, "Can not load io module");
+          return NULL;
+        }      
+        PyObject* cls = PyObject_GetAttrString(module, "StringIO");
+        if (!cls){
+          PyErr_SetString(PyExc_RuntimeError, "Can not load StringIO");
+          return NULL;
+        }      
+        int check = PyObject_IsInstance(obj2, cls);
+        Py_DECREF(module);
+        if (! check){
+          SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
+          return NULL;
+        }
+        
+        PyObject *input_str3 = PyObject_CallMethod(obj2, "getvalue", NULL);
+        if (PyErr_Occurred()) {
+          PyErr_SetString(PyExc_RuntimeError, "Can not read from StringIO");
+          return NULL;
+        }
+        
+        char *buf = nullptr;
+        PyObject *str = PyUnicode_AsUTF8String(input_str3);	 
+        PyBytes_AsStringAndSize(str, &buf, &len3);
+        stream3 = new std::istringstream(buf);
+        Py_DECREF(str);
+        Py_DECREF(input_str3);	 
+      } else {
+        // if it is string, extract filename as char*
+        PyObject* str = PyUnicode_AsEncodedString(obj2, "utf-8", "~E~");	
+        const char* filename = PyBytes_AsString(str);
+        temp3 = new PyMFEM::wFILE(filename, 8, true);
+        Py_DECREF(str);
+      }
+    }
+    if (stream3 == 0){
+      if (temp3->isGZ()){
+        in_gz3 = new mfem::ifgzstream(temp3->getFilename());
+        arg3 = in_gz3;
+      } else {
+        in_txt3.open(temp3->getFilename(), std::ifstream::in);
+        in_txt3.precision(temp3->getPrecision());
+        arg3 = &in_txt3;
+      }
+      if (temp3->isTemporary()){
+        delete temp3;
+      }
+    } else {
+      arg3 = stream3;
+    }
   }
-  if (!argp3) {
-    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "FiniteElementSpace_Load" "', argument " "3"" of type '" "std::istream &""'"); 
-  }
-  arg3 = reinterpret_cast< std::istream * >(argp3);
   {
     try {
       result = (mfem::FiniteElementCollection *)(arg1)->Load(arg2,*arg3);
@@ -9511,8 +9580,40 @@ SWIGINTERN PyObject *_wrap_FiniteElementSpace_Load(PyObject *SWIGUNUSEDPARM(self
     }	 
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__FiniteElementCollection, 0 |  0 );
+  {
+    if (stream3) {
+      ret3 = PyLong_FromSsize_t(len3);
+      if (PyErr_Occurred()) {
+        PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
+        return NULL;
+      }
+      delete stream3;    
+      Py_XDECREF(resultobj);   /* Blow away any previous result */
+      resultobj = ret3;    
+    }
+  }
+  {
+    if (!stream3) {
+      if (temp3) {
+        in_txt3.close();
+      }
+      if (in_gz3){
+        delete in_gz3;
+      }
+    }  
+  }
   return resultobj;
 fail:
+  {
+    if (!stream3) {
+      if (temp3) {
+        in_txt3.close();
+      }
+      if (in_gz3){
+        delete in_gz3;
+      }
+    }  
+  }
   return NULL;
 }
 
@@ -9724,7 +9825,8 @@ SWIGINTERN PyObject *_wrap_FiniteElementSpace_Save(PyObject *self, PyObject *arg
               _v = 0;	   	   	   
             }
           } else {
-            _v = 0;
+            std::cout << "it is text (out)\n";	
+            _v = 1;
           }
         } else {
           _v = 1;
@@ -9809,8 +9911,13 @@ SWIGINTERN PyObject *_wrap_new_QuadratureSpace__SWIG_1(PyObject *SWIGUNUSEDPARM(
   std::istream *arg2 = 0 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
-  void *argp2 = 0 ;
-  int res2 = 0 ;
+  PyMFEM::wFILE *temp2 = 0 ;
+  std::ifstream in_txt2 ;
+  mfem::ifgzstream *in_gz2 = 0 ;
+  PyObject *input_str2 = 0 ;
+  std::istringstream *stream2 = 0 ;
+  Py_ssize_t len2 = 0 ;
+  PyObject *ret2 = 0 ;
   mfem::QuadratureSpace *result = 0 ;
   
   if ((nobjs < 2) || (nobjs > 2)) SWIG_fail;
@@ -9819,14 +9926,64 @@ SWIGINTERN PyObject *_wrap_new_QuadratureSpace__SWIG_1(PyObject *SWIGUNUSEDPARM(
     SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "new_QuadratureSpace" "', argument " "1"" of type '" "mfem::Mesh *""'"); 
   }
   arg1 = reinterpret_cast< mfem::Mesh * >(argp1);
-  res2 = SWIG_ConvertPtr(swig_obj[1], &argp2, SWIGTYPE_p_std__istream,  0 );
-  if (!SWIG_IsOK(res2)) {
-    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "new_QuadratureSpace" "', argument " "2"" of type '" "std::istream &""'"); 
+  {
+    //  PyMFEM::wFILE or string argument or StringIO
+    if (SWIG_ConvertPtr(swig_obj[1], (void **) &temp2, SWIGTYPE_p_PyMFEM__wFILE, 0 | 0) == -1) {
+      if (!PyString_Check(swig_obj[1]) && !PyUnicode_Check(swig_obj[1])) {
+        // not string, check if it is StringIO
+        PyObject* module = PyImport_ImportModule("io");
+        if (!module){
+          PyErr_SetString(PyExc_RuntimeError, "Can not load io module");
+          return NULL;
+        }      
+        PyObject* cls = PyObject_GetAttrString(module, "StringIO");
+        if (!cls){
+          PyErr_SetString(PyExc_RuntimeError, "Can not load StringIO");
+          return NULL;
+        }      
+        int check = PyObject_IsInstance(swig_obj[1], cls);
+        Py_DECREF(module);
+        if (! check){
+          SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
+          return NULL;
+        }
+        
+        PyObject *input_str2 = PyObject_CallMethod(swig_obj[1], "getvalue", NULL);
+        if (PyErr_Occurred()) {
+          PyErr_SetString(PyExc_RuntimeError, "Can not read from StringIO");
+          return NULL;
+        }
+        
+        char *buf = nullptr;
+        PyObject *str = PyUnicode_AsUTF8String(input_str2);	 
+        PyBytes_AsStringAndSize(str, &buf, &len2);
+        stream2 = new std::istringstream(buf);
+        Py_DECREF(str);
+        Py_DECREF(input_str2);	 
+      } else {
+        // if it is string, extract filename as char*
+        PyObject* str = PyUnicode_AsEncodedString(swig_obj[1], "utf-8", "~E~");	
+        const char* filename = PyBytes_AsString(str);
+        temp2 = new PyMFEM::wFILE(filename, 8, true);
+        Py_DECREF(str);
+      }
+    }
+    if (stream2 == 0){
+      if (temp2->isGZ()){
+        in_gz2 = new mfem::ifgzstream(temp2->getFilename());
+        arg2 = in_gz2;
+      } else {
+        in_txt2.open(temp2->getFilename(), std::ifstream::in);
+        in_txt2.precision(temp2->getPrecision());
+        arg2 = &in_txt2;
+      }
+      if (temp2->isTemporary()){
+        delete temp2;
+      }
+    } else {
+      arg2 = stream2;
+    }
   }
-  if (!argp2) {
-    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "new_QuadratureSpace" "', argument " "2"" of type '" "std::istream &""'"); 
-  }
-  arg2 = reinterpret_cast< std::istream * >(argp2);
   {
     try {
       result = (mfem::QuadratureSpace *)new mfem::QuadratureSpace(arg1,*arg2);
@@ -9847,8 +10004,40 @@ SWIGINTERN PyObject *_wrap_new_QuadratureSpace__SWIG_1(PyObject *SWIGUNUSEDPARM(
     }	 
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__QuadratureSpace, SWIG_POINTER_NEW |  0 );
+  {
+    if (stream2) {
+      ret2 = PyLong_FromSsize_t(len2);
+      if (PyErr_Occurred()) {
+        PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
+        return NULL;
+      }
+      delete stream2;    
+      Py_XDECREF(resultobj);   /* Blow away any previous result */
+      resultobj = ret2;    
+    }
+  }
+  {
+    if (!stream2) {
+      if (temp2) {
+        in_txt2.close();
+      }
+      if (in_gz2){
+        delete in_gz2;
+      }
+    }  
+  }
   return resultobj;
 fail:
+  {
+    if (!stream2) {
+      if (temp2) {
+        in_txt2.close();
+      }
+      if (in_gz2){
+        delete in_gz2;
+      }
+    }  
+  }
   return NULL;
 }
 
@@ -9867,20 +10056,6 @@ SWIGINTERN PyObject *_wrap_new_QuadratureSpace(PyObject *self, PyObject *args) {
     int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_mfem__Mesh, 0);
     _v = SWIG_CheckState(res);
     if (_v) {
-      void *vptr = 0;
-      int res = SWIG_ConvertPtr(argv[1], &vptr, SWIGTYPE_p_std__istream, SWIG_POINTER_NO_NULL);
-      _v = SWIG_CheckState(res);
-      if (_v) {
-        return _wrap_new_QuadratureSpace__SWIG_1(self, argc, argv);
-      }
-    }
-  }
-  if (argc == 2) {
-    int _v;
-    void *vptr = 0;
-    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_mfem__Mesh, 0);
-    _v = SWIG_CheckState(res);
-    if (_v) {
       {
         if ((PyArray_PyIntAsInt(argv[1]) == -1) && PyErr_Occurred()) {
           PyErr_Clear();
@@ -9891,6 +10066,45 @@ SWIGINTERN PyObject *_wrap_new_QuadratureSpace(PyObject *self, PyObject *args) {
       }
       if (_v) {
         return _wrap_new_QuadratureSpace__SWIG_0(self, argc, argv);
+      }
+    }
+  }
+  if (argc == 2) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_mfem__Mesh, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      {
+        void *ptr;
+        //std::string *ptr2 = (std::string *)0;
+        if (SWIG_ConvertPtr(argv[1], (void **) &ptr, SWIGTYPE_p_PyMFEM__wFILE, 0 |0) == -1) {
+          PyErr_Clear();
+          if (!PyString_Check(argv[1]) && !PyUnicode_Check(argv[1])) {
+            // not string
+            _v = 1;	   	
+            PyObject* module = PyImport_ImportModule("io");
+            if (!module){
+              _v = 0;	   
+            }      
+            PyObject* cls = PyObject_GetAttrString(module, "StringIO");
+            if (!cls){
+              _v = 0;	   	   
+            }      
+            int check = PyObject_IsInstance(argv[1], cls);
+            Py_DECREF(module);
+            if (! check){
+              _v = 0;	   	   	   
+            }
+          } else {
+            _v = 1;
+          }
+        } else {
+          _v = 1;
+        }
+      }
+      if (_v) {
+        return _wrap_new_QuadratureSpace__SWIG_1(self, argc, argv);
       }
     }
   }
@@ -10125,10 +10339,10 @@ SWIGINTERN PyObject *_wrap_QuadratureSpace_Save__SWIG_0(PyObject *SWIGUNUSEDPARM
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyMFEM::wFILE *temp2 = 0 ;
-  std::ofstream out2 ;
-  int use_stringio2 = 0 ;
+  std::ofstream out_txt2 ;
+  mfem::ofgzstream *out_gz2 = 0 ;
   PyObject *string_io2 = 0 ;
-  std::ostringstream stream2 ;
+  std::ostringstream *stream2 = 0 ;
   PyObject *ret2 = 0 ;
   
   if ((nobjs < 2) || (nobjs > 2)) SWIG_fail;
@@ -10158,29 +10372,33 @@ SWIGINTERN PyObject *_wrap_QuadratureSpace_Save__SWIG_0(PyObject *SWIGUNUSEDPARM
           SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
           return NULL;
         }
-        use_stringio2=1;
         string_io2=swig_obj[1];
+        stream2 = new std::ostringstream();
       } else {
         // if it is string, extract filename as char*
         PyObject* str = PyUnicode_AsEncodedString(swig_obj[1], "utf-8", "~E~");	
         const char* filename = PyBytes_AsString(str);
-        temp2 = new PyMFEM::wFILE(filename, 8, true);	
+        temp2 = new PyMFEM::wFILE(filename, 8, true);
+        Py_DECREF(str);	 
       }
     }
     
-    if (use_stringio2 == 0){
+    if (stream2 == 0){
       if (temp2->isSTDOUT() == 1) {
         arg2 = &std::cout;
+      } else if (temp2->isGZ()){
+        out_gz2 = new mfem::ofgzstream(temp2->getFilename(), true);
+        arg2 = out_gz2;	     
       } else {
-        out2.open(temp2->getFilename());
-        out2.precision(temp2->getPrecision());
-        if (temp2->isTemporary()){
-          delete temp2;
-        }
-        arg2 = &out2;
+        out_txt2.open(temp2->getFilename());
+        out_txt2.precision(temp2->getPrecision());
+        arg2 = &out_txt2;
+      }
+      if (temp2->isTemporary()){
+        delete temp2;
       }
     } else {
-      arg2 = &stream2;
+      arg2 = stream2;
     }
   }
   {
@@ -10204,8 +10422,8 @@ SWIGINTERN PyObject *_wrap_QuadratureSpace_Save__SWIG_0(PyObject *SWIGUNUSEDPARM
   }
   resultobj = SWIG_Py_Void();
   {
-    if (use_stringio2 == 1) {
-      std::string str =  stream2.str();
+    if (stream2) {
+      std::string str =  stream2->str();
       const char* s = str.c_str();
       const int n = str.length();
       ret2 = PyObject_CallMethod(string_io2, "write", "s#",
@@ -10214,15 +10432,21 @@ SWIGINTERN PyObject *_wrap_QuadratureSpace_Save__SWIG_0(PyObject *SWIGUNUSEDPARM
         PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
         return NULL;
       }
+      delete stream2;
       Py_XDECREF(resultobj);   /* Blow away any previous result */
       resultobj = ret2;    
     }
   }
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -10230,10 +10454,15 @@ SWIGINTERN PyObject *_wrap_QuadratureSpace_Save__SWIG_0(PyObject *SWIGUNUSEDPARM
   return resultobj;
 fail:
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -10409,7 +10638,8 @@ SWIGINTERN PyObject *_wrap_QuadratureSpace_Save(PyObject *self, PyObject *args) 
               _v = 0;	   	   	   
             }
           } else {
-            _v = 0;
+            std::cout << "it is text (out)\n";	
+            _v = 1;
           }
         } else {
           _v = 1;
@@ -12522,7 +12752,6 @@ static swig_type_info _swigt__p_mfem__STable = {"_p_mfem__STable", 0, 0, 0, 0, 0
 static swig_type_info _swigt__p_pri_t = {"_p_pri_t", "pri_t *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_quad_t = {"_p_quad_t", "quad_t *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_seg_t = {"_p_seg_t", "seg_t *", 0, 0, (void*)0, 0};
-static swig_type_info _swigt__p_std__istream = {"_p_std__istream", "std::istream *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_tet_t = {"_p_tet_t", "tet_t *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_tri_t = {"_p_tri_t", "tri_t *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_void = {"_p_void", "void *", 0, 0, (void*)0, 0};
@@ -12795,7 +13024,6 @@ static swig_type_info *swig_type_initial[] = {
   &_swigt__p_pri_t,
   &_swigt__p_quad_t,
   &_swigt__p_seg_t,
-  &_swigt__p_std__istream,
   &_swigt__p_tet_t,
   &_swigt__p_tri_t,
   &_swigt__p_void,
@@ -13068,7 +13296,6 @@ static swig_cast_info _swigc__p_mfem__Table[] = {  {&_swigt__p_mfem__STable, _p_
 static swig_cast_info _swigc__p_pri_t[] = {  {&_swigt__p_pri_t, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_quad_t[] = {  {&_swigt__p_quad_t, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_seg_t[] = {  {&_swigt__p_seg_t, 0, 0, 0},{0, 0, 0, 0}};
-static swig_cast_info _swigc__p_std__istream[] = {  {&_swigt__p_std__istream, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_tet_t[] = {  {&_swigt__p_tet_t, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_tri_t[] = {  {&_swigt__p_tri_t, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_void[] = {  {&_swigt__p_void, 0, 0, 0},{0, 0, 0, 0}};
@@ -13341,7 +13568,6 @@ static swig_cast_info *swig_cast_initial[] = {
   _swigc__p_pri_t,
   _swigc__p_quad_t,
   _swigc__p_seg_t,
-  _swigc__p_std__istream,
   _swigc__p_tet_t,
   _swigc__p_tri_t,
   _swigc__p_void,

--- a/mfem/_ser/fespace_wrap.cxx
+++ b/mfem/_ser/fespace_wrap.cxx
@@ -9479,7 +9479,6 @@ SWIGINTERN PyObject *_wrap_FiniteElementSpace_Load(PyObject *SWIGUNUSEDPARM(self
   PyMFEM::wFILE *temp3 = 0 ;
   std::ifstream in_txt3 ;
   mfem::ifgzstream *in_gz3 = 0 ;
-  PyObject *input_str3 = 0 ;
   std::istringstream *stream3 = 0 ;
   Py_ssize_t len3 = 0 ;
   PyObject *ret3 = 0 ;
@@ -9524,18 +9523,18 @@ SWIGINTERN PyObject *_wrap_FiniteElementSpace_Load(PyObject *SWIGUNUSEDPARM(self
           return NULL;
         }
         
-        PyObject *input_str3 = PyObject_CallMethod(obj2, "getvalue", NULL);
+        PyObject *input_str = PyObject_CallMethod(obj2, "getvalue", NULL);
         if (PyErr_Occurred()) {
           PyErr_SetString(PyExc_RuntimeError, "Can not read from StringIO");
           return NULL;
         }
         
         char *buf = nullptr;
-        PyObject *str = PyUnicode_AsUTF8String(input_str3);	 
+        PyObject *str = PyUnicode_AsUTF8String(input_str);	 
         PyBytes_AsStringAndSize(str, &buf, &len3);
         stream3 = new std::istringstream(buf);
         Py_DECREF(str);
-        Py_DECREF(input_str3);	 
+        Py_DECREF(input_str);	 
       } else {
         // if it is string, extract filename as char*
         PyObject* str = PyUnicode_AsEncodedString(obj2, "utf-8", "~E~");	
@@ -9825,7 +9824,6 @@ SWIGINTERN PyObject *_wrap_FiniteElementSpace_Save(PyObject *self, PyObject *arg
               _v = 0;	   	   	   
             }
           } else {
-            std::cout << "it is text (out)\n";	
             _v = 1;
           }
         } else {
@@ -9914,7 +9912,6 @@ SWIGINTERN PyObject *_wrap_new_QuadratureSpace__SWIG_1(PyObject *SWIGUNUSEDPARM(
   PyMFEM::wFILE *temp2 = 0 ;
   std::ifstream in_txt2 ;
   mfem::ifgzstream *in_gz2 = 0 ;
-  PyObject *input_str2 = 0 ;
   std::istringstream *stream2 = 0 ;
   Py_ssize_t len2 = 0 ;
   PyObject *ret2 = 0 ;
@@ -9948,18 +9945,18 @@ SWIGINTERN PyObject *_wrap_new_QuadratureSpace__SWIG_1(PyObject *SWIGUNUSEDPARM(
           return NULL;
         }
         
-        PyObject *input_str2 = PyObject_CallMethod(swig_obj[1], "getvalue", NULL);
+        PyObject *input_str = PyObject_CallMethod(swig_obj[1], "getvalue", NULL);
         if (PyErr_Occurred()) {
           PyErr_SetString(PyExc_RuntimeError, "Can not read from StringIO");
           return NULL;
         }
         
         char *buf = nullptr;
-        PyObject *str = PyUnicode_AsUTF8String(input_str2);	 
+        PyObject *str = PyUnicode_AsUTF8String(input_str);	 
         PyBytes_AsStringAndSize(str, &buf, &len2);
         stream2 = new std::istringstream(buf);
         Py_DECREF(str);
-        Py_DECREF(input_str2);	 
+        Py_DECREF(input_str);	 
       } else {
         // if it is string, extract filename as char*
         PyObject* str = PyUnicode_AsEncodedString(swig_obj[1], "utf-8", "~E~");	
@@ -10638,7 +10635,6 @@ SWIGINTERN PyObject *_wrap_QuadratureSpace_Save(PyObject *self, PyObject *args) 
               _v = 0;	   	   	   
             }
           } else {
-            std::cout << "it is text (out)\n";	
             _v = 1;
           }
         } else {

--- a/mfem/_ser/gridfunc.i
+++ b/mfem/_ser/gridfunc.i
@@ -103,13 +103,6 @@ GridFunction(mfem::FiniteElementSpace *fes, const mfem::Vector &v, int offset){
    gf = new mfem::GridFunction(fes, v.GetData() + offset);
    return gf;
 }
-
-void Save(const char *gf_file, const int precision) const
-{
-     std::ofstream mesh_ofs(gf_file);	
-     mesh_ofs.precision(precision);
-     self->Save(mesh_ofs);	
-}
  
 void SaveToFile(const char *gf_file, const int precision) const
    {
@@ -207,8 +200,8 @@ fem/gridfunc.hpp:   void Save(std::ostream &out) const;
 fem/gridfunc.hpp:   void SaveVTK(std::ostream &out, const std::string &field_name, int ref);
 fem/gridfunc.hpp:   void SaveSTL(std::ostream &out, int TimesToRefine = 1);
 */
-//#ifndef SWIGIMPORTED
-//OSTREAM_ADD_DEFAULT_FILE(GridFunction, Save)
-//OSTREAM_ADD_DEFAULT_FILE(QuadratureFunction, Save)
-//#endif   
+#ifndef SWIGIMPORTED
+OSTREAM_ADD_DEFAULT_FILE(GridFunction, Save)
+OSTREAM_ADD_DEFAULT_FILE(QuadratureFunction, Save)
+#endif   
   

--- a/mfem/_ser/gridfunc.i
+++ b/mfem/_ser/gridfunc.i
@@ -47,6 +47,7 @@ import_array();
 
 %import "../common/io_stream_typemap.i"
 OSTREAM_TYPEMAP(std::ostream&)
+ISTREAM_TYPEMAP(std::istream&)
 
 %rename(Assign) mfem::GridFunction::operator=;
 
@@ -96,21 +97,18 @@ def GetNodalValues(self, *args):
 
 namespace mfem{
 %extend GridFunction{
-GridFunction(Mesh *m, const char *grid_file){
-   mfem::GridFunction *gf;
-   std::ifstream igrid(grid_file);
-   if (!igrid) {
-      std::cerr << "\nCan not open grid function file: " << grid_file << '\n' << std::endl;
-      return NULL;
-   }
-   gf = new mfem::GridFunction(m, igrid);
-   return gf;
-}
- 
+     
 GridFunction(mfem::FiniteElementSpace *fes, const mfem::Vector &v, int offset){
    mfem::GridFunction *gf;   
    gf = new mfem::GridFunction(fes, v.GetData() + offset);
    return gf;
+}
+
+void Save(const char *gf_file, const int precision) const
+{
+     std::ofstream mesh_ofs(gf_file);	
+     mesh_ofs.precision(precision);
+     self->Save(mesh_ofs);	
 }
  
 void SaveToFile(const char *gf_file, const int precision) const
@@ -196,7 +194,7 @@ def __imul__(self, v):
     ret = _gridfunc.GridFunction_imul(self, v)
     ret.thisown = 0
     return self
-      
+
 GridFunction.__iadd__  = __iadd__
 GridFunction.__idiv__  = __idiv__
 GridFunction.__isub__  = __isub__
@@ -206,12 +204,11 @@ GridFunction.__imul__  = __imul__
 /*
 fem/gridfunc.hpp:   virtual void Save(std::ostream &out) const;
 fem/gridfunc.hpp:   void Save(std::ostream &out) const;
-
 fem/gridfunc.hpp:   void SaveVTK(std::ostream &out, const std::string &field_name, int ref);
 fem/gridfunc.hpp:   void SaveSTL(std::ostream &out, int TimesToRefine = 1);
 */
-#ifndef SWIGIMPORTED
-OSTREAM_ADD_DEFAULT_FILE(GridFunction, Save)
-OSTREAM_ADD_DEFAULT_FILE(QuadratureFunction, Save)
-#endif   
+//#ifndef SWIGIMPORTED
+//OSTREAM_ADD_DEFAULT_FILE(GridFunction, Save)
+//OSTREAM_ADD_DEFAULT_FILE(QuadratureFunction, Save)
+//#endif   
   

--- a/mfem/_ser/gridfunc.py
+++ b/mfem/_ser/gridfunc.py
@@ -530,14 +530,6 @@ class GridFunction(mfem._ser.vector.Vector):
         """
         _gridfunc.GridFunction_swiginit(self, _gridfunc.new_GridFunction(*args))
 
-    def Save(self, *args):
-        r"""
-        Save(GridFunction self, std::ostream & out)
-        Save(GridFunction self, char const * gf_file, int const precision)
-        """
-        return _gridfunc.GridFunction_Save(self, *args)
-    Save = _swig_new_instance_method(_gridfunc.GridFunction_Save)
-
     def SaveToFile(self, gf_file, precision):
         r"""SaveToFile(GridFunction self, char const * gf_file, int const precision)"""
         return _gridfunc.GridFunction_SaveToFile(self, gf_file, precision)
@@ -570,6 +562,14 @@ class GridFunction(mfem._ser.vector.Vector):
         r"""idiv(GridFunction self, double c) -> GridFunction"""
         return _gridfunc.GridFunction_idiv(self, c)
     idiv = _swig_new_instance_method(_gridfunc.GridFunction_idiv)
+
+    def Save(self, *args):
+        r"""
+        Save(GridFunction self, std::ostream & out)
+        Save(GridFunction self, char const * file, int precision=8)
+        """
+        return _gridfunc.GridFunction_Save(self, *args)
+    Save = _swig_new_instance_method(_gridfunc.GridFunction_Save)
 
 # Register GridFunction in _gridfunc:
 _gridfunc.GridFunction_swigregister(GridFunction)
@@ -641,9 +641,12 @@ class QuadratureFunction(mfem._ser.vector.Vector):
         return _gridfunc.QuadratureFunction_GetElementValues(self, *args)
     GetElementValues = _swig_new_instance_method(_gridfunc.QuadratureFunction_GetElementValues)
 
-    def Save(self, out):
-        r"""Save(QuadratureFunction self, std::ostream & out)"""
-        return _gridfunc.QuadratureFunction_Save(self, out)
+    def Save(self, *args):
+        r"""
+        Save(QuadratureFunction self, std::ostream & out)
+        Save(QuadratureFunction self, char const * file, int precision=8)
+        """
+        return _gridfunc.QuadratureFunction_Save(self, *args)
     Save = _swig_new_instance_method(_gridfunc.QuadratureFunction_Save)
 
 # Register QuadratureFunction in _gridfunc:

--- a/mfem/_ser/gridfunc.py
+++ b/mfem/_ser/gridfunc.py
@@ -526,10 +526,17 @@ class GridFunction(mfem._ser.vector.Vector):
         __init__(GridFunction self, FiniteElementSpace f, double * data) -> GridFunction
         __init__(GridFunction self, Mesh m, std::istream & input) -> GridFunction
         __init__(GridFunction self, Mesh m, mfem::GridFunction *[] gf_array, int num_pieces) -> GridFunction
-        __init__(GridFunction self, Mesh m, char const * grid_file) -> GridFunction
         __init__(GridFunction self, FiniteElementSpace fes, Vector v, int offset) -> GridFunction
         """
         _gridfunc.GridFunction_swiginit(self, _gridfunc.new_GridFunction(*args))
+
+    def Save(self, *args):
+        r"""
+        Save(GridFunction self, std::ostream & out)
+        Save(GridFunction self, char const * gf_file, int const precision)
+        """
+        return _gridfunc.GridFunction_Save(self, *args)
+    Save = _swig_new_instance_method(_gridfunc.GridFunction_Save)
 
     def SaveToFile(self, gf_file, precision):
         r"""SaveToFile(GridFunction self, char const * gf_file, int const precision)"""
@@ -563,14 +570,6 @@ class GridFunction(mfem._ser.vector.Vector):
         r"""idiv(GridFunction self, double c) -> GridFunction"""
         return _gridfunc.GridFunction_idiv(self, c)
     idiv = _swig_new_instance_method(_gridfunc.GridFunction_idiv)
-
-    def Save(self, *args):
-        r"""
-        Save(GridFunction self, std::ostream & out)
-        Save(GridFunction self, char const * file, int precision=8)
-        """
-        return _gridfunc.GridFunction_Save(self, *args)
-    Save = _swig_new_instance_method(_gridfunc.GridFunction_Save)
 
 # Register GridFunction in _gridfunc:
 _gridfunc.GridFunction_swigregister(GridFunction)
@@ -642,12 +641,9 @@ class QuadratureFunction(mfem._ser.vector.Vector):
         return _gridfunc.QuadratureFunction_GetElementValues(self, *args)
     GetElementValues = _swig_new_instance_method(_gridfunc.QuadratureFunction_GetElementValues)
 
-    def Save(self, *args):
-        r"""
-        Save(QuadratureFunction self, std::ostream & out)
-        Save(QuadratureFunction self, char const * file, int precision=8)
-        """
-        return _gridfunc.QuadratureFunction_Save(self, *args)
+    def Save(self, out):
+        r"""Save(QuadratureFunction self, std::ostream & out)"""
+        return _gridfunc.QuadratureFunction_Save(self, out)
     Save = _swig_new_instance_method(_gridfunc.QuadratureFunction_Save)
 
 # Register QuadratureFunction in _gridfunc:

--- a/mfem/_ser/gridfunc_wrap.cxx
+++ b/mfem/_ser/gridfunc_wrap.cxx
@@ -3267,12 +3267,11 @@ namespace Swig {
 #define SWIGTYPE_p_pri_t swig_types[194]
 #define SWIGTYPE_p_quad_t swig_types[195]
 #define SWIGTYPE_p_seg_t swig_types[196]
-#define SWIGTYPE_p_std__istream swig_types[197]
-#define SWIGTYPE_p_std__ostream swig_types[198]
-#define SWIGTYPE_p_tet_t swig_types[199]
-#define SWIGTYPE_p_tri_t swig_types[200]
-static swig_type_info *swig_types[202];
-static swig_module_info swig_module = {swig_types, 201, 0, 0, 0, 0};
+#define SWIGTYPE_p_std__ostream swig_types[197]
+#define SWIGTYPE_p_tet_t swig_types[198]
+#define SWIGTYPE_p_tri_t swig_types[199]
+static swig_type_info *swig_types[201];
+static swig_module_info swig_module = {swig_types, 200, 0, 0, 0, 0};
 #define SWIG_TypeQuery(name) SWIG_TypeQueryModule(&swig_module, &swig_module, name)
 #define SWIG_MangledTypeQuery(name) SWIG_MangledTypeQueryModule(&swig_module, &swig_module, name)
 
@@ -3719,23 +3718,18 @@ SWIG_AsPtr_std_string (PyObject * obj, std::string **val)
   return SWIG_ERROR;
 }
 
-
-
-
-SWIGINTERN mfem::GridFunction *new_mfem_GridFunction__SWIG_6(mfem::Mesh *m,char const *grid_file){
-   mfem::GridFunction *gf;
-   std::ifstream igrid(grid_file);
-   if (!igrid) {
-      std::cerr << "\nCan not open grid function file: " << grid_file << '\n' << std::endl;
-      return NULL;
-   }
-   gf = new mfem::GridFunction(m, igrid);
-   return gf;
-}
-SWIGINTERN mfem::GridFunction *new_mfem_GridFunction__SWIG_7(mfem::FiniteElementSpace *fes,mfem::Vector const &v,int offset){
+SWIGINTERN mfem::GridFunction *new_mfem_GridFunction__SWIG_6(mfem::FiniteElementSpace *fes,mfem::Vector const &v,int offset){
    mfem::GridFunction *gf;   
    gf = new mfem::GridFunction(fes, v.GetData() + offset);
    return gf;
+}
+
+
+
+SWIGINTERN void mfem_GridFunction_Save__SWIG_1(mfem::GridFunction const *self,char const *gf_file,int const precision){
+     std::ofstream mesh_ofs(gf_file);	
+     mesh_ofs.precision(precision);
+     self->Save(mesh_ofs);	
 }
 SWIGINTERN void mfem_GridFunction_SaveToFile(mfem::GridFunction const *self,char const *gf_file,int const precision){
         std::cerr << "\nWarning Deprecated : Use Save(filename) insteead of SaveToFile \n";
@@ -3792,17 +3786,6 @@ SWIGINTERN mfem::GridFunction &mfem_GridFunction_idiv(mfem::GridFunction *self,d
       * self /= c;
       return *self;
    }
-SWIGINTERN void mfem_GridFunction_Save__SWIG_1(mfem::GridFunction *self,char const *file,int precision=8){
-  std::ofstream ofile(file);
-  if (!ofile)
-     {
-        std::cerr << "\nCan not produce output file: " << file << '\n' << std::endl;
-        return;
-      }
-  ofile.precision(precision);  
-  self -> Save(ofile);
-  ofile.close();
-  }
 
 SWIGINTERNINLINE PyObject*
   SWIG_From_bool  (bool value)
@@ -3810,17 +3793,6 @@ SWIGINTERNINLINE PyObject*
   return PyBool_FromLong(value ? 1 : 0);
 }
 
-SWIGINTERN void mfem_QuadratureFunction_Save__SWIG_1(mfem::QuadratureFunction *self,char const *file,int precision=8){
-  std::ofstream ofile(file);
-  if (!ofile)
-     {
-        std::cerr << "\nCan not produce output file: " << file << '\n' << std::endl;
-        return;
-      }
-  ofile.precision(precision);  
-  self -> Save(ofile);
-  ofile.close();
-  }
 
 
 /* ---------------------------------------------------
@@ -3997,8 +3969,12 @@ SWIGINTERN PyObject *_wrap_new_GridFunction__SWIG_4(PyObject *SWIGUNUSEDPARM(sel
   std::istream *arg2 = 0 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
-  void *argp2 = 0 ;
-  int res2 = 0 ;
+  PyMFEM::wFILE *temp2 = 0 ;
+  std::ifstream in_txt2 ;
+  mfem::ifgzstream *in_gz2 = 0 ;
+  std::istringstream *stream2 = 0 ;
+  Py_ssize_t len2 = 0 ;
+  PyObject *ret2 = 0 ;
   mfem::GridFunction *result = 0 ;
   
   if ((nobjs < 2) || (nobjs > 2)) SWIG_fail;
@@ -4007,14 +3983,64 @@ SWIGINTERN PyObject *_wrap_new_GridFunction__SWIG_4(PyObject *SWIGUNUSEDPARM(sel
     SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "new_GridFunction" "', argument " "1"" of type '" "mfem::Mesh *""'"); 
   }
   arg1 = reinterpret_cast< mfem::Mesh * >(argp1);
-  res2 = SWIG_ConvertPtr(swig_obj[1], &argp2, SWIGTYPE_p_std__istream,  0 );
-  if (!SWIG_IsOK(res2)) {
-    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "new_GridFunction" "', argument " "2"" of type '" "std::istream &""'"); 
+  {
+    //  PyMFEM::wFILE or string argument or StringIO
+    if (SWIG_ConvertPtr(swig_obj[1], (void **) &temp2, SWIGTYPE_p_PyMFEM__wFILE, 0 | 0) == -1) {
+      if (!PyString_Check(swig_obj[1]) && !PyUnicode_Check(swig_obj[1])) {
+        // not string, check if it is StringIO
+        PyObject* module = PyImport_ImportModule("io");
+        if (!module){
+          PyErr_SetString(PyExc_RuntimeError, "Can not load io module");
+          return NULL;
+        }      
+        PyObject* cls = PyObject_GetAttrString(module, "StringIO");
+        if (!cls){
+          PyErr_SetString(PyExc_RuntimeError, "Can not load StringIO");
+          return NULL;
+        }      
+        int check = PyObject_IsInstance(swig_obj[1], cls);
+        Py_DECREF(module);
+        if (! check){
+          SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
+          return NULL;
+        }
+        
+        PyObject *input_str = PyObject_CallMethod(swig_obj[1], "getvalue", NULL);
+        if (PyErr_Occurred()) {
+          PyErr_SetString(PyExc_RuntimeError, "Can not read from StringIO");
+          return NULL;
+        }
+        
+        char *buf = nullptr;
+        PyObject *str = PyUnicode_AsUTF8String(input_str);	 
+        PyBytes_AsStringAndSize(str, &buf, &len2);
+        stream2 = new std::istringstream(buf);
+        Py_DECREF(str);
+        Py_DECREF(input_str);	 
+      } else {
+        // if it is string, extract filename as char*
+        PyObject* str = PyUnicode_AsEncodedString(swig_obj[1], "utf-8", "~E~");	
+        const char* filename = PyBytes_AsString(str);
+        temp2 = new PyMFEM::wFILE(filename, 8, true);
+        Py_DECREF(str);
+      }
+    }
+    if (stream2 == 0){
+      if (temp2->isGZ()){
+        in_gz2 = new mfem::ifgzstream(temp2->getFilename());
+        arg2 = in_gz2;
+      } else {
+        in_txt2.open(temp2->getFilename(), std::ifstream::in);
+        in_txt2.precision(temp2->getPrecision());
+        arg2 = &in_txt2;
+      }
+      if (temp2->isTemporary()){
+        delete temp2;
+      }
+    } else {
+      arg2 = stream2;
+    }
   }
-  if (!argp2) {
-    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "new_GridFunction" "', argument " "2"" of type '" "std::istream &""'"); 
-  }
-  arg2 = reinterpret_cast< std::istream * >(argp2);
   {
     try {
       result = (mfem::GridFunction *)new mfem::GridFunction(arg1,*arg2);
@@ -4035,8 +4061,40 @@ SWIGINTERN PyObject *_wrap_new_GridFunction__SWIG_4(PyObject *SWIGUNUSEDPARM(sel
     }	 
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__GridFunction, SWIG_POINTER_NEW |  0 );
+  {
+    if (stream2) {
+      ret2 = PyLong_FromSsize_t(len2);
+      if (PyErr_Occurred()) {
+        PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
+        return NULL;
+      }
+      delete stream2;    
+      Py_XDECREF(resultobj);   /* Blow away any previous result */
+      resultobj = ret2;    
+    }
+  }
+  {
+    if (!stream2) {
+      if (temp2) {
+        in_txt2.close();
+      }
+      if (in_gz2){
+        delete in_gz2;
+      }
+    }  
+  }
   return resultobj;
 fail:
+  {
+    if (!stream2) {
+      if (temp2) {
+        in_txt2.close();
+      }
+      if (in_gz2){
+        delete in_gz2;
+      }
+    }  
+  }
   return NULL;
 }
 
@@ -12913,10 +12971,10 @@ SWIGINTERN PyObject *_wrap_GridFunction_Save__SWIG_0(PyObject *SWIGUNUSEDPARM(se
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyMFEM::wFILE *temp2 = 0 ;
-  std::ofstream out2 ;
-  int use_stringio2 = 0 ;
+  std::ofstream out_txt2 ;
+  mfem::ofgzstream *out_gz2 = 0 ;
   PyObject *string_io2 = 0 ;
-  std::ostringstream stream2 ;
+  std::ostringstream *stream2 = 0 ;
   PyObject *ret2 = 0 ;
   
   if ((nobjs < 2) || (nobjs > 2)) SWIG_fail;
@@ -12946,29 +13004,33 @@ SWIGINTERN PyObject *_wrap_GridFunction_Save__SWIG_0(PyObject *SWIGUNUSEDPARM(se
           SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
           return NULL;
         }
-        use_stringio2=1;
         string_io2=swig_obj[1];
+        stream2 = new std::ostringstream();
       } else {
         // if it is string, extract filename as char*
         PyObject* str = PyUnicode_AsEncodedString(swig_obj[1], "utf-8", "~E~");	
         const char* filename = PyBytes_AsString(str);
-        temp2 = new PyMFEM::wFILE(filename, 8, true);	
+        temp2 = new PyMFEM::wFILE(filename, 8, true);
+        Py_DECREF(str);	 
       }
     }
     
-    if (use_stringio2 == 0){
+    if (stream2 == 0){
       if (temp2->isSTDOUT() == 1) {
         arg2 = &std::cout;
+      } else if (temp2->isGZ()){
+        out_gz2 = new mfem::ofgzstream(temp2->getFilename(), true);
+        arg2 = out_gz2;	     
       } else {
-        out2.open(temp2->getFilename());
-        out2.precision(temp2->getPrecision());
-        if (temp2->isTemporary()){
-          delete temp2;
-        }
-        arg2 = &out2;
+        out_txt2.open(temp2->getFilename());
+        out_txt2.precision(temp2->getPrecision());
+        arg2 = &out_txt2;
+      }
+      if (temp2->isTemporary()){
+        delete temp2;
       }
     } else {
-      arg2 = &stream2;
+      arg2 = stream2;
     }
   }
   {
@@ -12992,8 +13054,8 @@ SWIGINTERN PyObject *_wrap_GridFunction_Save__SWIG_0(PyObject *SWIGUNUSEDPARM(se
   }
   resultobj = SWIG_Py_Void();
   {
-    if (use_stringio2 == 1) {
-      std::string str =  stream2.str();
+    if (stream2) {
+      std::string str =  stream2->str();
       const char* s = str.c_str();
       const int n = str.length();
       ret2 = PyObject_CallMethod(string_io2, "write", "s#",
@@ -13002,15 +13064,21 @@ SWIGINTERN PyObject *_wrap_GridFunction_Save__SWIG_0(PyObject *SWIGUNUSEDPARM(se
         PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
         return NULL;
       }
+      delete stream2;
       Py_XDECREF(resultobj);   /* Blow away any previous result */
       resultobj = ret2;    
     }
   }
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -13018,10 +13086,15 @@ SWIGINTERN PyObject *_wrap_GridFunction_Save__SWIG_0(PyObject *SWIGUNUSEDPARM(se
   return resultobj;
 fail:
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -13039,10 +13112,10 @@ SWIGINTERN PyObject *_wrap_GridFunction_SaveVTK(PyObject *SWIGUNUSEDPARM(self), 
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyMFEM::wFILE *temp2 = 0 ;
-  std::ofstream out2 ;
-  int use_stringio2 = 0 ;
+  std::ofstream out_txt2 ;
+  mfem::ofgzstream *out_gz2 = 0 ;
   PyObject *string_io2 = 0 ;
-  std::ostringstream stream2 ;
+  std::ostringstream *stream2 = 0 ;
   PyObject *ret2 = 0 ;
   int res3 = SWIG_OLDOBJ ;
   PyObject * obj0 = 0 ;
@@ -13080,29 +13153,33 @@ SWIGINTERN PyObject *_wrap_GridFunction_SaveVTK(PyObject *SWIGUNUSEDPARM(self), 
           SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
           return NULL;
         }
-        use_stringio2=1;
         string_io2=obj1;
+        stream2 = new std::ostringstream();
       } else {
         // if it is string, extract filename as char*
         PyObject* str = PyUnicode_AsEncodedString(obj1, "utf-8", "~E~");	
         const char* filename = PyBytes_AsString(str);
-        temp2 = new PyMFEM::wFILE(filename, 8, true);	
+        temp2 = new PyMFEM::wFILE(filename, 8, true);
+        Py_DECREF(str);	 
       }
     }
     
-    if (use_stringio2 == 0){
+    if (stream2 == 0){
       if (temp2->isSTDOUT() == 1) {
         arg2 = &std::cout;
+      } else if (temp2->isGZ()){
+        out_gz2 = new mfem::ofgzstream(temp2->getFilename(), true);
+        arg2 = out_gz2;	     
       } else {
-        out2.open(temp2->getFilename());
-        out2.precision(temp2->getPrecision());
-        if (temp2->isTemporary()){
-          delete temp2;
-        }
-        arg2 = &out2;
+        out_txt2.open(temp2->getFilename());
+        out_txt2.precision(temp2->getPrecision());
+        arg2 = &out_txt2;
+      }
+      if (temp2->isTemporary()){
+        delete temp2;
       }
     } else {
-      arg2 = &stream2;
+      arg2 = stream2;
     }
   }
   {
@@ -13143,8 +13220,8 @@ SWIGINTERN PyObject *_wrap_GridFunction_SaveVTK(PyObject *SWIGUNUSEDPARM(self), 
   }
   resultobj = SWIG_Py_Void();
   {
-    if (use_stringio2 == 1) {
-      std::string str =  stream2.str();
+    if (stream2) {
+      std::string str =  stream2->str();
       const char* s = str.c_str();
       const int n = str.length();
       ret2 = PyObject_CallMethod(string_io2, "write", "s#",
@@ -13153,15 +13230,21 @@ SWIGINTERN PyObject *_wrap_GridFunction_SaveVTK(PyObject *SWIGUNUSEDPARM(self), 
         PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
         return NULL;
       }
+      delete stream2;
       Py_XDECREF(resultobj);   /* Blow away any previous result */
       resultobj = ret2;    
     }
   }
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -13170,10 +13253,15 @@ SWIGINTERN PyObject *_wrap_GridFunction_SaveVTK(PyObject *SWIGUNUSEDPARM(self), 
   return resultobj;
 fail:
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -13191,10 +13279,10 @@ SWIGINTERN PyObject *_wrap_GridFunction_SaveSTL(PyObject *SWIGUNUSEDPARM(self), 
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyMFEM::wFILE *temp2 = 0 ;
-  std::ofstream out2 ;
-  int use_stringio2 = 0 ;
+  std::ofstream out_txt2 ;
+  mfem::ofgzstream *out_gz2 = 0 ;
   PyObject *string_io2 = 0 ;
-  std::ostringstream stream2 ;
+  std::ostringstream *stream2 = 0 ;
   PyObject *ret2 = 0 ;
   PyObject * obj0 = 0 ;
   PyObject * obj1 = 0 ;
@@ -13230,29 +13318,33 @@ SWIGINTERN PyObject *_wrap_GridFunction_SaveSTL(PyObject *SWIGUNUSEDPARM(self), 
           SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
           return NULL;
         }
-        use_stringio2=1;
         string_io2=obj1;
+        stream2 = new std::ostringstream();
       } else {
         // if it is string, extract filename as char*
         PyObject* str = PyUnicode_AsEncodedString(obj1, "utf-8", "~E~");	
         const char* filename = PyBytes_AsString(str);
-        temp2 = new PyMFEM::wFILE(filename, 8, true);	
+        temp2 = new PyMFEM::wFILE(filename, 8, true);
+        Py_DECREF(str);	 
       }
     }
     
-    if (use_stringio2 == 0){
+    if (stream2 == 0){
       if (temp2->isSTDOUT() == 1) {
         arg2 = &std::cout;
+      } else if (temp2->isGZ()){
+        out_gz2 = new mfem::ofgzstream(temp2->getFilename(), true);
+        arg2 = out_gz2;	     
       } else {
-        out2.open(temp2->getFilename());
-        out2.precision(temp2->getPrecision());
-        if (temp2->isTemporary()){
-          delete temp2;
-        }
-        arg2 = &out2;
+        out_txt2.open(temp2->getFilename());
+        out_txt2.precision(temp2->getPrecision());
+        arg2 = &out_txt2;
+      }
+      if (temp2->isTemporary()){
+        delete temp2;
       }
     } else {
-      arg2 = &stream2;
+      arg2 = stream2;
     }
   }
   if (obj2) {
@@ -13284,8 +13376,8 @@ SWIGINTERN PyObject *_wrap_GridFunction_SaveSTL(PyObject *SWIGUNUSEDPARM(self), 
   }
   resultobj = SWIG_Py_Void();
   {
-    if (use_stringio2 == 1) {
-      std::string str =  stream2.str();
+    if (stream2) {
+      std::string str =  stream2->str();
       const char* s = str.c_str();
       const int n = str.length();
       ret2 = PyObject_CallMethod(string_io2, "write", "s#",
@@ -13294,15 +13386,21 @@ SWIGINTERN PyObject *_wrap_GridFunction_SaveSTL(PyObject *SWIGUNUSEDPARM(self), 
         PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
         return NULL;
       }
+      delete stream2;
       Py_XDECREF(resultobj);   /* Blow away any previous result */
       resultobj = ret2;    
     }
   }
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -13310,10 +13408,15 @@ SWIGINTERN PyObject *_wrap_GridFunction_SaveSTL(PyObject *SWIGUNUSEDPARM(self), 
   return resultobj;
 fail:
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -13364,56 +13467,6 @@ fail:
 
 SWIGINTERN PyObject *_wrap_new_GridFunction__SWIG_6(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
   PyObject *resultobj = 0;
-  mfem::Mesh *arg1 = (mfem::Mesh *) 0 ;
-  char *arg2 = (char *) 0 ;
-  void *argp1 = 0 ;
-  int res1 = 0 ;
-  int res2 ;
-  char *buf2 = 0 ;
-  int alloc2 = 0 ;
-  mfem::GridFunction *result = 0 ;
-  
-  if ((nobjs < 2) || (nobjs > 2)) SWIG_fail;
-  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_mfem__Mesh, 0 |  0 );
-  if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "new_GridFunction" "', argument " "1"" of type '" "mfem::Mesh *""'"); 
-  }
-  arg1 = reinterpret_cast< mfem::Mesh * >(argp1);
-  res2 = SWIG_AsCharPtrAndSize(swig_obj[1], &buf2, NULL, &alloc2);
-  if (!SWIG_IsOK(res2)) {
-    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "new_GridFunction" "', argument " "2"" of type '" "char const *""'");
-  }
-  arg2 = reinterpret_cast< char * >(buf2);
-  {
-    try {
-      result = (mfem::GridFunction *)new_mfem_GridFunction__SWIG_6(arg1,(char const *)arg2);
-    }
-#ifdef  MFEM_USE_EXCEPTIONS
-    catch (mfem::ErrorException &_e) {
-      std::string s("PyMFEM error (mfem::ErrorException): "), s2(_e.what());
-      s = s + s2;    
-      SWIG_exception(SWIG_RuntimeError, s.c_str());
-    }
-#endif
-    
-    catch (Swig::DirectorException &e){
-      SWIG_fail;
-    }    
-    catch (...) {
-      SWIG_exception(SWIG_RuntimeError, "unknown exception");
-    }	 
-  }
-  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__GridFunction, SWIG_POINTER_NEW |  0 );
-  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
-  return resultobj;
-fail:
-  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
-  return NULL;
-}
-
-
-SWIGINTERN PyObject *_wrap_new_GridFunction__SWIG_7(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
-  PyObject *resultobj = 0;
   mfem::FiniteElementSpace *arg1 = (mfem::FiniteElementSpace *) 0 ;
   mfem::Vector *arg2 = 0 ;
   int arg3 ;
@@ -13445,7 +13498,7 @@ SWIGINTERN PyObject *_wrap_new_GridFunction__SWIG_7(PyObject *SWIGUNUSEDPARM(sel
   }
   {
     try {
-      result = (mfem::GridFunction *)new_mfem_GridFunction__SWIG_7(arg1,(mfem::Vector const &)*arg2,arg3);
+      result = (mfem::GridFunction *)new_mfem_GridFunction__SWIG_6(arg1,(mfem::Vector const &)*arg2,arg3);
     }
 #ifdef  MFEM_USE_EXCEPTIONS
     catch (mfem::ErrorException &_e) {
@@ -13517,24 +13570,36 @@ SWIGINTERN PyObject *_wrap_new_GridFunction(PyObject *self, PyObject *args) {
     int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_mfem__Mesh, 0);
     _v = SWIG_CheckState(res);
     if (_v) {
-      void *vptr = 0;
-      int res = SWIG_ConvertPtr(argv[1], &vptr, SWIGTYPE_p_std__istream, SWIG_POINTER_NO_NULL);
-      _v = SWIG_CheckState(res);
+      {
+        void *ptr;
+        //std::string *ptr2 = (std::string *)0;
+        if (SWIG_ConvertPtr(argv[1], (void **) &ptr, SWIGTYPE_p_PyMFEM__wFILE, 0 |0) == -1) {
+          PyErr_Clear();
+          if (!PyString_Check(argv[1]) && !PyUnicode_Check(argv[1])) {
+            // not string
+            _v = 1;	   	
+            PyObject* module = PyImport_ImportModule("io");
+            if (!module){
+              _v = 0;	   
+            }      
+            PyObject* cls = PyObject_GetAttrString(module, "StringIO");
+            if (!cls){
+              _v = 0;	   	   
+            }      
+            int check = PyObject_IsInstance(argv[1], cls);
+            Py_DECREF(module);
+            if (! check){
+              _v = 0;	   	   	   
+            }
+          } else {
+            _v = 1;
+          }
+        } else {
+          _v = 1;
+        }
+      }
       if (_v) {
         return _wrap_new_GridFunction__SWIG_4(self, argc, argv);
-      }
-    }
-  }
-  if (argc == 2) {
-    int _v;
-    void *vptr = 0;
-    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_mfem__Mesh, 0);
-    _v = SWIG_CheckState(res);
-    if (_v) {
-      int res = SWIG_AsCharPtrAndSize(argv[1], 0, NULL, 0);
-      _v = SWIG_CheckState(res);
-      if (_v) {
-        return _wrap_new_GridFunction__SWIG_6(self, argc, argv);
       }
     }
   }
@@ -13580,7 +13645,7 @@ SWIGINTERN PyObject *_wrap_new_GridFunction(PyObject *self, PyObject *args) {
           }
         }
         if (_v) {
-          return _wrap_new_GridFunction__SWIG_7(self, argc, argv);
+          return _wrap_new_GridFunction__SWIG_6(self, argc, argv);
         }
       }
     }
@@ -13595,8 +13660,143 @@ fail:
     "    mfem::GridFunction::GridFunction(mfem::FiniteElementSpace *,double *)\n"
     "    mfem::GridFunction::GridFunction(mfem::Mesh *,std::istream &)\n"
     "    mfem::GridFunction::GridFunction(mfem::Mesh *,mfem::GridFunction *[],int)\n"
-    "    mfem::GridFunction::GridFunction(mfem::Mesh *,char const *)\n"
     "    mfem::GridFunction::GridFunction(mfem::FiniteElementSpace *,mfem::Vector const &,int)\n");
+  return 0;
+}
+
+
+SWIGINTERN PyObject *_wrap_GridFunction_Save__SWIG_1(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
+  PyObject *resultobj = 0;
+  mfem::GridFunction *arg1 = (mfem::GridFunction *) 0 ;
+  char *arg2 = (char *) 0 ;
+  int arg3 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int res2 ;
+  char *buf2 = 0 ;
+  int alloc2 = 0 ;
+  
+  if ((nobjs < 3) || (nobjs > 3)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_mfem__GridFunction, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "GridFunction_Save" "', argument " "1"" of type '" "mfem::GridFunction const *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::GridFunction * >(argp1);
+  res2 = SWIG_AsCharPtrAndSize(swig_obj[1], &buf2, NULL, &alloc2);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "GridFunction_Save" "', argument " "2"" of type '" "char const *""'");
+  }
+  arg2 = reinterpret_cast< char * >(buf2);
+  {
+    if ((PyArray_PyIntAsInt(swig_obj[2]) == -1) && PyErr_Occurred()) {
+      SWIG_exception_fail(SWIG_TypeError, "Input must be integer");
+    };  
+    arg3 = PyArray_PyIntAsInt(swig_obj[2]);
+  }
+  {
+    try {
+      mfem_GridFunction_Save__SWIG_1((mfem::GridFunction const *)arg1,(char const *)arg2,arg3);
+    }
+#ifdef  MFEM_USE_EXCEPTIONS
+    catch (mfem::ErrorException &_e) {
+      std::string s("PyMFEM error (mfem::ErrorException): "), s2(_e.what());
+      s = s + s2;    
+      SWIG_exception(SWIG_RuntimeError, s.c_str());
+    }
+#endif
+    
+    catch (Swig::DirectorException &e){
+      SWIG_fail;
+    }    
+    catch (...) {
+      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+    }	 
+  }
+  resultobj = SWIG_Py_Void();
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return resultobj;
+fail:
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_GridFunction_Save(PyObject *self, PyObject *args) {
+  Py_ssize_t argc;
+  PyObject *argv[4] = {
+    0
+  };
+  
+  if (!(argc = SWIG_Python_UnpackTuple(args, "GridFunction_Save", 0, 3, argv))) SWIG_fail;
+  --argc;
+  if (argc == 2) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_mfem__GridFunction, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      {
+        void *ptr;
+        //std::string *ptr2 = (std::string *)0;
+        if (SWIG_ConvertPtr(argv[1], (void **) &ptr, SWIGTYPE_p_PyMFEM__wFILE, 0 |0) == -1) {
+          PyErr_Clear();
+          if (!PyString_Check(argv[1]) && !PyUnicode_Check(argv[1])) {
+            // not string
+            _v = 1;	   	
+            PyObject* module = PyImport_ImportModule("io");
+            if (!module){
+              _v = 0;	   
+            }      
+            PyObject* cls = PyObject_GetAttrString(module, "StringIO");
+            if (!cls){
+              _v = 0;	   	   
+            }      
+            int check = PyObject_IsInstance(argv[1], cls);
+            Py_DECREF(module);
+            if (! check){
+              _v = 0;	   	   	   
+            }
+          } else {
+            _v = 1;
+          }
+        } else {
+          _v = 1;
+        }
+      }
+      if (_v) {
+        return _wrap_GridFunction_Save__SWIG_0(self, argc, argv);
+      }
+    }
+  }
+  if (argc == 3) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_mfem__GridFunction, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      int res = SWIG_AsCharPtrAndSize(argv[1], 0, NULL, 0);
+      _v = SWIG_CheckState(res);
+      if (_v) {
+        {
+          if ((PyArray_PyIntAsInt(argv[2]) == -1) && PyErr_Occurred()) {
+            PyErr_Clear();
+            _v = 0;
+          } else {
+            _v = 1;    
+          }
+        }
+        if (_v) {
+          return _wrap_GridFunction_Save__SWIG_1(self, argc, argv);
+        }
+      }
+    }
+  }
+  
+fail:
+  SWIG_Python_RaiseOrModifyTypeError("Wrong number or type of arguments for overloaded function 'GridFunction_Save'.\n"
+    "  Possible C/C++ prototypes are:\n"
+    "    mfem::GridFunction::Save(std::ostream &) const\n"
+    "    mfem::GridFunction::Save(char const *,int const) const\n");
   return 0;
 }
 
@@ -14015,147 +14215,6 @@ fail:
 }
 
 
-SWIGINTERN PyObject *_wrap_GridFunction_Save__SWIG_1(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
-  PyObject *resultobj = 0;
-  mfem::GridFunction *arg1 = (mfem::GridFunction *) 0 ;
-  char *arg2 = (char *) 0 ;
-  int arg3 = (int) 8 ;
-  void *argp1 = 0 ;
-  int res1 = 0 ;
-  int res2 ;
-  char *buf2 = 0 ;
-  int alloc2 = 0 ;
-  
-  if ((nobjs < 2) || (nobjs > 3)) SWIG_fail;
-  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_mfem__GridFunction, 0 |  0 );
-  if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "GridFunction_Save" "', argument " "1"" of type '" "mfem::GridFunction *""'"); 
-  }
-  arg1 = reinterpret_cast< mfem::GridFunction * >(argp1);
-  res2 = SWIG_AsCharPtrAndSize(swig_obj[1], &buf2, NULL, &alloc2);
-  if (!SWIG_IsOK(res2)) {
-    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "GridFunction_Save" "', argument " "2"" of type '" "char const *""'");
-  }
-  arg2 = reinterpret_cast< char * >(buf2);
-  if (swig_obj[2]) {
-    {
-      if ((PyArray_PyIntAsInt(swig_obj[2]) == -1) && PyErr_Occurred()) {
-        SWIG_exception_fail(SWIG_TypeError, "Input must be integer");
-      };  
-      arg3 = PyArray_PyIntAsInt(swig_obj[2]);
-    }
-  }
-  {
-    try {
-      mfem_GridFunction_Save__SWIG_1(arg1,(char const *)arg2,arg3);
-    }
-#ifdef  MFEM_USE_EXCEPTIONS
-    catch (mfem::ErrorException &_e) {
-      std::string s("PyMFEM error (mfem::ErrorException): "), s2(_e.what());
-      s = s + s2;    
-      SWIG_exception(SWIG_RuntimeError, s.c_str());
-    }
-#endif
-    
-    catch (Swig::DirectorException &e){
-      SWIG_fail;
-    }    
-    catch (...) {
-      SWIG_exception(SWIG_RuntimeError, "unknown exception");
-    }	 
-  }
-  resultobj = SWIG_Py_Void();
-  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
-  return resultobj;
-fail:
-  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
-  return NULL;
-}
-
-
-SWIGINTERN PyObject *_wrap_GridFunction_Save(PyObject *self, PyObject *args) {
-  Py_ssize_t argc;
-  PyObject *argv[4] = {
-    0
-  };
-  
-  if (!(argc = SWIG_Python_UnpackTuple(args, "GridFunction_Save", 0, 3, argv))) SWIG_fail;
-  --argc;
-  if ((argc >= 2) && (argc <= 3)) {
-    int _v;
-    void *vptr = 0;
-    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_mfem__GridFunction, 0);
-    _v = SWIG_CheckState(res);
-    if (_v) {
-      int res = SWIG_AsCharPtrAndSize(argv[1], 0, NULL, 0);
-      _v = SWIG_CheckState(res);
-      if (_v) {
-        if (argc <= 2) {
-          return _wrap_GridFunction_Save__SWIG_1(self, argc, argv);
-        }
-        {
-          if ((PyArray_PyIntAsInt(argv[2]) == -1) && PyErr_Occurred()) {
-            PyErr_Clear();
-            _v = 0;
-          } else {
-            _v = 1;    
-          }
-        }
-        if (_v) {
-          return _wrap_GridFunction_Save__SWIG_1(self, argc, argv);
-        }
-      }
-    }
-  }
-  if (argc == 2) {
-    int _v;
-    void *vptr = 0;
-    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_mfem__GridFunction, 0);
-    _v = SWIG_CheckState(res);
-    if (_v) {
-      {
-        void *ptr;
-        //std::string *ptr2 = (std::string *)0;
-        if (SWIG_ConvertPtr(argv[1], (void **) &ptr, SWIGTYPE_p_PyMFEM__wFILE, 0 |0) == -1) {
-          PyErr_Clear();
-          if (!PyString_Check(argv[1]) && !PyUnicode_Check(argv[1])) {
-            // not string
-            _v = 1;	   	
-            PyObject* module = PyImport_ImportModule("io");
-            if (!module){
-              _v = 0;	   
-            }      
-            PyObject* cls = PyObject_GetAttrString(module, "StringIO");
-            if (!cls){
-              _v = 0;	   	   
-            }      
-            int check = PyObject_IsInstance(argv[1], cls);
-            Py_DECREF(module);
-            if (! check){
-              _v = 0;	   	   	   
-            }
-          } else {
-            _v = 0;
-          }
-        } else {
-          _v = 1;
-        }
-      }
-      if (_v) {
-        return _wrap_GridFunction_Save__SWIG_0(self, argc, argv);
-      }
-    }
-  }
-  
-fail:
-  SWIG_Python_RaiseOrModifyTypeError("Wrong number or type of arguments for overloaded function 'GridFunction_Save'.\n"
-    "  Possible C/C++ prototypes are:\n"
-    "    mfem::GridFunction::Save(std::ostream &) const\n"
-    "    mfem::GridFunction::Save(char const *,int)\n");
-  return 0;
-}
-
-
 SWIGINTERN PyObject *GridFunction_swigregister(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *obj;
   if (!SWIG_Python_UnpackTuple(args, "swigregister", 1, 1, &obj)) return NULL;
@@ -14172,10 +14231,10 @@ SWIGINTERN PyObject *_wrap___lshift____SWIG_2(PyObject *SWIGUNUSEDPARM(self), Py
   std::ostream *arg1 = 0 ;
   mfem::GridFunction *arg2 = 0 ;
   PyMFEM::wFILE *temp1 = 0 ;
-  std::ofstream out1 ;
-  int use_stringio1 = 0 ;
+  std::ofstream out_txt1 ;
+  mfem::ofgzstream *out_gz1 = 0 ;
   PyObject *string_io1 = 0 ;
-  std::ostringstream stream1 ;
+  std::ostringstream *stream1 = 0 ;
   PyObject *ret1 = 0 ;
   void *argp2 = 0 ;
   int res2 = 0 ;
@@ -14203,29 +14262,33 @@ SWIGINTERN PyObject *_wrap___lshift____SWIG_2(PyObject *SWIGUNUSEDPARM(self), Py
           SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
           return NULL;
         }
-        use_stringio1=1;
         string_io1=swig_obj[0];
+        stream1 = new std::ostringstream();
       } else {
         // if it is string, extract filename as char*
         PyObject* str = PyUnicode_AsEncodedString(swig_obj[0], "utf-8", "~E~");	
         const char* filename = PyBytes_AsString(str);
-        temp1 = new PyMFEM::wFILE(filename, 8, true);	
+        temp1 = new PyMFEM::wFILE(filename, 8, true);
+        Py_DECREF(str);	 
       }
     }
     
-    if (use_stringio1 == 0){
+    if (stream1 == 0){
       if (temp1->isSTDOUT() == 1) {
         arg1 = &std::cout;
+      } else if (temp1->isGZ()){
+        out_gz1 = new mfem::ofgzstream(temp1->getFilename(), true);
+        arg1 = out_gz1;	     
       } else {
-        out1.open(temp1->getFilename());
-        out1.precision(temp1->getPrecision());
-        if (temp1->isTemporary()){
-          delete temp1;
-        }
-        arg1 = &out1;
+        out_txt1.open(temp1->getFilename());
+        out_txt1.precision(temp1->getPrecision());
+        arg1 = &out_txt1;
+      }
+      if (temp1->isTemporary()){
+        delete temp1;
       }
     } else {
-      arg1 = &stream1;
+      arg1 = stream1;
     }
   }
   res2 = SWIG_ConvertPtr(swig_obj[1], &argp2, SWIGTYPE_p_mfem__GridFunction,  0  | 0);
@@ -14257,8 +14320,8 @@ SWIGINTERN PyObject *_wrap___lshift____SWIG_2(PyObject *SWIGUNUSEDPARM(self), Py
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_std__ostream, 0 |  0 );
   {
-    if (use_stringio1 == 1) {
-      std::string str =  stream1.str();
+    if (stream1) {
+      std::string str =  stream1->str();
       const char* s = str.c_str();
       const int n = str.length();
       ret1 = PyObject_CallMethod(string_io1, "write", "s#",
@@ -14267,15 +14330,21 @@ SWIGINTERN PyObject *_wrap___lshift____SWIG_2(PyObject *SWIGUNUSEDPARM(self), Py
         PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
         return NULL;
       }
+      delete stream1;
       Py_XDECREF(resultobj);   /* Blow away any previous result */
       resultobj = ret1;    
     }
   }
   {
-    if (use_stringio1 == 0) {
+    if (!stream1) {
       if (temp1) {
         if (temp1->isSTDOUT() != 1) {
-          out1.close();
+          if (out_txt1.is_open()){
+            out_txt1.close();
+          }
+          if (out_gz1){
+            delete out_gz1;
+          }
         }
       }
     }
@@ -14283,10 +14352,15 @@ SWIGINTERN PyObject *_wrap___lshift____SWIG_2(PyObject *SWIGUNUSEDPARM(self), Py
   return resultobj;
 fail:
   {
-    if (use_stringio1 == 0) {
+    if (!stream1) {
       if (temp1) {
         if (temp1->isSTDOUT() != 1) {
-          out1.close();
+          if (out_txt1.is_open()){
+            out_txt1.close();
+          }
+          if (out_gz1){
+            delete out_gz1;
+          }
         }
       }
     }
@@ -14480,8 +14554,12 @@ SWIGINTERN PyObject *_wrap_new_QuadratureFunction__SWIG_4(PyObject *SWIGUNUSEDPA
   std::istream *arg2 = 0 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
-  void *argp2 = 0 ;
-  int res2 = 0 ;
+  PyMFEM::wFILE *temp2 = 0 ;
+  std::ifstream in_txt2 ;
+  mfem::ifgzstream *in_gz2 = 0 ;
+  std::istringstream *stream2 = 0 ;
+  Py_ssize_t len2 = 0 ;
+  PyObject *ret2 = 0 ;
   mfem::QuadratureFunction *result = 0 ;
   
   if ((nobjs < 2) || (nobjs > 2)) SWIG_fail;
@@ -14490,14 +14568,64 @@ SWIGINTERN PyObject *_wrap_new_QuadratureFunction__SWIG_4(PyObject *SWIGUNUSEDPA
     SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "new_QuadratureFunction" "', argument " "1"" of type '" "mfem::Mesh *""'"); 
   }
   arg1 = reinterpret_cast< mfem::Mesh * >(argp1);
-  res2 = SWIG_ConvertPtr(swig_obj[1], &argp2, SWIGTYPE_p_std__istream,  0 );
-  if (!SWIG_IsOK(res2)) {
-    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "new_QuadratureFunction" "', argument " "2"" of type '" "std::istream &""'"); 
+  {
+    //  PyMFEM::wFILE or string argument or StringIO
+    if (SWIG_ConvertPtr(swig_obj[1], (void **) &temp2, SWIGTYPE_p_PyMFEM__wFILE, 0 | 0) == -1) {
+      if (!PyString_Check(swig_obj[1]) && !PyUnicode_Check(swig_obj[1])) {
+        // not string, check if it is StringIO
+        PyObject* module = PyImport_ImportModule("io");
+        if (!module){
+          PyErr_SetString(PyExc_RuntimeError, "Can not load io module");
+          return NULL;
+        }      
+        PyObject* cls = PyObject_GetAttrString(module, "StringIO");
+        if (!cls){
+          PyErr_SetString(PyExc_RuntimeError, "Can not load StringIO");
+          return NULL;
+        }      
+        int check = PyObject_IsInstance(swig_obj[1], cls);
+        Py_DECREF(module);
+        if (! check){
+          SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
+          return NULL;
+        }
+        
+        PyObject *input_str = PyObject_CallMethod(swig_obj[1], "getvalue", NULL);
+        if (PyErr_Occurred()) {
+          PyErr_SetString(PyExc_RuntimeError, "Can not read from StringIO");
+          return NULL;
+        }
+        
+        char *buf = nullptr;
+        PyObject *str = PyUnicode_AsUTF8String(input_str);	 
+        PyBytes_AsStringAndSize(str, &buf, &len2);
+        stream2 = new std::istringstream(buf);
+        Py_DECREF(str);
+        Py_DECREF(input_str);	 
+      } else {
+        // if it is string, extract filename as char*
+        PyObject* str = PyUnicode_AsEncodedString(swig_obj[1], "utf-8", "~E~");	
+        const char* filename = PyBytes_AsString(str);
+        temp2 = new PyMFEM::wFILE(filename, 8, true);
+        Py_DECREF(str);
+      }
+    }
+    if (stream2 == 0){
+      if (temp2->isGZ()){
+        in_gz2 = new mfem::ifgzstream(temp2->getFilename());
+        arg2 = in_gz2;
+      } else {
+        in_txt2.open(temp2->getFilename(), std::ifstream::in);
+        in_txt2.precision(temp2->getPrecision());
+        arg2 = &in_txt2;
+      }
+      if (temp2->isTemporary()){
+        delete temp2;
+      }
+    } else {
+      arg2 = stream2;
+    }
   }
-  if (!argp2) {
-    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "new_QuadratureFunction" "', argument " "2"" of type '" "std::istream &""'"); 
-  }
-  arg2 = reinterpret_cast< std::istream * >(argp2);
   {
     try {
       result = (mfem::QuadratureFunction *)new mfem::QuadratureFunction(arg1,*arg2);
@@ -14518,8 +14646,40 @@ SWIGINTERN PyObject *_wrap_new_QuadratureFunction__SWIG_4(PyObject *SWIGUNUSEDPA
     }	 
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__QuadratureFunction, SWIG_POINTER_NEW |  0 );
+  {
+    if (stream2) {
+      ret2 = PyLong_FromSsize_t(len2);
+      if (PyErr_Occurred()) {
+        PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
+        return NULL;
+      }
+      delete stream2;    
+      Py_XDECREF(resultobj);   /* Blow away any previous result */
+      resultobj = ret2;    
+    }
+  }
+  {
+    if (!stream2) {
+      if (temp2) {
+        in_txt2.close();
+      }
+      if (in_gz2){
+        delete in_gz2;
+      }
+    }  
+  }
   return resultobj;
 fail:
+  {
+    if (!stream2) {
+      if (temp2) {
+        in_txt2.close();
+      }
+      if (in_gz2){
+        delete in_gz2;
+      }
+    }  
+  }
   return NULL;
 }
 
@@ -14598,9 +14758,34 @@ SWIGINTERN PyObject *_wrap_new_QuadratureFunction(PyObject *self, PyObject *args
     int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_mfem__Mesh, 0);
     _v = SWIG_CheckState(res);
     if (_v) {
-      void *vptr = 0;
-      int res = SWIG_ConvertPtr(argv[1], &vptr, SWIGTYPE_p_std__istream, SWIG_POINTER_NO_NULL);
-      _v = SWIG_CheckState(res);
+      {
+        void *ptr;
+        //std::string *ptr2 = (std::string *)0;
+        if (SWIG_ConvertPtr(argv[1], (void **) &ptr, SWIGTYPE_p_PyMFEM__wFILE, 0 |0) == -1) {
+          PyErr_Clear();
+          if (!PyString_Check(argv[1]) && !PyUnicode_Check(argv[1])) {
+            // not string
+            _v = 1;	   	
+            PyObject* module = PyImport_ImportModule("io");
+            if (!module){
+              _v = 0;	   
+            }      
+            PyObject* cls = PyObject_GetAttrString(module, "StringIO");
+            if (!cls){
+              _v = 0;	   	   
+            }      
+            int check = PyObject_IsInstance(argv[1], cls);
+            Py_DECREF(module);
+            if (! check){
+              _v = 0;	   	   	   
+            }
+          } else {
+            _v = 1;
+          }
+        } else {
+          _v = 1;
+        }
+      }
       if (_v) {
         return _wrap_new_QuadratureFunction__SWIG_4(self, argc, argv);
       }
@@ -15665,29 +15850,34 @@ fail:
 }
 
 
-SWIGINTERN PyObject *_wrap_QuadratureFunction_Save__SWIG_0(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
+SWIGINTERN PyObject *_wrap_QuadratureFunction_Save(PyObject *SWIGUNUSEDPARM(self), PyObject *args, PyObject *kwargs) {
   PyObject *resultobj = 0;
   mfem::QuadratureFunction *arg1 = (mfem::QuadratureFunction *) 0 ;
   std::ostream *arg2 = 0 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyMFEM::wFILE *temp2 = 0 ;
-  std::ofstream out2 ;
-  int use_stringio2 = 0 ;
+  std::ofstream out_txt2 ;
+  mfem::ofgzstream *out_gz2 = 0 ;
   PyObject *string_io2 = 0 ;
-  std::ostringstream stream2 ;
+  std::ostringstream *stream2 = 0 ;
   PyObject *ret2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  char * kwnames[] = {
+    (char *)"self",  (char *)"out",  NULL 
+  };
   
-  if ((nobjs < 2) || (nobjs > 2)) SWIG_fail;
-  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_mfem__QuadratureFunction, 0 |  0 );
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OO:QuadratureFunction_Save", kwnames, &obj0, &obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_mfem__QuadratureFunction, 0 |  0 );
   if (!SWIG_IsOK(res1)) {
     SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "QuadratureFunction_Save" "', argument " "1"" of type '" "mfem::QuadratureFunction const *""'"); 
   }
   arg1 = reinterpret_cast< mfem::QuadratureFunction * >(argp1);
   {
     //  PyMFEM::wFILE or string argument or StringIO
-    if (SWIG_ConvertPtr(swig_obj[1], (void **) &temp2, SWIGTYPE_p_PyMFEM__wFILE, 0 | 0) == -1) {
-      if (!PyString_Check(swig_obj[1]) && !PyUnicode_Check(swig_obj[1])) {
+    if (SWIG_ConvertPtr(obj1, (void **) &temp2, SWIGTYPE_p_PyMFEM__wFILE, 0 | 0) == -1) {
+      if (!PyString_Check(obj1) && !PyUnicode_Check(obj1)) {
         // not string, check if it is StringIO
         PyObject* module = PyImport_ImportModule("io");
         if (!module){
@@ -15699,35 +15889,39 @@ SWIGINTERN PyObject *_wrap_QuadratureFunction_Save__SWIG_0(PyObject *SWIGUNUSEDP
           PyErr_SetString(PyExc_RuntimeError, "Can not load StringIO");
           return NULL;
         }      
-        int check = PyObject_IsInstance(swig_obj[1], cls);
+        int check = PyObject_IsInstance(obj1, cls);
         Py_DECREF(module);
         if (! check){
           SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
           return NULL;
         }
-        use_stringio2=1;
-        string_io2=swig_obj[1];
+        string_io2=obj1;
+        stream2 = new std::ostringstream();
       } else {
         // if it is string, extract filename as char*
-        PyObject* str = PyUnicode_AsEncodedString(swig_obj[1], "utf-8", "~E~");	
+        PyObject* str = PyUnicode_AsEncodedString(obj1, "utf-8", "~E~");	
         const char* filename = PyBytes_AsString(str);
-        temp2 = new PyMFEM::wFILE(filename, 8, true);	
+        temp2 = new PyMFEM::wFILE(filename, 8, true);
+        Py_DECREF(str);	 
       }
     }
     
-    if (use_stringio2 == 0){
+    if (stream2 == 0){
       if (temp2->isSTDOUT() == 1) {
         arg2 = &std::cout;
+      } else if (temp2->isGZ()){
+        out_gz2 = new mfem::ofgzstream(temp2->getFilename(), true);
+        arg2 = out_gz2;	     
       } else {
-        out2.open(temp2->getFilename());
-        out2.precision(temp2->getPrecision());
-        if (temp2->isTemporary()){
-          delete temp2;
-        }
-        arg2 = &out2;
+        out_txt2.open(temp2->getFilename());
+        out_txt2.precision(temp2->getPrecision());
+        arg2 = &out_txt2;
+      }
+      if (temp2->isTemporary()){
+        delete temp2;
       }
     } else {
-      arg2 = &stream2;
+      arg2 = stream2;
     }
   }
   {
@@ -15751,8 +15945,8 @@ SWIGINTERN PyObject *_wrap_QuadratureFunction_Save__SWIG_0(PyObject *SWIGUNUSEDP
   }
   resultobj = SWIG_Py_Void();
   {
-    if (use_stringio2 == 1) {
-      std::string str =  stream2.str();
+    if (stream2) {
+      std::string str =  stream2->str();
       const char* s = str.c_str();
       const int n = str.length();
       ret2 = PyObject_CallMethod(string_io2, "write", "s#",
@@ -15761,15 +15955,21 @@ SWIGINTERN PyObject *_wrap_QuadratureFunction_Save__SWIG_0(PyObject *SWIGUNUSEDP
         PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
         return NULL;
       }
+      delete stream2;
       Py_XDECREF(resultobj);   /* Blow away any previous result */
       resultobj = ret2;    
     }
   }
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -15777,156 +15977,20 @@ SWIGINTERN PyObject *_wrap_QuadratureFunction_Save__SWIG_0(PyObject *SWIGUNUSEDP
   return resultobj;
 fail:
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
   }
   return NULL;
-}
-
-
-SWIGINTERN PyObject *_wrap_QuadratureFunction_Save__SWIG_1(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
-  PyObject *resultobj = 0;
-  mfem::QuadratureFunction *arg1 = (mfem::QuadratureFunction *) 0 ;
-  char *arg2 = (char *) 0 ;
-  int arg3 = (int) 8 ;
-  void *argp1 = 0 ;
-  int res1 = 0 ;
-  int res2 ;
-  char *buf2 = 0 ;
-  int alloc2 = 0 ;
-  
-  if ((nobjs < 2) || (nobjs > 3)) SWIG_fail;
-  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_mfem__QuadratureFunction, 0 |  0 );
-  if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "QuadratureFunction_Save" "', argument " "1"" of type '" "mfem::QuadratureFunction *""'"); 
-  }
-  arg1 = reinterpret_cast< mfem::QuadratureFunction * >(argp1);
-  res2 = SWIG_AsCharPtrAndSize(swig_obj[1], &buf2, NULL, &alloc2);
-  if (!SWIG_IsOK(res2)) {
-    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "QuadratureFunction_Save" "', argument " "2"" of type '" "char const *""'");
-  }
-  arg2 = reinterpret_cast< char * >(buf2);
-  if (swig_obj[2]) {
-    {
-      if ((PyArray_PyIntAsInt(swig_obj[2]) == -1) && PyErr_Occurred()) {
-        SWIG_exception_fail(SWIG_TypeError, "Input must be integer");
-      };  
-      arg3 = PyArray_PyIntAsInt(swig_obj[2]);
-    }
-  }
-  {
-    try {
-      mfem_QuadratureFunction_Save__SWIG_1(arg1,(char const *)arg2,arg3);
-    }
-#ifdef  MFEM_USE_EXCEPTIONS
-    catch (mfem::ErrorException &_e) {
-      std::string s("PyMFEM error (mfem::ErrorException): "), s2(_e.what());
-      s = s + s2;    
-      SWIG_exception(SWIG_RuntimeError, s.c_str());
-    }
-#endif
-    
-    catch (Swig::DirectorException &e){
-      SWIG_fail;
-    }    
-    catch (...) {
-      SWIG_exception(SWIG_RuntimeError, "unknown exception");
-    }	 
-  }
-  resultobj = SWIG_Py_Void();
-  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
-  return resultobj;
-fail:
-  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
-  return NULL;
-}
-
-
-SWIGINTERN PyObject *_wrap_QuadratureFunction_Save(PyObject *self, PyObject *args) {
-  Py_ssize_t argc;
-  PyObject *argv[4] = {
-    0
-  };
-  
-  if (!(argc = SWIG_Python_UnpackTuple(args, "QuadratureFunction_Save", 0, 3, argv))) SWIG_fail;
-  --argc;
-  if ((argc >= 2) && (argc <= 3)) {
-    int _v;
-    void *vptr = 0;
-    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_mfem__QuadratureFunction, 0);
-    _v = SWIG_CheckState(res);
-    if (_v) {
-      int res = SWIG_AsCharPtrAndSize(argv[1], 0, NULL, 0);
-      _v = SWIG_CheckState(res);
-      if (_v) {
-        if (argc <= 2) {
-          return _wrap_QuadratureFunction_Save__SWIG_1(self, argc, argv);
-        }
-        {
-          if ((PyArray_PyIntAsInt(argv[2]) == -1) && PyErr_Occurred()) {
-            PyErr_Clear();
-            _v = 0;
-          } else {
-            _v = 1;    
-          }
-        }
-        if (_v) {
-          return _wrap_QuadratureFunction_Save__SWIG_1(self, argc, argv);
-        }
-      }
-    }
-  }
-  if (argc == 2) {
-    int _v;
-    void *vptr = 0;
-    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_mfem__QuadratureFunction, 0);
-    _v = SWIG_CheckState(res);
-    if (_v) {
-      {
-        void *ptr;
-        //std::string *ptr2 = (std::string *)0;
-        if (SWIG_ConvertPtr(argv[1], (void **) &ptr, SWIGTYPE_p_PyMFEM__wFILE, 0 |0) == -1) {
-          PyErr_Clear();
-          if (!PyString_Check(argv[1]) && !PyUnicode_Check(argv[1])) {
-            // not string
-            _v = 1;	   	
-            PyObject* module = PyImport_ImportModule("io");
-            if (!module){
-              _v = 0;	   
-            }      
-            PyObject* cls = PyObject_GetAttrString(module, "StringIO");
-            if (!cls){
-              _v = 0;	   	   
-            }      
-            int check = PyObject_IsInstance(argv[1], cls);
-            Py_DECREF(module);
-            if (! check){
-              _v = 0;	   	   	   
-            }
-          } else {
-            _v = 0;
-          }
-        } else {
-          _v = 1;
-        }
-      }
-      if (_v) {
-        return _wrap_QuadratureFunction_Save__SWIG_0(self, argc, argv);
-      }
-    }
-  }
-  
-fail:
-  SWIG_Python_RaiseOrModifyTypeError("Wrong number or type of arguments for overloaded function 'QuadratureFunction_Save'.\n"
-    "  Possible C/C++ prototypes are:\n"
-    "    mfem::QuadratureFunction::Save(std::ostream &) const\n"
-    "    mfem::QuadratureFunction::Save(char const *,int)\n");
-  return 0;
 }
 
 
@@ -15946,10 +16010,10 @@ SWIGINTERN PyObject *_wrap___lshift____SWIG_3(PyObject *SWIGUNUSEDPARM(self), Py
   std::ostream *arg1 = 0 ;
   mfem::QuadratureFunction *arg2 = 0 ;
   PyMFEM::wFILE *temp1 = 0 ;
-  std::ofstream out1 ;
-  int use_stringio1 = 0 ;
+  std::ofstream out_txt1 ;
+  mfem::ofgzstream *out_gz1 = 0 ;
   PyObject *string_io1 = 0 ;
-  std::ostringstream stream1 ;
+  std::ostringstream *stream1 = 0 ;
   PyObject *ret1 = 0 ;
   void *argp2 = 0 ;
   int res2 = 0 ;
@@ -15977,29 +16041,33 @@ SWIGINTERN PyObject *_wrap___lshift____SWIG_3(PyObject *SWIGUNUSEDPARM(self), Py
           SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
           return NULL;
         }
-        use_stringio1=1;
         string_io1=swig_obj[0];
+        stream1 = new std::ostringstream();
       } else {
         // if it is string, extract filename as char*
         PyObject* str = PyUnicode_AsEncodedString(swig_obj[0], "utf-8", "~E~");	
         const char* filename = PyBytes_AsString(str);
-        temp1 = new PyMFEM::wFILE(filename, 8, true);	
+        temp1 = new PyMFEM::wFILE(filename, 8, true);
+        Py_DECREF(str);	 
       }
     }
     
-    if (use_stringio1 == 0){
+    if (stream1 == 0){
       if (temp1->isSTDOUT() == 1) {
         arg1 = &std::cout;
+      } else if (temp1->isGZ()){
+        out_gz1 = new mfem::ofgzstream(temp1->getFilename(), true);
+        arg1 = out_gz1;	     
       } else {
-        out1.open(temp1->getFilename());
-        out1.precision(temp1->getPrecision());
-        if (temp1->isTemporary()){
-          delete temp1;
-        }
-        arg1 = &out1;
+        out_txt1.open(temp1->getFilename());
+        out_txt1.precision(temp1->getPrecision());
+        arg1 = &out_txt1;
+      }
+      if (temp1->isTemporary()){
+        delete temp1;
       }
     } else {
-      arg1 = &stream1;
+      arg1 = stream1;
     }
   }
   res2 = SWIG_ConvertPtr(swig_obj[1], &argp2, SWIGTYPE_p_mfem__QuadratureFunction,  0  | 0);
@@ -16031,8 +16099,8 @@ SWIGINTERN PyObject *_wrap___lshift____SWIG_3(PyObject *SWIGUNUSEDPARM(self), Py
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_std__ostream, 0 |  0 );
   {
-    if (use_stringio1 == 1) {
-      std::string str =  stream1.str();
+    if (stream1) {
+      std::string str =  stream1->str();
       const char* s = str.c_str();
       const int n = str.length();
       ret1 = PyObject_CallMethod(string_io1, "write", "s#",
@@ -16041,15 +16109,21 @@ SWIGINTERN PyObject *_wrap___lshift____SWIG_3(PyObject *SWIGUNUSEDPARM(self), Py
         PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
         return NULL;
       }
+      delete stream1;
       Py_XDECREF(resultobj);   /* Blow away any previous result */
       resultobj = ret1;    
     }
   }
   {
-    if (use_stringio1 == 0) {
+    if (!stream1) {
       if (temp1) {
         if (temp1->isSTDOUT() != 1) {
-          out1.close();
+          if (out_txt1.is_open()){
+            out_txt1.close();
+          }
+          if (out_gz1){
+            delete out_gz1;
+          }
         }
       }
     }
@@ -16057,10 +16131,15 @@ SWIGINTERN PyObject *_wrap___lshift____SWIG_3(PyObject *SWIGUNUSEDPARM(self), Py
   return resultobj;
 fail:
   {
-    if (use_stringio1 == 0) {
+    if (!stream1) {
       if (temp1) {
         if (temp1->isSTDOUT() != 1) {
-          out1.close();
+          if (out_txt1.is_open()){
+            out_txt1.close();
+          }
+          if (out_gz1){
+            delete out_gz1;
+          }
         }
       }
     }
@@ -16103,7 +16182,7 @@ SWIGINTERN PyObject *_wrap___lshift__(PyObject *self, PyObject *args) {
             _v = 0;	   	   	   
           }
         } else {
-          _v = 0;
+          _v = 1;
         }
       } else {
         _v = 1;
@@ -16141,7 +16220,7 @@ SWIGINTERN PyObject *_wrap___lshift__(PyObject *self, PyObject *args) {
             _v = 0;	   	   	   
           }
         } else {
-          _v = 0;
+          _v = 1;
         }
       } else {
         _v = 1;
@@ -16764,8 +16843,11 @@ static PyMethodDef SwigMethods[] = {
 		"GridFunction(FiniteElementSpace f, double * data)\n"
 		"GridFunction(Mesh m, std::istream & input)\n"
 		"GridFunction(Mesh m, mfem::GridFunction *[] gf_array, int num_pieces)\n"
-		"GridFunction(Mesh m, char const * grid_file)\n"
 		"new_GridFunction(FiniteElementSpace fes, Vector v, int offset) -> GridFunction\n"
+		""},
+	 { "GridFunction_Save", _wrap_GridFunction_Save, METH_VARARGS, "\n"
+		"GridFunction_Save(GridFunction self, std::ostream & out)\n"
+		"GridFunction_Save(GridFunction self, char const * gf_file, int const precision)\n"
 		""},
 	 { "GridFunction_SaveToFile", (PyCFunction)(void(*)(void))_wrap_GridFunction_SaveToFile, METH_VARARGS|METH_KEYWORDS, "GridFunction_SaveToFile(GridFunction self, char const * gf_file, int const precision)"},
 	 { "GridFunction_WriteToStream", (PyCFunction)(void(*)(void))_wrap_GridFunction_WriteToStream, METH_VARARGS|METH_KEYWORDS, "GridFunction_WriteToStream(GridFunction self, PyObject * StringIO) -> PyObject *"},
@@ -16776,10 +16858,6 @@ static PyMethodDef SwigMethods[] = {
 		""},
 	 { "GridFunction_imul", (PyCFunction)(void(*)(void))_wrap_GridFunction_imul, METH_VARARGS|METH_KEYWORDS, "GridFunction_imul(GridFunction self, double c) -> GridFunction"},
 	 { "GridFunction_idiv", (PyCFunction)(void(*)(void))_wrap_GridFunction_idiv, METH_VARARGS|METH_KEYWORDS, "GridFunction_idiv(GridFunction self, double c) -> GridFunction"},
-	 { "GridFunction_Save", _wrap_GridFunction_Save, METH_VARARGS, "\n"
-		"GridFunction_Save(GridFunction self, std::ostream & out)\n"
-		"GridFunction_Save(GridFunction self, char const * file, int precision=8)\n"
-		""},
 	 { "GridFunction_swigregister", GridFunction_swigregister, METH_O, NULL},
 	 { "GridFunction_swiginit", GridFunction_swiginit, METH_VARARGS, NULL},
 	 { "new_QuadratureFunction", _wrap_new_QuadratureFunction, METH_VARARGS, "\n"
@@ -16808,10 +16886,7 @@ static PyMethodDef SwigMethods[] = {
 		"QuadratureFunction_GetElementValues(QuadratureFunction self, int idx, DenseMatrix values)\n"
 		"QuadratureFunction_GetElementValues(QuadratureFunction self, int idx, DenseMatrix values)\n"
 		""},
-	 { "QuadratureFunction_Save", _wrap_QuadratureFunction_Save, METH_VARARGS, "\n"
-		"QuadratureFunction_Save(QuadratureFunction self, std::ostream & out)\n"
-		"QuadratureFunction_Save(QuadratureFunction self, char const * file, int precision=8)\n"
-		""},
+	 { "QuadratureFunction_Save", (PyCFunction)(void(*)(void))_wrap_QuadratureFunction_Save, METH_VARARGS|METH_KEYWORDS, "QuadratureFunction_Save(QuadratureFunction self, std::ostream & out)"},
 	 { "QuadratureFunction_swigregister", QuadratureFunction_swigregister, METH_O, NULL},
 	 { "QuadratureFunction_swiginit", QuadratureFunction_swiginit, METH_VARARGS, NULL},
 	 { "__lshift__", _wrap___lshift__, METH_VARARGS, "\n"
@@ -16994,8 +17069,11 @@ static PyMethodDef SwigMethods_proxydocs[] = {
 		"GridFunction(FiniteElementSpace f, double * data)\n"
 		"GridFunction(Mesh m, std::istream & input)\n"
 		"GridFunction(Mesh m, mfem::GridFunction *[] gf_array, int num_pieces)\n"
-		"GridFunction(Mesh m, char const * grid_file)\n"
 		"new_GridFunction(FiniteElementSpace fes, Vector v, int offset) -> GridFunction\n"
+		""},
+	 { "GridFunction_Save", _wrap_GridFunction_Save, METH_VARARGS, "\n"
+		"Save(GridFunction self, std::ostream & out)\n"
+		"Save(GridFunction self, char const * gf_file, int const precision)\n"
 		""},
 	 { "GridFunction_SaveToFile", (PyCFunction)(void(*)(void))_wrap_GridFunction_SaveToFile, METH_VARARGS|METH_KEYWORDS, "SaveToFile(GridFunction self, char const * gf_file, int const precision)"},
 	 { "GridFunction_WriteToStream", (PyCFunction)(void(*)(void))_wrap_GridFunction_WriteToStream, METH_VARARGS|METH_KEYWORDS, "WriteToStream(GridFunction self, PyObject * StringIO) -> PyObject *"},
@@ -17006,10 +17084,6 @@ static PyMethodDef SwigMethods_proxydocs[] = {
 		""},
 	 { "GridFunction_imul", (PyCFunction)(void(*)(void))_wrap_GridFunction_imul, METH_VARARGS|METH_KEYWORDS, "imul(GridFunction self, double c) -> GridFunction"},
 	 { "GridFunction_idiv", (PyCFunction)(void(*)(void))_wrap_GridFunction_idiv, METH_VARARGS|METH_KEYWORDS, "idiv(GridFunction self, double c) -> GridFunction"},
-	 { "GridFunction_Save", _wrap_GridFunction_Save, METH_VARARGS, "\n"
-		"Save(GridFunction self, std::ostream & out)\n"
-		"Save(GridFunction self, char const * file, int precision=8)\n"
-		""},
 	 { "GridFunction_swigregister", GridFunction_swigregister, METH_O, NULL},
 	 { "GridFunction_swiginit", GridFunction_swiginit, METH_VARARGS, NULL},
 	 { "new_QuadratureFunction", _wrap_new_QuadratureFunction, METH_VARARGS, "\n"
@@ -17038,10 +17112,7 @@ static PyMethodDef SwigMethods_proxydocs[] = {
 		"GetElementValues(QuadratureFunction self, int idx, DenseMatrix values)\n"
 		"GetElementValues(QuadratureFunction self, int idx, DenseMatrix values)\n"
 		""},
-	 { "QuadratureFunction_Save", _wrap_QuadratureFunction_Save, METH_VARARGS, "\n"
-		"Save(QuadratureFunction self, std::ostream & out)\n"
-		"Save(QuadratureFunction self, char const * file, int precision=8)\n"
-		""},
+	 { "QuadratureFunction_Save", (PyCFunction)(void(*)(void))_wrap_QuadratureFunction_Save, METH_VARARGS|METH_KEYWORDS, "Save(QuadratureFunction self, std::ostream & out)"},
 	 { "QuadratureFunction_swigregister", QuadratureFunction_swigregister, METH_O, NULL},
 	 { "QuadratureFunction_swiginit", QuadratureFunction_swiginit, METH_VARARGS, NULL},
 	 { "__lshift__", _wrap___lshift__, METH_VARARGS, "\n"
@@ -17773,7 +17844,6 @@ static swig_type_info _swigt__p_p_mfem__GridFunction = {"_p_p_mfem__GridFunction
 static swig_type_info _swigt__p_pri_t = {"_p_pri_t", "pri_t *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_quad_t = {"_p_quad_t", "quad_t *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_seg_t = {"_p_seg_t", "seg_t *", 0, 0, (void*)0, 0};
-static swig_type_info _swigt__p_std__istream = {"_p_std__istream", "std::istream *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_std__ostream = {"_p_std__ostream", "std::ostream *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_mfem__OutStream = {"_p_mfem__OutStream", 0, 0, 0, 0, 0};
 static swig_type_info _swigt__p_tet_t = {"_p_tet_t", "tet_t *", 0, 0, (void*)0, 0};
@@ -17977,7 +18047,6 @@ static swig_type_info *swig_type_initial[] = {
   &_swigt__p_pri_t,
   &_swigt__p_quad_t,
   &_swigt__p_seg_t,
-  &_swigt__p_std__istream,
   &_swigt__p_std__ostream,
   &_swigt__p_tet_t,
   &_swigt__p_tri_t,
@@ -18179,7 +18248,6 @@ static swig_cast_info _swigc__p_p_mfem__GridFunction[] = {  {&_swigt__p_p_mfem__
 static swig_cast_info _swigc__p_pri_t[] = {  {&_swigt__p_pri_t, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_quad_t[] = {  {&_swigt__p_quad_t, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_seg_t[] = {  {&_swigt__p_seg_t, 0, 0, 0},{0, 0, 0, 0}};
-static swig_cast_info _swigc__p_std__istream[] = {  {&_swigt__p_std__istream, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_mfem__OutStream[] = {{&_swigt__p_mfem__OutStream, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_std__ostream[] = {  {&_swigt__p_std__ostream, 0, 0, 0},  {&_swigt__p_mfem__OutStream, _p_mfem__OutStreamTo_p_std__ostream, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_tet_t[] = {  {&_swigt__p_tet_t, 0, 0, 0},{0, 0, 0, 0}};
@@ -18383,7 +18451,6 @@ static swig_cast_info *swig_cast_initial[] = {
   _swigc__p_pri_t,
   _swigc__p_quad_t,
   _swigc__p_seg_t,
-  _swigc__p_std__istream,
   _swigc__p_std__ostream,
   _swigc__p_tet_t,
   _swigc__p_tri_t,

--- a/mfem/_ser/gridfunc_wrap.cxx
+++ b/mfem/_ser/gridfunc_wrap.cxx
@@ -3726,11 +3726,6 @@ SWIGINTERN mfem::GridFunction *new_mfem_GridFunction__SWIG_6(mfem::FiniteElement
 
 
 
-SWIGINTERN void mfem_GridFunction_Save__SWIG_1(mfem::GridFunction const *self,char const *gf_file,int const precision){
-     std::ofstream mesh_ofs(gf_file);	
-     mesh_ofs.precision(precision);
-     self->Save(mesh_ofs);	
-}
 SWIGINTERN void mfem_GridFunction_SaveToFile(mfem::GridFunction const *self,char const *gf_file,int const precision){
         std::cerr << "\nWarning Deprecated : Use Save(filename) insteead of SaveToFile \n";
 	std::ofstream mesh_ofs(gf_file);	
@@ -3786,6 +3781,17 @@ SWIGINTERN mfem::GridFunction &mfem_GridFunction_idiv(mfem::GridFunction *self,d
       * self /= c;
       return *self;
    }
+SWIGINTERN void mfem_GridFunction_Save__SWIG_1(mfem::GridFunction *self,char const *file,int precision=8){
+  std::ofstream ofile(file);
+  if (!ofile)
+     {
+        std::cerr << "\nCan not produce output file: " << file << '\n' << std::endl;
+        return;
+      }
+  ofile.precision(precision);  
+  self -> Save(ofile);
+  ofile.close();
+  }
 
 SWIGINTERNINLINE PyObject*
   SWIG_From_bool  (bool value)
@@ -3793,6 +3799,17 @@ SWIGINTERNINLINE PyObject*
   return PyBool_FromLong(value ? 1 : 0);
 }
 
+SWIGINTERN void mfem_QuadratureFunction_Save__SWIG_1(mfem::QuadratureFunction *self,char const *file,int precision=8){
+  std::ofstream ofile(file);
+  if (!ofile)
+     {
+        std::cerr << "\nCan not produce output file: " << file << '\n' << std::endl;
+        return;
+      }
+  ofile.precision(precision);  
+  self -> Save(ofile);
+  ofile.close();
+  }
 
 
 /* ---------------------------------------------------
@@ -13665,142 +13682,6 @@ fail:
 }
 
 
-SWIGINTERN PyObject *_wrap_GridFunction_Save__SWIG_1(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
-  PyObject *resultobj = 0;
-  mfem::GridFunction *arg1 = (mfem::GridFunction *) 0 ;
-  char *arg2 = (char *) 0 ;
-  int arg3 ;
-  void *argp1 = 0 ;
-  int res1 = 0 ;
-  int res2 ;
-  char *buf2 = 0 ;
-  int alloc2 = 0 ;
-  
-  if ((nobjs < 3) || (nobjs > 3)) SWIG_fail;
-  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_mfem__GridFunction, 0 |  0 );
-  if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "GridFunction_Save" "', argument " "1"" of type '" "mfem::GridFunction const *""'"); 
-  }
-  arg1 = reinterpret_cast< mfem::GridFunction * >(argp1);
-  res2 = SWIG_AsCharPtrAndSize(swig_obj[1], &buf2, NULL, &alloc2);
-  if (!SWIG_IsOK(res2)) {
-    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "GridFunction_Save" "', argument " "2"" of type '" "char const *""'");
-  }
-  arg2 = reinterpret_cast< char * >(buf2);
-  {
-    if ((PyArray_PyIntAsInt(swig_obj[2]) == -1) && PyErr_Occurred()) {
-      SWIG_exception_fail(SWIG_TypeError, "Input must be integer");
-    };  
-    arg3 = PyArray_PyIntAsInt(swig_obj[2]);
-  }
-  {
-    try {
-      mfem_GridFunction_Save__SWIG_1((mfem::GridFunction const *)arg1,(char const *)arg2,arg3);
-    }
-#ifdef  MFEM_USE_EXCEPTIONS
-    catch (mfem::ErrorException &_e) {
-      std::string s("PyMFEM error (mfem::ErrorException): "), s2(_e.what());
-      s = s + s2;    
-      SWIG_exception(SWIG_RuntimeError, s.c_str());
-    }
-#endif
-    
-    catch (Swig::DirectorException &e){
-      SWIG_fail;
-    }    
-    catch (...) {
-      SWIG_exception(SWIG_RuntimeError, "unknown exception");
-    }	 
-  }
-  resultobj = SWIG_Py_Void();
-  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
-  return resultobj;
-fail:
-  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
-  return NULL;
-}
-
-
-SWIGINTERN PyObject *_wrap_GridFunction_Save(PyObject *self, PyObject *args) {
-  Py_ssize_t argc;
-  PyObject *argv[4] = {
-    0
-  };
-  
-  if (!(argc = SWIG_Python_UnpackTuple(args, "GridFunction_Save", 0, 3, argv))) SWIG_fail;
-  --argc;
-  if (argc == 2) {
-    int _v;
-    void *vptr = 0;
-    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_mfem__GridFunction, 0);
-    _v = SWIG_CheckState(res);
-    if (_v) {
-      {
-        void *ptr;
-        //std::string *ptr2 = (std::string *)0;
-        if (SWIG_ConvertPtr(argv[1], (void **) &ptr, SWIGTYPE_p_PyMFEM__wFILE, 0 |0) == -1) {
-          PyErr_Clear();
-          if (!PyString_Check(argv[1]) && !PyUnicode_Check(argv[1])) {
-            // not string
-            _v = 1;	   	
-            PyObject* module = PyImport_ImportModule("io");
-            if (!module){
-              _v = 0;	   
-            }      
-            PyObject* cls = PyObject_GetAttrString(module, "StringIO");
-            if (!cls){
-              _v = 0;	   	   
-            }      
-            int check = PyObject_IsInstance(argv[1], cls);
-            Py_DECREF(module);
-            if (! check){
-              _v = 0;	   	   	   
-            }
-          } else {
-            _v = 1;
-          }
-        } else {
-          _v = 1;
-        }
-      }
-      if (_v) {
-        return _wrap_GridFunction_Save__SWIG_0(self, argc, argv);
-      }
-    }
-  }
-  if (argc == 3) {
-    int _v;
-    void *vptr = 0;
-    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_mfem__GridFunction, 0);
-    _v = SWIG_CheckState(res);
-    if (_v) {
-      int res = SWIG_AsCharPtrAndSize(argv[1], 0, NULL, 0);
-      _v = SWIG_CheckState(res);
-      if (_v) {
-        {
-          if ((PyArray_PyIntAsInt(argv[2]) == -1) && PyErr_Occurred()) {
-            PyErr_Clear();
-            _v = 0;
-          } else {
-            _v = 1;    
-          }
-        }
-        if (_v) {
-          return _wrap_GridFunction_Save__SWIG_1(self, argc, argv);
-        }
-      }
-    }
-  }
-  
-fail:
-  SWIG_Python_RaiseOrModifyTypeError("Wrong number or type of arguments for overloaded function 'GridFunction_Save'.\n"
-    "  Possible C/C++ prototypes are:\n"
-    "    mfem::GridFunction::Save(std::ostream &) const\n"
-    "    mfem::GridFunction::Save(char const *,int const) const\n");
-  return 0;
-}
-
-
 SWIGINTERN PyObject *_wrap_GridFunction_SaveToFile(PyObject *SWIGUNUSEDPARM(self), PyObject *args, PyObject *kwargs) {
   PyObject *resultobj = 0;
   mfem::GridFunction *arg1 = (mfem::GridFunction *) 0 ;
@@ -14212,6 +14093,147 @@ SWIGINTERN PyObject *_wrap_GridFunction_idiv(PyObject *SWIGUNUSEDPARM(self), PyO
   return resultobj;
 fail:
   return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_GridFunction_Save__SWIG_1(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
+  PyObject *resultobj = 0;
+  mfem::GridFunction *arg1 = (mfem::GridFunction *) 0 ;
+  char *arg2 = (char *) 0 ;
+  int arg3 = (int) 8 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int res2 ;
+  char *buf2 = 0 ;
+  int alloc2 = 0 ;
+  
+  if ((nobjs < 2) || (nobjs > 3)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_mfem__GridFunction, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "GridFunction_Save" "', argument " "1"" of type '" "mfem::GridFunction *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::GridFunction * >(argp1);
+  res2 = SWIG_AsCharPtrAndSize(swig_obj[1], &buf2, NULL, &alloc2);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "GridFunction_Save" "', argument " "2"" of type '" "char const *""'");
+  }
+  arg2 = reinterpret_cast< char * >(buf2);
+  if (swig_obj[2]) {
+    {
+      if ((PyArray_PyIntAsInt(swig_obj[2]) == -1) && PyErr_Occurred()) {
+        SWIG_exception_fail(SWIG_TypeError, "Input must be integer");
+      };  
+      arg3 = PyArray_PyIntAsInt(swig_obj[2]);
+    }
+  }
+  {
+    try {
+      mfem_GridFunction_Save__SWIG_1(arg1,(char const *)arg2,arg3);
+    }
+#ifdef  MFEM_USE_EXCEPTIONS
+    catch (mfem::ErrorException &_e) {
+      std::string s("PyMFEM error (mfem::ErrorException): "), s2(_e.what());
+      s = s + s2;    
+      SWIG_exception(SWIG_RuntimeError, s.c_str());
+    }
+#endif
+    
+    catch (Swig::DirectorException &e){
+      SWIG_fail;
+    }    
+    catch (...) {
+      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+    }	 
+  }
+  resultobj = SWIG_Py_Void();
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return resultobj;
+fail:
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_GridFunction_Save(PyObject *self, PyObject *args) {
+  Py_ssize_t argc;
+  PyObject *argv[4] = {
+    0
+  };
+  
+  if (!(argc = SWIG_Python_UnpackTuple(args, "GridFunction_Save", 0, 3, argv))) SWIG_fail;
+  --argc;
+  if ((argc >= 2) && (argc <= 3)) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_mfem__GridFunction, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      int res = SWIG_AsCharPtrAndSize(argv[1], 0, NULL, 0);
+      _v = SWIG_CheckState(res);
+      if (_v) {
+        if (argc <= 2) {
+          return _wrap_GridFunction_Save__SWIG_1(self, argc, argv);
+        }
+        {
+          if ((PyArray_PyIntAsInt(argv[2]) == -1) && PyErr_Occurred()) {
+            PyErr_Clear();
+            _v = 0;
+          } else {
+            _v = 1;    
+          }
+        }
+        if (_v) {
+          return _wrap_GridFunction_Save__SWIG_1(self, argc, argv);
+        }
+      }
+    }
+  }
+  if (argc == 2) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_mfem__GridFunction, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      {
+        void *ptr;
+        //std::string *ptr2 = (std::string *)0;
+        if (SWIG_ConvertPtr(argv[1], (void **) &ptr, SWIGTYPE_p_PyMFEM__wFILE, 0 |0) == -1) {
+          PyErr_Clear();
+          if (!PyString_Check(argv[1]) && !PyUnicode_Check(argv[1])) {
+            // not string
+            _v = 1;	   	
+            PyObject* module = PyImport_ImportModule("io");
+            if (!module){
+              _v = 0;	   
+            }      
+            PyObject* cls = PyObject_GetAttrString(module, "StringIO");
+            if (!cls){
+              _v = 0;	   	   
+            }      
+            int check = PyObject_IsInstance(argv[1], cls);
+            Py_DECREF(module);
+            if (! check){
+              _v = 0;	   	   	   
+            }
+          } else {
+            _v = 1;
+          }
+        } else {
+          _v = 1;
+        }
+      }
+      if (_v) {
+        return _wrap_GridFunction_Save__SWIG_0(self, argc, argv);
+      }
+    }
+  }
+  
+fail:
+  SWIG_Python_RaiseOrModifyTypeError("Wrong number or type of arguments for overloaded function 'GridFunction_Save'.\n"
+    "  Possible C/C++ prototypes are:\n"
+    "    mfem::GridFunction::Save(std::ostream &) const\n"
+    "    mfem::GridFunction::Save(char const *,int)\n");
+  return 0;
 }
 
 
@@ -15850,7 +15872,7 @@ fail:
 }
 
 
-SWIGINTERN PyObject *_wrap_QuadratureFunction_Save(PyObject *SWIGUNUSEDPARM(self), PyObject *args, PyObject *kwargs) {
+SWIGINTERN PyObject *_wrap_QuadratureFunction_Save__SWIG_0(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
   PyObject *resultobj = 0;
   mfem::QuadratureFunction *arg1 = (mfem::QuadratureFunction *) 0 ;
   std::ostream *arg2 = 0 ;
@@ -15862,22 +15884,17 @@ SWIGINTERN PyObject *_wrap_QuadratureFunction_Save(PyObject *SWIGUNUSEDPARM(self
   PyObject *string_io2 = 0 ;
   std::ostringstream *stream2 = 0 ;
   PyObject *ret2 = 0 ;
-  PyObject * obj0 = 0 ;
-  PyObject * obj1 = 0 ;
-  char * kwnames[] = {
-    (char *)"self",  (char *)"out",  NULL 
-  };
   
-  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OO:QuadratureFunction_Save", kwnames, &obj0, &obj1)) SWIG_fail;
-  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_mfem__QuadratureFunction, 0 |  0 );
+  if ((nobjs < 2) || (nobjs > 2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_mfem__QuadratureFunction, 0 |  0 );
   if (!SWIG_IsOK(res1)) {
     SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "QuadratureFunction_Save" "', argument " "1"" of type '" "mfem::QuadratureFunction const *""'"); 
   }
   arg1 = reinterpret_cast< mfem::QuadratureFunction * >(argp1);
   {
     //  PyMFEM::wFILE or string argument or StringIO
-    if (SWIG_ConvertPtr(obj1, (void **) &temp2, SWIGTYPE_p_PyMFEM__wFILE, 0 | 0) == -1) {
-      if (!PyString_Check(obj1) && !PyUnicode_Check(obj1)) {
+    if (SWIG_ConvertPtr(swig_obj[1], (void **) &temp2, SWIGTYPE_p_PyMFEM__wFILE, 0 | 0) == -1) {
+      if (!PyString_Check(swig_obj[1]) && !PyUnicode_Check(swig_obj[1])) {
         // not string, check if it is StringIO
         PyObject* module = PyImport_ImportModule("io");
         if (!module){
@@ -15889,17 +15906,17 @@ SWIGINTERN PyObject *_wrap_QuadratureFunction_Save(PyObject *SWIGUNUSEDPARM(self
           PyErr_SetString(PyExc_RuntimeError, "Can not load StringIO");
           return NULL;
         }      
-        int check = PyObject_IsInstance(obj1, cls);
+        int check = PyObject_IsInstance(swig_obj[1], cls);
         Py_DECREF(module);
         if (! check){
           SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
           return NULL;
         }
-        string_io2=obj1;
+        string_io2=swig_obj[1];
         stream2 = new std::ostringstream();
       } else {
         // if it is string, extract filename as char*
-        PyObject* str = PyUnicode_AsEncodedString(obj1, "utf-8", "~E~");	
+        PyObject* str = PyUnicode_AsEncodedString(swig_obj[1], "utf-8", "~E~");	
         const char* filename = PyBytes_AsString(str);
         temp2 = new PyMFEM::wFILE(filename, 8, true);
         Py_DECREF(str);	 
@@ -15991,6 +16008,147 @@ fail:
     }
   }
   return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_QuadratureFunction_Save__SWIG_1(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
+  PyObject *resultobj = 0;
+  mfem::QuadratureFunction *arg1 = (mfem::QuadratureFunction *) 0 ;
+  char *arg2 = (char *) 0 ;
+  int arg3 = (int) 8 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int res2 ;
+  char *buf2 = 0 ;
+  int alloc2 = 0 ;
+  
+  if ((nobjs < 2) || (nobjs > 3)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_mfem__QuadratureFunction, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "QuadratureFunction_Save" "', argument " "1"" of type '" "mfem::QuadratureFunction *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::QuadratureFunction * >(argp1);
+  res2 = SWIG_AsCharPtrAndSize(swig_obj[1], &buf2, NULL, &alloc2);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "QuadratureFunction_Save" "', argument " "2"" of type '" "char const *""'");
+  }
+  arg2 = reinterpret_cast< char * >(buf2);
+  if (swig_obj[2]) {
+    {
+      if ((PyArray_PyIntAsInt(swig_obj[2]) == -1) && PyErr_Occurred()) {
+        SWIG_exception_fail(SWIG_TypeError, "Input must be integer");
+      };  
+      arg3 = PyArray_PyIntAsInt(swig_obj[2]);
+    }
+  }
+  {
+    try {
+      mfem_QuadratureFunction_Save__SWIG_1(arg1,(char const *)arg2,arg3);
+    }
+#ifdef  MFEM_USE_EXCEPTIONS
+    catch (mfem::ErrorException &_e) {
+      std::string s("PyMFEM error (mfem::ErrorException): "), s2(_e.what());
+      s = s + s2;    
+      SWIG_exception(SWIG_RuntimeError, s.c_str());
+    }
+#endif
+    
+    catch (Swig::DirectorException &e){
+      SWIG_fail;
+    }    
+    catch (...) {
+      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+    }	 
+  }
+  resultobj = SWIG_Py_Void();
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return resultobj;
+fail:
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_QuadratureFunction_Save(PyObject *self, PyObject *args) {
+  Py_ssize_t argc;
+  PyObject *argv[4] = {
+    0
+  };
+  
+  if (!(argc = SWIG_Python_UnpackTuple(args, "QuadratureFunction_Save", 0, 3, argv))) SWIG_fail;
+  --argc;
+  if ((argc >= 2) && (argc <= 3)) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_mfem__QuadratureFunction, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      int res = SWIG_AsCharPtrAndSize(argv[1], 0, NULL, 0);
+      _v = SWIG_CheckState(res);
+      if (_v) {
+        if (argc <= 2) {
+          return _wrap_QuadratureFunction_Save__SWIG_1(self, argc, argv);
+        }
+        {
+          if ((PyArray_PyIntAsInt(argv[2]) == -1) && PyErr_Occurred()) {
+            PyErr_Clear();
+            _v = 0;
+          } else {
+            _v = 1;    
+          }
+        }
+        if (_v) {
+          return _wrap_QuadratureFunction_Save__SWIG_1(self, argc, argv);
+        }
+      }
+    }
+  }
+  if (argc == 2) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_mfem__QuadratureFunction, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      {
+        void *ptr;
+        //std::string *ptr2 = (std::string *)0;
+        if (SWIG_ConvertPtr(argv[1], (void **) &ptr, SWIGTYPE_p_PyMFEM__wFILE, 0 |0) == -1) {
+          PyErr_Clear();
+          if (!PyString_Check(argv[1]) && !PyUnicode_Check(argv[1])) {
+            // not string
+            _v = 1;	   	
+            PyObject* module = PyImport_ImportModule("io");
+            if (!module){
+              _v = 0;	   
+            }      
+            PyObject* cls = PyObject_GetAttrString(module, "StringIO");
+            if (!cls){
+              _v = 0;	   	   
+            }      
+            int check = PyObject_IsInstance(argv[1], cls);
+            Py_DECREF(module);
+            if (! check){
+              _v = 0;	   	   	   
+            }
+          } else {
+            _v = 1;
+          }
+        } else {
+          _v = 1;
+        }
+      }
+      if (_v) {
+        return _wrap_QuadratureFunction_Save__SWIG_0(self, argc, argv);
+      }
+    }
+  }
+  
+fail:
+  SWIG_Python_RaiseOrModifyTypeError("Wrong number or type of arguments for overloaded function 'QuadratureFunction_Save'.\n"
+    "  Possible C/C++ prototypes are:\n"
+    "    mfem::QuadratureFunction::Save(std::ostream &) const\n"
+    "    mfem::QuadratureFunction::Save(char const *,int)\n");
+  return 0;
 }
 
 
@@ -16845,10 +17003,6 @@ static PyMethodDef SwigMethods[] = {
 		"GridFunction(Mesh m, mfem::GridFunction *[] gf_array, int num_pieces)\n"
 		"new_GridFunction(FiniteElementSpace fes, Vector v, int offset) -> GridFunction\n"
 		""},
-	 { "GridFunction_Save", _wrap_GridFunction_Save, METH_VARARGS, "\n"
-		"GridFunction_Save(GridFunction self, std::ostream & out)\n"
-		"GridFunction_Save(GridFunction self, char const * gf_file, int const precision)\n"
-		""},
 	 { "GridFunction_SaveToFile", (PyCFunction)(void(*)(void))_wrap_GridFunction_SaveToFile, METH_VARARGS|METH_KEYWORDS, "GridFunction_SaveToFile(GridFunction self, char const * gf_file, int const precision)"},
 	 { "GridFunction_WriteToStream", (PyCFunction)(void(*)(void))_wrap_GridFunction_WriteToStream, METH_VARARGS|METH_KEYWORDS, "GridFunction_WriteToStream(GridFunction self, PyObject * StringIO) -> PyObject *"},
 	 { "GridFunction_iadd", (PyCFunction)(void(*)(void))_wrap_GridFunction_iadd, METH_VARARGS|METH_KEYWORDS, "GridFunction_iadd(GridFunction self, GridFunction c) -> GridFunction"},
@@ -16858,6 +17012,10 @@ static PyMethodDef SwigMethods[] = {
 		""},
 	 { "GridFunction_imul", (PyCFunction)(void(*)(void))_wrap_GridFunction_imul, METH_VARARGS|METH_KEYWORDS, "GridFunction_imul(GridFunction self, double c) -> GridFunction"},
 	 { "GridFunction_idiv", (PyCFunction)(void(*)(void))_wrap_GridFunction_idiv, METH_VARARGS|METH_KEYWORDS, "GridFunction_idiv(GridFunction self, double c) -> GridFunction"},
+	 { "GridFunction_Save", _wrap_GridFunction_Save, METH_VARARGS, "\n"
+		"GridFunction_Save(GridFunction self, std::ostream & out)\n"
+		"GridFunction_Save(GridFunction self, char const * file, int precision=8)\n"
+		""},
 	 { "GridFunction_swigregister", GridFunction_swigregister, METH_O, NULL},
 	 { "GridFunction_swiginit", GridFunction_swiginit, METH_VARARGS, NULL},
 	 { "new_QuadratureFunction", _wrap_new_QuadratureFunction, METH_VARARGS, "\n"
@@ -16886,7 +17044,10 @@ static PyMethodDef SwigMethods[] = {
 		"QuadratureFunction_GetElementValues(QuadratureFunction self, int idx, DenseMatrix values)\n"
 		"QuadratureFunction_GetElementValues(QuadratureFunction self, int idx, DenseMatrix values)\n"
 		""},
-	 { "QuadratureFunction_Save", (PyCFunction)(void(*)(void))_wrap_QuadratureFunction_Save, METH_VARARGS|METH_KEYWORDS, "QuadratureFunction_Save(QuadratureFunction self, std::ostream & out)"},
+	 { "QuadratureFunction_Save", _wrap_QuadratureFunction_Save, METH_VARARGS, "\n"
+		"QuadratureFunction_Save(QuadratureFunction self, std::ostream & out)\n"
+		"QuadratureFunction_Save(QuadratureFunction self, char const * file, int precision=8)\n"
+		""},
 	 { "QuadratureFunction_swigregister", QuadratureFunction_swigregister, METH_O, NULL},
 	 { "QuadratureFunction_swiginit", QuadratureFunction_swiginit, METH_VARARGS, NULL},
 	 { "__lshift__", _wrap___lshift__, METH_VARARGS, "\n"
@@ -17071,10 +17232,6 @@ static PyMethodDef SwigMethods_proxydocs[] = {
 		"GridFunction(Mesh m, mfem::GridFunction *[] gf_array, int num_pieces)\n"
 		"new_GridFunction(FiniteElementSpace fes, Vector v, int offset) -> GridFunction\n"
 		""},
-	 { "GridFunction_Save", _wrap_GridFunction_Save, METH_VARARGS, "\n"
-		"Save(GridFunction self, std::ostream & out)\n"
-		"Save(GridFunction self, char const * gf_file, int const precision)\n"
-		""},
 	 { "GridFunction_SaveToFile", (PyCFunction)(void(*)(void))_wrap_GridFunction_SaveToFile, METH_VARARGS|METH_KEYWORDS, "SaveToFile(GridFunction self, char const * gf_file, int const precision)"},
 	 { "GridFunction_WriteToStream", (PyCFunction)(void(*)(void))_wrap_GridFunction_WriteToStream, METH_VARARGS|METH_KEYWORDS, "WriteToStream(GridFunction self, PyObject * StringIO) -> PyObject *"},
 	 { "GridFunction_iadd", (PyCFunction)(void(*)(void))_wrap_GridFunction_iadd, METH_VARARGS|METH_KEYWORDS, "iadd(GridFunction self, GridFunction c) -> GridFunction"},
@@ -17084,6 +17241,10 @@ static PyMethodDef SwigMethods_proxydocs[] = {
 		""},
 	 { "GridFunction_imul", (PyCFunction)(void(*)(void))_wrap_GridFunction_imul, METH_VARARGS|METH_KEYWORDS, "imul(GridFunction self, double c) -> GridFunction"},
 	 { "GridFunction_idiv", (PyCFunction)(void(*)(void))_wrap_GridFunction_idiv, METH_VARARGS|METH_KEYWORDS, "idiv(GridFunction self, double c) -> GridFunction"},
+	 { "GridFunction_Save", _wrap_GridFunction_Save, METH_VARARGS, "\n"
+		"Save(GridFunction self, std::ostream & out)\n"
+		"Save(GridFunction self, char const * file, int precision=8)\n"
+		""},
 	 { "GridFunction_swigregister", GridFunction_swigregister, METH_O, NULL},
 	 { "GridFunction_swiginit", GridFunction_swiginit, METH_VARARGS, NULL},
 	 { "new_QuadratureFunction", _wrap_new_QuadratureFunction, METH_VARARGS, "\n"
@@ -17112,7 +17273,10 @@ static PyMethodDef SwigMethods_proxydocs[] = {
 		"GetElementValues(QuadratureFunction self, int idx, DenseMatrix values)\n"
 		"GetElementValues(QuadratureFunction self, int idx, DenseMatrix values)\n"
 		""},
-	 { "QuadratureFunction_Save", (PyCFunction)(void(*)(void))_wrap_QuadratureFunction_Save, METH_VARARGS|METH_KEYWORDS, "Save(QuadratureFunction self, std::ostream & out)"},
+	 { "QuadratureFunction_Save", _wrap_QuadratureFunction_Save, METH_VARARGS, "\n"
+		"Save(QuadratureFunction self, std::ostream & out)\n"
+		"Save(QuadratureFunction self, char const * file, int precision=8)\n"
+		""},
 	 { "QuadratureFunction_swigregister", QuadratureFunction_swigregister, METH_O, NULL},
 	 { "QuadratureFunction_swiginit", QuadratureFunction_swiginit, METH_VARARGS, NULL},
 	 { "__lshift__", _wrap___lshift__, METH_VARARGS, "\n"

--- a/mfem/_ser/handle_wrap.cxx
+++ b/mfem/_ser/handle_wrap.cxx
@@ -5903,10 +5903,10 @@ SWIGINTERN PyObject *_wrap_OperatorHandle_PrintMatlab(PyObject *SWIGUNUSEDPARM(s
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyMFEM::wFILE *temp2 = 0 ;
-  std::ofstream out2 ;
-  int use_stringio2 = 0 ;
+  std::ofstream out_txt2 ;
+  mfem::ofgzstream *out_gz2 = 0 ;
   PyObject *string_io2 = 0 ;
-  std::ostringstream stream2 ;
+  std::ostringstream *stream2 = 0 ;
   PyObject *ret2 = 0 ;
   PyObject * obj0 = 0 ;
   PyObject * obj1 = 0 ;
@@ -5943,29 +5943,33 @@ SWIGINTERN PyObject *_wrap_OperatorHandle_PrintMatlab(PyObject *SWIGUNUSEDPARM(s
           SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
           return NULL;
         }
-        use_stringio2=1;
         string_io2=obj1;
+        stream2 = new std::ostringstream();
       } else {
         // if it is string, extract filename as char*
         PyObject* str = PyUnicode_AsEncodedString(obj1, "utf-8", "~E~");	
         const char* filename = PyBytes_AsString(str);
-        temp2 = new PyMFEM::wFILE(filename, 8, true);	
+        temp2 = new PyMFEM::wFILE(filename, 8, true);
+        Py_DECREF(str);	 
       }
     }
     
-    if (use_stringio2 == 0){
+    if (stream2 == 0){
       if (temp2->isSTDOUT() == 1) {
         arg2 = &std::cout;
+      } else if (temp2->isGZ()){
+        out_gz2 = new mfem::ofgzstream(temp2->getFilename(), true);
+        arg2 = out_gz2;	     
       } else {
-        out2.open(temp2->getFilename());
-        out2.precision(temp2->getPrecision());
-        if (temp2->isTemporary()){
-          delete temp2;
-        }
-        arg2 = &out2;
+        out_txt2.open(temp2->getFilename());
+        out_txt2.precision(temp2->getPrecision());
+        arg2 = &out_txt2;
+      }
+      if (temp2->isTemporary()){
+        delete temp2;
       }
     } else {
-      arg2 = &stream2;
+      arg2 = stream2;
     }
   }
   if (obj2) {
@@ -6005,8 +6009,8 @@ SWIGINTERN PyObject *_wrap_OperatorHandle_PrintMatlab(PyObject *SWIGUNUSEDPARM(s
   }
   resultobj = SWIG_Py_Void();
   {
-    if (use_stringio2 == 1) {
-      std::string str =  stream2.str();
+    if (stream2) {
+      std::string str =  stream2->str();
       const char* s = str.c_str();
       const int n = str.length();
       ret2 = PyObject_CallMethod(string_io2, "write", "s#",
@@ -6015,15 +6019,21 @@ SWIGINTERN PyObject *_wrap_OperatorHandle_PrintMatlab(PyObject *SWIGUNUSEDPARM(s
         PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
         return NULL;
       }
+      delete stream2;
       Py_XDECREF(resultobj);   /* Blow away any previous result */
       resultobj = ret2;    
     }
   }
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -6031,10 +6041,15 @@ SWIGINTERN PyObject *_wrap_OperatorHandle_PrintMatlab(PyObject *SWIGUNUSEDPARM(s
   return resultobj;
 fail:
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }

--- a/mfem/_ser/io_stream.i
+++ b/mfem/_ser/io_stream.i
@@ -14,4 +14,3 @@
 %pythoncode %{
   STDOUT = wFILE()
 %}
-//

--- a/mfem/_ser/io_stream.py
+++ b/mfem/_ser/io_stream.py
@@ -92,6 +92,11 @@ class wFILE(object):
         return _io_stream.wFILE_getFilename(self)
     getFilename = _swig_new_instance_method(_io_stream.wFILE_getFilename)
 
+    def isGZ(self):
+        r"""isGZ(wFILE self) -> bool"""
+        return _io_stream.wFILE_isGZ(self)
+    isGZ = _swig_new_instance_method(_io_stream.wFILE_isGZ)
+
     def getPrecision(self):
         r"""getPrecision(wFILE self) -> int"""
         return _io_stream.wFILE_getPrecision(self)

--- a/mfem/_ser/io_stream_wrap.cxx
+++ b/mfem/_ser/io_stream_wrap.cxx
@@ -3279,6 +3279,29 @@ fail:
 }
 
 
+SWIGINTERN PyObject *_wrap_wFILE_isGZ(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  PyMFEM::wFILE *arg1 = (PyMFEM::wFILE *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject *swig_obj[1] ;
+  bool result;
+  
+  if (!args) SWIG_fail;
+  swig_obj[0] = args;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_PyMFEM__wFILE, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "wFILE_isGZ" "', argument " "1"" of type '" "PyMFEM::wFILE *""'"); 
+  }
+  arg1 = reinterpret_cast< PyMFEM::wFILE * >(argp1);
+  result = (bool)(arg1)->isGZ();
+  resultobj = SWIG_From_bool(static_cast< bool >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
 SWIGINTERN PyObject *_wrap_wFILE_getPrecision(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   PyMFEM::wFILE *arg1 = (PyMFEM::wFILE *) 0 ;
@@ -3378,6 +3401,7 @@ static PyMethodDef SwigMethods[] = {
 	 { "wFILE_isSTDOUT", _wrap_wFILE_isSTDOUT, METH_O, "wFILE_isSTDOUT(wFILE self) -> int"},
 	 { "wFILE_isTemporary", _wrap_wFILE_isTemporary, METH_O, "wFILE_isTemporary(wFILE self) -> bool"},
 	 { "wFILE_getFilename", _wrap_wFILE_getFilename, METH_O, "wFILE_getFilename(wFILE self) -> char *"},
+	 { "wFILE_isGZ", _wrap_wFILE_isGZ, METH_O, "wFILE_isGZ(wFILE self) -> bool"},
 	 { "wFILE_getPrecision", _wrap_wFILE_getPrecision, METH_O, "wFILE_getPrecision(wFILE self) -> int"},
 	 { "wFILE_setPrecision", (PyCFunction)(void(*)(void))_wrap_wFILE_setPrecision, METH_VARARGS|METH_KEYWORDS, "wFILE_setPrecision(wFILE self, int precision)"},
 	 { "delete_wFILE", _wrap_delete_wFILE, METH_O, "delete_wFILE(wFILE self)"},
@@ -3396,6 +3420,7 @@ static PyMethodDef SwigMethods_proxydocs[] = {
 	 { "wFILE_isSTDOUT", _wrap_wFILE_isSTDOUT, METH_O, "isSTDOUT(wFILE self) -> int"},
 	 { "wFILE_isTemporary", _wrap_wFILE_isTemporary, METH_O, "isTemporary(wFILE self) -> bool"},
 	 { "wFILE_getFilename", _wrap_wFILE_getFilename, METH_O, "getFilename(wFILE self) -> char *"},
+	 { "wFILE_isGZ", _wrap_wFILE_isGZ, METH_O, "isGZ(wFILE self) -> bool"},
 	 { "wFILE_getPrecision", _wrap_wFILE_getPrecision, METH_O, "getPrecision(wFILE self) -> int"},
 	 { "wFILE_setPrecision", (PyCFunction)(void(*)(void))_wrap_wFILE_setPrecision, METH_VARARGS|METH_KEYWORDS, "setPrecision(wFILE self, int precision)"},
 	 { "delete_wFILE", _wrap_delete_wFILE, METH_O, "delete_wFILE(wFILE self)"},

--- a/mfem/_ser/matrix.i
+++ b/mfem/_ser/matrix.i
@@ -5,6 +5,7 @@
 %{
 #include <fstream>
 #include <iostream>
+#include "general/zstr.hpp"
 #include "numpy/arrayobject.h"  
 #include "../common/io_stream.hpp"      
 #include "pyoperator.hpp"

--- a/mfem/_ser/matrix_wrap.cxx
+++ b/mfem/_ser/matrix_wrap.cxx
@@ -4014,7 +4014,6 @@ SWIGINTERN PyObject *_wrap_Matrix_Print(PyObject *self, PyObject *args) {
               _v = 0;	   	   	   
             }
           } else {
-            std::cout << "it is text (out)\n";	
             _v = 1;
           }
         } else {

--- a/mfem/_ser/mesh.i
+++ b/mfem/_ser/mesh.i
@@ -51,6 +51,7 @@ import_array();
 
 %import "../common/io_stream_typemap.i"
 OSTREAM_TYPEMAP(std::ostream&)
+ISTREAM_TYPEMAP(std::istream&)
 
 // this prevent automatic conversion from int to double so
 // that it select collect overloaded method....

--- a/mfem/_ser/mesh.i
+++ b/mfem/_ser/mesh.i
@@ -344,19 +344,19 @@ def CartesianPartitioning(self, nxyz, return_list=False):
 
 namespace mfem{
 %extend Mesh{
-   Mesh(const char *mesh_file, int generate_edges, int refine,
-        bool fix_orientation = true){
-
-        mfem::Mesh *mesh;
-        std::ifstream imesh(mesh_file);
-        if (!imesh)
-        {
-	  std::cerr << "\nCan not open mesh file: " << mesh_file << '\n' << std::endl;
-   	  return NULL;
-        }
-	mesh = new mfem::Mesh(imesh, generate_edges, refine, fix_orientation);
-	return mesh;
-   }
+    //Mesh(const char *mesh_file, int generate_edges, int refine,
+    //    bool fix_orientation = true){
+    //
+    //    mfem::Mesh *mesh;
+    //    std::ifstream imesh(mesh_file);
+    //    if (!imesh)
+    //    {
+    //	  std::cerr << "\nCan not open mesh file: " << mesh_file << '\n' << std::endl;
+    //  return NULL;
+    //    }
+    //	mesh = new mfem::Mesh(imesh, generate_edges, refine, fix_orientation);
+    //	return mesh;
+    //   }
    Mesh(int nx, int ny, int nz, const char *type, bool generate_edges = 0,
         double sx = 1.0, double sy = 1.0, double sz = 1.0,
 	bool sfc_ordering = true){

--- a/mfem/_ser/mesh_wrap.cxx
+++ b/mfem/_ser/mesh_wrap.cxx
@@ -3234,12 +3234,11 @@ namespace Swig {
 #define SWIGTYPE_p_pri_t swig_types[163]
 #define SWIGTYPE_p_quad_t swig_types[164]
 #define SWIGTYPE_p_seg_t swig_types[165]
-#define SWIGTYPE_p_std__istream swig_types[166]
-#define SWIGTYPE_p_std__ostream swig_types[167]
-#define SWIGTYPE_p_tet_t swig_types[168]
-#define SWIGTYPE_p_tri_t swig_types[169]
-static swig_type_info *swig_types[171];
-static swig_module_info swig_module = {swig_types, 170, 0, 0, 0, 0};
+#define SWIGTYPE_p_std__ostream swig_types[166]
+#define SWIGTYPE_p_tet_t swig_types[167]
+#define SWIGTYPE_p_tri_t swig_types[168]
+static swig_type_info *swig_types[170];
+static swig_module_info swig_module = {swig_types, 169, 0, 0, 0, 0};
 #define SWIG_TypeQuery(name) SWIG_TypeQueryModule(&swig_module, &swig_module, name)
 #define SWIG_MangledTypeQuery(name) SWIG_MangledTypeQueryModule(&swig_module, &swig_module, name)
 
@@ -8788,21 +8787,76 @@ SWIGINTERN PyObject *_wrap_new_Mesh__SWIG_9(PyObject *SWIGUNUSEDPARM(self), Py_s
   int arg2 = (int) 0 ;
   int arg3 = (int) 1 ;
   bool arg4 = (bool) true ;
-  void *argp1 = 0 ;
-  int res1 = 0 ;
+  PyMFEM::wFILE *temp1 = 0 ;
+  std::ifstream in_txt1 ;
+  mfem::ifgzstream *in_gz1 = 0 ;
+  PyObject *input_str1 = 0 ;
+  std::istringstream *stream1 = 0 ;
+  Py_ssize_t len1 = 0 ;
+  PyObject *ret1 = 0 ;
   bool val4 ;
   int ecode4 = 0 ;
   mfem::Mesh *result = 0 ;
   
   if ((nobjs < 1) || (nobjs > 4)) SWIG_fail;
-  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1, SWIGTYPE_p_std__istream,  0 );
-  if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "new_Mesh" "', argument " "1"" of type '" "std::istream &""'"); 
+  {
+    //  PyMFEM::wFILE or string argument or StringIO
+    if (SWIG_ConvertPtr(swig_obj[0], (void **) &temp1, SWIGTYPE_p_PyMFEM__wFILE, 0 | 0) == -1) {
+      if (!PyString_Check(swig_obj[0]) && !PyUnicode_Check(swig_obj[0])) {
+        // not string, check if it is StringIO
+        PyObject* module = PyImport_ImportModule("io");
+        if (!module){
+          PyErr_SetString(PyExc_RuntimeError, "Can not load io module");
+          return NULL;
+        }      
+        PyObject* cls = PyObject_GetAttrString(module, "StringIO");
+        if (!cls){
+          PyErr_SetString(PyExc_RuntimeError, "Can not load StringIO");
+          return NULL;
+        }      
+        int check = PyObject_IsInstance(swig_obj[0], cls);
+        Py_DECREF(module);
+        if (! check){
+          SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
+          return NULL;
+        }
+        
+        PyObject *input_str1 = PyObject_CallMethod(swig_obj[0], "getvalue", NULL);
+        if (PyErr_Occurred()) {
+          PyErr_SetString(PyExc_RuntimeError, "Can not read from StringIO");
+          return NULL;
+        }
+        
+        char *buf = nullptr;
+        PyObject *str = PyUnicode_AsUTF8String(input_str1);	 
+        PyBytes_AsStringAndSize(str, &buf, &len1);
+        stream1 = new std::istringstream(buf);
+        Py_DECREF(str);
+        Py_DECREF(input_str1);	 
+      } else {
+        // if it is string, extract filename as char*
+        PyObject* str = PyUnicode_AsEncodedString(swig_obj[0], "utf-8", "~E~");	
+        const char* filename = PyBytes_AsString(str);
+        temp1 = new PyMFEM::wFILE(filename, 8, true);
+        Py_DECREF(str);
+      }
+    }
+    if (stream1 == 0){
+      if (temp1->isGZ()){
+        in_gz1 = new mfem::ifgzstream(temp1->getFilename());
+        arg1 = in_gz1;
+      } else {
+        in_txt1.open(temp1->getFilename(), std::ifstream::in);
+        in_txt1.precision(temp1->getPrecision());
+        arg1 = &in_txt1;
+      }
+      if (temp1->isTemporary()){
+        delete temp1;
+      }
+    } else {
+      arg1 = stream1;
+    }
   }
-  if (!argp1) {
-    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "new_Mesh" "', argument " "1"" of type '" "std::istream &""'"); 
-  }
-  arg1 = reinterpret_cast< std::istream * >(argp1);
   if (swig_obj[1]) {
     {
       if ((PyArray_PyIntAsInt(swig_obj[1]) == -1) && PyErr_Occurred()) {
@@ -8846,8 +8900,40 @@ SWIGINTERN PyObject *_wrap_new_Mesh__SWIG_9(PyObject *SWIGUNUSEDPARM(self), Py_s
     }	 
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__Mesh, SWIG_POINTER_NEW |  0 );
+  {
+    if (stream1) {
+      ret1 = PyLong_FromSsize_t(len1);
+      if (PyErr_Occurred()) {
+        PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
+        return NULL;
+      }
+      delete stream1;    
+      Py_XDECREF(resultobj);   /* Blow away any previous result */
+      resultobj = ret1;    
+    }
+  }
+  {
+    if (!stream1) {
+      if (temp1) {
+        in_txt1.close();
+      }
+      if (in_gz1){
+        delete in_gz1;
+      }
+    }  
+  }
   return resultobj;
 fail:
+  {
+    if (!stream1) {
+      if (temp1) {
+        in_txt1.close();
+      }
+      if (in_gz1){
+        delete in_gz1;
+      }
+    }  
+  }
   return NULL;
 }
 
@@ -8960,8 +9046,13 @@ SWIGINTERN PyObject *_wrap_Mesh_Load(PyObject *SWIGUNUSEDPARM(self), PyObject *a
   bool arg5 = (bool) true ;
   void *argp1 = 0 ;
   int res1 = 0 ;
-  void *argp2 = 0 ;
-  int res2 = 0 ;
+  PyMFEM::wFILE *temp2 = 0 ;
+  std::ifstream in_txt2 ;
+  mfem::ifgzstream *in_gz2 = 0 ;
+  PyObject *input_str2 = 0 ;
+  std::istringstream *stream2 = 0 ;
+  Py_ssize_t len2 = 0 ;
+  PyObject *ret2 = 0 ;
   bool val5 ;
   int ecode5 = 0 ;
   PyObject * obj0 = 0 ;
@@ -8979,14 +9070,64 @@ SWIGINTERN PyObject *_wrap_Mesh_Load(PyObject *SWIGUNUSEDPARM(self), PyObject *a
     SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "Mesh_Load" "', argument " "1"" of type '" "mfem::Mesh *""'"); 
   }
   arg1 = reinterpret_cast< mfem::Mesh * >(argp1);
-  res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_std__istream,  0 );
-  if (!SWIG_IsOK(res2)) {
-    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "Mesh_Load" "', argument " "2"" of type '" "std::istream &""'"); 
+  {
+    //  PyMFEM::wFILE or string argument or StringIO
+    if (SWIG_ConvertPtr(obj1, (void **) &temp2, SWIGTYPE_p_PyMFEM__wFILE, 0 | 0) == -1) {
+      if (!PyString_Check(obj1) && !PyUnicode_Check(obj1)) {
+        // not string, check if it is StringIO
+        PyObject* module = PyImport_ImportModule("io");
+        if (!module){
+          PyErr_SetString(PyExc_RuntimeError, "Can not load io module");
+          return NULL;
+        }      
+        PyObject* cls = PyObject_GetAttrString(module, "StringIO");
+        if (!cls){
+          PyErr_SetString(PyExc_RuntimeError, "Can not load StringIO");
+          return NULL;
+        }      
+        int check = PyObject_IsInstance(obj1, cls);
+        Py_DECREF(module);
+        if (! check){
+          SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
+          return NULL;
+        }
+        
+        PyObject *input_str2 = PyObject_CallMethod(obj1, "getvalue", NULL);
+        if (PyErr_Occurred()) {
+          PyErr_SetString(PyExc_RuntimeError, "Can not read from StringIO");
+          return NULL;
+        }
+        
+        char *buf = nullptr;
+        PyObject *str = PyUnicode_AsUTF8String(input_str2);	 
+        PyBytes_AsStringAndSize(str, &buf, &len2);
+        stream2 = new std::istringstream(buf);
+        Py_DECREF(str);
+        Py_DECREF(input_str2);	 
+      } else {
+        // if it is string, extract filename as char*
+        PyObject* str = PyUnicode_AsEncodedString(obj1, "utf-8", "~E~");	
+        const char* filename = PyBytes_AsString(str);
+        temp2 = new PyMFEM::wFILE(filename, 8, true);
+        Py_DECREF(str);
+      }
+    }
+    if (stream2 == 0){
+      if (temp2->isGZ()){
+        in_gz2 = new mfem::ifgzstream(temp2->getFilename());
+        arg2 = in_gz2;
+      } else {
+        in_txt2.open(temp2->getFilename(), std::ifstream::in);
+        in_txt2.precision(temp2->getPrecision());
+        arg2 = &in_txt2;
+      }
+      if (temp2->isTemporary()){
+        delete temp2;
+      }
+    } else {
+      arg2 = stream2;
+    }
   }
-  if (!argp2) {
-    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "Mesh_Load" "', argument " "2"" of type '" "std::istream &""'"); 
-  }
-  arg2 = reinterpret_cast< std::istream * >(argp2);
   if (obj2) {
     {
       if ((PyArray_PyIntAsInt(obj2) == -1) && PyErr_Occurred()) {
@@ -9030,8 +9171,40 @@ SWIGINTERN PyObject *_wrap_Mesh_Load(PyObject *SWIGUNUSEDPARM(self), PyObject *a
     }	 
   }
   resultobj = SWIG_Py_Void();
+  {
+    if (stream2) {
+      ret2 = PyLong_FromSsize_t(len2);
+      if (PyErr_Occurred()) {
+        PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
+        return NULL;
+      }
+      delete stream2;    
+      Py_XDECREF(resultobj);   /* Blow away any previous result */
+      resultobj = ret2;    
+    }
+  }
+  {
+    if (!stream2) {
+      if (temp2) {
+        in_txt2.close();
+      }
+      if (in_gz2){
+        delete in_gz2;
+      }
+    }  
+  }
   return resultobj;
 fail:
+  {
+    if (!stream2) {
+      if (temp2) {
+        in_txt2.close();
+      }
+      if (in_gz2){
+        delete in_gz2;
+      }
+    }  
+  }
   return NULL;
 }
 
@@ -16571,10 +16744,10 @@ SWIGINTERN PyObject *_wrap_Mesh_PrintXG__SWIG_0(PyObject *SWIGUNUSEDPARM(self), 
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyMFEM::wFILE *temp2 = 0 ;
-  std::ofstream out2 ;
-  int use_stringio2 = 0 ;
+  std::ofstream out_txt2 ;
+  mfem::ofgzstream *out_gz2 = 0 ;
   PyObject *string_io2 = 0 ;
-  std::ostringstream stream2 ;
+  std::ostringstream *stream2 = 0 ;
   PyObject *ret2 = 0 ;
   
   if ((nobjs < 1) || (nobjs > 2)) SWIG_fail;
@@ -16605,29 +16778,33 @@ SWIGINTERN PyObject *_wrap_Mesh_PrintXG__SWIG_0(PyObject *SWIGUNUSEDPARM(self), 
             SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
             return NULL;
           }
-          use_stringio2=1;
           string_io2=swig_obj[1];
+          stream2 = new std::ostringstream();
         } else {
           // if it is string, extract filename as char*
           PyObject* str = PyUnicode_AsEncodedString(swig_obj[1], "utf-8", "~E~");	
           const char* filename = PyBytes_AsString(str);
-          temp2 = new PyMFEM::wFILE(filename, 8, true);	
+          temp2 = new PyMFEM::wFILE(filename, 8, true);
+          Py_DECREF(str);	 
         }
       }
       
-      if (use_stringio2 == 0){
+      if (stream2 == 0){
         if (temp2->isSTDOUT() == 1) {
           arg2 = &std::cout;
+        } else if (temp2->isGZ()){
+          out_gz2 = new mfem::ofgzstream(temp2->getFilename(), true);
+          arg2 = out_gz2;	     
         } else {
-          out2.open(temp2->getFilename());
-          out2.precision(temp2->getPrecision());
-          if (temp2->isTemporary()){
-            delete temp2;
-          }
-          arg2 = &out2;
+          out_txt2.open(temp2->getFilename());
+          out_txt2.precision(temp2->getPrecision());
+          arg2 = &out_txt2;
+        }
+        if (temp2->isTemporary()){
+          delete temp2;
         }
       } else {
-        arg2 = &stream2;
+        arg2 = stream2;
       }
     }
   }
@@ -16652,8 +16829,8 @@ SWIGINTERN PyObject *_wrap_Mesh_PrintXG__SWIG_0(PyObject *SWIGUNUSEDPARM(self), 
   }
   resultobj = SWIG_Py_Void();
   {
-    if (use_stringio2 == 1) {
-      std::string str =  stream2.str();
+    if (stream2) {
+      std::string str =  stream2->str();
       const char* s = str.c_str();
       const int n = str.length();
       ret2 = PyObject_CallMethod(string_io2, "write", "s#",
@@ -16662,15 +16839,21 @@ SWIGINTERN PyObject *_wrap_Mesh_PrintXG__SWIG_0(PyObject *SWIGUNUSEDPARM(self), 
         PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
         return NULL;
       }
+      delete stream2;
       Py_XDECREF(resultobj);   /* Blow away any previous result */
       resultobj = ret2;    
     }
   }
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -16678,10 +16861,15 @@ SWIGINTERN PyObject *_wrap_Mesh_PrintXG__SWIG_0(PyObject *SWIGUNUSEDPARM(self), 
   return resultobj;
 fail:
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -16698,10 +16886,10 @@ SWIGINTERN PyObject *_wrap_Mesh_Print__SWIG_0(PyObject *SWIGUNUSEDPARM(self), Py
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyMFEM::wFILE *temp2 = 0 ;
-  std::ofstream out2 ;
-  int use_stringio2 = 0 ;
+  std::ofstream out_txt2 ;
+  mfem::ofgzstream *out_gz2 = 0 ;
   PyObject *string_io2 = 0 ;
-  std::ostringstream stream2 ;
+  std::ostringstream *stream2 = 0 ;
   PyObject *ret2 = 0 ;
   
   if ((nobjs < 1) || (nobjs > 2)) SWIG_fail;
@@ -16732,29 +16920,33 @@ SWIGINTERN PyObject *_wrap_Mesh_Print__SWIG_0(PyObject *SWIGUNUSEDPARM(self), Py
             SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
             return NULL;
           }
-          use_stringio2=1;
           string_io2=swig_obj[1];
+          stream2 = new std::ostringstream();
         } else {
           // if it is string, extract filename as char*
           PyObject* str = PyUnicode_AsEncodedString(swig_obj[1], "utf-8", "~E~");	
           const char* filename = PyBytes_AsString(str);
-          temp2 = new PyMFEM::wFILE(filename, 8, true);	
+          temp2 = new PyMFEM::wFILE(filename, 8, true);
+          Py_DECREF(str);	 
         }
       }
       
-      if (use_stringio2 == 0){
+      if (stream2 == 0){
         if (temp2->isSTDOUT() == 1) {
           arg2 = &std::cout;
+        } else if (temp2->isGZ()){
+          out_gz2 = new mfem::ofgzstream(temp2->getFilename(), true);
+          arg2 = out_gz2;	     
         } else {
-          out2.open(temp2->getFilename());
-          out2.precision(temp2->getPrecision());
-          if (temp2->isTemporary()){
-            delete temp2;
-          }
-          arg2 = &out2;
+          out_txt2.open(temp2->getFilename());
+          out_txt2.precision(temp2->getPrecision());
+          arg2 = &out_txt2;
+        }
+        if (temp2->isTemporary()){
+          delete temp2;
         }
       } else {
-        arg2 = &stream2;
+        arg2 = stream2;
       }
     }
   }
@@ -16779,8 +16971,8 @@ SWIGINTERN PyObject *_wrap_Mesh_Print__SWIG_0(PyObject *SWIGUNUSEDPARM(self), Py
   }
   resultobj = SWIG_Py_Void();
   {
-    if (use_stringio2 == 1) {
-      std::string str =  stream2.str();
+    if (stream2) {
+      std::string str =  stream2->str();
       const char* s = str.c_str();
       const int n = str.length();
       ret2 = PyObject_CallMethod(string_io2, "write", "s#",
@@ -16789,15 +16981,21 @@ SWIGINTERN PyObject *_wrap_Mesh_Print__SWIG_0(PyObject *SWIGUNUSEDPARM(self), Py
         PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
         return NULL;
       }
+      delete stream2;
       Py_XDECREF(resultobj);   /* Blow away any previous result */
       resultobj = ret2;    
     }
   }
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -16805,10 +17003,15 @@ SWIGINTERN PyObject *_wrap_Mesh_Print__SWIG_0(PyObject *SWIGUNUSEDPARM(self), Py
   return resultobj;
 fail:
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -16824,10 +17027,10 @@ SWIGINTERN PyObject *_wrap_Mesh_PrintVTK__SWIG_0(PyObject *SWIGUNUSEDPARM(self),
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyMFEM::wFILE *temp2 = 0 ;
-  std::ofstream out2 ;
-  int use_stringio2 = 0 ;
+  std::ofstream out_txt2 ;
+  mfem::ofgzstream *out_gz2 = 0 ;
   PyObject *string_io2 = 0 ;
-  std::ostringstream stream2 ;
+  std::ostringstream *stream2 = 0 ;
   PyObject *ret2 = 0 ;
   
   if ((nobjs < 2) || (nobjs > 2)) SWIG_fail;
@@ -16857,29 +17060,33 @@ SWIGINTERN PyObject *_wrap_Mesh_PrintVTK__SWIG_0(PyObject *SWIGUNUSEDPARM(self),
           SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
           return NULL;
         }
-        use_stringio2=1;
         string_io2=swig_obj[1];
+        stream2 = new std::ostringstream();
       } else {
         // if it is string, extract filename as char*
         PyObject* str = PyUnicode_AsEncodedString(swig_obj[1], "utf-8", "~E~");	
         const char* filename = PyBytes_AsString(str);
-        temp2 = new PyMFEM::wFILE(filename, 8, true);	
+        temp2 = new PyMFEM::wFILE(filename, 8, true);
+        Py_DECREF(str);	 
       }
     }
     
-    if (use_stringio2 == 0){
+    if (stream2 == 0){
       if (temp2->isSTDOUT() == 1) {
         arg2 = &std::cout;
+      } else if (temp2->isGZ()){
+        out_gz2 = new mfem::ofgzstream(temp2->getFilename(), true);
+        arg2 = out_gz2;	     
       } else {
-        out2.open(temp2->getFilename());
-        out2.precision(temp2->getPrecision());
-        if (temp2->isTemporary()){
-          delete temp2;
-        }
-        arg2 = &out2;
+        out_txt2.open(temp2->getFilename());
+        out_txt2.precision(temp2->getPrecision());
+        arg2 = &out_txt2;
+      }
+      if (temp2->isTemporary()){
+        delete temp2;
       }
     } else {
-      arg2 = &stream2;
+      arg2 = stream2;
     }
   }
   {
@@ -16903,8 +17110,8 @@ SWIGINTERN PyObject *_wrap_Mesh_PrintVTK__SWIG_0(PyObject *SWIGUNUSEDPARM(self),
   }
   resultobj = SWIG_Py_Void();
   {
-    if (use_stringio2 == 1) {
-      std::string str =  stream2.str();
+    if (stream2) {
+      std::string str =  stream2->str();
       const char* s = str.c_str();
       const int n = str.length();
       ret2 = PyObject_CallMethod(string_io2, "write", "s#",
@@ -16913,15 +17120,21 @@ SWIGINTERN PyObject *_wrap_Mesh_PrintVTK__SWIG_0(PyObject *SWIGUNUSEDPARM(self),
         PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
         return NULL;
       }
+      delete stream2;
       Py_XDECREF(resultobj);   /* Blow away any previous result */
       resultobj = ret2;    
     }
   }
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -16929,10 +17142,15 @@ SWIGINTERN PyObject *_wrap_Mesh_PrintVTK__SWIG_0(PyObject *SWIGUNUSEDPARM(self),
   return resultobj;
 fail:
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -16950,10 +17168,10 @@ SWIGINTERN PyObject *_wrap_Mesh_PrintVTK__SWIG_1(PyObject *SWIGUNUSEDPARM(self),
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyMFEM::wFILE *temp2 = 0 ;
-  std::ofstream out2 ;
-  int use_stringio2 = 0 ;
+  std::ofstream out_txt2 ;
+  mfem::ofgzstream *out_gz2 = 0 ;
   PyObject *string_io2 = 0 ;
-  std::ostringstream stream2 ;
+  std::ostringstream *stream2 = 0 ;
   PyObject *ret2 = 0 ;
   
   if ((nobjs < 3) || (nobjs > 4)) SWIG_fail;
@@ -16983,29 +17201,33 @@ SWIGINTERN PyObject *_wrap_Mesh_PrintVTK__SWIG_1(PyObject *SWIGUNUSEDPARM(self),
           SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
           return NULL;
         }
-        use_stringio2=1;
         string_io2=swig_obj[1];
+        stream2 = new std::ostringstream();
       } else {
         // if it is string, extract filename as char*
         PyObject* str = PyUnicode_AsEncodedString(swig_obj[1], "utf-8", "~E~");	
         const char* filename = PyBytes_AsString(str);
-        temp2 = new PyMFEM::wFILE(filename, 8, true);	
+        temp2 = new PyMFEM::wFILE(filename, 8, true);
+        Py_DECREF(str);	 
       }
     }
     
-    if (use_stringio2 == 0){
+    if (stream2 == 0){
       if (temp2->isSTDOUT() == 1) {
         arg2 = &std::cout;
+      } else if (temp2->isGZ()){
+        out_gz2 = new mfem::ofgzstream(temp2->getFilename(), true);
+        arg2 = out_gz2;	     
       } else {
-        out2.open(temp2->getFilename());
-        out2.precision(temp2->getPrecision());
-        if (temp2->isTemporary()){
-          delete temp2;
-        }
-        arg2 = &out2;
+        out_txt2.open(temp2->getFilename());
+        out_txt2.precision(temp2->getPrecision());
+        arg2 = &out_txt2;
+      }
+      if (temp2->isTemporary()){
+        delete temp2;
       }
     } else {
-      arg2 = &stream2;
+      arg2 = stream2;
     }
   }
   {
@@ -17043,8 +17265,8 @@ SWIGINTERN PyObject *_wrap_Mesh_PrintVTK__SWIG_1(PyObject *SWIGUNUSEDPARM(self),
   }
   resultobj = SWIG_Py_Void();
   {
-    if (use_stringio2 == 1) {
-      std::string str =  stream2.str();
+    if (stream2) {
+      std::string str =  stream2->str();
       const char* s = str.c_str();
       const int n = str.length();
       ret2 = PyObject_CallMethod(string_io2, "write", "s#",
@@ -17053,15 +17275,21 @@ SWIGINTERN PyObject *_wrap_Mesh_PrintVTK__SWIG_1(PyObject *SWIGUNUSEDPARM(self),
         PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
         return NULL;
       }
+      delete stream2;
       Py_XDECREF(resultobj);   /* Blow away any previous result */
       resultobj = ret2;    
     }
   }
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -17069,10 +17297,15 @@ SWIGINTERN PyObject *_wrap_Mesh_PrintVTK__SWIG_1(PyObject *SWIGUNUSEDPARM(self),
   return resultobj;
 fail:
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -17093,10 +17326,10 @@ SWIGINTERN PyObject *_wrap_Mesh_PrintVTU__SWIG_0(PyObject *SWIGUNUSEDPARM(self),
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyMFEM::wFILE *temp2 = 0 ;
-  std::ofstream out2 ;
-  int use_stringio2 = 0 ;
+  std::ofstream out_txt2 ;
+  mfem::ofgzstream *out_gz2 = 0 ;
   PyObject *string_io2 = 0 ;
-  std::ostringstream stream2 ;
+  std::ostringstream *stream2 = 0 ;
   PyObject *ret2 = 0 ;
   int val4 ;
   int ecode4 = 0 ;
@@ -17132,29 +17365,33 @@ SWIGINTERN PyObject *_wrap_Mesh_PrintVTU__SWIG_0(PyObject *SWIGUNUSEDPARM(self),
           SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
           return NULL;
         }
-        use_stringio2=1;
         string_io2=swig_obj[1];
+        stream2 = new std::ostringstream();
       } else {
         // if it is string, extract filename as char*
         PyObject* str = PyUnicode_AsEncodedString(swig_obj[1], "utf-8", "~E~");	
         const char* filename = PyBytes_AsString(str);
-        temp2 = new PyMFEM::wFILE(filename, 8, true);	
+        temp2 = new PyMFEM::wFILE(filename, 8, true);
+        Py_DECREF(str);	 
       }
     }
     
-    if (use_stringio2 == 0){
+    if (stream2 == 0){
       if (temp2->isSTDOUT() == 1) {
         arg2 = &std::cout;
+      } else if (temp2->isGZ()){
+        out_gz2 = new mfem::ofgzstream(temp2->getFilename(), true);
+        arg2 = out_gz2;	     
       } else {
-        out2.open(temp2->getFilename());
-        out2.precision(temp2->getPrecision());
-        if (temp2->isTemporary()){
-          delete temp2;
-        }
-        arg2 = &out2;
+        out_txt2.open(temp2->getFilename());
+        out_txt2.precision(temp2->getPrecision());
+        arg2 = &out_txt2;
+      }
+      if (temp2->isTemporary()){
+        delete temp2;
       }
     } else {
-      arg2 = &stream2;
+      arg2 = stream2;
     }
   }
   if (swig_obj[2]) {
@@ -17215,8 +17452,8 @@ SWIGINTERN PyObject *_wrap_Mesh_PrintVTU__SWIG_0(PyObject *SWIGUNUSEDPARM(self),
   }
   resultobj = SWIG_Py_Void();
   {
-    if (use_stringio2 == 1) {
-      std::string str =  stream2.str();
+    if (stream2) {
+      std::string str =  stream2->str();
       const char* s = str.c_str();
       const int n = str.length();
       ret2 = PyObject_CallMethod(string_io2, "write", "s#",
@@ -17225,15 +17462,21 @@ SWIGINTERN PyObject *_wrap_Mesh_PrintVTU__SWIG_0(PyObject *SWIGUNUSEDPARM(self),
         PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
         return NULL;
       }
+      delete stream2;
       Py_XDECREF(resultobj);   /* Blow away any previous result */
       resultobj = ret2;    
     }
   }
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -17241,10 +17484,15 @@ SWIGINTERN PyObject *_wrap_Mesh_PrintVTU__SWIG_0(PyObject *SWIGUNUSEDPARM(self),
   return resultobj;
 fail:
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -17429,7 +17677,8 @@ SWIGINTERN PyObject *_wrap_Mesh_PrintVTU(PyObject *self, PyObject *args) {
               _v = 0;	   	   	   
             }
           } else {
-            _v = 0;
+            std::cout << "it is text (out)\n";	
+            _v = 1;
           }
         } else {
           _v = 1;
@@ -17663,10 +17912,10 @@ SWIGINTERN PyObject *_wrap_Mesh_PrintWithPartitioning(PyObject *SWIGUNUSEDPARM(s
   void *argp2 = 0 ;
   int res2 = 0 ;
   PyMFEM::wFILE *temp3 = 0 ;
-  std::ofstream out3 ;
-  int use_stringio3 = 0 ;
+  std::ofstream out_txt3 ;
+  mfem::ofgzstream *out_gz3 = 0 ;
   PyObject *string_io3 = 0 ;
-  std::ostringstream stream3 ;
+  std::ostringstream *stream3 = 0 ;
   PyObject *ret3 = 0 ;
   PyObject * obj0 = 0 ;
   PyObject * obj1 = 0 ;
@@ -17708,29 +17957,33 @@ SWIGINTERN PyObject *_wrap_Mesh_PrintWithPartitioning(PyObject *SWIGUNUSEDPARM(s
           SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
           return NULL;
         }
-        use_stringio3=1;
         string_io3=obj2;
+        stream3 = new std::ostringstream();
       } else {
         // if it is string, extract filename as char*
         PyObject* str = PyUnicode_AsEncodedString(obj2, "utf-8", "~E~");	
         const char* filename = PyBytes_AsString(str);
-        temp3 = new PyMFEM::wFILE(filename, 8, true);	
+        temp3 = new PyMFEM::wFILE(filename, 8, true);
+        Py_DECREF(str);	 
       }
     }
     
-    if (use_stringio3 == 0){
+    if (stream3 == 0){
       if (temp3->isSTDOUT() == 1) {
         arg3 = &std::cout;
+      } else if (temp3->isGZ()){
+        out_gz3 = new mfem::ofgzstream(temp3->getFilename(), true);
+        arg3 = out_gz3;	     
       } else {
-        out3.open(temp3->getFilename());
-        out3.precision(temp3->getPrecision());
-        if (temp3->isTemporary()){
-          delete temp3;
-        }
-        arg3 = &out3;
+        out_txt3.open(temp3->getFilename());
+        out_txt3.precision(temp3->getPrecision());
+        arg3 = &out_txt3;
+      }
+      if (temp3->isTemporary()){
+        delete temp3;
       }
     } else {
-      arg3 = &stream3;
+      arg3 = stream3;
     }
   }
   if (obj3) {
@@ -17762,8 +18015,8 @@ SWIGINTERN PyObject *_wrap_Mesh_PrintWithPartitioning(PyObject *SWIGUNUSEDPARM(s
   }
   resultobj = SWIG_Py_Void();
   {
-    if (use_stringio3 == 1) {
-      std::string str =  stream3.str();
+    if (stream3) {
+      std::string str =  stream3->str();
       const char* s = str.c_str();
       const int n = str.length();
       ret3 = PyObject_CallMethod(string_io3, "write", "s#",
@@ -17772,15 +18025,21 @@ SWIGINTERN PyObject *_wrap_Mesh_PrintWithPartitioning(PyObject *SWIGUNUSEDPARM(s
         PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
         return NULL;
       }
+      delete stream3;
       Py_XDECREF(resultobj);   /* Blow away any previous result */
       resultobj = ret3;    
     }
   }
   {
-    if (use_stringio3 == 0) {
+    if (!stream3) {
       if (temp3) {
         if (temp3->isSTDOUT() != 1) {
-          out3.close();
+          if (out_txt3.is_open()){
+            out_txt3.close();
+          }
+          if (out_gz3){
+            delete out_gz3;
+          }
         }
       }
     }
@@ -17788,10 +18047,15 @@ SWIGINTERN PyObject *_wrap_Mesh_PrintWithPartitioning(PyObject *SWIGUNUSEDPARM(s
   return resultobj;
 fail:
   {
-    if (use_stringio3 == 0) {
+    if (!stream3) {
       if (temp3) {
         if (temp3->isSTDOUT() != 1) {
-          out3.close();
+          if (out_txt3.is_open()){
+            out_txt3.close();
+          }
+          if (out_gz3){
+            delete out_gz3;
+          }
         }
       }
     }
@@ -17811,10 +18075,10 @@ SWIGINTERN PyObject *_wrap_Mesh_PrintElementsWithPartitioning(PyObject *SWIGUNUS
   void *argp2 = 0 ;
   int res2 = 0 ;
   PyMFEM::wFILE *temp3 = 0 ;
-  std::ofstream out3 ;
-  int use_stringio3 = 0 ;
+  std::ofstream out_txt3 ;
+  mfem::ofgzstream *out_gz3 = 0 ;
   PyObject *string_io3 = 0 ;
-  std::ostringstream stream3 ;
+  std::ostringstream *stream3 = 0 ;
   PyObject *ret3 = 0 ;
   PyObject * obj0 = 0 ;
   PyObject * obj1 = 0 ;
@@ -17856,29 +18120,33 @@ SWIGINTERN PyObject *_wrap_Mesh_PrintElementsWithPartitioning(PyObject *SWIGUNUS
           SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
           return NULL;
         }
-        use_stringio3=1;
         string_io3=obj2;
+        stream3 = new std::ostringstream();
       } else {
         // if it is string, extract filename as char*
         PyObject* str = PyUnicode_AsEncodedString(obj2, "utf-8", "~E~");	
         const char* filename = PyBytes_AsString(str);
-        temp3 = new PyMFEM::wFILE(filename, 8, true);	
+        temp3 = new PyMFEM::wFILE(filename, 8, true);
+        Py_DECREF(str);	 
       }
     }
     
-    if (use_stringio3 == 0){
+    if (stream3 == 0){
       if (temp3->isSTDOUT() == 1) {
         arg3 = &std::cout;
+      } else if (temp3->isGZ()){
+        out_gz3 = new mfem::ofgzstream(temp3->getFilename(), true);
+        arg3 = out_gz3;	     
       } else {
-        out3.open(temp3->getFilename());
-        out3.precision(temp3->getPrecision());
-        if (temp3->isTemporary()){
-          delete temp3;
-        }
-        arg3 = &out3;
+        out_txt3.open(temp3->getFilename());
+        out_txt3.precision(temp3->getPrecision());
+        arg3 = &out_txt3;
+      }
+      if (temp3->isTemporary()){
+        delete temp3;
       }
     } else {
-      arg3 = &stream3;
+      arg3 = stream3;
     }
   }
   if (obj3) {
@@ -17910,8 +18178,8 @@ SWIGINTERN PyObject *_wrap_Mesh_PrintElementsWithPartitioning(PyObject *SWIGUNUS
   }
   resultobj = SWIG_Py_Void();
   {
-    if (use_stringio3 == 1) {
-      std::string str =  stream3.str();
+    if (stream3) {
+      std::string str =  stream3->str();
       const char* s = str.c_str();
       const int n = str.length();
       ret3 = PyObject_CallMethod(string_io3, "write", "s#",
@@ -17920,15 +18188,21 @@ SWIGINTERN PyObject *_wrap_Mesh_PrintElementsWithPartitioning(PyObject *SWIGUNUS
         PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
         return NULL;
       }
+      delete stream3;
       Py_XDECREF(resultobj);   /* Blow away any previous result */
       resultobj = ret3;    
     }
   }
   {
-    if (use_stringio3 == 0) {
+    if (!stream3) {
       if (temp3) {
         if (temp3->isSTDOUT() != 1) {
-          out3.close();
+          if (out_txt3.is_open()){
+            out_txt3.close();
+          }
+          if (out_gz3){
+            delete out_gz3;
+          }
         }
       }
     }
@@ -17936,10 +18210,15 @@ SWIGINTERN PyObject *_wrap_Mesh_PrintElementsWithPartitioning(PyObject *SWIGUNUS
   return resultobj;
 fail:
   {
-    if (use_stringio3 == 0) {
+    if (!stream3) {
       if (temp3) {
         if (temp3->isSTDOUT() != 1) {
-          out3.close();
+          if (out_txt3.is_open()){
+            out_txt3.close();
+          }
+          if (out_gz3){
+            delete out_gz3;
+          }
         }
       }
     }
@@ -17958,10 +18237,10 @@ SWIGINTERN PyObject *_wrap_Mesh_PrintSurfaces(PyObject *SWIGUNUSEDPARM(self), Py
   void *argp2 = 0 ;
   int res2 = 0 ;
   PyMFEM::wFILE *temp3 = 0 ;
-  std::ofstream out3 ;
-  int use_stringio3 = 0 ;
+  std::ofstream out_txt3 ;
+  mfem::ofgzstream *out_gz3 = 0 ;
   PyObject *string_io3 = 0 ;
-  std::ostringstream stream3 ;
+  std::ostringstream *stream3 = 0 ;
   PyObject *ret3 = 0 ;
   PyObject * obj0 = 0 ;
   PyObject * obj1 = 0 ;
@@ -18005,29 +18284,33 @@ SWIGINTERN PyObject *_wrap_Mesh_PrintSurfaces(PyObject *SWIGUNUSEDPARM(self), Py
           SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
           return NULL;
         }
-        use_stringio3=1;
         string_io3=obj2;
+        stream3 = new std::ostringstream();
       } else {
         // if it is string, extract filename as char*
         PyObject* str = PyUnicode_AsEncodedString(obj2, "utf-8", "~E~");	
         const char* filename = PyBytes_AsString(str);
-        temp3 = new PyMFEM::wFILE(filename, 8, true);	
+        temp3 = new PyMFEM::wFILE(filename, 8, true);
+        Py_DECREF(str);	 
       }
     }
     
-    if (use_stringio3 == 0){
+    if (stream3 == 0){
       if (temp3->isSTDOUT() == 1) {
         arg3 = &std::cout;
+      } else if (temp3->isGZ()){
+        out_gz3 = new mfem::ofgzstream(temp3->getFilename(), true);
+        arg3 = out_gz3;	     
       } else {
-        out3.open(temp3->getFilename());
-        out3.precision(temp3->getPrecision());
-        if (temp3->isTemporary()){
-          delete temp3;
-        }
-        arg3 = &out3;
+        out_txt3.open(temp3->getFilename());
+        out_txt3.precision(temp3->getPrecision());
+        arg3 = &out_txt3;
+      }
+      if (temp3->isTemporary()){
+        delete temp3;
       }
     } else {
-      arg3 = &stream3;
+      arg3 = stream3;
     }
   }
   {
@@ -18051,8 +18334,8 @@ SWIGINTERN PyObject *_wrap_Mesh_PrintSurfaces(PyObject *SWIGUNUSEDPARM(self), Py
   }
   resultobj = SWIG_Py_Void();
   {
-    if (use_stringio3 == 1) {
-      std::string str =  stream3.str();
+    if (stream3) {
+      std::string str =  stream3->str();
       const char* s = str.c_str();
       const int n = str.length();
       ret3 = PyObject_CallMethod(string_io3, "write", "s#",
@@ -18061,15 +18344,21 @@ SWIGINTERN PyObject *_wrap_Mesh_PrintSurfaces(PyObject *SWIGUNUSEDPARM(self), Py
         PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
         return NULL;
       }
+      delete stream3;
       Py_XDECREF(resultobj);   /* Blow away any previous result */
       resultobj = ret3;    
     }
   }
   {
-    if (use_stringio3 == 0) {
+    if (!stream3) {
       if (temp3) {
         if (temp3->isSTDOUT() != 1) {
-          out3.close();
+          if (out_txt3.is_open()){
+            out_txt3.close();
+          }
+          if (out_gz3){
+            delete out_gz3;
+          }
         }
       }
     }
@@ -18077,10 +18366,15 @@ SWIGINTERN PyObject *_wrap_Mesh_PrintSurfaces(PyObject *SWIGUNUSEDPARM(self), Py
   return resultobj;
 fail:
   {
-    if (use_stringio3 == 0) {
+    if (!stream3) {
       if (temp3) {
         if (temp3->isSTDOUT() != 1) {
-          out3.close();
+          if (out_txt3.is_open()){
+            out_txt3.close();
+          }
+          if (out_gz3){
+            delete out_gz3;
+          }
         }
       }
     }
@@ -18905,10 +19199,10 @@ SWIGINTERN PyObject *_wrap_Mesh_PrintElementsByGeometry(PyObject *SWIGUNUSEDPARM
   void *argp2 = 0 ;
   int res2 = 0 ;
   PyMFEM::wFILE *temp3 = 0 ;
-  std::ofstream out3 ;
-  int use_stringio3 = 0 ;
+  std::ofstream out_txt3 ;
+  mfem::ofgzstream *out_gz3 = 0 ;
   PyObject *string_io3 = 0 ;
-  std::ostringstream stream3 ;
+  std::ostringstream *stream3 = 0 ;
   PyObject *ret3 = 0 ;
   PyObject * obj0 = 0 ;
   PyObject * obj1 = 0 ;
@@ -18953,29 +19247,33 @@ SWIGINTERN PyObject *_wrap_Mesh_PrintElementsByGeometry(PyObject *SWIGUNUSEDPARM
           SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
           return NULL;
         }
-        use_stringio3=1;
         string_io3=obj2;
+        stream3 = new std::ostringstream();
       } else {
         // if it is string, extract filename as char*
         PyObject* str = PyUnicode_AsEncodedString(obj2, "utf-8", "~E~");	
         const char* filename = PyBytes_AsString(str);
-        temp3 = new PyMFEM::wFILE(filename, 8, true);	
+        temp3 = new PyMFEM::wFILE(filename, 8, true);
+        Py_DECREF(str);	 
       }
     }
     
-    if (use_stringio3 == 0){
+    if (stream3 == 0){
       if (temp3->isSTDOUT() == 1) {
         arg3 = &std::cout;
+      } else if (temp3->isGZ()){
+        out_gz3 = new mfem::ofgzstream(temp3->getFilename(), true);
+        arg3 = out_gz3;	     
       } else {
-        out3.open(temp3->getFilename());
-        out3.precision(temp3->getPrecision());
-        if (temp3->isTemporary()){
-          delete temp3;
-        }
-        arg3 = &out3;
+        out_txt3.open(temp3->getFilename());
+        out_txt3.precision(temp3->getPrecision());
+        arg3 = &out_txt3;
+      }
+      if (temp3->isTemporary()){
+        delete temp3;
       }
     } else {
-      arg3 = &stream3;
+      arg3 = stream3;
     }
   }
   {
@@ -18999,8 +19297,8 @@ SWIGINTERN PyObject *_wrap_Mesh_PrintElementsByGeometry(PyObject *SWIGUNUSEDPARM
   }
   resultobj = SWIG_Py_Void();
   {
-    if (use_stringio3 == 1) {
-      std::string str =  stream3.str();
+    if (stream3) {
+      std::string str =  stream3->str();
       const char* s = str.c_str();
       const int n = str.length();
       ret3 = PyObject_CallMethod(string_io3, "write", "s#",
@@ -19009,15 +19307,21 @@ SWIGINTERN PyObject *_wrap_Mesh_PrintElementsByGeometry(PyObject *SWIGUNUSEDPARM
         PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
         return NULL;
       }
+      delete stream3;
       Py_XDECREF(resultobj);   /* Blow away any previous result */
       resultobj = ret3;    
     }
   }
   {
-    if (use_stringio3 == 0) {
+    if (!stream3) {
       if (temp3) {
         if (temp3->isSTDOUT() != 1) {
-          out3.close();
+          if (out_txt3.is_open()){
+            out_txt3.close();
+          }
+          if (out_gz3){
+            delete out_gz3;
+          }
         }
       }
     }
@@ -19025,10 +19329,15 @@ SWIGINTERN PyObject *_wrap_Mesh_PrintElementsByGeometry(PyObject *SWIGUNUSEDPARM
   return resultobj;
 fail:
   {
-    if (use_stringio3 == 0) {
+    if (!stream3) {
       if (temp3) {
         if (temp3->isSTDOUT() != 1) {
-          out3.close();
+          if (out_txt3.is_open()){
+            out_txt3.close();
+          }
+          if (out_gz3){
+            delete out_gz3;
+          }
         }
       }
     }
@@ -19051,10 +19360,10 @@ SWIGINTERN PyObject *_wrap_Mesh_PrintCharacteristics(PyObject *SWIGUNUSEDPARM(se
   void *argp3 = 0 ;
   int res3 = 0 ;
   PyMFEM::wFILE *temp4 = 0 ;
-  std::ofstream out4 ;
-  int use_stringio4 = 0 ;
+  std::ofstream out_txt4 ;
+  mfem::ofgzstream *out_gz4 = 0 ;
   PyObject *string_io4 = 0 ;
-  std::ostringstream stream4 ;
+  std::ostringstream *stream4 = 0 ;
   PyObject *ret4 = 0 ;
   PyObject * obj0 = 0 ;
   PyObject * obj1 = 0 ;
@@ -19106,29 +19415,33 @@ SWIGINTERN PyObject *_wrap_Mesh_PrintCharacteristics(PyObject *SWIGUNUSEDPARM(se
             SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
             return NULL;
           }
-          use_stringio4=1;
           string_io4=obj3;
+          stream4 = new std::ostringstream();
         } else {
           // if it is string, extract filename as char*
           PyObject* str = PyUnicode_AsEncodedString(obj3, "utf-8", "~E~");	
           const char* filename = PyBytes_AsString(str);
-          temp4 = new PyMFEM::wFILE(filename, 8, true);	
+          temp4 = new PyMFEM::wFILE(filename, 8, true);
+          Py_DECREF(str);	 
         }
       }
       
-      if (use_stringio4 == 0){
+      if (stream4 == 0){
         if (temp4->isSTDOUT() == 1) {
           arg4 = &std::cout;
+        } else if (temp4->isGZ()){
+          out_gz4 = new mfem::ofgzstream(temp4->getFilename(), true);
+          arg4 = out_gz4;	     
         } else {
-          out4.open(temp4->getFilename());
-          out4.precision(temp4->getPrecision());
-          if (temp4->isTemporary()){
-            delete temp4;
-          }
-          arg4 = &out4;
+          out_txt4.open(temp4->getFilename());
+          out_txt4.precision(temp4->getPrecision());
+          arg4 = &out_txt4;
+        }
+        if (temp4->isTemporary()){
+          delete temp4;
         }
       } else {
-        arg4 = &stream4;
+        arg4 = stream4;
       }
     }
   }
@@ -19153,8 +19466,8 @@ SWIGINTERN PyObject *_wrap_Mesh_PrintCharacteristics(PyObject *SWIGUNUSEDPARM(se
   }
   resultobj = SWIG_Py_Void();
   {
-    if (use_stringio4 == 1) {
-      std::string str =  stream4.str();
+    if (stream4) {
+      std::string str =  stream4->str();
       const char* s = str.c_str();
       const int n = str.length();
       ret4 = PyObject_CallMethod(string_io4, "write", "s#",
@@ -19163,15 +19476,21 @@ SWIGINTERN PyObject *_wrap_Mesh_PrintCharacteristics(PyObject *SWIGUNUSEDPARM(se
         PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
         return NULL;
       }
+      delete stream4;
       Py_XDECREF(resultobj);   /* Blow away any previous result */
       resultobj = ret4;    
     }
   }
   {
-    if (use_stringio4 == 0) {
+    if (!stream4) {
       if (temp4) {
         if (temp4->isSTDOUT() != 1) {
-          out4.close();
+          if (out_txt4.is_open()){
+            out_txt4.close();
+          }
+          if (out_gz4){
+            delete out_gz4;
+          }
         }
       }
     }
@@ -19179,10 +19498,15 @@ SWIGINTERN PyObject *_wrap_Mesh_PrintCharacteristics(PyObject *SWIGUNUSEDPARM(se
   return resultobj;
 fail:
   {
-    if (use_stringio4 == 0) {
+    if (!stream4) {
       if (temp4) {
         if (temp4->isSTDOUT() != 1) {
-          out4.close();
+          if (out_txt4.is_open()){
+            out_txt4.close();
+          }
+          if (out_gz4){
+            delete out_gz4;
+          }
         }
       }
     }
@@ -19199,10 +19523,10 @@ SWIGINTERN PyObject *_wrap_Mesh_PrintInfo__SWIG_0(PyObject *SWIGUNUSEDPARM(self)
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyMFEM::wFILE *temp2 = 0 ;
-  std::ofstream out2 ;
-  int use_stringio2 = 0 ;
+  std::ofstream out_txt2 ;
+  mfem::ofgzstream *out_gz2 = 0 ;
   PyObject *string_io2 = 0 ;
-  std::ostringstream stream2 ;
+  std::ostringstream *stream2 = 0 ;
   PyObject *ret2 = 0 ;
   
   if ((nobjs < 1) || (nobjs > 2)) SWIG_fail;
@@ -19233,29 +19557,33 @@ SWIGINTERN PyObject *_wrap_Mesh_PrintInfo__SWIG_0(PyObject *SWIGUNUSEDPARM(self)
             SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
             return NULL;
           }
-          use_stringio2=1;
           string_io2=swig_obj[1];
+          stream2 = new std::ostringstream();
         } else {
           // if it is string, extract filename as char*
           PyObject* str = PyUnicode_AsEncodedString(swig_obj[1], "utf-8", "~E~");	
           const char* filename = PyBytes_AsString(str);
-          temp2 = new PyMFEM::wFILE(filename, 8, true);	
+          temp2 = new PyMFEM::wFILE(filename, 8, true);
+          Py_DECREF(str);	 
         }
       }
       
-      if (use_stringio2 == 0){
+      if (stream2 == 0){
         if (temp2->isSTDOUT() == 1) {
           arg2 = &std::cout;
+        } else if (temp2->isGZ()){
+          out_gz2 = new mfem::ofgzstream(temp2->getFilename(), true);
+          arg2 = out_gz2;	     
         } else {
-          out2.open(temp2->getFilename());
-          out2.precision(temp2->getPrecision());
-          if (temp2->isTemporary()){
-            delete temp2;
-          }
-          arg2 = &out2;
+          out_txt2.open(temp2->getFilename());
+          out_txt2.precision(temp2->getPrecision());
+          arg2 = &out_txt2;
+        }
+        if (temp2->isTemporary()){
+          delete temp2;
         }
       } else {
-        arg2 = &stream2;
+        arg2 = stream2;
       }
     }
   }
@@ -19280,8 +19608,8 @@ SWIGINTERN PyObject *_wrap_Mesh_PrintInfo__SWIG_0(PyObject *SWIGUNUSEDPARM(self)
   }
   resultobj = SWIG_Py_Void();
   {
-    if (use_stringio2 == 1) {
-      std::string str =  stream2.str();
+    if (stream2) {
+      std::string str =  stream2->str();
       const char* s = str.c_str();
       const int n = str.length();
       ret2 = PyObject_CallMethod(string_io2, "write", "s#",
@@ -19290,15 +19618,21 @@ SWIGINTERN PyObject *_wrap_Mesh_PrintInfo__SWIG_0(PyObject *SWIGUNUSEDPARM(self)
         PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
         return NULL;
       }
+      delete stream2;
       Py_XDECREF(resultobj);   /* Blow away any previous result */
       resultobj = ret2;    
     }
   }
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -19306,10 +19640,15 @@ SWIGINTERN PyObject *_wrap_Mesh_PrintInfo__SWIG_0(PyObject *SWIGUNUSEDPARM(self)
   return resultobj;
 fail:
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -19696,50 +20035,6 @@ SWIGINTERN PyObject *_wrap_new_Mesh(PyObject *self, PyObject *args) {
       }
     }
   }
-  if ((argc >= 1) && (argc <= 4)) {
-    int _v;
-    void *vptr = 0;
-    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_std__istream, SWIG_POINTER_NO_NULL);
-    _v = SWIG_CheckState(res);
-    if (_v) {
-      if (argc <= 1) {
-        return _wrap_new_Mesh__SWIG_9(self, argc, argv);
-      }
-      {
-        if ((PyArray_PyIntAsInt(argv[1]) == -1) && PyErr_Occurred()) {
-          PyErr_Clear();
-          _v = 0;
-        } else {
-          _v = 1;    
-        }
-      }
-      if (_v) {
-        if (argc <= 2) {
-          return _wrap_new_Mesh__SWIG_9(self, argc, argv);
-        }
-        {
-          if ((PyArray_PyIntAsInt(argv[2]) == -1) && PyErr_Occurred()) {
-            PyErr_Clear();
-            _v = 0;
-          } else {
-            _v = 1;    
-          }
-        }
-        if (_v) {
-          if (argc <= 3) {
-            return _wrap_new_Mesh__SWIG_9(self, argc, argv);
-          }
-          {
-            int res = SWIG_AsVal_bool(argv[3], NULL);
-            _v = SWIG_CheckState(res);
-          }
-          if (_v) {
-            return _wrap_new_Mesh__SWIG_9(self, argc, argv);
-          }
-        }
-      }
-    }
-  }
   if ((argc >= 1) && (argc <= 2)) {
     int _v;
     {
@@ -19804,6 +20099,75 @@ SWIGINTERN PyObject *_wrap_new_Mesh(PyObject *self, PyObject *args) {
           }
           if (_v) {
             return _wrap_new_Mesh__SWIG_8(self, argc, argv);
+          }
+        }
+      }
+    }
+  }
+  if ((argc >= 1) && (argc <= 4)) {
+    int _v;
+    {
+      void *ptr;
+      //std::string *ptr2 = (std::string *)0;
+      if (SWIG_ConvertPtr(argv[0], (void **) &ptr, SWIGTYPE_p_PyMFEM__wFILE, 0 |0) == -1) {
+        PyErr_Clear();
+        if (!PyString_Check(argv[0]) && !PyUnicode_Check(argv[0])) {
+          // not string
+          _v = 1;	   	
+          PyObject* module = PyImport_ImportModule("io");
+          if (!module){
+            _v = 0;	   
+          }      
+          PyObject* cls = PyObject_GetAttrString(module, "StringIO");
+          if (!cls){
+            _v = 0;	   	   
+          }      
+          int check = PyObject_IsInstance(argv[0], cls);
+          Py_DECREF(module);
+          if (! check){
+            _v = 0;	   	   	   
+          }
+        } else {
+          _v = 1;
+        }
+      } else {
+        _v = 1;
+      }
+    }
+    if (_v) {
+      if (argc <= 1) {
+        return _wrap_new_Mesh__SWIG_9(self, argc, argv);
+      }
+      {
+        if ((PyArray_PyIntAsInt(argv[1]) == -1) && PyErr_Occurred()) {
+          PyErr_Clear();
+          _v = 0;
+        } else {
+          _v = 1;    
+        }
+      }
+      if (_v) {
+        if (argc <= 2) {
+          return _wrap_new_Mesh__SWIG_9(self, argc, argv);
+        }
+        {
+          if ((PyArray_PyIntAsInt(argv[2]) == -1) && PyErr_Occurred()) {
+            PyErr_Clear();
+            _v = 0;
+          } else {
+            _v = 1;    
+          }
+        }
+        if (_v) {
+          if (argc <= 3) {
+            return _wrap_new_Mesh__SWIG_9(self, argc, argv);
+          }
+          {
+            int res = SWIG_AsVal_bool(argv[3], NULL);
+            _v = SWIG_CheckState(res);
+          }
+          if (_v) {
+            return _wrap_new_Mesh__SWIG_9(self, argc, argv);
           }
         }
       }
@@ -21052,7 +21416,8 @@ SWIGINTERN PyObject *_wrap_Mesh_PrintInfo(PyObject *self, PyObject *args) {
               _v = 0;	   	   	   
             }
           } else {
-            _v = 0;
+            std::cout << "it is text (out)\n";	
+            _v = 1;
           }
         } else {
           _v = 1;
@@ -21196,7 +21561,8 @@ SWIGINTERN PyObject *_wrap_Mesh_Print(PyObject *self, PyObject *args) {
               _v = 0;	   	   	   
             }
           } else {
-            _v = 0;
+            std::cout << "it is text (out)\n";	
+            _v = 1;
           }
         } else {
           _v = 1;
@@ -21340,7 +21706,8 @@ SWIGINTERN PyObject *_wrap_Mesh_PrintXG(PyObject *self, PyObject *args) {
               _v = 0;	   	   	   
             }
           } else {
-            _v = 0;
+            std::cout << "it is text (out)\n";	
+            _v = 1;
           }
         } else {
           _v = 1;
@@ -21507,7 +21874,8 @@ SWIGINTERN PyObject *_wrap_Mesh_PrintVTK(PyObject *self, PyObject *args) {
               _v = 0;	   	   	   
             }
           } else {
-            _v = 0;
+            std::cout << "it is text (out)\n";	
+            _v = 1;
           }
         } else {
           _v = 1;
@@ -21546,7 +21914,8 @@ SWIGINTERN PyObject *_wrap_Mesh_PrintVTK(PyObject *self, PyObject *args) {
               _v = 0;	   	   	   
             }
           } else {
-            _v = 0;
+            std::cout << "it is text (out)\n";	
+            _v = 1;
           }
         } else {
           _v = 1;
@@ -21607,10 +21976,10 @@ SWIGINTERN PyObject *_wrap___lshift____SWIG_3(PyObject *SWIGUNUSEDPARM(self), Py
   std::ostream *arg1 = 0 ;
   mfem::Mesh *arg2 = 0 ;
   PyMFEM::wFILE *temp1 = 0 ;
-  std::ofstream out1 ;
-  int use_stringio1 = 0 ;
+  std::ofstream out_txt1 ;
+  mfem::ofgzstream *out_gz1 = 0 ;
   PyObject *string_io1 = 0 ;
-  std::ostringstream stream1 ;
+  std::ostringstream *stream1 = 0 ;
   PyObject *ret1 = 0 ;
   void *argp2 = 0 ;
   int res2 = 0 ;
@@ -21638,29 +22007,33 @@ SWIGINTERN PyObject *_wrap___lshift____SWIG_3(PyObject *SWIGUNUSEDPARM(self), Py
           SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
           return NULL;
         }
-        use_stringio1=1;
         string_io1=swig_obj[0];
+        stream1 = new std::ostringstream();
       } else {
         // if it is string, extract filename as char*
         PyObject* str = PyUnicode_AsEncodedString(swig_obj[0], "utf-8", "~E~");	
         const char* filename = PyBytes_AsString(str);
-        temp1 = new PyMFEM::wFILE(filename, 8, true);	
+        temp1 = new PyMFEM::wFILE(filename, 8, true);
+        Py_DECREF(str);	 
       }
     }
     
-    if (use_stringio1 == 0){
+    if (stream1 == 0){
       if (temp1->isSTDOUT() == 1) {
         arg1 = &std::cout;
+      } else if (temp1->isGZ()){
+        out_gz1 = new mfem::ofgzstream(temp1->getFilename(), true);
+        arg1 = out_gz1;	     
       } else {
-        out1.open(temp1->getFilename());
-        out1.precision(temp1->getPrecision());
-        if (temp1->isTemporary()){
-          delete temp1;
-        }
-        arg1 = &out1;
+        out_txt1.open(temp1->getFilename());
+        out_txt1.precision(temp1->getPrecision());
+        arg1 = &out_txt1;
+      }
+      if (temp1->isTemporary()){
+        delete temp1;
       }
     } else {
-      arg1 = &stream1;
+      arg1 = stream1;
     }
   }
   res2 = SWIG_ConvertPtr(swig_obj[1], &argp2, SWIGTYPE_p_mfem__Mesh,  0  | 0);
@@ -21692,8 +22065,8 @@ SWIGINTERN PyObject *_wrap___lshift____SWIG_3(PyObject *SWIGUNUSEDPARM(self), Py
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_std__ostream, 0 |  0 );
   {
-    if (use_stringio1 == 1) {
-      std::string str =  stream1.str();
+    if (stream1) {
+      std::string str =  stream1->str();
       const char* s = str.c_str();
       const int n = str.length();
       ret1 = PyObject_CallMethod(string_io1, "write", "s#",
@@ -21702,15 +22075,21 @@ SWIGINTERN PyObject *_wrap___lshift____SWIG_3(PyObject *SWIGUNUSEDPARM(self), Py
         PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
         return NULL;
       }
+      delete stream1;
       Py_XDECREF(resultobj);   /* Blow away any previous result */
       resultobj = ret1;    
     }
   }
   {
-    if (use_stringio1 == 0) {
+    if (!stream1) {
       if (temp1) {
         if (temp1->isSTDOUT() != 1) {
-          out1.close();
+          if (out_txt1.is_open()){
+            out_txt1.close();
+          }
+          if (out_gz1){
+            delete out_gz1;
+          }
         }
       }
     }
@@ -21718,10 +22097,15 @@ SWIGINTERN PyObject *_wrap___lshift____SWIG_3(PyObject *SWIGUNUSEDPARM(self), Py
   return resultobj;
 fail:
   {
-    if (use_stringio1 == 0) {
+    if (!stream1) {
       if (temp1) {
         if (temp1->isSTDOUT() != 1) {
-          out1.close();
+          if (out_txt1.is_open()){
+            out_txt1.close();
+          }
+          if (out_gz1){
+            delete out_gz1;
+          }
         }
       }
     }
@@ -21764,7 +22148,8 @@ SWIGINTERN PyObject *_wrap___lshift__(PyObject *self, PyObject *args) {
             _v = 0;	   	   	   
           }
         } else {
-          _v = 0;
+          std::cout << "it is text (out)\n";	
+          _v = 1;
         }
       } else {
         _v = 1;
@@ -24608,7 +24993,6 @@ static swig_type_info _swigt__p_p_mfem__Mesh = {"_p_p_mfem__Mesh", "mfem::Mesh *
 static swig_type_info _swigt__p_pri_t = {"_p_pri_t", "pri_t *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_quad_t = {"_p_quad_t", "quad_t *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_seg_t = {"_p_seg_t", "seg_t *", 0, 0, (void*)0, 0};
-static swig_type_info _swigt__p_std__istream = {"_p_std__istream", "std::istream *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_std__ostream = {"_p_std__ostream", "std::ostream *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_mfem__OutStream = {"_p_mfem__OutStream", 0, 0, 0, 0, 0};
 static swig_type_info _swigt__p_tet_t = {"_p_tet_t", "tet_t *", 0, 0, (void*)0, 0};
@@ -24781,7 +25165,6 @@ static swig_type_info *swig_type_initial[] = {
   &_swigt__p_pri_t,
   &_swigt__p_quad_t,
   &_swigt__p_seg_t,
-  &_swigt__p_std__istream,
   &_swigt__p_std__ostream,
   &_swigt__p_tet_t,
   &_swigt__p_tri_t,
@@ -24952,7 +25335,6 @@ static swig_cast_info _swigc__p_p_mfem__Mesh[] = {  {&_swigt__p_p_mfem__Mesh, 0,
 static swig_cast_info _swigc__p_pri_t[] = {  {&_swigt__p_pri_t, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_quad_t[] = {  {&_swigt__p_quad_t, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_seg_t[] = {  {&_swigt__p_seg_t, 0, 0, 0},{0, 0, 0, 0}};
-static swig_cast_info _swigc__p_std__istream[] = {  {&_swigt__p_std__istream, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_mfem__OutStream[] = {{&_swigt__p_mfem__OutStream, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_std__ostream[] = {  {&_swigt__p_std__ostream, 0, 0, 0},  {&_swigt__p_mfem__OutStream, _p_mfem__OutStreamTo_p_std__ostream, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_tet_t[] = {  {&_swigt__p_tet_t, 0, 0, 0},{0, 0, 0, 0}};
@@ -25125,7 +25507,6 @@ static swig_cast_info *swig_cast_initial[] = {
   _swigc__p_pri_t,
   _swigc__p_quad_t,
   _swigc__p_seg_t,
-  _swigc__p_std__istream,
   _swigc__p_std__ostream,
   _swigc__p_tet_t,
   _swigc__p_tri_t,

--- a/mfem/_ser/mesh_wrap.cxx
+++ b/mfem/_ser/mesh_wrap.cxx
@@ -8790,7 +8790,6 @@ SWIGINTERN PyObject *_wrap_new_Mesh__SWIG_9(PyObject *SWIGUNUSEDPARM(self), Py_s
   PyMFEM::wFILE *temp1 = 0 ;
   std::ifstream in_txt1 ;
   mfem::ifgzstream *in_gz1 = 0 ;
-  PyObject *input_str1 = 0 ;
   std::istringstream *stream1 = 0 ;
   Py_ssize_t len1 = 0 ;
   PyObject *ret1 = 0 ;
@@ -8821,18 +8820,18 @@ SWIGINTERN PyObject *_wrap_new_Mesh__SWIG_9(PyObject *SWIGUNUSEDPARM(self), Py_s
           return NULL;
         }
         
-        PyObject *input_str1 = PyObject_CallMethod(swig_obj[0], "getvalue", NULL);
+        PyObject *input_str = PyObject_CallMethod(swig_obj[0], "getvalue", NULL);
         if (PyErr_Occurred()) {
           PyErr_SetString(PyExc_RuntimeError, "Can not read from StringIO");
           return NULL;
         }
         
         char *buf = nullptr;
-        PyObject *str = PyUnicode_AsUTF8String(input_str1);	 
+        PyObject *str = PyUnicode_AsUTF8String(input_str);	 
         PyBytes_AsStringAndSize(str, &buf, &len1);
         stream1 = new std::istringstream(buf);
         Py_DECREF(str);
-        Py_DECREF(input_str1);	 
+        Py_DECREF(input_str);	 
       } else {
         // if it is string, extract filename as char*
         PyObject* str = PyUnicode_AsEncodedString(swig_obj[0], "utf-8", "~E~");	
@@ -9049,7 +9048,6 @@ SWIGINTERN PyObject *_wrap_Mesh_Load(PyObject *SWIGUNUSEDPARM(self), PyObject *a
   PyMFEM::wFILE *temp2 = 0 ;
   std::ifstream in_txt2 ;
   mfem::ifgzstream *in_gz2 = 0 ;
-  PyObject *input_str2 = 0 ;
   std::istringstream *stream2 = 0 ;
   Py_ssize_t len2 = 0 ;
   PyObject *ret2 = 0 ;
@@ -9092,18 +9090,18 @@ SWIGINTERN PyObject *_wrap_Mesh_Load(PyObject *SWIGUNUSEDPARM(self), PyObject *a
           return NULL;
         }
         
-        PyObject *input_str2 = PyObject_CallMethod(obj1, "getvalue", NULL);
+        PyObject *input_str = PyObject_CallMethod(obj1, "getvalue", NULL);
         if (PyErr_Occurred()) {
           PyErr_SetString(PyExc_RuntimeError, "Can not read from StringIO");
           return NULL;
         }
         
         char *buf = nullptr;
-        PyObject *str = PyUnicode_AsUTF8String(input_str2);	 
+        PyObject *str = PyUnicode_AsUTF8String(input_str);	 
         PyBytes_AsStringAndSize(str, &buf, &len2);
         stream2 = new std::istringstream(buf);
         Py_DECREF(str);
-        Py_DECREF(input_str2);	 
+        Py_DECREF(input_str);	 
       } else {
         // if it is string, extract filename as char*
         PyObject* str = PyUnicode_AsEncodedString(obj1, "utf-8", "~E~");	
@@ -17677,7 +17675,6 @@ SWIGINTERN PyObject *_wrap_Mesh_PrintVTU(PyObject *self, PyObject *args) {
               _v = 0;	   	   	   
             }
           } else {
-            std::cout << "it is text (out)\n";	
             _v = 1;
           }
         } else {
@@ -21416,7 +21413,6 @@ SWIGINTERN PyObject *_wrap_Mesh_PrintInfo(PyObject *self, PyObject *args) {
               _v = 0;	   	   	   
             }
           } else {
-            std::cout << "it is text (out)\n";	
             _v = 1;
           }
         } else {
@@ -21561,7 +21557,6 @@ SWIGINTERN PyObject *_wrap_Mesh_Print(PyObject *self, PyObject *args) {
               _v = 0;	   	   	   
             }
           } else {
-            std::cout << "it is text (out)\n";	
             _v = 1;
           }
         } else {
@@ -21706,7 +21701,6 @@ SWIGINTERN PyObject *_wrap_Mesh_PrintXG(PyObject *self, PyObject *args) {
               _v = 0;	   	   	   
             }
           } else {
-            std::cout << "it is text (out)\n";	
             _v = 1;
           }
         } else {
@@ -21874,7 +21868,6 @@ SWIGINTERN PyObject *_wrap_Mesh_PrintVTK(PyObject *self, PyObject *args) {
               _v = 0;	   	   	   
             }
           } else {
-            std::cout << "it is text (out)\n";	
             _v = 1;
           }
         } else {
@@ -21914,7 +21907,6 @@ SWIGINTERN PyObject *_wrap_Mesh_PrintVTK(PyObject *self, PyObject *args) {
               _v = 0;	   	   	   
             }
           } else {
-            std::cout << "it is text (out)\n";	
             _v = 1;
           }
         } else {
@@ -22148,7 +22140,6 @@ SWIGINTERN PyObject *_wrap___lshift__(PyObject *self, PyObject *args) {
             _v = 0;	   	   	   
           }
         } else {
-          std::cout << "it is text (out)\n";	
           _v = 1;
         }
       } else {

--- a/mfem/_ser/ncmesh.i
+++ b/mfem/_ser/ncmesh.i
@@ -5,7 +5,8 @@
 %{
 #include <fstream>
 #include <iostream>
-#include "../common/io_stream.hpp"           
+#include "../common/io_stream.hpp"
+#include "general/zstr.hpp"  
 #include "mesh/ncmesh.hpp"
 #include "numpy/arrayobject.h"    
 %}
@@ -22,6 +23,7 @@
 
 %import "../common/io_stream_typemap.i"
 OSTREAM_TYPEMAP(std::ostream&)
+ISTREAM_TYPEMAP(std::istream&)
 
 %immutable embeddings;
 

--- a/mfem/_ser/ncmesh_wrap.cxx
+++ b/mfem/_ser/ncmesh_wrap.cxx
@@ -3206,7 +3206,8 @@ namespace swig {
 
 #include <fstream>
 #include <iostream>
-#include "../common/io_stream.hpp"           
+#include "../common/io_stream.hpp"
+#include "general/zstr.hpp"  
 #include "mesh/ncmesh.hpp"
 #include "numpy/arrayobject.h"    
 
@@ -6390,10 +6391,10 @@ SWIGINTERN PyObject *_wrap_NCMesh_PrintVertexParents__SWIG_0(PyObject *SWIGUNUSE
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyMFEM::wFILE *temp2 = 0 ;
-  std::ofstream out2 ;
-  int use_stringio2 = 0 ;
+  std::ofstream out_txt2 ;
+  mfem::ofgzstream *out_gz2 = 0 ;
   PyObject *string_io2 = 0 ;
-  std::ostringstream stream2 ;
+  std::ostringstream *stream2 = 0 ;
   PyObject *ret2 = 0 ;
   
   if ((nobjs < 2) || (nobjs > 2)) SWIG_fail;
@@ -6423,29 +6424,33 @@ SWIGINTERN PyObject *_wrap_NCMesh_PrintVertexParents__SWIG_0(PyObject *SWIGUNUSE
           SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
           return NULL;
         }
-        use_stringio2=1;
         string_io2=swig_obj[1];
+        stream2 = new std::ostringstream();
       } else {
         // if it is string, extract filename as char*
         PyObject* str = PyUnicode_AsEncodedString(swig_obj[1], "utf-8", "~E~");	
         const char* filename = PyBytes_AsString(str);
-        temp2 = new PyMFEM::wFILE(filename, 8, true);	
+        temp2 = new PyMFEM::wFILE(filename, 8, true);
+        Py_DECREF(str);	 
       }
     }
     
-    if (use_stringio2 == 0){
+    if (stream2 == 0){
       if (temp2->isSTDOUT() == 1) {
         arg2 = &std::cout;
+      } else if (temp2->isGZ()){
+        out_gz2 = new mfem::ofgzstream(temp2->getFilename(), true);
+        arg2 = out_gz2;	     
       } else {
-        out2.open(temp2->getFilename());
-        out2.precision(temp2->getPrecision());
-        if (temp2->isTemporary()){
-          delete temp2;
-        }
-        arg2 = &out2;
+        out_txt2.open(temp2->getFilename());
+        out_txt2.precision(temp2->getPrecision());
+        arg2 = &out_txt2;
+      }
+      if (temp2->isTemporary()){
+        delete temp2;
       }
     } else {
-      arg2 = &stream2;
+      arg2 = stream2;
     }
   }
   {
@@ -6469,8 +6474,8 @@ SWIGINTERN PyObject *_wrap_NCMesh_PrintVertexParents__SWIG_0(PyObject *SWIGUNUSE
   }
   resultobj = SWIG_Py_Void();
   {
-    if (use_stringio2 == 1) {
-      std::string str =  stream2.str();
+    if (stream2) {
+      std::string str =  stream2->str();
       const char* s = str.c_str();
       const int n = str.length();
       ret2 = PyObject_CallMethod(string_io2, "write", "s#",
@@ -6479,15 +6484,21 @@ SWIGINTERN PyObject *_wrap_NCMesh_PrintVertexParents__SWIG_0(PyObject *SWIGUNUSE
         PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
         return NULL;
       }
+      delete stream2;
       Py_XDECREF(resultobj);   /* Blow away any previous result */
       resultobj = ret2;    
     }
   }
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -6495,10 +6506,15 @@ SWIGINTERN PyObject *_wrap_NCMesh_PrintVertexParents__SWIG_0(PyObject *SWIGUNUSE
   return resultobj;
 fail:
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -6514,10 +6530,10 @@ SWIGINTERN PyObject *_wrap_NCMesh_PrintCoarseElements__SWIG_0(PyObject *SWIGUNUS
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyMFEM::wFILE *temp2 = 0 ;
-  std::ofstream out2 ;
-  int use_stringio2 = 0 ;
+  std::ofstream out_txt2 ;
+  mfem::ofgzstream *out_gz2 = 0 ;
   PyObject *string_io2 = 0 ;
-  std::ostringstream stream2 ;
+  std::ostringstream *stream2 = 0 ;
   PyObject *ret2 = 0 ;
   
   if ((nobjs < 2) || (nobjs > 2)) SWIG_fail;
@@ -6547,29 +6563,33 @@ SWIGINTERN PyObject *_wrap_NCMesh_PrintCoarseElements__SWIG_0(PyObject *SWIGUNUS
           SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
           return NULL;
         }
-        use_stringio2=1;
         string_io2=swig_obj[1];
+        stream2 = new std::ostringstream();
       } else {
         // if it is string, extract filename as char*
         PyObject* str = PyUnicode_AsEncodedString(swig_obj[1], "utf-8", "~E~");	
         const char* filename = PyBytes_AsString(str);
-        temp2 = new PyMFEM::wFILE(filename, 8, true);	
+        temp2 = new PyMFEM::wFILE(filename, 8, true);
+        Py_DECREF(str);	 
       }
     }
     
-    if (use_stringio2 == 0){
+    if (stream2 == 0){
       if (temp2->isSTDOUT() == 1) {
         arg2 = &std::cout;
+      } else if (temp2->isGZ()){
+        out_gz2 = new mfem::ofgzstream(temp2->getFilename(), true);
+        arg2 = out_gz2;	     
       } else {
-        out2.open(temp2->getFilename());
-        out2.precision(temp2->getPrecision());
-        if (temp2->isTemporary()){
-          delete temp2;
-        }
-        arg2 = &out2;
+        out_txt2.open(temp2->getFilename());
+        out_txt2.precision(temp2->getPrecision());
+        arg2 = &out_txt2;
+      }
+      if (temp2->isTemporary()){
+        delete temp2;
       }
     } else {
-      arg2 = &stream2;
+      arg2 = stream2;
     }
   }
   {
@@ -6593,8 +6613,8 @@ SWIGINTERN PyObject *_wrap_NCMesh_PrintCoarseElements__SWIG_0(PyObject *SWIGUNUS
   }
   resultobj = SWIG_Py_Void();
   {
-    if (use_stringio2 == 1) {
-      std::string str =  stream2.str();
+    if (stream2) {
+      std::string str =  stream2->str();
       const char* s = str.c_str();
       const int n = str.length();
       ret2 = PyObject_CallMethod(string_io2, "write", "s#",
@@ -6603,15 +6623,21 @@ SWIGINTERN PyObject *_wrap_NCMesh_PrintCoarseElements__SWIG_0(PyObject *SWIGUNUS
         PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
         return NULL;
       }
+      delete stream2;
       Py_XDECREF(resultobj);   /* Blow away any previous result */
       resultobj = ret2;    
     }
   }
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -6619,10 +6645,15 @@ SWIGINTERN PyObject *_wrap_NCMesh_PrintCoarseElements__SWIG_0(PyObject *SWIGUNUS
   return resultobj;
 fail:
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -6637,8 +6668,13 @@ SWIGINTERN PyObject *_wrap_NCMesh_LoadVertexParents(PyObject *SWIGUNUSEDPARM(sel
   std::istream *arg2 = 0 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
-  void *argp2 = 0 ;
-  int res2 = 0 ;
+  PyMFEM::wFILE *temp2 = 0 ;
+  std::ifstream in_txt2 ;
+  mfem::ifgzstream *in_gz2 = 0 ;
+  PyObject *input_str2 = 0 ;
+  std::istringstream *stream2 = 0 ;
+  Py_ssize_t len2 = 0 ;
+  PyObject *ret2 = 0 ;
   PyObject * obj0 = 0 ;
   PyObject * obj1 = 0 ;
   char * kwnames[] = {
@@ -6651,14 +6687,64 @@ SWIGINTERN PyObject *_wrap_NCMesh_LoadVertexParents(PyObject *SWIGUNUSEDPARM(sel
     SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "NCMesh_LoadVertexParents" "', argument " "1"" of type '" "mfem::NCMesh *""'"); 
   }
   arg1 = reinterpret_cast< mfem::NCMesh * >(argp1);
-  res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_std__istream,  0 );
-  if (!SWIG_IsOK(res2)) {
-    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "NCMesh_LoadVertexParents" "', argument " "2"" of type '" "std::istream &""'"); 
+  {
+    //  PyMFEM::wFILE or string argument or StringIO
+    if (SWIG_ConvertPtr(obj1, (void **) &temp2, SWIGTYPE_p_PyMFEM__wFILE, 0 | 0) == -1) {
+      if (!PyString_Check(obj1) && !PyUnicode_Check(obj1)) {
+        // not string, check if it is StringIO
+        PyObject* module = PyImport_ImportModule("io");
+        if (!module){
+          PyErr_SetString(PyExc_RuntimeError, "Can not load io module");
+          return NULL;
+        }      
+        PyObject* cls = PyObject_GetAttrString(module, "StringIO");
+        if (!cls){
+          PyErr_SetString(PyExc_RuntimeError, "Can not load StringIO");
+          return NULL;
+        }      
+        int check = PyObject_IsInstance(obj1, cls);
+        Py_DECREF(module);
+        if (! check){
+          SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
+          return NULL;
+        }
+        
+        PyObject *input_str2 = PyObject_CallMethod(obj1, "getvalue", NULL);
+        if (PyErr_Occurred()) {
+          PyErr_SetString(PyExc_RuntimeError, "Can not read from StringIO");
+          return NULL;
+        }
+        
+        char *buf = nullptr;
+        PyObject *str = PyUnicode_AsUTF8String(input_str2);	 
+        PyBytes_AsStringAndSize(str, &buf, &len2);
+        stream2 = new std::istringstream(buf);
+        Py_DECREF(str);
+        Py_DECREF(input_str2);	 
+      } else {
+        // if it is string, extract filename as char*
+        PyObject* str = PyUnicode_AsEncodedString(obj1, "utf-8", "~E~");	
+        const char* filename = PyBytes_AsString(str);
+        temp2 = new PyMFEM::wFILE(filename, 8, true);
+        Py_DECREF(str);
+      }
+    }
+    if (stream2 == 0){
+      if (temp2->isGZ()){
+        in_gz2 = new mfem::ifgzstream(temp2->getFilename());
+        arg2 = in_gz2;
+      } else {
+        in_txt2.open(temp2->getFilename(), std::ifstream::in);
+        in_txt2.precision(temp2->getPrecision());
+        arg2 = &in_txt2;
+      }
+      if (temp2->isTemporary()){
+        delete temp2;
+      }
+    } else {
+      arg2 = stream2;
+    }
   }
-  if (!argp2) {
-    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "NCMesh_LoadVertexParents" "', argument " "2"" of type '" "std::istream &""'"); 
-  }
-  arg2 = reinterpret_cast< std::istream * >(argp2);
   {
     try {
       (arg1)->LoadVertexParents(*arg2);
@@ -6679,8 +6765,40 @@ SWIGINTERN PyObject *_wrap_NCMesh_LoadVertexParents(PyObject *SWIGUNUSEDPARM(sel
     }	 
   }
   resultobj = SWIG_Py_Void();
+  {
+    if (stream2) {
+      ret2 = PyLong_FromSsize_t(len2);
+      if (PyErr_Occurred()) {
+        PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
+        return NULL;
+      }
+      delete stream2;    
+      Py_XDECREF(resultobj);   /* Blow away any previous result */
+      resultobj = ret2;    
+    }
+  }
+  {
+    if (!stream2) {
+      if (temp2) {
+        in_txt2.close();
+      }
+      if (in_gz2){
+        delete in_gz2;
+      }
+    }  
+  }
   return resultobj;
 fail:
+  {
+    if (!stream2) {
+      if (temp2) {
+        in_txt2.close();
+      }
+      if (in_gz2){
+        delete in_gz2;
+      }
+    }  
+  }
   return NULL;
 }
 
@@ -6691,8 +6809,13 @@ SWIGINTERN PyObject *_wrap_NCMesh_LoadCoarseElements(PyObject *SWIGUNUSEDPARM(se
   std::istream *arg2 = 0 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
-  void *argp2 = 0 ;
-  int res2 = 0 ;
+  PyMFEM::wFILE *temp2 = 0 ;
+  std::ifstream in_txt2 ;
+  mfem::ifgzstream *in_gz2 = 0 ;
+  PyObject *input_str2 = 0 ;
+  std::istringstream *stream2 = 0 ;
+  Py_ssize_t len2 = 0 ;
+  PyObject *ret2 = 0 ;
   PyObject * obj0 = 0 ;
   PyObject * obj1 = 0 ;
   char * kwnames[] = {
@@ -6705,14 +6828,64 @@ SWIGINTERN PyObject *_wrap_NCMesh_LoadCoarseElements(PyObject *SWIGUNUSEDPARM(se
     SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "NCMesh_LoadCoarseElements" "', argument " "1"" of type '" "mfem::NCMesh *""'"); 
   }
   arg1 = reinterpret_cast< mfem::NCMesh * >(argp1);
-  res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_std__istream,  0 );
-  if (!SWIG_IsOK(res2)) {
-    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "NCMesh_LoadCoarseElements" "', argument " "2"" of type '" "std::istream &""'"); 
+  {
+    //  PyMFEM::wFILE or string argument or StringIO
+    if (SWIG_ConvertPtr(obj1, (void **) &temp2, SWIGTYPE_p_PyMFEM__wFILE, 0 | 0) == -1) {
+      if (!PyString_Check(obj1) && !PyUnicode_Check(obj1)) {
+        // not string, check if it is StringIO
+        PyObject* module = PyImport_ImportModule("io");
+        if (!module){
+          PyErr_SetString(PyExc_RuntimeError, "Can not load io module");
+          return NULL;
+        }      
+        PyObject* cls = PyObject_GetAttrString(module, "StringIO");
+        if (!cls){
+          PyErr_SetString(PyExc_RuntimeError, "Can not load StringIO");
+          return NULL;
+        }      
+        int check = PyObject_IsInstance(obj1, cls);
+        Py_DECREF(module);
+        if (! check){
+          SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
+          return NULL;
+        }
+        
+        PyObject *input_str2 = PyObject_CallMethod(obj1, "getvalue", NULL);
+        if (PyErr_Occurred()) {
+          PyErr_SetString(PyExc_RuntimeError, "Can not read from StringIO");
+          return NULL;
+        }
+        
+        char *buf = nullptr;
+        PyObject *str = PyUnicode_AsUTF8String(input_str2);	 
+        PyBytes_AsStringAndSize(str, &buf, &len2);
+        stream2 = new std::istringstream(buf);
+        Py_DECREF(str);
+        Py_DECREF(input_str2);	 
+      } else {
+        // if it is string, extract filename as char*
+        PyObject* str = PyUnicode_AsEncodedString(obj1, "utf-8", "~E~");	
+        const char* filename = PyBytes_AsString(str);
+        temp2 = new PyMFEM::wFILE(filename, 8, true);
+        Py_DECREF(str);
+      }
+    }
+    if (stream2 == 0){
+      if (temp2->isGZ()){
+        in_gz2 = new mfem::ifgzstream(temp2->getFilename());
+        arg2 = in_gz2;
+      } else {
+        in_txt2.open(temp2->getFilename(), std::ifstream::in);
+        in_txt2.precision(temp2->getPrecision());
+        arg2 = &in_txt2;
+      }
+      if (temp2->isTemporary()){
+        delete temp2;
+      }
+    } else {
+      arg2 = stream2;
+    }
   }
-  if (!argp2) {
-    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "NCMesh_LoadCoarseElements" "', argument " "2"" of type '" "std::istream &""'"); 
-  }
-  arg2 = reinterpret_cast< std::istream * >(argp2);
   {
     try {
       (arg1)->LoadCoarseElements(*arg2);
@@ -6733,8 +6906,40 @@ SWIGINTERN PyObject *_wrap_NCMesh_LoadCoarseElements(PyObject *SWIGUNUSEDPARM(se
     }	 
   }
   resultobj = SWIG_Py_Void();
+  {
+    if (stream2) {
+      ret2 = PyLong_FromSsize_t(len2);
+      if (PyErr_Occurred()) {
+        PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
+        return NULL;
+      }
+      delete stream2;    
+      Py_XDECREF(resultobj);   /* Blow away any previous result */
+      resultobj = ret2;    
+    }
+  }
+  {
+    if (!stream2) {
+      if (temp2) {
+        in_txt2.close();
+      }
+      if (in_gz2){
+        delete in_gz2;
+      }
+    }  
+  }
   return resultobj;
 fail:
+  {
+    if (!stream2) {
+      if (temp2) {
+        in_txt2.close();
+      }
+      if (in_gz2){
+        delete in_gz2;
+      }
+    }  
+  }
   return NULL;
 }
 
@@ -6923,10 +7128,10 @@ SWIGINTERN PyObject *_wrap_NCMesh_PrintStats__SWIG_0(PyObject *SWIGUNUSEDPARM(se
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyMFEM::wFILE *temp2 = 0 ;
-  std::ofstream out2 ;
-  int use_stringio2 = 0 ;
+  std::ofstream out_txt2 ;
+  mfem::ofgzstream *out_gz2 = 0 ;
   PyObject *string_io2 = 0 ;
-  std::ostringstream stream2 ;
+  std::ostringstream *stream2 = 0 ;
   PyObject *ret2 = 0 ;
   
   if ((nobjs < 1) || (nobjs > 2)) SWIG_fail;
@@ -6957,29 +7162,33 @@ SWIGINTERN PyObject *_wrap_NCMesh_PrintStats__SWIG_0(PyObject *SWIGUNUSEDPARM(se
             SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
             return NULL;
           }
-          use_stringio2=1;
           string_io2=swig_obj[1];
+          stream2 = new std::ostringstream();
         } else {
           // if it is string, extract filename as char*
           PyObject* str = PyUnicode_AsEncodedString(swig_obj[1], "utf-8", "~E~");	
           const char* filename = PyBytes_AsString(str);
-          temp2 = new PyMFEM::wFILE(filename, 8, true);	
+          temp2 = new PyMFEM::wFILE(filename, 8, true);
+          Py_DECREF(str);	 
         }
       }
       
-      if (use_stringio2 == 0){
+      if (stream2 == 0){
         if (temp2->isSTDOUT() == 1) {
           arg2 = &std::cout;
+        } else if (temp2->isGZ()){
+          out_gz2 = new mfem::ofgzstream(temp2->getFilename(), true);
+          arg2 = out_gz2;	     
         } else {
-          out2.open(temp2->getFilename());
-          out2.precision(temp2->getPrecision());
-          if (temp2->isTemporary()){
-            delete temp2;
-          }
-          arg2 = &out2;
+          out_txt2.open(temp2->getFilename());
+          out_txt2.precision(temp2->getPrecision());
+          arg2 = &out_txt2;
+        }
+        if (temp2->isTemporary()){
+          delete temp2;
         }
       } else {
-        arg2 = &stream2;
+        arg2 = stream2;
       }
     }
   }
@@ -7004,8 +7213,8 @@ SWIGINTERN PyObject *_wrap_NCMesh_PrintStats__SWIG_0(PyObject *SWIGUNUSEDPARM(se
   }
   resultobj = SWIG_Py_Void();
   {
-    if (use_stringio2 == 1) {
-      std::string str =  stream2.str();
+    if (stream2) {
+      std::string str =  stream2->str();
       const char* s = str.c_str();
       const int n = str.length();
       ret2 = PyObject_CallMethod(string_io2, "write", "s#",
@@ -7014,15 +7223,21 @@ SWIGINTERN PyObject *_wrap_NCMesh_PrintStats__SWIG_0(PyObject *SWIGUNUSEDPARM(se
         PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
         return NULL;
       }
+      delete stream2;
       Py_XDECREF(resultobj);   /* Blow away any previous result */
       resultobj = ret2;    
     }
   }
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -7030,10 +7245,15 @@ SWIGINTERN PyObject *_wrap_NCMesh_PrintStats__SWIG_0(PyObject *SWIGUNUSEDPARM(se
   return resultobj;
 fail:
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -7209,7 +7429,8 @@ SWIGINTERN PyObject *_wrap_NCMesh_PrintVertexParents(PyObject *self, PyObject *a
               _v = 0;	   	   	   
             }
           } else {
-            _v = 0;
+            std::cout << "it is text (out)\n";	
+            _v = 1;
           }
         } else {
           _v = 1;
@@ -7398,7 +7619,8 @@ SWIGINTERN PyObject *_wrap_NCMesh_PrintCoarseElements(PyObject *self, PyObject *
               _v = 0;	   	   	   
             }
           } else {
-            _v = 0;
+            std::cout << "it is text (out)\n";	
+            _v = 1;
           }
         } else {
           _v = 1;
@@ -7517,7 +7739,8 @@ SWIGINTERN PyObject *_wrap_NCMesh_PrintStats(PyObject *self, PyObject *args) {
               _v = 0;	   	   	   
             }
           } else {
-            _v = 0;
+            std::cout << "it is text (out)\n";	
+            _v = 1;
           }
         } else {
           _v = 1;

--- a/mfem/_ser/ncmesh_wrap.cxx
+++ b/mfem/_ser/ncmesh_wrap.cxx
@@ -6671,7 +6671,6 @@ SWIGINTERN PyObject *_wrap_NCMesh_LoadVertexParents(PyObject *SWIGUNUSEDPARM(sel
   PyMFEM::wFILE *temp2 = 0 ;
   std::ifstream in_txt2 ;
   mfem::ifgzstream *in_gz2 = 0 ;
-  PyObject *input_str2 = 0 ;
   std::istringstream *stream2 = 0 ;
   Py_ssize_t len2 = 0 ;
   PyObject *ret2 = 0 ;
@@ -6709,18 +6708,18 @@ SWIGINTERN PyObject *_wrap_NCMesh_LoadVertexParents(PyObject *SWIGUNUSEDPARM(sel
           return NULL;
         }
         
-        PyObject *input_str2 = PyObject_CallMethod(obj1, "getvalue", NULL);
+        PyObject *input_str = PyObject_CallMethod(obj1, "getvalue", NULL);
         if (PyErr_Occurred()) {
           PyErr_SetString(PyExc_RuntimeError, "Can not read from StringIO");
           return NULL;
         }
         
         char *buf = nullptr;
-        PyObject *str = PyUnicode_AsUTF8String(input_str2);	 
+        PyObject *str = PyUnicode_AsUTF8String(input_str);	 
         PyBytes_AsStringAndSize(str, &buf, &len2);
         stream2 = new std::istringstream(buf);
         Py_DECREF(str);
-        Py_DECREF(input_str2);	 
+        Py_DECREF(input_str);	 
       } else {
         // if it is string, extract filename as char*
         PyObject* str = PyUnicode_AsEncodedString(obj1, "utf-8", "~E~");	
@@ -6812,7 +6811,6 @@ SWIGINTERN PyObject *_wrap_NCMesh_LoadCoarseElements(PyObject *SWIGUNUSEDPARM(se
   PyMFEM::wFILE *temp2 = 0 ;
   std::ifstream in_txt2 ;
   mfem::ifgzstream *in_gz2 = 0 ;
-  PyObject *input_str2 = 0 ;
   std::istringstream *stream2 = 0 ;
   Py_ssize_t len2 = 0 ;
   PyObject *ret2 = 0 ;
@@ -6850,18 +6848,18 @@ SWIGINTERN PyObject *_wrap_NCMesh_LoadCoarseElements(PyObject *SWIGUNUSEDPARM(se
           return NULL;
         }
         
-        PyObject *input_str2 = PyObject_CallMethod(obj1, "getvalue", NULL);
+        PyObject *input_str = PyObject_CallMethod(obj1, "getvalue", NULL);
         if (PyErr_Occurred()) {
           PyErr_SetString(PyExc_RuntimeError, "Can not read from StringIO");
           return NULL;
         }
         
         char *buf = nullptr;
-        PyObject *str = PyUnicode_AsUTF8String(input_str2);	 
+        PyObject *str = PyUnicode_AsUTF8String(input_str);	 
         PyBytes_AsStringAndSize(str, &buf, &len2);
         stream2 = new std::istringstream(buf);
         Py_DECREF(str);
-        Py_DECREF(input_str2);	 
+        Py_DECREF(input_str);	 
       } else {
         // if it is string, extract filename as char*
         PyObject* str = PyUnicode_AsEncodedString(obj1, "utf-8", "~E~");	
@@ -7429,7 +7427,6 @@ SWIGINTERN PyObject *_wrap_NCMesh_PrintVertexParents(PyObject *self, PyObject *a
               _v = 0;	   	   	   
             }
           } else {
-            std::cout << "it is text (out)\n";	
             _v = 1;
           }
         } else {
@@ -7619,7 +7616,6 @@ SWIGINTERN PyObject *_wrap_NCMesh_PrintCoarseElements(PyObject *self, PyObject *
               _v = 0;	   	   	   
             }
           } else {
-            std::cout << "it is text (out)\n";	
             _v = 1;
           }
         } else {
@@ -7739,7 +7735,6 @@ SWIGINTERN PyObject *_wrap_NCMesh_PrintStats(PyObject *self, PyObject *args) {
               _v = 0;	   	   	   
             }
           } else {
-            std::cout << "it is text (out)\n";	
             _v = 1;
           }
         } else {

--- a/mfem/_ser/ode_wrap.cxx
+++ b/mfem/_ser/ode_wrap.cxx
@@ -10079,10 +10079,10 @@ SWIGINTERN PyObject *_wrap_NewmarkSolver_PrintProperties(PyObject *SWIGUNUSEDPAR
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyMFEM::wFILE *temp2 = 0 ;
-  std::ofstream out2 ;
-  int use_stringio2 = 0 ;
+  std::ofstream out_txt2 ;
+  mfem::ofgzstream *out_gz2 = 0 ;
   PyObject *string_io2 = 0 ;
-  std::ostringstream stream2 ;
+  std::ostringstream *stream2 = 0 ;
   PyObject *ret2 = 0 ;
   PyObject * obj0 = 0 ;
   PyObject * obj1 = 0 ;
@@ -10118,29 +10118,33 @@ SWIGINTERN PyObject *_wrap_NewmarkSolver_PrintProperties(PyObject *SWIGUNUSEDPAR
             SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
             return NULL;
           }
-          use_stringio2=1;
           string_io2=obj1;
+          stream2 = new std::ostringstream();
         } else {
           // if it is string, extract filename as char*
           PyObject* str = PyUnicode_AsEncodedString(obj1, "utf-8", "~E~");	
           const char* filename = PyBytes_AsString(str);
-          temp2 = new PyMFEM::wFILE(filename, 8, true);	
+          temp2 = new PyMFEM::wFILE(filename, 8, true);
+          Py_DECREF(str);	 
         }
       }
       
-      if (use_stringio2 == 0){
+      if (stream2 == 0){
         if (temp2->isSTDOUT() == 1) {
           arg2 = &std::cout;
+        } else if (temp2->isGZ()){
+          out_gz2 = new mfem::ofgzstream(temp2->getFilename(), true);
+          arg2 = out_gz2;	     
         } else {
-          out2.open(temp2->getFilename());
-          out2.precision(temp2->getPrecision());
-          if (temp2->isTemporary()){
-            delete temp2;
-          }
-          arg2 = &out2;
+          out_txt2.open(temp2->getFilename());
+          out_txt2.precision(temp2->getPrecision());
+          arg2 = &out_txt2;
+        }
+        if (temp2->isTemporary()){
+          delete temp2;
         }
       } else {
-        arg2 = &stream2;
+        arg2 = stream2;
       }
     }
   }
@@ -10165,8 +10169,8 @@ SWIGINTERN PyObject *_wrap_NewmarkSolver_PrintProperties(PyObject *SWIGUNUSEDPAR
   }
   resultobj = SWIG_Py_Void();
   {
-    if (use_stringio2 == 1) {
-      std::string str =  stream2.str();
+    if (stream2) {
+      std::string str =  stream2->str();
       const char* s = str.c_str();
       const int n = str.length();
       ret2 = PyObject_CallMethod(string_io2, "write", "s#",
@@ -10175,15 +10179,21 @@ SWIGINTERN PyObject *_wrap_NewmarkSolver_PrintProperties(PyObject *SWIGUNUSEDPAR
         PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
         return NULL;
       }
+      delete stream2;
       Py_XDECREF(resultobj);   /* Blow away any previous result */
       resultobj = ret2;    
     }
   }
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -10191,10 +10201,15 @@ SWIGINTERN PyObject *_wrap_NewmarkSolver_PrintProperties(PyObject *SWIGUNUSEDPAR
   return resultobj;
 fail:
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -10693,10 +10708,10 @@ SWIGINTERN PyObject *_wrap_GeneralizedAlpha2Solver_PrintProperties(PyObject *SWI
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyMFEM::wFILE *temp2 = 0 ;
-  std::ofstream out2 ;
-  int use_stringio2 = 0 ;
+  std::ofstream out_txt2 ;
+  mfem::ofgzstream *out_gz2 = 0 ;
   PyObject *string_io2 = 0 ;
-  std::ostringstream stream2 ;
+  std::ostringstream *stream2 = 0 ;
   PyObject *ret2 = 0 ;
   PyObject * obj0 = 0 ;
   PyObject * obj1 = 0 ;
@@ -10732,29 +10747,33 @@ SWIGINTERN PyObject *_wrap_GeneralizedAlpha2Solver_PrintProperties(PyObject *SWI
             SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
             return NULL;
           }
-          use_stringio2=1;
           string_io2=obj1;
+          stream2 = new std::ostringstream();
         } else {
           // if it is string, extract filename as char*
           PyObject* str = PyUnicode_AsEncodedString(obj1, "utf-8", "~E~");	
           const char* filename = PyBytes_AsString(str);
-          temp2 = new PyMFEM::wFILE(filename, 8, true);	
+          temp2 = new PyMFEM::wFILE(filename, 8, true);
+          Py_DECREF(str);	 
         }
       }
       
-      if (use_stringio2 == 0){
+      if (stream2 == 0){
         if (temp2->isSTDOUT() == 1) {
           arg2 = &std::cout;
+        } else if (temp2->isGZ()){
+          out_gz2 = new mfem::ofgzstream(temp2->getFilename(), true);
+          arg2 = out_gz2;	     
         } else {
-          out2.open(temp2->getFilename());
-          out2.precision(temp2->getPrecision());
-          if (temp2->isTemporary()){
-            delete temp2;
-          }
-          arg2 = &out2;
+          out_txt2.open(temp2->getFilename());
+          out_txt2.precision(temp2->getPrecision());
+          arg2 = &out_txt2;
+        }
+        if (temp2->isTemporary()){
+          delete temp2;
         }
       } else {
-        arg2 = &stream2;
+        arg2 = stream2;
       }
     }
   }
@@ -10779,8 +10798,8 @@ SWIGINTERN PyObject *_wrap_GeneralizedAlpha2Solver_PrintProperties(PyObject *SWI
   }
   resultobj = SWIG_Py_Void();
   {
-    if (use_stringio2 == 1) {
-      std::string str =  stream2.str();
+    if (stream2) {
+      std::string str =  stream2->str();
       const char* s = str.c_str();
       const int n = str.length();
       ret2 = PyObject_CallMethod(string_io2, "write", "s#",
@@ -10789,15 +10808,21 @@ SWIGINTERN PyObject *_wrap_GeneralizedAlpha2Solver_PrintProperties(PyObject *SWI
         PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
         return NULL;
       }
+      delete stream2;
       Py_XDECREF(resultobj);   /* Blow away any previous result */
       resultobj = ret2;    
     }
   }
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -10805,10 +10830,15 @@ SWIGINTERN PyObject *_wrap_GeneralizedAlpha2Solver_PrintProperties(PyObject *SWI
   return resultobj;
 fail:
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }

--- a/mfem/_ser/operators.i
+++ b/mfem/_ser/operators.i
@@ -5,7 +5,8 @@
 %{
 #include <fstream>
 #include <iostream>  
-  
+
+#include "general/zstr.hpp"  
 #include "../common/io_stream.hpp"        
 #include "pyoperator.hpp"
 #include "numpy/arrayobject.h"

--- a/mfem/_ser/operators_wrap.cxx
+++ b/mfem/_ser/operators_wrap.cxx
@@ -3208,7 +3208,8 @@ namespace swig {
 
 #include <fstream>
 #include <iostream>  
-  
+
+#include "general/zstr.hpp"  
 #include "../common/io_stream.hpp"        
 #include "pyoperator.hpp"
 #include "numpy/arrayobject.h"
@@ -7722,10 +7723,10 @@ SWIGINTERN PyObject *_wrap_Operator_PrintMatlab__SWIG_0(PyObject *SWIGUNUSEDPARM
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyMFEM::wFILE *temp2 = 0 ;
-  std::ofstream out2 ;
-  int use_stringio2 = 0 ;
+  std::ofstream out_txt2 ;
+  mfem::ofgzstream *out_gz2 = 0 ;
   PyObject *string_io2 = 0 ;
-  std::ostringstream stream2 ;
+  std::ostringstream *stream2 = 0 ;
   PyObject *ret2 = 0 ;
   
   if ((nobjs < 2) || (nobjs > 4)) SWIG_fail;
@@ -7755,29 +7756,33 @@ SWIGINTERN PyObject *_wrap_Operator_PrintMatlab__SWIG_0(PyObject *SWIGUNUSEDPARM
           SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
           return NULL;
         }
-        use_stringio2=1;
         string_io2=swig_obj[1];
+        stream2 = new std::ostringstream();
       } else {
         // if it is string, extract filename as char*
         PyObject* str = PyUnicode_AsEncodedString(swig_obj[1], "utf-8", "~E~");	
         const char* filename = PyBytes_AsString(str);
-        temp2 = new PyMFEM::wFILE(filename, 8, true);	
+        temp2 = new PyMFEM::wFILE(filename, 8, true);
+        Py_DECREF(str);	 
       }
     }
     
-    if (use_stringio2 == 0){
+    if (stream2 == 0){
       if (temp2->isSTDOUT() == 1) {
         arg2 = &std::cout;
+      } else if (temp2->isGZ()){
+        out_gz2 = new mfem::ofgzstream(temp2->getFilename(), true);
+        arg2 = out_gz2;	     
       } else {
-        out2.open(temp2->getFilename());
-        out2.precision(temp2->getPrecision());
-        if (temp2->isTemporary()){
-          delete temp2;
-        }
-        arg2 = &out2;
+        out_txt2.open(temp2->getFilename());
+        out_txt2.precision(temp2->getPrecision());
+        arg2 = &out_txt2;
+      }
+      if (temp2->isTemporary()){
+        delete temp2;
       }
     } else {
-      arg2 = &stream2;
+      arg2 = stream2;
     }
   }
   if (swig_obj[2]) {
@@ -7817,8 +7822,8 @@ SWIGINTERN PyObject *_wrap_Operator_PrintMatlab__SWIG_0(PyObject *SWIGUNUSEDPARM
   }
   resultobj = SWIG_Py_Void();
   {
-    if (use_stringio2 == 1) {
-      std::string str =  stream2.str();
+    if (stream2) {
+      std::string str =  stream2->str();
       const char* s = str.c_str();
       const int n = str.length();
       ret2 = PyObject_CallMethod(string_io2, "write", "s#",
@@ -7827,15 +7832,21 @@ SWIGINTERN PyObject *_wrap_Operator_PrintMatlab__SWIG_0(PyObject *SWIGUNUSEDPARM
         PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
         return NULL;
       }
+      delete stream2;
       Py_XDECREF(resultobj);   /* Blow away any previous result */
       resultobj = ret2;    
     }
   }
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -7843,10 +7854,15 @@ SWIGINTERN PyObject *_wrap_Operator_PrintMatlab__SWIG_0(PyObject *SWIGUNUSEDPARM
   return resultobj;
 fail:
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -8056,7 +8072,8 @@ SWIGINTERN PyObject *_wrap_Operator_PrintMatlab(PyObject *self, PyObject *args) 
               _v = 0;	   	   	   
             }
           } else {
-            _v = 0;
+            std::cout << "it is text (out)\n";	
+            _v = 1;
           }
         } else {
           _v = 1;

--- a/mfem/_ser/operators_wrap.cxx
+++ b/mfem/_ser/operators_wrap.cxx
@@ -8072,7 +8072,6 @@ SWIGINTERN PyObject *_wrap_Operator_PrintMatlab(PyObject *self, PyObject *args) 
               _v = 0;	   	   	   
             }
           } else {
-            std::cout << "it is text (out)\n";	
             _v = 1;
           }
         } else {

--- a/mfem/_ser/sparsemat.i
+++ b/mfem/_ser/sparsemat.i
@@ -5,6 +5,7 @@
 #include <limits>
 #include <cmath>
 #include <cstring>
+#include "general/zstr.hpp"  
 #include "linalg/handle.hpp"  
 #include "linalg/sparsemat.hpp"
 #include "numpy/arrayobject.h"

--- a/mfem/_ser/sparsemat_wrap.cxx
+++ b/mfem/_ser/sparsemat_wrap.cxx
@@ -14023,7 +14023,6 @@ SWIGINTERN PyObject *_wrap_SparseMatrix_Print(PyObject *self, PyObject *args) {
               _v = 0;	   	   	   
             }
           } else {
-            std::cout << "it is text (out)\n";	
             _v = 1;
           }
         } else {
@@ -14181,7 +14180,6 @@ SWIGINTERN PyObject *_wrap_SparseMatrix_PrintMatlab(PyObject *self, PyObject *ar
               _v = 0;	   	   	   
             }
           } else {
-            std::cout << "it is text (out)\n";	
             _v = 1;
           }
         } else {
@@ -14326,7 +14324,6 @@ SWIGINTERN PyObject *_wrap_SparseMatrix_PrintMM(PyObject *self, PyObject *args) 
               _v = 0;	   	   	   
             }
           } else {
-            std::cout << "it is text (out)\n";	
             _v = 1;
           }
         } else {
@@ -14541,7 +14538,6 @@ SWIGINTERN PyObject *_wrap_SparseMatrix_PrintCSR(PyObject *self, PyObject *args)
               _v = 0;	   	   	   
             }
           } else {
-            std::cout << "it is text (out)\n";	
             _v = 1;
           }
         } else {
@@ -14731,7 +14727,6 @@ SWIGINTERN PyObject *_wrap_SparseMatrix_PrintCSR2(PyObject *self, PyObject *args
               _v = 0;	   	   	   
             }
           } else {
-            std::cout << "it is text (out)\n";	
             _v = 1;
           }
         } else {
@@ -14921,7 +14916,6 @@ SWIGINTERN PyObject *_wrap_SparseMatrix_PrintInfo(PyObject *self, PyObject *args
               _v = 0;	   	   	   
             }
           } else {
-            std::cout << "it is text (out)\n";	
             _v = 1;
           }
         } else {

--- a/mfem/_ser/sparsemat_wrap.cxx
+++ b/mfem/_ser/sparsemat_wrap.cxx
@@ -3214,6 +3214,7 @@ namespace swig {
 #include <limits>
 #include <cmath>
 #include <cstring>
+#include "general/zstr.hpp"  
 #include "linalg/handle.hpp"  
 #include "linalg/sparsemat.hpp"
 #include "numpy/arrayobject.h"
@@ -12344,10 +12345,10 @@ SWIGINTERN PyObject *_wrap_SparseMatrix_Print__SWIG_0(PyObject *SWIGUNUSEDPARM(s
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyMFEM::wFILE *temp2 = 0 ;
-  std::ofstream out2 ;
-  int use_stringio2 = 0 ;
+  std::ofstream out_txt2 ;
+  mfem::ofgzstream *out_gz2 = 0 ;
   PyObject *string_io2 = 0 ;
-  std::ostringstream stream2 ;
+  std::ostringstream *stream2 = 0 ;
   PyObject *ret2 = 0 ;
   
   if ((nobjs < 1) || (nobjs > 3)) SWIG_fail;
@@ -12378,29 +12379,33 @@ SWIGINTERN PyObject *_wrap_SparseMatrix_Print__SWIG_0(PyObject *SWIGUNUSEDPARM(s
             SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
             return NULL;
           }
-          use_stringio2=1;
           string_io2=swig_obj[1];
+          stream2 = new std::ostringstream();
         } else {
           // if it is string, extract filename as char*
           PyObject* str = PyUnicode_AsEncodedString(swig_obj[1], "utf-8", "~E~");	
           const char* filename = PyBytes_AsString(str);
-          temp2 = new PyMFEM::wFILE(filename, 8, true);	
+          temp2 = new PyMFEM::wFILE(filename, 8, true);
+          Py_DECREF(str);	 
         }
       }
       
-      if (use_stringio2 == 0){
+      if (stream2 == 0){
         if (temp2->isSTDOUT() == 1) {
           arg2 = &std::cout;
+        } else if (temp2->isGZ()){
+          out_gz2 = new mfem::ofgzstream(temp2->getFilename(), true);
+          arg2 = out_gz2;	     
         } else {
-          out2.open(temp2->getFilename());
-          out2.precision(temp2->getPrecision());
-          if (temp2->isTemporary()){
-            delete temp2;
-          }
-          arg2 = &out2;
+          out_txt2.open(temp2->getFilename());
+          out_txt2.precision(temp2->getPrecision());
+          arg2 = &out_txt2;
+        }
+        if (temp2->isTemporary()){
+          delete temp2;
         }
       } else {
-        arg2 = &stream2;
+        arg2 = stream2;
       }
     }
   }
@@ -12433,8 +12438,8 @@ SWIGINTERN PyObject *_wrap_SparseMatrix_Print__SWIG_0(PyObject *SWIGUNUSEDPARM(s
   }
   resultobj = SWIG_Py_Void();
   {
-    if (use_stringio2 == 1) {
-      std::string str =  stream2.str();
+    if (stream2) {
+      std::string str =  stream2->str();
       const char* s = str.c_str();
       const int n = str.length();
       ret2 = PyObject_CallMethod(string_io2, "write", "s#",
@@ -12443,15 +12448,21 @@ SWIGINTERN PyObject *_wrap_SparseMatrix_Print__SWIG_0(PyObject *SWIGUNUSEDPARM(s
         PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
         return NULL;
       }
+      delete stream2;
       Py_XDECREF(resultobj);   /* Blow away any previous result */
       resultobj = ret2;    
     }
   }
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -12459,10 +12470,15 @@ SWIGINTERN PyObject *_wrap_SparseMatrix_Print__SWIG_0(PyObject *SWIGUNUSEDPARM(s
   return resultobj;
 fail:
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -12479,10 +12495,10 @@ SWIGINTERN PyObject *_wrap_SparseMatrix_PrintMatlab__SWIG_0(PyObject *SWIGUNUSED
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyMFEM::wFILE *temp2 = 0 ;
-  std::ofstream out2 ;
-  int use_stringio2 = 0 ;
+  std::ofstream out_txt2 ;
+  mfem::ofgzstream *out_gz2 = 0 ;
   PyObject *string_io2 = 0 ;
-  std::ostringstream stream2 ;
+  std::ostringstream *stream2 = 0 ;
   PyObject *ret2 = 0 ;
   
   if ((nobjs < 1) || (nobjs > 2)) SWIG_fail;
@@ -12513,29 +12529,33 @@ SWIGINTERN PyObject *_wrap_SparseMatrix_PrintMatlab__SWIG_0(PyObject *SWIGUNUSED
             SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
             return NULL;
           }
-          use_stringio2=1;
           string_io2=swig_obj[1];
+          stream2 = new std::ostringstream();
         } else {
           // if it is string, extract filename as char*
           PyObject* str = PyUnicode_AsEncodedString(swig_obj[1], "utf-8", "~E~");	
           const char* filename = PyBytes_AsString(str);
-          temp2 = new PyMFEM::wFILE(filename, 8, true);	
+          temp2 = new PyMFEM::wFILE(filename, 8, true);
+          Py_DECREF(str);	 
         }
       }
       
-      if (use_stringio2 == 0){
+      if (stream2 == 0){
         if (temp2->isSTDOUT() == 1) {
           arg2 = &std::cout;
+        } else if (temp2->isGZ()){
+          out_gz2 = new mfem::ofgzstream(temp2->getFilename(), true);
+          arg2 = out_gz2;	     
         } else {
-          out2.open(temp2->getFilename());
-          out2.precision(temp2->getPrecision());
-          if (temp2->isTemporary()){
-            delete temp2;
-          }
-          arg2 = &out2;
+          out_txt2.open(temp2->getFilename());
+          out_txt2.precision(temp2->getPrecision());
+          arg2 = &out_txt2;
+        }
+        if (temp2->isTemporary()){
+          delete temp2;
         }
       } else {
-        arg2 = &stream2;
+        arg2 = stream2;
       }
     }
   }
@@ -12560,8 +12580,8 @@ SWIGINTERN PyObject *_wrap_SparseMatrix_PrintMatlab__SWIG_0(PyObject *SWIGUNUSED
   }
   resultobj = SWIG_Py_Void();
   {
-    if (use_stringio2 == 1) {
-      std::string str =  stream2.str();
+    if (stream2) {
+      std::string str =  stream2->str();
       const char* s = str.c_str();
       const int n = str.length();
       ret2 = PyObject_CallMethod(string_io2, "write", "s#",
@@ -12570,15 +12590,21 @@ SWIGINTERN PyObject *_wrap_SparseMatrix_PrintMatlab__SWIG_0(PyObject *SWIGUNUSED
         PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
         return NULL;
       }
+      delete stream2;
       Py_XDECREF(resultobj);   /* Blow away any previous result */
       resultobj = ret2;    
     }
   }
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -12586,10 +12612,15 @@ SWIGINTERN PyObject *_wrap_SparseMatrix_PrintMatlab__SWIG_0(PyObject *SWIGUNUSED
   return resultobj;
 fail:
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -12606,10 +12637,10 @@ SWIGINTERN PyObject *_wrap_SparseMatrix_PrintMM__SWIG_0(PyObject *SWIGUNUSEDPARM
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyMFEM::wFILE *temp2 = 0 ;
-  std::ofstream out2 ;
-  int use_stringio2 = 0 ;
+  std::ofstream out_txt2 ;
+  mfem::ofgzstream *out_gz2 = 0 ;
   PyObject *string_io2 = 0 ;
-  std::ostringstream stream2 ;
+  std::ostringstream *stream2 = 0 ;
   PyObject *ret2 = 0 ;
   
   if ((nobjs < 1) || (nobjs > 2)) SWIG_fail;
@@ -12640,29 +12671,33 @@ SWIGINTERN PyObject *_wrap_SparseMatrix_PrintMM__SWIG_0(PyObject *SWIGUNUSEDPARM
             SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
             return NULL;
           }
-          use_stringio2=1;
           string_io2=swig_obj[1];
+          stream2 = new std::ostringstream();
         } else {
           // if it is string, extract filename as char*
           PyObject* str = PyUnicode_AsEncodedString(swig_obj[1], "utf-8", "~E~");	
           const char* filename = PyBytes_AsString(str);
-          temp2 = new PyMFEM::wFILE(filename, 8, true);	
+          temp2 = new PyMFEM::wFILE(filename, 8, true);
+          Py_DECREF(str);	 
         }
       }
       
-      if (use_stringio2 == 0){
+      if (stream2 == 0){
         if (temp2->isSTDOUT() == 1) {
           arg2 = &std::cout;
+        } else if (temp2->isGZ()){
+          out_gz2 = new mfem::ofgzstream(temp2->getFilename(), true);
+          arg2 = out_gz2;	     
         } else {
-          out2.open(temp2->getFilename());
-          out2.precision(temp2->getPrecision());
-          if (temp2->isTemporary()){
-            delete temp2;
-          }
-          arg2 = &out2;
+          out_txt2.open(temp2->getFilename());
+          out_txt2.precision(temp2->getPrecision());
+          arg2 = &out_txt2;
+        }
+        if (temp2->isTemporary()){
+          delete temp2;
         }
       } else {
-        arg2 = &stream2;
+        arg2 = stream2;
       }
     }
   }
@@ -12687,8 +12722,8 @@ SWIGINTERN PyObject *_wrap_SparseMatrix_PrintMM__SWIG_0(PyObject *SWIGUNUSEDPARM
   }
   resultobj = SWIG_Py_Void();
   {
-    if (use_stringio2 == 1) {
-      std::string str =  stream2.str();
+    if (stream2) {
+      std::string str =  stream2->str();
       const char* s = str.c_str();
       const int n = str.length();
       ret2 = PyObject_CallMethod(string_io2, "write", "s#",
@@ -12697,15 +12732,21 @@ SWIGINTERN PyObject *_wrap_SparseMatrix_PrintMM__SWIG_0(PyObject *SWIGUNUSEDPARM
         PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
         return NULL;
       }
+      delete stream2;
       Py_XDECREF(resultobj);   /* Blow away any previous result */
       resultobj = ret2;    
     }
   }
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -12713,10 +12754,15 @@ SWIGINTERN PyObject *_wrap_SparseMatrix_PrintMM__SWIG_0(PyObject *SWIGUNUSEDPARM
   return resultobj;
 fail:
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -12732,10 +12778,10 @@ SWIGINTERN PyObject *_wrap_SparseMatrix_PrintCSR__SWIG_0(PyObject *SWIGUNUSEDPAR
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyMFEM::wFILE *temp2 = 0 ;
-  std::ofstream out2 ;
-  int use_stringio2 = 0 ;
+  std::ofstream out_txt2 ;
+  mfem::ofgzstream *out_gz2 = 0 ;
   PyObject *string_io2 = 0 ;
-  std::ostringstream stream2 ;
+  std::ostringstream *stream2 = 0 ;
   PyObject *ret2 = 0 ;
   
   if ((nobjs < 2) || (nobjs > 2)) SWIG_fail;
@@ -12765,29 +12811,33 @@ SWIGINTERN PyObject *_wrap_SparseMatrix_PrintCSR__SWIG_0(PyObject *SWIGUNUSEDPAR
           SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
           return NULL;
         }
-        use_stringio2=1;
         string_io2=swig_obj[1];
+        stream2 = new std::ostringstream();
       } else {
         // if it is string, extract filename as char*
         PyObject* str = PyUnicode_AsEncodedString(swig_obj[1], "utf-8", "~E~");	
         const char* filename = PyBytes_AsString(str);
-        temp2 = new PyMFEM::wFILE(filename, 8, true);	
+        temp2 = new PyMFEM::wFILE(filename, 8, true);
+        Py_DECREF(str);	 
       }
     }
     
-    if (use_stringio2 == 0){
+    if (stream2 == 0){
       if (temp2->isSTDOUT() == 1) {
         arg2 = &std::cout;
+      } else if (temp2->isGZ()){
+        out_gz2 = new mfem::ofgzstream(temp2->getFilename(), true);
+        arg2 = out_gz2;	     
       } else {
-        out2.open(temp2->getFilename());
-        out2.precision(temp2->getPrecision());
-        if (temp2->isTemporary()){
-          delete temp2;
-        }
-        arg2 = &out2;
+        out_txt2.open(temp2->getFilename());
+        out_txt2.precision(temp2->getPrecision());
+        arg2 = &out_txt2;
+      }
+      if (temp2->isTemporary()){
+        delete temp2;
       }
     } else {
-      arg2 = &stream2;
+      arg2 = stream2;
     }
   }
   {
@@ -12811,8 +12861,8 @@ SWIGINTERN PyObject *_wrap_SparseMatrix_PrintCSR__SWIG_0(PyObject *SWIGUNUSEDPAR
   }
   resultobj = SWIG_Py_Void();
   {
-    if (use_stringio2 == 1) {
-      std::string str =  stream2.str();
+    if (stream2) {
+      std::string str =  stream2->str();
       const char* s = str.c_str();
       const int n = str.length();
       ret2 = PyObject_CallMethod(string_io2, "write", "s#",
@@ -12821,15 +12871,21 @@ SWIGINTERN PyObject *_wrap_SparseMatrix_PrintCSR__SWIG_0(PyObject *SWIGUNUSEDPAR
         PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
         return NULL;
       }
+      delete stream2;
       Py_XDECREF(resultobj);   /* Blow away any previous result */
       resultobj = ret2;    
     }
   }
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -12837,10 +12893,15 @@ SWIGINTERN PyObject *_wrap_SparseMatrix_PrintCSR__SWIG_0(PyObject *SWIGUNUSEDPAR
   return resultobj;
 fail:
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -12856,10 +12917,10 @@ SWIGINTERN PyObject *_wrap_SparseMatrix_PrintCSR2__SWIG_0(PyObject *SWIGUNUSEDPA
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyMFEM::wFILE *temp2 = 0 ;
-  std::ofstream out2 ;
-  int use_stringio2 = 0 ;
+  std::ofstream out_txt2 ;
+  mfem::ofgzstream *out_gz2 = 0 ;
   PyObject *string_io2 = 0 ;
-  std::ostringstream stream2 ;
+  std::ostringstream *stream2 = 0 ;
   PyObject *ret2 = 0 ;
   
   if ((nobjs < 2) || (nobjs > 2)) SWIG_fail;
@@ -12889,29 +12950,33 @@ SWIGINTERN PyObject *_wrap_SparseMatrix_PrintCSR2__SWIG_0(PyObject *SWIGUNUSEDPA
           SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
           return NULL;
         }
-        use_stringio2=1;
         string_io2=swig_obj[1];
+        stream2 = new std::ostringstream();
       } else {
         // if it is string, extract filename as char*
         PyObject* str = PyUnicode_AsEncodedString(swig_obj[1], "utf-8", "~E~");	
         const char* filename = PyBytes_AsString(str);
-        temp2 = new PyMFEM::wFILE(filename, 8, true);	
+        temp2 = new PyMFEM::wFILE(filename, 8, true);
+        Py_DECREF(str);	 
       }
     }
     
-    if (use_stringio2 == 0){
+    if (stream2 == 0){
       if (temp2->isSTDOUT() == 1) {
         arg2 = &std::cout;
+      } else if (temp2->isGZ()){
+        out_gz2 = new mfem::ofgzstream(temp2->getFilename(), true);
+        arg2 = out_gz2;	     
       } else {
-        out2.open(temp2->getFilename());
-        out2.precision(temp2->getPrecision());
-        if (temp2->isTemporary()){
-          delete temp2;
-        }
-        arg2 = &out2;
+        out_txt2.open(temp2->getFilename());
+        out_txt2.precision(temp2->getPrecision());
+        arg2 = &out_txt2;
+      }
+      if (temp2->isTemporary()){
+        delete temp2;
       }
     } else {
-      arg2 = &stream2;
+      arg2 = stream2;
     }
   }
   {
@@ -12935,8 +13000,8 @@ SWIGINTERN PyObject *_wrap_SparseMatrix_PrintCSR2__SWIG_0(PyObject *SWIGUNUSEDPA
   }
   resultobj = SWIG_Py_Void();
   {
-    if (use_stringio2 == 1) {
-      std::string str =  stream2.str();
+    if (stream2) {
+      std::string str =  stream2->str();
       const char* s = str.c_str();
       const int n = str.length();
       ret2 = PyObject_CallMethod(string_io2, "write", "s#",
@@ -12945,15 +13010,21 @@ SWIGINTERN PyObject *_wrap_SparseMatrix_PrintCSR2__SWIG_0(PyObject *SWIGUNUSEDPA
         PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
         return NULL;
       }
+      delete stream2;
       Py_XDECREF(resultobj);   /* Blow away any previous result */
       resultobj = ret2;    
     }
   }
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -12961,10 +13032,15 @@ SWIGINTERN PyObject *_wrap_SparseMatrix_PrintCSR2__SWIG_0(PyObject *SWIGUNUSEDPA
   return resultobj;
 fail:
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -12980,10 +13056,10 @@ SWIGINTERN PyObject *_wrap_SparseMatrix_PrintInfo__SWIG_0(PyObject *SWIGUNUSEDPA
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyMFEM::wFILE *temp2 = 0 ;
-  std::ofstream out2 ;
-  int use_stringio2 = 0 ;
+  std::ofstream out_txt2 ;
+  mfem::ofgzstream *out_gz2 = 0 ;
   PyObject *string_io2 = 0 ;
-  std::ostringstream stream2 ;
+  std::ostringstream *stream2 = 0 ;
   PyObject *ret2 = 0 ;
   
   if ((nobjs < 2) || (nobjs > 2)) SWIG_fail;
@@ -13013,29 +13089,33 @@ SWIGINTERN PyObject *_wrap_SparseMatrix_PrintInfo__SWIG_0(PyObject *SWIGUNUSEDPA
           SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
           return NULL;
         }
-        use_stringio2=1;
         string_io2=swig_obj[1];
+        stream2 = new std::ostringstream();
       } else {
         // if it is string, extract filename as char*
         PyObject* str = PyUnicode_AsEncodedString(swig_obj[1], "utf-8", "~E~");	
         const char* filename = PyBytes_AsString(str);
-        temp2 = new PyMFEM::wFILE(filename, 8, true);	
+        temp2 = new PyMFEM::wFILE(filename, 8, true);
+        Py_DECREF(str);	 
       }
     }
     
-    if (use_stringio2 == 0){
+    if (stream2 == 0){
       if (temp2->isSTDOUT() == 1) {
         arg2 = &std::cout;
+      } else if (temp2->isGZ()){
+        out_gz2 = new mfem::ofgzstream(temp2->getFilename(), true);
+        arg2 = out_gz2;	     
       } else {
-        out2.open(temp2->getFilename());
-        out2.precision(temp2->getPrecision());
-        if (temp2->isTemporary()){
-          delete temp2;
-        }
-        arg2 = &out2;
+        out_txt2.open(temp2->getFilename());
+        out_txt2.precision(temp2->getPrecision());
+        arg2 = &out_txt2;
+      }
+      if (temp2->isTemporary()){
+        delete temp2;
       }
     } else {
-      arg2 = &stream2;
+      arg2 = stream2;
     }
   }
   {
@@ -13059,8 +13139,8 @@ SWIGINTERN PyObject *_wrap_SparseMatrix_PrintInfo__SWIG_0(PyObject *SWIGUNUSEDPA
   }
   resultobj = SWIG_Py_Void();
   {
-    if (use_stringio2 == 1) {
-      std::string str =  stream2.str();
+    if (stream2) {
+      std::string str =  stream2->str();
       const char* s = str.c_str();
       const int n = str.length();
       ret2 = PyObject_CallMethod(string_io2, "write", "s#",
@@ -13069,15 +13149,21 @@ SWIGINTERN PyObject *_wrap_SparseMatrix_PrintInfo__SWIG_0(PyObject *SWIGUNUSEDPA
         PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
         return NULL;
       }
+      delete stream2;
       Py_XDECREF(resultobj);   /* Blow away any previous result */
       resultobj = ret2;    
     }
   }
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -13085,10 +13171,15 @@ SWIGINTERN PyObject *_wrap_SparseMatrix_PrintInfo__SWIG_0(PyObject *SWIGUNUSEDPA
   return resultobj;
 fail:
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -13932,7 +14023,8 @@ SWIGINTERN PyObject *_wrap_SparseMatrix_Print(PyObject *self, PyObject *args) {
               _v = 0;	   	   	   
             }
           } else {
-            _v = 0;
+            std::cout << "it is text (out)\n";	
+            _v = 1;
           }
         } else {
           _v = 1;
@@ -14089,7 +14181,8 @@ SWIGINTERN PyObject *_wrap_SparseMatrix_PrintMatlab(PyObject *self, PyObject *ar
               _v = 0;	   	   	   
             }
           } else {
-            _v = 0;
+            std::cout << "it is text (out)\n";	
+            _v = 1;
           }
         } else {
           _v = 1;
@@ -14233,7 +14326,8 @@ SWIGINTERN PyObject *_wrap_SparseMatrix_PrintMM(PyObject *self, PyObject *args) 
               _v = 0;	   	   	   
             }
           } else {
-            _v = 0;
+            std::cout << "it is text (out)\n";	
+            _v = 1;
           }
         } else {
           _v = 1;
@@ -14447,7 +14541,8 @@ SWIGINTERN PyObject *_wrap_SparseMatrix_PrintCSR(PyObject *self, PyObject *args)
               _v = 0;	   	   	   
             }
           } else {
-            _v = 0;
+            std::cout << "it is text (out)\n";	
+            _v = 1;
           }
         } else {
           _v = 1;
@@ -14636,7 +14731,8 @@ SWIGINTERN PyObject *_wrap_SparseMatrix_PrintCSR2(PyObject *self, PyObject *args
               _v = 0;	   	   	   
             }
           } else {
-            _v = 0;
+            std::cout << "it is text (out)\n";	
+            _v = 1;
           }
         } else {
           _v = 1;
@@ -14825,7 +14921,8 @@ SWIGINTERN PyObject *_wrap_SparseMatrix_PrintInfo(PyObject *self, PyObject *args
               _v = 0;	   	   	   
             }
           } else {
-            _v = 0;
+            std::cout << "it is text (out)\n";	
+            _v = 1;
           }
         } else {
           _v = 1;
@@ -14863,10 +14960,10 @@ SWIGINTERN PyObject *_wrap___lshift__(PyObject *SWIGUNUSEDPARM(self), PyObject *
   std::ostream *arg1 = 0 ;
   mfem::SparseMatrix *arg2 = 0 ;
   PyMFEM::wFILE *temp1 = 0 ;
-  std::ofstream out1 ;
-  int use_stringio1 = 0 ;
+  std::ofstream out_txt1 ;
+  mfem::ofgzstream *out_gz1 = 0 ;
   PyObject *string_io1 = 0 ;
-  std::ostringstream stream1 ;
+  std::ostringstream *stream1 = 0 ;
   PyObject *ret1 = 0 ;
   void *argp2 = 0 ;
   int res2 = 0 ;
@@ -14899,29 +14996,33 @@ SWIGINTERN PyObject *_wrap___lshift__(PyObject *SWIGUNUSEDPARM(self), PyObject *
           SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
           return NULL;
         }
-        use_stringio1=1;
         string_io1=obj0;
+        stream1 = new std::ostringstream();
       } else {
         // if it is string, extract filename as char*
         PyObject* str = PyUnicode_AsEncodedString(obj0, "utf-8", "~E~");	
         const char* filename = PyBytes_AsString(str);
-        temp1 = new PyMFEM::wFILE(filename, 8, true);	
+        temp1 = new PyMFEM::wFILE(filename, 8, true);
+        Py_DECREF(str);	 
       }
     }
     
-    if (use_stringio1 == 0){
+    if (stream1 == 0){
       if (temp1->isSTDOUT() == 1) {
         arg1 = &std::cout;
+      } else if (temp1->isGZ()){
+        out_gz1 = new mfem::ofgzstream(temp1->getFilename(), true);
+        arg1 = out_gz1;	     
       } else {
-        out1.open(temp1->getFilename());
-        out1.precision(temp1->getPrecision());
-        if (temp1->isTemporary()){
-          delete temp1;
-        }
-        arg1 = &out1;
+        out_txt1.open(temp1->getFilename());
+        out_txt1.precision(temp1->getPrecision());
+        arg1 = &out_txt1;
+      }
+      if (temp1->isTemporary()){
+        delete temp1;
       }
     } else {
-      arg1 = &stream1;
+      arg1 = stream1;
     }
   }
   res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_mfem__SparseMatrix,  0  | 0);
@@ -14953,8 +15054,8 @@ SWIGINTERN PyObject *_wrap___lshift__(PyObject *SWIGUNUSEDPARM(self), PyObject *
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_std__ostream, 0 |  0 );
   {
-    if (use_stringio1 == 1) {
-      std::string str =  stream1.str();
+    if (stream1) {
+      std::string str =  stream1->str();
       const char* s = str.c_str();
       const int n = str.length();
       ret1 = PyObject_CallMethod(string_io1, "write", "s#",
@@ -14963,15 +15064,21 @@ SWIGINTERN PyObject *_wrap___lshift__(PyObject *SWIGUNUSEDPARM(self), PyObject *
         PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
         return NULL;
       }
+      delete stream1;
       Py_XDECREF(resultobj);   /* Blow away any previous result */
       resultobj = ret1;    
     }
   }
   {
-    if (use_stringio1 == 0) {
+    if (!stream1) {
       if (temp1) {
         if (temp1->isSTDOUT() != 1) {
-          out1.close();
+          if (out_txt1.is_open()){
+            out_txt1.close();
+          }
+          if (out_gz1){
+            delete out_gz1;
+          }
         }
       }
     }
@@ -14979,10 +15086,15 @@ SWIGINTERN PyObject *_wrap___lshift__(PyObject *SWIGUNUSEDPARM(self), PyObject *
   return resultobj;
 fail:
   {
-    if (use_stringio1 == 0) {
+    if (!stream1) {
       if (temp1) {
         if (temp1->isSTDOUT() != 1) {
-          out1.close();
+          if (out_txt1.is_open()){
+            out_txt1.close();
+          }
+          if (out_gz1){
+            delete out_gz1;
+          }
         }
       }
     }

--- a/mfem/_ser/stable3d_wrap.cxx
+++ b/mfem/_ser/stable3d_wrap.cxx
@@ -4426,7 +4426,6 @@ SWIGINTERN PyObject *_wrap_STable3D_Print(PyObject *self, PyObject *args) {
               _v = 0;	   	   	   
             }
           } else {
-            std::cout << "it is text (out)\n";	
             _v = 1;
           }
         } else {

--- a/mfem/_ser/stable3d_wrap.cxx
+++ b/mfem/_ser/stable3d_wrap.cxx
@@ -4155,10 +4155,10 @@ SWIGINTERN PyObject *_wrap_STable3D_Print__SWIG_0(PyObject *SWIGUNUSEDPARM(self)
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyMFEM::wFILE *temp2 = 0 ;
-  std::ofstream out2 ;
-  int use_stringio2 = 0 ;
+  std::ofstream out_txt2 ;
+  mfem::ofgzstream *out_gz2 = 0 ;
   PyObject *string_io2 = 0 ;
-  std::ostringstream stream2 ;
+  std::ostringstream *stream2 = 0 ;
   PyObject *ret2 = 0 ;
   
   if ((nobjs < 1) || (nobjs > 2)) SWIG_fail;
@@ -4189,29 +4189,33 @@ SWIGINTERN PyObject *_wrap_STable3D_Print__SWIG_0(PyObject *SWIGUNUSEDPARM(self)
             SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
             return NULL;
           }
-          use_stringio2=1;
           string_io2=swig_obj[1];
+          stream2 = new std::ostringstream();
         } else {
           // if it is string, extract filename as char*
           PyObject* str = PyUnicode_AsEncodedString(swig_obj[1], "utf-8", "~E~");	
           const char* filename = PyBytes_AsString(str);
-          temp2 = new PyMFEM::wFILE(filename, 8, true);	
+          temp2 = new PyMFEM::wFILE(filename, 8, true);
+          Py_DECREF(str);	 
         }
       }
       
-      if (use_stringio2 == 0){
+      if (stream2 == 0){
         if (temp2->isSTDOUT() == 1) {
           arg2 = &std::cout;
+        } else if (temp2->isGZ()){
+          out_gz2 = new mfem::ofgzstream(temp2->getFilename(), true);
+          arg2 = out_gz2;	     
         } else {
-          out2.open(temp2->getFilename());
-          out2.precision(temp2->getPrecision());
-          if (temp2->isTemporary()){
-            delete temp2;
-          }
-          arg2 = &out2;
+          out_txt2.open(temp2->getFilename());
+          out_txt2.precision(temp2->getPrecision());
+          arg2 = &out_txt2;
+        }
+        if (temp2->isTemporary()){
+          delete temp2;
         }
       } else {
-        arg2 = &stream2;
+        arg2 = stream2;
       }
     }
   }
@@ -4236,8 +4240,8 @@ SWIGINTERN PyObject *_wrap_STable3D_Print__SWIG_0(PyObject *SWIGUNUSEDPARM(self)
   }
   resultobj = SWIG_Py_Void();
   {
-    if (use_stringio2 == 1) {
-      std::string str =  stream2.str();
+    if (stream2) {
+      std::string str =  stream2->str();
       const char* s = str.c_str();
       const int n = str.length();
       ret2 = PyObject_CallMethod(string_io2, "write", "s#",
@@ -4246,15 +4250,21 @@ SWIGINTERN PyObject *_wrap_STable3D_Print__SWIG_0(PyObject *SWIGUNUSEDPARM(self)
         PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
         return NULL;
       }
+      delete stream2;
       Py_XDECREF(resultobj);   /* Blow away any previous result */
       resultobj = ret2;    
     }
   }
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -4262,10 +4272,15 @@ SWIGINTERN PyObject *_wrap_STable3D_Print__SWIG_0(PyObject *SWIGUNUSEDPARM(self)
   return resultobj;
 fail:
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -4411,7 +4426,8 @@ SWIGINTERN PyObject *_wrap_STable3D_Print(PyObject *self, PyObject *args) {
               _v = 0;	   	   	   
             }
           } else {
-            _v = 0;
+            std::cout << "it is text (out)\n";	
+            _v = 1;
           }
         } else {
           _v = 1;

--- a/mfem/_ser/table.i
+++ b/mfem/_ser/table.i
@@ -5,6 +5,7 @@
 %{
 #include <fstream>  
 #include <iostream>
+#include "general/zstr.hpp"  
 #include "numpy/arrayobject.h"    
 #include "../common/io_stream.hpp"      
 #include "general/table.hpp"

--- a/mfem/_ser/table_wrap.cxx
+++ b/mfem/_ser/table_wrap.cxx
@@ -2670,10 +2670,9 @@ SWIGINTERN PyObject *SWIG_PyStaticMethod_New(PyObject *SWIGUNUSEDPARM(self), PyO
 #define SWIGTYPE_p_mfem__MemoryT_int_t swig_types[7]
 #define SWIGTYPE_p_mfem__STable swig_types[8]
 #define SWIGTYPE_p_mfem__Table swig_types[9]
-#define SWIGTYPE_p_std__istream swig_types[10]
-#define SWIGTYPE_p_void swig_types[11]
-static swig_type_info *swig_types[13];
-static swig_module_info swig_module = {swig_types, 12, 0, 0, 0, 0};
+#define SWIGTYPE_p_void swig_types[10]
+static swig_type_info *swig_types[12];
+static swig_module_info swig_module = {swig_types, 11, 0, 0, 0, 0};
 #define SWIG_TypeQuery(name) SWIG_TypeQueryModule(&swig_module, &swig_module, name)
 #define SWIG_MangledTypeQuery(name) SWIG_MangledTypeQueryModule(&swig_module, &swig_module, name)
 
@@ -2779,6 +2778,7 @@ namespace swig {
 
 #include <fstream>  
 #include <iostream>
+#include "general/zstr.hpp"  
 #include "numpy/arrayobject.h"    
 #include "../common/io_stream.hpp"      
 #include "general/table.hpp"
@@ -5267,10 +5267,10 @@ SWIGINTERN PyObject *_wrap_Table_Print__SWIG_0(PyObject *SWIGUNUSEDPARM(self), P
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyMFEM::wFILE *temp2 = 0 ;
-  std::ofstream out2 ;
-  int use_stringio2 = 0 ;
+  std::ofstream out_txt2 ;
+  mfem::ofgzstream *out_gz2 = 0 ;
   PyObject *string_io2 = 0 ;
-  std::ostringstream stream2 ;
+  std::ostringstream *stream2 = 0 ;
   PyObject *ret2 = 0 ;
   
   if ((nobjs < 1) || (nobjs > 3)) SWIG_fail;
@@ -5301,29 +5301,33 @@ SWIGINTERN PyObject *_wrap_Table_Print__SWIG_0(PyObject *SWIGUNUSEDPARM(self), P
             SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
             return NULL;
           }
-          use_stringio2=1;
           string_io2=swig_obj[1];
+          stream2 = new std::ostringstream();
         } else {
           // if it is string, extract filename as char*
           PyObject* str = PyUnicode_AsEncodedString(swig_obj[1], "utf-8", "~E~");	
           const char* filename = PyBytes_AsString(str);
-          temp2 = new PyMFEM::wFILE(filename, 8, true);	
+          temp2 = new PyMFEM::wFILE(filename, 8, true);
+          Py_DECREF(str);	 
         }
       }
       
-      if (use_stringio2 == 0){
+      if (stream2 == 0){
         if (temp2->isSTDOUT() == 1) {
           arg2 = &std::cout;
+        } else if (temp2->isGZ()){
+          out_gz2 = new mfem::ofgzstream(temp2->getFilename(), true);
+          arg2 = out_gz2;	     
         } else {
-          out2.open(temp2->getFilename());
-          out2.precision(temp2->getPrecision());
-          if (temp2->isTemporary()){
-            delete temp2;
-          }
-          arg2 = &out2;
+          out_txt2.open(temp2->getFilename());
+          out_txt2.precision(temp2->getPrecision());
+          arg2 = &out_txt2;
+        }
+        if (temp2->isTemporary()){
+          delete temp2;
         }
       } else {
-        arg2 = &stream2;
+        arg2 = stream2;
       }
     }
   }
@@ -5353,8 +5357,8 @@ SWIGINTERN PyObject *_wrap_Table_Print__SWIG_0(PyObject *SWIGUNUSEDPARM(self), P
   }
   resultobj = SWIG_Py_Void();
   {
-    if (use_stringio2 == 1) {
-      std::string str =  stream2.str();
+    if (stream2) {
+      std::string str =  stream2->str();
       const char* s = str.c_str();
       const int n = str.length();
       ret2 = PyObject_CallMethod(string_io2, "write", "s#",
@@ -5363,15 +5367,21 @@ SWIGINTERN PyObject *_wrap_Table_Print__SWIG_0(PyObject *SWIGUNUSEDPARM(self), P
         PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
         return NULL;
       }
+      delete stream2;
       Py_XDECREF(resultobj);   /* Blow away any previous result */
       resultobj = ret2;    
     }
   }
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -5379,10 +5389,15 @@ SWIGINTERN PyObject *_wrap_Table_Print__SWIG_0(PyObject *SWIGUNUSEDPARM(self), P
   return resultobj;
 fail:
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -5398,10 +5413,10 @@ SWIGINTERN PyObject *_wrap_Table_PrintMatlab__SWIG_0(PyObject *SWIGUNUSEDPARM(se
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyMFEM::wFILE *temp2 = 0 ;
-  std::ofstream out2 ;
-  int use_stringio2 = 0 ;
+  std::ofstream out_txt2 ;
+  mfem::ofgzstream *out_gz2 = 0 ;
   PyObject *string_io2 = 0 ;
-  std::ostringstream stream2 ;
+  std::ostringstream *stream2 = 0 ;
   PyObject *ret2 = 0 ;
   
   if ((nobjs < 2) || (nobjs > 2)) SWIG_fail;
@@ -5431,29 +5446,33 @@ SWIGINTERN PyObject *_wrap_Table_PrintMatlab__SWIG_0(PyObject *SWIGUNUSEDPARM(se
           SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
           return NULL;
         }
-        use_stringio2=1;
         string_io2=swig_obj[1];
+        stream2 = new std::ostringstream();
       } else {
         // if it is string, extract filename as char*
         PyObject* str = PyUnicode_AsEncodedString(swig_obj[1], "utf-8", "~E~");	
         const char* filename = PyBytes_AsString(str);
-        temp2 = new PyMFEM::wFILE(filename, 8, true);	
+        temp2 = new PyMFEM::wFILE(filename, 8, true);
+        Py_DECREF(str);	 
       }
     }
     
-    if (use_stringio2 == 0){
+    if (stream2 == 0){
       if (temp2->isSTDOUT() == 1) {
         arg2 = &std::cout;
+      } else if (temp2->isGZ()){
+        out_gz2 = new mfem::ofgzstream(temp2->getFilename(), true);
+        arg2 = out_gz2;	     
       } else {
-        out2.open(temp2->getFilename());
-        out2.precision(temp2->getPrecision());
-        if (temp2->isTemporary()){
-          delete temp2;
-        }
-        arg2 = &out2;
+        out_txt2.open(temp2->getFilename());
+        out_txt2.precision(temp2->getPrecision());
+        arg2 = &out_txt2;
+      }
+      if (temp2->isTemporary()){
+        delete temp2;
       }
     } else {
-      arg2 = &stream2;
+      arg2 = stream2;
     }
   }
   {
@@ -5474,8 +5493,8 @@ SWIGINTERN PyObject *_wrap_Table_PrintMatlab__SWIG_0(PyObject *SWIGUNUSEDPARM(se
   }
   resultobj = SWIG_Py_Void();
   {
-    if (use_stringio2 == 1) {
-      std::string str =  stream2.str();
+    if (stream2) {
+      std::string str =  stream2->str();
       const char* s = str.c_str();
       const int n = str.length();
       ret2 = PyObject_CallMethod(string_io2, "write", "s#",
@@ -5484,15 +5503,21 @@ SWIGINTERN PyObject *_wrap_Table_PrintMatlab__SWIG_0(PyObject *SWIGUNUSEDPARM(se
         PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
         return NULL;
       }
+      delete stream2;
       Py_XDECREF(resultobj);   /* Blow away any previous result */
       resultobj = ret2;    
     }
   }
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -5500,10 +5525,15 @@ SWIGINTERN PyObject *_wrap_Table_PrintMatlab__SWIG_0(PyObject *SWIGUNUSEDPARM(se
   return resultobj;
 fail:
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -5519,10 +5549,10 @@ SWIGINTERN PyObject *_wrap_Table_Save__SWIG_0(PyObject *SWIGUNUSEDPARM(self), Py
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyMFEM::wFILE *temp2 = 0 ;
-  std::ofstream out2 ;
-  int use_stringio2 = 0 ;
+  std::ofstream out_txt2 ;
+  mfem::ofgzstream *out_gz2 = 0 ;
   PyObject *string_io2 = 0 ;
-  std::ostringstream stream2 ;
+  std::ostringstream *stream2 = 0 ;
   PyObject *ret2 = 0 ;
   
   if ((nobjs < 2) || (nobjs > 2)) SWIG_fail;
@@ -5552,29 +5582,33 @@ SWIGINTERN PyObject *_wrap_Table_Save__SWIG_0(PyObject *SWIGUNUSEDPARM(self), Py
           SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
           return NULL;
         }
-        use_stringio2=1;
         string_io2=swig_obj[1];
+        stream2 = new std::ostringstream();
       } else {
         // if it is string, extract filename as char*
         PyObject* str = PyUnicode_AsEncodedString(swig_obj[1], "utf-8", "~E~");	
         const char* filename = PyBytes_AsString(str);
-        temp2 = new PyMFEM::wFILE(filename, 8, true);	
+        temp2 = new PyMFEM::wFILE(filename, 8, true);
+        Py_DECREF(str);	 
       }
     }
     
-    if (use_stringio2 == 0){
+    if (stream2 == 0){
       if (temp2->isSTDOUT() == 1) {
         arg2 = &std::cout;
+      } else if (temp2->isGZ()){
+        out_gz2 = new mfem::ofgzstream(temp2->getFilename(), true);
+        arg2 = out_gz2;	     
       } else {
-        out2.open(temp2->getFilename());
-        out2.precision(temp2->getPrecision());
-        if (temp2->isTemporary()){
-          delete temp2;
-        }
-        arg2 = &out2;
+        out_txt2.open(temp2->getFilename());
+        out_txt2.precision(temp2->getPrecision());
+        arg2 = &out_txt2;
+      }
+      if (temp2->isTemporary()){
+        delete temp2;
       }
     } else {
-      arg2 = &stream2;
+      arg2 = stream2;
     }
   }
   {
@@ -5595,8 +5629,8 @@ SWIGINTERN PyObject *_wrap_Table_Save__SWIG_0(PyObject *SWIGUNUSEDPARM(self), Py
   }
   resultobj = SWIG_Py_Void();
   {
-    if (use_stringio2 == 1) {
-      std::string str =  stream2.str();
+    if (stream2) {
+      std::string str =  stream2->str();
       const char* s = str.c_str();
       const int n = str.length();
       ret2 = PyObject_CallMethod(string_io2, "write", "s#",
@@ -5605,15 +5639,21 @@ SWIGINTERN PyObject *_wrap_Table_Save__SWIG_0(PyObject *SWIGUNUSEDPARM(self), Py
         PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
         return NULL;
       }
+      delete stream2;
       Py_XDECREF(resultobj);   /* Blow away any previous result */
       resultobj = ret2;    
     }
   }
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -5621,10 +5661,15 @@ SWIGINTERN PyObject *_wrap_Table_Save__SWIG_0(PyObject *SWIGUNUSEDPARM(self), Py
   return resultobj;
 fail:
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -5639,8 +5684,13 @@ SWIGINTERN PyObject *_wrap_Table_Load(PyObject *SWIGUNUSEDPARM(self), PyObject *
   std::istream *arg2 = 0 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
-  void *argp2 = 0 ;
-  int res2 = 0 ;
+  PyMFEM::wFILE *temp2 = 0 ;
+  std::ifstream in_txt2 ;
+  mfem::ifgzstream *in_gz2 = 0 ;
+  PyObject *input_str2 = 0 ;
+  std::istringstream *stream2 = 0 ;
+  Py_ssize_t len2 = 0 ;
+  PyObject *ret2 = 0 ;
   PyObject * obj0 = 0 ;
   PyObject * obj1 = 0 ;
   char * kwnames[] = {
@@ -5653,14 +5703,64 @@ SWIGINTERN PyObject *_wrap_Table_Load(PyObject *SWIGUNUSEDPARM(self), PyObject *
     SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "Table_Load" "', argument " "1"" of type '" "mfem::Table *""'"); 
   }
   arg1 = reinterpret_cast< mfem::Table * >(argp1);
-  res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_std__istream,  0 );
-  if (!SWIG_IsOK(res2)) {
-    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "Table_Load" "', argument " "2"" of type '" "std::istream &""'"); 
+  {
+    //  PyMFEM::wFILE or string argument or StringIO
+    if (SWIG_ConvertPtr(obj1, (void **) &temp2, SWIGTYPE_p_PyMFEM__wFILE, 0 | 0) == -1) {
+      if (!PyString_Check(obj1) && !PyUnicode_Check(obj1)) {
+        // not string, check if it is StringIO
+        PyObject* module = PyImport_ImportModule("io");
+        if (!module){
+          PyErr_SetString(PyExc_RuntimeError, "Can not load io module");
+          return NULL;
+        }      
+        PyObject* cls = PyObject_GetAttrString(module, "StringIO");
+        if (!cls){
+          PyErr_SetString(PyExc_RuntimeError, "Can not load StringIO");
+          return NULL;
+        }      
+        int check = PyObject_IsInstance(obj1, cls);
+        Py_DECREF(module);
+        if (! check){
+          SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
+          return NULL;
+        }
+        
+        PyObject *input_str2 = PyObject_CallMethod(obj1, "getvalue", NULL);
+        if (PyErr_Occurred()) {
+          PyErr_SetString(PyExc_RuntimeError, "Can not read from StringIO");
+          return NULL;
+        }
+        
+        char *buf = nullptr;
+        PyObject *str = PyUnicode_AsUTF8String(input_str2);	 
+        PyBytes_AsStringAndSize(str, &buf, &len2);
+        stream2 = new std::istringstream(buf);
+        Py_DECREF(str);
+        Py_DECREF(input_str2);	 
+      } else {
+        // if it is string, extract filename as char*
+        PyObject* str = PyUnicode_AsEncodedString(obj1, "utf-8", "~E~");	
+        const char* filename = PyBytes_AsString(str);
+        temp2 = new PyMFEM::wFILE(filename, 8, true);
+        Py_DECREF(str);
+      }
+    }
+    if (stream2 == 0){
+      if (temp2->isGZ()){
+        in_gz2 = new mfem::ifgzstream(temp2->getFilename());
+        arg2 = in_gz2;
+      } else {
+        in_txt2.open(temp2->getFilename(), std::ifstream::in);
+        in_txt2.precision(temp2->getPrecision());
+        arg2 = &in_txt2;
+      }
+      if (temp2->isTemporary()){
+        delete temp2;
+      }
+    } else {
+      arg2 = stream2;
+    }
   }
-  if (!argp2) {
-    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "Table_Load" "', argument " "2"" of type '" "std::istream &""'"); 
-  }
-  arg2 = reinterpret_cast< std::istream * >(argp2);
   {
     try {
       (arg1)->Load(*arg2);
@@ -5678,8 +5778,40 @@ SWIGINTERN PyObject *_wrap_Table_Load(PyObject *SWIGUNUSEDPARM(self), PyObject *
     }	 
   }
   resultobj = SWIG_Py_Void();
+  {
+    if (stream2) {
+      ret2 = PyLong_FromSsize_t(len2);
+      if (PyErr_Occurred()) {
+        PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
+        return NULL;
+      }
+      delete stream2;    
+      Py_XDECREF(resultobj);   /* Blow away any previous result */
+      resultobj = ret2;    
+    }
+  }
+  {
+    if (!stream2) {
+      if (temp2) {
+        in_txt2.close();
+      }
+      if (in_gz2){
+        delete in_gz2;
+      }
+    }  
+  }
   return resultobj;
 fail:
+  {
+    if (!stream2) {
+      if (temp2) {
+        in_txt2.close();
+      }
+      if (in_gz2){
+        delete in_gz2;
+      }
+    }  
+  }
   return NULL;
 }
 
@@ -6040,7 +6172,8 @@ SWIGINTERN PyObject *_wrap_Table_Print(PyObject *self, PyObject *args) {
               _v = 0;	   	   	   
             }
           } else {
-            _v = 0;
+            std::cout << "it is text (out)\n";	
+            _v = 1;
           }
         } else {
           _v = 1;
@@ -6217,7 +6350,8 @@ SWIGINTERN PyObject *_wrap_Table_PrintMatlab(PyObject *self, PyObject *args) {
               _v = 0;	   	   	   
             }
           } else {
-            _v = 0;
+            std::cout << "it is text (out)\n";	
+            _v = 1;
           }
         } else {
           _v = 1;
@@ -6399,7 +6533,8 @@ SWIGINTERN PyObject *_wrap_Table_Save(PyObject *self, PyObject *args) {
               _v = 0;	   	   	   
             }
           } else {
-            _v = 0;
+            std::cout << "it is text (out)\n";	
+            _v = 1;
           }
         } else {
           _v = 1;
@@ -7138,7 +7273,6 @@ static swig_type_info _swigt__p_mfem__DSTable = {"_p_mfem__DSTable", "mfem::DSTa
 static swig_type_info _swigt__p_mfem__MemoryT_int_t = {"_p_mfem__MemoryT_int_t", "mfem::Memory< int > *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_mfem__STable = {"_p_mfem__STable", "mfem::STable *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_mfem__Table = {"_p_mfem__Table", "mfem::Table *", 0, 0, (void*)0, 0};
-static swig_type_info _swigt__p_std__istream = {"_p_std__istream", "std::istream *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_void = {"_p_void", "void *", 0, 0, (void*)0, 0};
 
 static swig_type_info *swig_type_initial[] = {
@@ -7152,7 +7286,6 @@ static swig_type_info *swig_type_initial[] = {
   &_swigt__p_mfem__MemoryT_int_t,
   &_swigt__p_mfem__STable,
   &_swigt__p_mfem__Table,
-  &_swigt__p_std__istream,
   &_swigt__p_void,
 };
 
@@ -7166,7 +7299,6 @@ static swig_cast_info _swigc__p_mfem__DSTable[] = {  {&_swigt__p_mfem__DSTable, 
 static swig_cast_info _swigc__p_mfem__MemoryT_int_t[] = {  {&_swigt__p_mfem__MemoryT_int_t, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_mfem__STable[] = {  {&_swigt__p_mfem__STable, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_mfem__Table[] = {  {&_swigt__p_mfem__STable, _p_mfem__STableTo_p_mfem__Table, 0, 0},  {&_swigt__p_mfem__Table, 0, 0, 0},{0, 0, 0, 0}};
-static swig_cast_info _swigc__p_std__istream[] = {  {&_swigt__p_std__istream, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_void[] = {  {&_swigt__p_void, 0, 0, 0},{0, 0, 0, 0}};
 
 static swig_cast_info *swig_cast_initial[] = {
@@ -7180,7 +7312,6 @@ static swig_cast_info *swig_cast_initial[] = {
   _swigc__p_mfem__MemoryT_int_t,
   _swigc__p_mfem__STable,
   _swigc__p_mfem__Table,
-  _swigc__p_std__istream,
   _swigc__p_void,
 };
 

--- a/mfem/_ser/table_wrap.cxx
+++ b/mfem/_ser/table_wrap.cxx
@@ -5687,7 +5687,6 @@ SWIGINTERN PyObject *_wrap_Table_Load(PyObject *SWIGUNUSEDPARM(self), PyObject *
   PyMFEM::wFILE *temp2 = 0 ;
   std::ifstream in_txt2 ;
   mfem::ifgzstream *in_gz2 = 0 ;
-  PyObject *input_str2 = 0 ;
   std::istringstream *stream2 = 0 ;
   Py_ssize_t len2 = 0 ;
   PyObject *ret2 = 0 ;
@@ -5725,18 +5724,18 @@ SWIGINTERN PyObject *_wrap_Table_Load(PyObject *SWIGUNUSEDPARM(self), PyObject *
           return NULL;
         }
         
-        PyObject *input_str2 = PyObject_CallMethod(obj1, "getvalue", NULL);
+        PyObject *input_str = PyObject_CallMethod(obj1, "getvalue", NULL);
         if (PyErr_Occurred()) {
           PyErr_SetString(PyExc_RuntimeError, "Can not read from StringIO");
           return NULL;
         }
         
         char *buf = nullptr;
-        PyObject *str = PyUnicode_AsUTF8String(input_str2);	 
+        PyObject *str = PyUnicode_AsUTF8String(input_str);	 
         PyBytes_AsStringAndSize(str, &buf, &len2);
         stream2 = new std::istringstream(buf);
         Py_DECREF(str);
-        Py_DECREF(input_str2);	 
+        Py_DECREF(input_str);	 
       } else {
         // if it is string, extract filename as char*
         PyObject* str = PyUnicode_AsEncodedString(obj1, "utf-8", "~E~");	
@@ -6172,7 +6171,6 @@ SWIGINTERN PyObject *_wrap_Table_Print(PyObject *self, PyObject *args) {
               _v = 0;	   	   	   
             }
           } else {
-            std::cout << "it is text (out)\n";	
             _v = 1;
           }
         } else {
@@ -6350,7 +6348,6 @@ SWIGINTERN PyObject *_wrap_Table_PrintMatlab(PyObject *self, PyObject *args) {
               _v = 0;	   	   	   
             }
           } else {
-            std::cout << "it is text (out)\n";	
             _v = 1;
           }
         } else {
@@ -6533,7 +6530,6 @@ SWIGINTERN PyObject *_wrap_Table_Save(PyObject *self, PyObject *args) {
               _v = 0;	   	   	   
             }
           } else {
-            std::cout << "it is text (out)\n";	
             _v = 1;
           }
         } else {

--- a/mfem/_ser/vector.i
+++ b/mfem/_ser/vector.i
@@ -41,6 +41,7 @@ import_array();
 
 %import "../common/io_stream_typemap.i"
 OSTREAM_TYPEMAP(std::ostream&)
+ISTREAM_TYPEMAP(std::istream&)
 
 ARRAY_TO_DOUBLEARRAY_IN(double *_data)
 

--- a/mfem/_ser/vector_wrap.cxx
+++ b/mfem/_ser/vector_wrap.cxx
@@ -4326,7 +4326,6 @@ SWIGINTERN PyObject *_wrap_Vector_Load__SWIG_1(PyObject *SWIGUNUSEDPARM(self), P
   PyMFEM::wFILE *temp2 = 0 ;
   std::ifstream in_txt2 ;
   mfem::ifgzstream *in_gz2 = 0 ;
-  PyObject *input_str2 = 0 ;
   std::istringstream *stream2 = 0 ;
   Py_ssize_t len2 = 0 ;
   PyObject *ret2 = 0 ;
@@ -4359,18 +4358,18 @@ SWIGINTERN PyObject *_wrap_Vector_Load__SWIG_1(PyObject *SWIGUNUSEDPARM(self), P
           return NULL;
         }
         
-        PyObject *input_str2 = PyObject_CallMethod(swig_obj[1], "getvalue", NULL);
+        PyObject *input_str = PyObject_CallMethod(swig_obj[1], "getvalue", NULL);
         if (PyErr_Occurred()) {
           PyErr_SetString(PyExc_RuntimeError, "Can not read from StringIO");
           return NULL;
         }
         
         char *buf = nullptr;
-        PyObject *str = PyUnicode_AsUTF8String(input_str2);	 
+        PyObject *str = PyUnicode_AsUTF8String(input_str);	 
         PyBytes_AsStringAndSize(str, &buf, &len2);
         stream2 = new std::istringstream(buf);
         Py_DECREF(str);
-        Py_DECREF(input_str2);	 
+        Py_DECREF(input_str);	 
       } else {
         // if it is string, extract filename as char*
         PyObject* str = PyUnicode_AsEncodedString(swig_obj[1], "utf-8", "~E~");	
@@ -4465,7 +4464,6 @@ SWIGINTERN PyObject *_wrap_Vector_Load__SWIG_2(PyObject *SWIGUNUSEDPARM(self), P
   PyMFEM::wFILE *temp2 = 0 ;
   std::ifstream in_txt2 ;
   mfem::ifgzstream *in_gz2 = 0 ;
-  PyObject *input_str2 = 0 ;
   std::istringstream *stream2 = 0 ;
   Py_ssize_t len2 = 0 ;
   PyObject *ret2 = 0 ;
@@ -4498,18 +4496,18 @@ SWIGINTERN PyObject *_wrap_Vector_Load__SWIG_2(PyObject *SWIGUNUSEDPARM(self), P
           return NULL;
         }
         
-        PyObject *input_str2 = PyObject_CallMethod(swig_obj[1], "getvalue", NULL);
+        PyObject *input_str = PyObject_CallMethod(swig_obj[1], "getvalue", NULL);
         if (PyErr_Occurred()) {
           PyErr_SetString(PyExc_RuntimeError, "Can not read from StringIO");
           return NULL;
         }
         
         char *buf = nullptr;
-        PyObject *str = PyUnicode_AsUTF8String(input_str2);	 
+        PyObject *str = PyUnicode_AsUTF8String(input_str);	 
         PyBytes_AsStringAndSize(str, &buf, &len2);
         stream2 = new std::istringstream(buf);
         Py_DECREF(str);
-        Py_DECREF(input_str2);	 
+        Py_DECREF(input_str);	 
       } else {
         // if it is string, extract filename as char*
         PyObject* str = PyUnicode_AsEncodedString(swig_obj[1], "utf-8", "~E~");	
@@ -9468,7 +9466,6 @@ SWIGINTERN PyObject *_wrap_Vector_Print(PyObject *self, PyObject *args) {
               _v = 0;	   	   	   
             }
           } else {
-            std::cout << "it is text (out)\n";	
             _v = 1;
           }
         } else {
@@ -9690,7 +9687,6 @@ SWIGINTERN PyObject *_wrap_Vector_Print_HYPRE(PyObject *self, PyObject *args) {
               _v = 0;	   	   	   
             }
           } else {
-            std::cout << "it is text (out)\n";	
             _v = 1;
           }
         } else {

--- a/mfem/_ser/vector_wrap.cxx
+++ b/mfem/_ser/vector_wrap.cxx
@@ -2672,10 +2672,9 @@ SWIGINTERN PyObject *SWIG_PyStaticMethod_New(PyObject *SWIGUNUSEDPARM(self), PyO
 #define SWIGTYPE_p_mfem__Vector swig_types[6]
 #define SWIGTYPE_p_p_double swig_types[7]
 #define SWIGTYPE_p_p_std__istream swig_types[8]
-#define SWIGTYPE_p_std__istream swig_types[9]
-#define SWIGTYPE_p_void swig_types[10]
-static swig_type_info *swig_types[12];
-static swig_module_info swig_module = {swig_types, 11, 0, 0, 0, 0};
+#define SWIGTYPE_p_void swig_types[9]
+static swig_type_info *swig_types[11];
+static swig_module_info swig_module = {swig_types, 10, 0, 0, 0, 0};
 #define SWIG_TypeQuery(name) SWIG_TypeQueryModule(&swig_module, &swig_module, name)
 #define SWIG_MangledTypeQuery(name) SWIG_MangledTypeQueryModule(&swig_module, &swig_module, name)
 
@@ -4324,8 +4323,13 @@ SWIGINTERN PyObject *_wrap_Vector_Load__SWIG_1(PyObject *SWIGUNUSEDPARM(self), P
   int arg3 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
-  void *argp2 = 0 ;
-  int res2 = 0 ;
+  PyMFEM::wFILE *temp2 = 0 ;
+  std::ifstream in_txt2 ;
+  mfem::ifgzstream *in_gz2 = 0 ;
+  PyObject *input_str2 = 0 ;
+  std::istringstream *stream2 = 0 ;
+  Py_ssize_t len2 = 0 ;
+  PyObject *ret2 = 0 ;
   
   if ((nobjs < 3) || (nobjs > 3)) SWIG_fail;
   res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_mfem__Vector, 0 |  0 );
@@ -4333,14 +4337,64 @@ SWIGINTERN PyObject *_wrap_Vector_Load__SWIG_1(PyObject *SWIGUNUSEDPARM(self), P
     SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "Vector_Load" "', argument " "1"" of type '" "mfem::Vector *""'"); 
   }
   arg1 = reinterpret_cast< mfem::Vector * >(argp1);
-  res2 = SWIG_ConvertPtr(swig_obj[1], &argp2, SWIGTYPE_p_std__istream,  0 );
-  if (!SWIG_IsOK(res2)) {
-    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "Vector_Load" "', argument " "2"" of type '" "std::istream &""'"); 
+  {
+    //  PyMFEM::wFILE or string argument or StringIO
+    if (SWIG_ConvertPtr(swig_obj[1], (void **) &temp2, SWIGTYPE_p_PyMFEM__wFILE, 0 | 0) == -1) {
+      if (!PyString_Check(swig_obj[1]) && !PyUnicode_Check(swig_obj[1])) {
+        // not string, check if it is StringIO
+        PyObject* module = PyImport_ImportModule("io");
+        if (!module){
+          PyErr_SetString(PyExc_RuntimeError, "Can not load io module");
+          return NULL;
+        }      
+        PyObject* cls = PyObject_GetAttrString(module, "StringIO");
+        if (!cls){
+          PyErr_SetString(PyExc_RuntimeError, "Can not load StringIO");
+          return NULL;
+        }      
+        int check = PyObject_IsInstance(swig_obj[1], cls);
+        Py_DECREF(module);
+        if (! check){
+          SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
+          return NULL;
+        }
+        
+        PyObject *input_str2 = PyObject_CallMethod(swig_obj[1], "getvalue", NULL);
+        if (PyErr_Occurred()) {
+          PyErr_SetString(PyExc_RuntimeError, "Can not read from StringIO");
+          return NULL;
+        }
+        
+        char *buf = nullptr;
+        PyObject *str = PyUnicode_AsUTF8String(input_str2);	 
+        PyBytes_AsStringAndSize(str, &buf, &len2);
+        stream2 = new std::istringstream(buf);
+        Py_DECREF(str);
+        Py_DECREF(input_str2);	 
+      } else {
+        // if it is string, extract filename as char*
+        PyObject* str = PyUnicode_AsEncodedString(swig_obj[1], "utf-8", "~E~");	
+        const char* filename = PyBytes_AsString(str);
+        temp2 = new PyMFEM::wFILE(filename, 8, true);
+        Py_DECREF(str);
+      }
+    }
+    if (stream2 == 0){
+      if (temp2->isGZ()){
+        in_gz2 = new mfem::ifgzstream(temp2->getFilename());
+        arg2 = in_gz2;
+      } else {
+        in_txt2.open(temp2->getFilename(), std::ifstream::in);
+        in_txt2.precision(temp2->getPrecision());
+        arg2 = &in_txt2;
+      }
+      if (temp2->isTemporary()){
+        delete temp2;
+      }
+    } else {
+      arg2 = stream2;
+    }
   }
-  if (!argp2) {
-    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "Vector_Load" "', argument " "2"" of type '" "std::istream &""'"); 
-  }
-  arg2 = reinterpret_cast< std::istream * >(argp2);
   {
     if ((PyArray_PyIntAsInt(swig_obj[2]) == -1) && PyErr_Occurred()) {
       SWIG_exception_fail(SWIG_TypeError, "Input must be integer");
@@ -4364,8 +4418,40 @@ SWIGINTERN PyObject *_wrap_Vector_Load__SWIG_1(PyObject *SWIGUNUSEDPARM(self), P
     }	 
   }
   resultobj = SWIG_Py_Void();
+  {
+    if (stream2) {
+      ret2 = PyLong_FromSsize_t(len2);
+      if (PyErr_Occurred()) {
+        PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
+        return NULL;
+      }
+      delete stream2;    
+      Py_XDECREF(resultobj);   /* Blow away any previous result */
+      resultobj = ret2;    
+    }
+  }
+  {
+    if (!stream2) {
+      if (temp2) {
+        in_txt2.close();
+      }
+      if (in_gz2){
+        delete in_gz2;
+      }
+    }  
+  }
   return resultobj;
 fail:
+  {
+    if (!stream2) {
+      if (temp2) {
+        in_txt2.close();
+      }
+      if (in_gz2){
+        delete in_gz2;
+      }
+    }  
+  }
   return NULL;
 }
 
@@ -4376,8 +4462,13 @@ SWIGINTERN PyObject *_wrap_Vector_Load__SWIG_2(PyObject *SWIGUNUSEDPARM(self), P
   std::istream *arg2 = 0 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
-  void *argp2 = 0 ;
-  int res2 = 0 ;
+  PyMFEM::wFILE *temp2 = 0 ;
+  std::ifstream in_txt2 ;
+  mfem::ifgzstream *in_gz2 = 0 ;
+  PyObject *input_str2 = 0 ;
+  std::istringstream *stream2 = 0 ;
+  Py_ssize_t len2 = 0 ;
+  PyObject *ret2 = 0 ;
   
   if ((nobjs < 2) || (nobjs > 2)) SWIG_fail;
   res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_mfem__Vector, 0 |  0 );
@@ -4385,14 +4476,64 @@ SWIGINTERN PyObject *_wrap_Vector_Load__SWIG_2(PyObject *SWIGUNUSEDPARM(self), P
     SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "Vector_Load" "', argument " "1"" of type '" "mfem::Vector *""'"); 
   }
   arg1 = reinterpret_cast< mfem::Vector * >(argp1);
-  res2 = SWIG_ConvertPtr(swig_obj[1], &argp2, SWIGTYPE_p_std__istream,  0 );
-  if (!SWIG_IsOK(res2)) {
-    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "Vector_Load" "', argument " "2"" of type '" "std::istream &""'"); 
+  {
+    //  PyMFEM::wFILE or string argument or StringIO
+    if (SWIG_ConvertPtr(swig_obj[1], (void **) &temp2, SWIGTYPE_p_PyMFEM__wFILE, 0 | 0) == -1) {
+      if (!PyString_Check(swig_obj[1]) && !PyUnicode_Check(swig_obj[1])) {
+        // not string, check if it is StringIO
+        PyObject* module = PyImport_ImportModule("io");
+        if (!module){
+          PyErr_SetString(PyExc_RuntimeError, "Can not load io module");
+          return NULL;
+        }      
+        PyObject* cls = PyObject_GetAttrString(module, "StringIO");
+        if (!cls){
+          PyErr_SetString(PyExc_RuntimeError, "Can not load StringIO");
+          return NULL;
+        }      
+        int check = PyObject_IsInstance(swig_obj[1], cls);
+        Py_DECREF(module);
+        if (! check){
+          SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
+          return NULL;
+        }
+        
+        PyObject *input_str2 = PyObject_CallMethod(swig_obj[1], "getvalue", NULL);
+        if (PyErr_Occurred()) {
+          PyErr_SetString(PyExc_RuntimeError, "Can not read from StringIO");
+          return NULL;
+        }
+        
+        char *buf = nullptr;
+        PyObject *str = PyUnicode_AsUTF8String(input_str2);	 
+        PyBytes_AsStringAndSize(str, &buf, &len2);
+        stream2 = new std::istringstream(buf);
+        Py_DECREF(str);
+        Py_DECREF(input_str2);	 
+      } else {
+        // if it is string, extract filename as char*
+        PyObject* str = PyUnicode_AsEncodedString(swig_obj[1], "utf-8", "~E~");	
+        const char* filename = PyBytes_AsString(str);
+        temp2 = new PyMFEM::wFILE(filename, 8, true);
+        Py_DECREF(str);
+      }
+    }
+    if (stream2 == 0){
+      if (temp2->isGZ()){
+        in_gz2 = new mfem::ifgzstream(temp2->getFilename());
+        arg2 = in_gz2;
+      } else {
+        in_txt2.open(temp2->getFilename(), std::ifstream::in);
+        in_txt2.precision(temp2->getPrecision());
+        arg2 = &in_txt2;
+      }
+      if (temp2->isTemporary()){
+        delete temp2;
+      }
+    } else {
+      arg2 = stream2;
+    }
   }
-  if (!argp2) {
-    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "Vector_Load" "', argument " "2"" of type '" "std::istream &""'"); 
-  }
-  arg2 = reinterpret_cast< std::istream * >(argp2);
   {
     try {
       (arg1)->Load(*arg2);
@@ -4410,8 +4551,40 @@ SWIGINTERN PyObject *_wrap_Vector_Load__SWIG_2(PyObject *SWIGUNUSEDPARM(self), P
     }	 
   }
   resultobj = SWIG_Py_Void();
+  {
+    if (stream2) {
+      ret2 = PyLong_FromSsize_t(len2);
+      if (PyErr_Occurred()) {
+        PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
+        return NULL;
+      }
+      delete stream2;    
+      Py_XDECREF(resultobj);   /* Blow away any previous result */
+      resultobj = ret2;    
+    }
+  }
+  {
+    if (!stream2) {
+      if (temp2) {
+        in_txt2.close();
+      }
+      if (in_gz2){
+        delete in_gz2;
+      }
+    }  
+  }
   return resultobj;
 fail:
+  {
+    if (!stream2) {
+      if (temp2) {
+        in_txt2.close();
+      }
+      if (in_gz2){
+        delete in_gz2;
+      }
+    }  
+  }
   return NULL;
 }
 
@@ -4430,9 +4603,34 @@ SWIGINTERN PyObject *_wrap_Vector_Load(PyObject *self, PyObject *args) {
     int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_mfem__Vector, 0);
     _v = SWIG_CheckState(res);
     if (_v) {
-      void *vptr = 0;
-      int res = SWIG_ConvertPtr(argv[1], &vptr, SWIGTYPE_p_std__istream, SWIG_POINTER_NO_NULL);
-      _v = SWIG_CheckState(res);
+      {
+        void *ptr;
+        //std::string *ptr2 = (std::string *)0;
+        if (SWIG_ConvertPtr(argv[1], (void **) &ptr, SWIGTYPE_p_PyMFEM__wFILE, 0 |0) == -1) {
+          PyErr_Clear();
+          if (!PyString_Check(argv[1]) && !PyUnicode_Check(argv[1])) {
+            // not string
+            _v = 1;	   	
+            PyObject* module = PyImport_ImportModule("io");
+            if (!module){
+              _v = 0;	   
+            }      
+            PyObject* cls = PyObject_GetAttrString(module, "StringIO");
+            if (!cls){
+              _v = 0;	   	   
+            }      
+            int check = PyObject_IsInstance(argv[1], cls);
+            Py_DECREF(module);
+            if (! check){
+              _v = 0;	   	   	   
+            }
+          } else {
+            _v = 1;
+          }
+        } else {
+          _v = 1;
+        }
+      }
       if (_v) {
         return _wrap_Vector_Load__SWIG_2(self, argc, argv);
       }
@@ -4444,9 +4642,34 @@ SWIGINTERN PyObject *_wrap_Vector_Load(PyObject *self, PyObject *args) {
     int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_mfem__Vector, 0);
     _v = SWIG_CheckState(res);
     if (_v) {
-      void *vptr = 0;
-      int res = SWIG_ConvertPtr(argv[1], &vptr, SWIGTYPE_p_std__istream, SWIG_POINTER_NO_NULL);
-      _v = SWIG_CheckState(res);
+      {
+        void *ptr;
+        //std::string *ptr2 = (std::string *)0;
+        if (SWIG_ConvertPtr(argv[1], (void **) &ptr, SWIGTYPE_p_PyMFEM__wFILE, 0 |0) == -1) {
+          PyErr_Clear();
+          if (!PyString_Check(argv[1]) && !PyUnicode_Check(argv[1])) {
+            // not string
+            _v = 1;	   	
+            PyObject* module = PyImport_ImportModule("io");
+            if (!module){
+              _v = 0;	   
+            }      
+            PyObject* cls = PyObject_GetAttrString(module, "StringIO");
+            if (!cls){
+              _v = 0;	   	   
+            }      
+            int check = PyObject_IsInstance(argv[1], cls);
+            Py_DECREF(module);
+            if (! check){
+              _v = 0;	   	   	   
+            }
+          } else {
+            _v = 1;
+          }
+        } else {
+          _v = 1;
+        }
+      }
       if (_v) {
         {
           if ((PyArray_PyIntAsInt(argv[2]) == -1) && PyErr_Occurred()) {
@@ -7557,10 +7780,10 @@ SWIGINTERN PyObject *_wrap_Vector_Print__SWIG_0(PyObject *SWIGUNUSEDPARM(self), 
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyMFEM::wFILE *temp2 = 0 ;
-  std::ofstream out2 ;
-  int use_stringio2 = 0 ;
+  std::ofstream out_txt2 ;
+  mfem::ofgzstream *out_gz2 = 0 ;
   PyObject *string_io2 = 0 ;
-  std::ostringstream stream2 ;
+  std::ostringstream *stream2 = 0 ;
   PyObject *ret2 = 0 ;
   
   if ((nobjs < 1) || (nobjs > 3)) SWIG_fail;
@@ -7591,29 +7814,33 @@ SWIGINTERN PyObject *_wrap_Vector_Print__SWIG_0(PyObject *SWIGUNUSEDPARM(self), 
             SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
             return NULL;
           }
-          use_stringio2=1;
           string_io2=swig_obj[1];
+          stream2 = new std::ostringstream();
         } else {
           // if it is string, extract filename as char*
           PyObject* str = PyUnicode_AsEncodedString(swig_obj[1], "utf-8", "~E~");	
           const char* filename = PyBytes_AsString(str);
-          temp2 = new PyMFEM::wFILE(filename, 8, true);	
+          temp2 = new PyMFEM::wFILE(filename, 8, true);
+          Py_DECREF(str);	 
         }
       }
       
-      if (use_stringio2 == 0){
+      if (stream2 == 0){
         if (temp2->isSTDOUT() == 1) {
           arg2 = &std::cout;
+        } else if (temp2->isGZ()){
+          out_gz2 = new mfem::ofgzstream(temp2->getFilename(), true);
+          arg2 = out_gz2;	     
         } else {
-          out2.open(temp2->getFilename());
-          out2.precision(temp2->getPrecision());
-          if (temp2->isTemporary()){
-            delete temp2;
-          }
-          arg2 = &out2;
+          out_txt2.open(temp2->getFilename());
+          out_txt2.precision(temp2->getPrecision());
+          arg2 = &out_txt2;
+        }
+        if (temp2->isTemporary()){
+          delete temp2;
         }
       } else {
-        arg2 = &stream2;
+        arg2 = stream2;
       }
     }
   }
@@ -7643,8 +7870,8 @@ SWIGINTERN PyObject *_wrap_Vector_Print__SWIG_0(PyObject *SWIGUNUSEDPARM(self), 
   }
   resultobj = SWIG_Py_Void();
   {
-    if (use_stringio2 == 1) {
-      std::string str =  stream2.str();
+    if (stream2) {
+      std::string str =  stream2->str();
       const char* s = str.c_str();
       const int n = str.length();
       ret2 = PyObject_CallMethod(string_io2, "write", "s#",
@@ -7653,15 +7880,21 @@ SWIGINTERN PyObject *_wrap_Vector_Print__SWIG_0(PyObject *SWIGUNUSEDPARM(self), 
         PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
         return NULL;
       }
+      delete stream2;
       Py_XDECREF(resultobj);   /* Blow away any previous result */
       resultobj = ret2;    
     }
   }
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -7669,10 +7902,15 @@ SWIGINTERN PyObject *_wrap_Vector_Print__SWIG_0(PyObject *SWIGUNUSEDPARM(self), 
   return resultobj;
 fail:
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -7688,10 +7926,10 @@ SWIGINTERN PyObject *_wrap_Vector_Print_HYPRE__SWIG_0(PyObject *SWIGUNUSEDPARM(s
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyMFEM::wFILE *temp2 = 0 ;
-  std::ofstream out2 ;
-  int use_stringio2 = 0 ;
+  std::ofstream out_txt2 ;
+  mfem::ofgzstream *out_gz2 = 0 ;
   PyObject *string_io2 = 0 ;
-  std::ostringstream stream2 ;
+  std::ostringstream *stream2 = 0 ;
   PyObject *ret2 = 0 ;
   
   if ((nobjs < 2) || (nobjs > 2)) SWIG_fail;
@@ -7721,29 +7959,33 @@ SWIGINTERN PyObject *_wrap_Vector_Print_HYPRE__SWIG_0(PyObject *SWIGUNUSEDPARM(s
           SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
           return NULL;
         }
-        use_stringio2=1;
         string_io2=swig_obj[1];
+        stream2 = new std::ostringstream();
       } else {
         // if it is string, extract filename as char*
         PyObject* str = PyUnicode_AsEncodedString(swig_obj[1], "utf-8", "~E~");	
         const char* filename = PyBytes_AsString(str);
-        temp2 = new PyMFEM::wFILE(filename, 8, true);	
+        temp2 = new PyMFEM::wFILE(filename, 8, true);
+        Py_DECREF(str);	 
       }
     }
     
-    if (use_stringio2 == 0){
+    if (stream2 == 0){
       if (temp2->isSTDOUT() == 1) {
         arg2 = &std::cout;
+      } else if (temp2->isGZ()){
+        out_gz2 = new mfem::ofgzstream(temp2->getFilename(), true);
+        arg2 = out_gz2;	     
       } else {
-        out2.open(temp2->getFilename());
-        out2.precision(temp2->getPrecision());
-        if (temp2->isTemporary()){
-          delete temp2;
-        }
-        arg2 = &out2;
+        out_txt2.open(temp2->getFilename());
+        out_txt2.precision(temp2->getPrecision());
+        arg2 = &out_txt2;
+      }
+      if (temp2->isTemporary()){
+        delete temp2;
       }
     } else {
-      arg2 = &stream2;
+      arg2 = stream2;
     }
   }
   {
@@ -7764,8 +8006,8 @@ SWIGINTERN PyObject *_wrap_Vector_Print_HYPRE__SWIG_0(PyObject *SWIGUNUSEDPARM(s
   }
   resultobj = SWIG_Py_Void();
   {
-    if (use_stringio2 == 1) {
-      std::string str =  stream2.str();
+    if (stream2) {
+      std::string str =  stream2->str();
       const char* s = str.c_str();
       const int n = str.length();
       ret2 = PyObject_CallMethod(string_io2, "write", "s#",
@@ -7774,15 +8016,21 @@ SWIGINTERN PyObject *_wrap_Vector_Print_HYPRE__SWIG_0(PyObject *SWIGUNUSEDPARM(s
         PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
         return NULL;
       }
+      delete stream2;
       Py_XDECREF(resultobj);   /* Blow away any previous result */
       resultobj = ret2;    
     }
   }
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -7790,10 +8038,15 @@ SWIGINTERN PyObject *_wrap_Vector_Print_HYPRE__SWIG_0(PyObject *SWIGUNUSEDPARM(s
   return resultobj;
 fail:
   {
-    if (use_stringio2 == 0) {
+    if (!stream2) {
       if (temp2) {
         if (temp2->isSTDOUT() != 1) {
-          out2.close();
+          if (out_txt2.is_open()){
+            out_txt2.close();
+          }
+          if (out_gz2){
+            delete out_gz2;
+          }
         }
       }
     }
@@ -9215,7 +9468,8 @@ SWIGINTERN PyObject *_wrap_Vector_Print(PyObject *self, PyObject *args) {
               _v = 0;	   	   	   
             }
           } else {
-            _v = 0;
+            std::cout << "it is text (out)\n";	
+            _v = 1;
           }
         } else {
           _v = 1;
@@ -9436,7 +9690,8 @@ SWIGINTERN PyObject *_wrap_Vector_Print_HYPRE(PyObject *self, PyObject *args) {
               _v = 0;	   	   	   
             }
           } else {
-            _v = 0;
+            std::cout << "it is text (out)\n";	
+            _v = 1;
           }
         } else {
           _v = 1;
@@ -9933,7 +10188,6 @@ static swig_type_info _swigt__p_mfem__MemoryT_double_t = {"_p_mfem__MemoryT_doub
 static swig_type_info _swigt__p_mfem__Vector = {"_p_mfem__Vector", "mfem::Vector *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_p_double = {"_p_p_double", "double **", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_p_std__istream = {"_p_p_std__istream", "std::istream **", 0, 0, (void*)0, 0};
-static swig_type_info _swigt__p_std__istream = {"_p_std__istream", "std::istream *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_void = {"_p_void", "void *", 0, 0, (void*)0, 0};
 
 static swig_type_info *swig_type_initial[] = {
@@ -9946,7 +10200,6 @@ static swig_type_info *swig_type_initial[] = {
   &_swigt__p_mfem__Vector,
   &_swigt__p_p_double,
   &_swigt__p_p_std__istream,
-  &_swigt__p_std__istream,
   &_swigt__p_void,
 };
 
@@ -9959,7 +10212,6 @@ static swig_cast_info _swigc__p_mfem__MemoryT_double_t[] = {  {&_swigt__p_mfem__
 static swig_cast_info _swigc__p_mfem__Vector[] = {  {&_swigt__p_mfem__Vector, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_p_double[] = {  {&_swigt__p_p_double, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_p_std__istream[] = {  {&_swigt__p_p_std__istream, 0, 0, 0},{0, 0, 0, 0}};
-static swig_cast_info _swigc__p_std__istream[] = {  {&_swigt__p_std__istream, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_void[] = {  {&_swigt__p_void, 0, 0, 0},{0, 0, 0, 0}};
 
 static swig_cast_info *swig_cast_initial[] = {
@@ -9972,7 +10224,6 @@ static swig_cast_info *swig_cast_initial[] = {
   _swigc__p_mfem__Vector,
   _swigc__p_p_double,
   _swigc__p_p_std__istream,
-  _swigc__p_std__istream,
   _swigc__p_void,
 };
 

--- a/mfem/_ser/vtk_wrap.cxx
+++ b/mfem/_ser/vtk_wrap.cxx
@@ -3466,10 +3466,10 @@ SWIGINTERN PyObject *_wrap_WriteVTKEncodedCompressed(PyObject *SWIGUNUSEDPARM(se
   uint32_t arg3 ;
   int arg4 ;
   PyMFEM::wFILE *temp1 = 0 ;
-  std::ofstream out1 ;
-  int use_stringio1 = 0 ;
+  std::ofstream out_txt1 ;
+  mfem::ofgzstream *out_gz1 = 0 ;
   PyObject *string_io1 = 0 ;
-  std::ostringstream stream1 ;
+  std::ostringstream *stream1 = 0 ;
   PyObject *ret1 = 0 ;
   int res2 ;
   void *argp3 ;
@@ -3504,29 +3504,33 @@ SWIGINTERN PyObject *_wrap_WriteVTKEncodedCompressed(PyObject *SWIGUNUSEDPARM(se
           SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
           return NULL;
         }
-        use_stringio1=1;
         string_io1=obj0;
+        stream1 = new std::ostringstream();
       } else {
         // if it is string, extract filename as char*
         PyObject* str = PyUnicode_AsEncodedString(obj0, "utf-8", "~E~");	
         const char* filename = PyBytes_AsString(str);
-        temp1 = new PyMFEM::wFILE(filename, 8, true);	
+        temp1 = new PyMFEM::wFILE(filename, 8, true);
+        Py_DECREF(str);	 
       }
     }
     
-    if (use_stringio1 == 0){
+    if (stream1 == 0){
       if (temp1->isSTDOUT() == 1) {
         arg1 = &std::cout;
+      } else if (temp1->isGZ()){
+        out_gz1 = new mfem::ofgzstream(temp1->getFilename(), true);
+        arg1 = out_gz1;	     
       } else {
-        out1.open(temp1->getFilename());
-        out1.precision(temp1->getPrecision());
-        if (temp1->isTemporary()){
-          delete temp1;
-        }
-        arg1 = &out1;
+        out_txt1.open(temp1->getFilename());
+        out_txt1.precision(temp1->getPrecision());
+        arg1 = &out_txt1;
+      }
+      if (temp1->isTemporary()){
+        delete temp1;
       }
     } else {
-      arg1 = &stream1;
+      arg1 = stream1;
     }
   }
   res2 = SWIG_ConvertPtr(obj1,SWIG_as_voidptrptr(&arg2), 0, 0);
@@ -3573,8 +3577,8 @@ SWIGINTERN PyObject *_wrap_WriteVTKEncodedCompressed(PyObject *SWIGUNUSEDPARM(se
   }
   resultobj = SWIG_Py_Void();
   {
-    if (use_stringio1 == 1) {
-      std::string str =  stream1.str();
+    if (stream1) {
+      std::string str =  stream1->str();
       const char* s = str.c_str();
       const int n = str.length();
       ret1 = PyObject_CallMethod(string_io1, "write", "s#",
@@ -3583,15 +3587,21 @@ SWIGINTERN PyObject *_wrap_WriteVTKEncodedCompressed(PyObject *SWIGUNUSEDPARM(se
         PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
         return NULL;
       }
+      delete stream1;
       Py_XDECREF(resultobj);   /* Blow away any previous result */
       resultobj = ret1;    
     }
   }
   {
-    if (use_stringio1 == 0) {
+    if (!stream1) {
       if (temp1) {
         if (temp1->isSTDOUT() != 1) {
-          out1.close();
+          if (out_txt1.is_open()){
+            out_txt1.close();
+          }
+          if (out_gz1){
+            delete out_gz1;
+          }
         }
       }
     }
@@ -3599,10 +3609,15 @@ SWIGINTERN PyObject *_wrap_WriteVTKEncodedCompressed(PyObject *SWIGUNUSEDPARM(se
   return resultobj;
 fail:
   {
-    if (use_stringio1 == 0) {
+    if (!stream1) {
       if (temp1) {
         if (temp1->isSTDOUT() != 1) {
-          out1.close();
+          if (out_txt1.is_open()){
+            out_txt1.close();
+          }
+          if (out_gz1){
+            delete out_gz1;
+          }
         }
       }
     }

--- a/mfem/common/io_stream.hpp
+++ b/mfem/common/io_stream.hpp
@@ -28,6 +28,14 @@ class wFILE
        char * getFilename(void){
 	 return _filename;
        }
+       bool isGZ(void){
+         int len = strlen(_filename);
+         if ((len >= 3) && strcmp(_filename+len-3, ".gz") == 0){
+	   return true;
+	 } else {
+	   return false;
+	 }
+       }
        int getPrecision(void){
 	 return _precision;
        }

--- a/mfem/common/io_stream_typemap.i
+++ b/mfem/common/io_stream_typemap.i
@@ -1,6 +1,14 @@
+//
+//
+//  ostream
+//
+//
+
 //usage OSTREAM_TYPEMAP(std::ostream&)
 %define OSTREAM_TYPEMAP(T)
-  %typemap(in) T (PyMFEM::wFILE *temp=0, std::ofstream out, int use_stringio=0, PyObject*string_io=0, std::ostringstream stream, PyObject* ret=0){
+  %typemap(in) T (PyMFEM::wFILE *temp=0, std::ofstream out_txt, mfem::ofgzstream *out_gz=0,
+		  PyObject *string_io=0, std::ostringstream *stream=0,
+		  PyObject *ret=0){
    //  PyMFEM::wFILE or string argument or StringIO
    if (SWIG_ConvertPtr($input, (void **) &temp, $descriptor(PyMFEM::wFILE *), 0 | 0) == -1) {
       if (!PyString_Check($input) && !PyUnicode_Check($input)) {	
@@ -21,29 +29,33 @@
             SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
             return NULL;
          }
-         use_stringio=1;
 	 string_io=$input;
+	 stream = new std::ostringstream();
       } else {
  	 // if it is string, extract filename as char*
          PyObject* str = PyUnicode_AsEncodedString($input, "utf-8", "~E~");	
          const char* filename = PyBytes_AsString(str);
-         temp = new PyMFEM::wFILE(filename, 8, true);	
+         temp = new PyMFEM::wFILE(filename, 8, true);
+         Py_DECREF(str);	 
       }
    }
 
-   if (use_stringio == 0){
+   if (stream == 0){
       if (temp->isSTDOUT() == 1) {
          $1 = &std::cout;
+      } else if (temp->isGZ()){
+ 	 out_gz = new mfem::ofgzstream(temp->getFilename(), true);
+         $1 = out_gz;	     
       } else {
-         out.open(temp->getFilename());
-         out.precision(temp->getPrecision());
-         if (temp->isTemporary()){
-            delete temp;
-         }
-         $1 = &out;
+         out_txt.open(temp->getFilename());
+         out_txt.precision(temp->getPrecision());
+         $1 = &out_txt;
+      }
+      if (temp->isTemporary()){
+         delete temp;
       }
    } else {
-      $1 = &stream;
+      $1 = stream;
    }
 }
 
@@ -69,7 +81,7 @@
              $1 = 0;	   	   	   
          }
       } else {
-        $1 = 0;
+        $1 = 1;
       }
     } else {
         $1 = 1;
@@ -77,18 +89,23 @@
 }
 
 %typemap(freearg) T {
-  if (use_stringio$argnum == 0) {  
+  if (!stream$argnum) {  
      if (temp$argnum) {
          if (temp$argnum->isSTDOUT() != 1) {
-            out$argnum.close();
+	   if (out_txt$argnum.is_open()){
+	     out_txt$argnum.close();
+	   }
+	   if (out_gz$argnum){
+	     delete out_gz$argnum;
+	   }
          }
      }
   }
  }
 
 %typemap(argout) T {
-  if (use_stringio$argnum == 1) {  
-    std::string str =  stream$argnum.str();
+  if (stream$argnum) {  
+    std::string str =  stream$argnum->str();
     const char* s = str.c_str();
     const int n = str.length();
     ret$argnum = PyObject_CallMethod(string_io$argnum, "write", "s#",
@@ -97,6 +114,7 @@
        PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
        return NULL;
     }
+    delete stream$argnum;
     Py_XDECREF($result);   /* Blow away any previous result */
     $result = ret$argnum;    
   }
@@ -140,4 +158,124 @@ void method(const char *file, int precision=8){
 };
 %enddef
 
+//
+//
+//  istream
+//
+//
+//usage ISTREAM_TYPEMAP(std::istream&)
+%define ISTREAM_TYPEMAP(T)
+  %typemap(in) T (PyMFEM::wFILE *temp=0, std::ifstream in_txt, mfem::ifgzstream *in_gz=0,
+		  std::istringstream *stream=0, Py_ssize_t len = 0, PyObject* ret=0){
+   //  PyMFEM::wFILE or string argument or StringIO
+   if (SWIG_ConvertPtr($input, (void **) &temp, $descriptor(PyMFEM::wFILE *), 0 | 0) == -1) {
+      if (!PyString_Check($input) && !PyUnicode_Check($input)) {	
+ 	 // not string, check if it is StringIO
+         PyObject* module = PyImport_ImportModule("io");
+         if (!module){
+             PyErr_SetString(PyExc_RuntimeError, "Can not load io module");
+             return NULL;
+         }      
+         PyObject* cls = PyObject_GetAttrString(module, "StringIO");
+         if (!cls){
+             PyErr_SetString(PyExc_RuntimeError, "Can not load StringIO");
+             return NULL;
+         }      
+         int check = PyObject_IsInstance($input, cls);
+         Py_DECREF(module);
+         if (! check){
+            SWIG_exception(SWIG_ValueError,"First argument must be string/wFILE/IOString");
+            return NULL;
+         }
+
+	 PyObject *input_str = PyObject_CallMethod($input, "getvalue", NULL);
+         if (PyErr_Occurred()) {
+             PyErr_SetString(PyExc_RuntimeError, "Can not read from StringIO");
+	     return NULL;
+         }
+	 
+         char *buf = nullptr;
+         PyObject *str = PyUnicode_AsUTF8String(input_str);	 
+         PyBytes_AsStringAndSize(str, &buf, &len);
+         stream = new std::istringstream(buf);
+         Py_DECREF(str);
+         Py_DECREF(input_str);	 
+      } else {
+ 	 // if it is string, extract filename as char*
+         PyObject* str = PyUnicode_AsEncodedString($input, "utf-8", "~E~");	
+         const char* filename = PyBytes_AsString(str);
+         temp = new PyMFEM::wFILE(filename, 8, true);
+         Py_DECREF(str);
+      }
+   }
+   if (stream == 0){
+      if (temp->isGZ()){
+  	 in_gz = new mfem::ifgzstream(temp->getFilename());
+         $1 = in_gz;
+      } else {
+  	 in_txt.open(temp->getFilename(), std::ifstream::in);
+         in_txt.precision(temp->getPrecision());
+         $1 = &in_txt;
+      }
+      if (temp->isTemporary()){
+         delete temp;
+      }
+   } else {
+      $1 = stream;
+   }
+}
+
+%typemap(typecheck, precedence=SWIG_TYPECHECK_STRING_ARRAY) T {
+  void *ptr;
+  //std::string *ptr2 = (std::string *)0;
+  if (SWIG_ConvertPtr($input, (void **) &ptr, $descriptor(PyMFEM::wFILE *), 0 |0) == -1) {
+      PyErr_Clear();
+      if (!PyString_Check($input) && !PyUnicode_Check($input)) {	
+ 	 // not string
+         $1 = 1;	   	
+         PyObject* module = PyImport_ImportModule("io");
+         if (!module){
+           $1 = 0;	   
+         }      
+         PyObject* cls = PyObject_GetAttrString(module, "StringIO");
+         if (!cls){
+           $1 = 0;	   	   
+         }      
+         int check = PyObject_IsInstance($input, cls);
+         Py_DECREF(module);
+         if (! check){
+             $1 = 0;	   	   	   
+         }
+      } else {
+        $1 = 1;
+      }
+    } else {
+        $1 = 1;
+    }
+}
+
+%typemap(freearg) T {
+  if (!stream$argnum) {    
+     if (temp$argnum) {
+         in_txt$argnum.close();
+     }
+     if (in_gz$argnum){
+        delete in_gz$argnum;
+     }
+  }  
+ }
+
+%typemap(argout) T {
+  if (stream$argnum) {  
+    ret$argnum = PyLong_FromSsize_t(len$argnum);
+    if (PyErr_Occurred()) {
+       PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
+       return NULL;
+    }
+    delete stream$argnum;    
+    Py_XDECREF($result);   /* Blow away any previous result */
+    $result = ret$argnum;    
+  }
+}
+%enddef
 

--- a/mfem/par.py
+++ b/mfem/par.py
@@ -64,6 +64,8 @@ from  mfem._par.pnonlinearform import *
 from  mfem._par.pgridfunc import *
 from  mfem._par.hypre import *
 from  mfem._par.stable3d import *
+from  mfem._par.vtk import *
+from  mfem._par.datacollection import *
 from  mfem._par.io_stream import wFILE, STDOUT
 
 import mfem._par.array as array

--- a/mfem/ser.py
+++ b/mfem/ser.py
@@ -47,6 +47,8 @@ from  mfem._ser.element import *
 from  mfem._ser.nonlininteg import *
 from  mfem._ser.nonlinearform import *
 from  mfem._ser.stable3d import *
+#from  mfem._ser.vtk import *
+#from  mfem._ser.datacollection import *
 from  mfem._ser.io_stream import wFILE, STDOUT
 
 

--- a/mfem/ser.py
+++ b/mfem/ser.py
@@ -47,8 +47,8 @@ from  mfem._ser.element import *
 from  mfem._ser.nonlininteg import *
 from  mfem._ser.nonlinearform import *
 from  mfem._ser.stable3d import *
-#from  mfem._ser.vtk import *
-#from  mfem._ser.datacollection import *
+from  mfem._ser.vtk import *
+from  mfem._ser.datacollection import *
 from  mfem._ser.io_stream import wFILE, STDOUT
 
 

--- a/setup.py
+++ b/setup.py
@@ -393,6 +393,7 @@ def cmake_make_mfem(serial=True):
                   'DMFEM_ENABLE_EXAMPLES': '1',
                   'DMFEM_ENABLE_MINIAPPS': '1',
                   'DCMAKE_SHARED_LINKER_FLAGS': '',
+                  'DMFEM_USE_ZLIB': '1',
                   'DCMAKE_CXX_FLAGS': cxx11_flag}
 
     if serial:

--- a/test/test_gz.py
+++ b/test/test_gz.py
@@ -58,6 +58,12 @@ def run_test():
     gf2.Load("out_test_gz.dat", gf.Size())
     odata2 = gf2.GetDataArray().copy()
     check(odata, odata2, ".dat file does not agree with original")
+
+    gf.Print("out_test_gz.dat.gz")
+    gf2.Load("out_test_gz.dat.gz", gf.Size())
+    odata2 = gf2.GetDataArray().copy()
+    check(odata, odata2, ".dat file does not agree with original")
+    
     
     c = mfem.ConstantCoefficient(2.0)
     gf.ProjectCoefficient(c)

--- a/test/test_gz.py
+++ b/test/test_gz.py
@@ -1,0 +1,96 @@
+from __future__ import print_function
+import os
+from os.path import expanduser, join
+import sys
+import numpy as np
+import io
+from mfem import path as mfem_path
+
+if len(sys.argv) > 1 and sys.argv[1] == '-p':   
+    import mfem.par as mfem
+    use_parallel = True
+    from mfem.common.mpi_debug import nicePrint as print
+    from mpi4py import MPI
+    myid  = MPI.COMM_WORLD.rank
+    
+else:
+    import mfem.ser as mfem
+    use_parallel = False
+    myid = 0
+
+def check(a, b, msg):
+    assert len(a) == len(b), msg
+    assert np.sum(np.abs(a-b)) == 0, msg
+    
+def check_mesh(m1, m2, msg):
+    assert m1.GetNE() == m2.GetNE(), msg
+    assert m1.GetNBE() == m2.GetNBE(), msg    
+    assert m1.GetNV() == m2.GetNV(), msg    
+    
+def run_test():
+    #meshfile = expanduser(join(mfem_path, 'data', 'semi_circle.mesh'))
+    meshfile = "../data/amr-quad.mesh"
+    mesh = mfem.Mesh(meshfile, 1, 1)
+    dim = mesh.Dimension()
+    sdim = mesh.SpaceDimension()    
+    fec = mfem.H1_FECollection(1, dim)
+    fespace = mfem.FiniteElementSpace(mesh, fec, 1)
+    print('Number of finite element unknowns: '+
+          str(fespace.GetTrueVSize()))
+    
+    c = mfem.ConstantCoefficient(1.0)
+    gf = mfem.GridFunction(fespace)
+    gf.ProjectCoefficient(c)
+
+    odata = gf.GetDataArray().copy()
+
+    gf.Save("out_test_gz.gf")
+    gf2 = mfem.GridFunction(mesh, "out_test_gz.gf")
+    odata2 = gf2.GetDataArray().copy()
+    check(odata, odata2, "text file does not agree with original")
+    
+    gf.Save("out_test_gz.gz")
+    gf2 = mfem.GridFunction(mesh, "out_test_gz.gz")
+    odata2 = gf2.GetDataArray().copy()
+    check(odata, odata2, ".gz file does not agree with original")
+    
+    gf.Print("out_test_gz.dat")
+    gf2.Load("out_test_gz.dat", gf.Size())
+    odata2 = gf2.GetDataArray().copy()
+    check(odata, odata2, ".dat file does not agree with original")
+    
+    c = mfem.ConstantCoefficient(2.0)
+    gf.ProjectCoefficient(c)
+    odata = gf.GetDataArray().copy()
+    
+    o = io.StringIO()    
+    gf.Print(o)
+    gf2.Load(o, gf.Size())
+    odata2 = gf2.GetDataArray().copy()
+    check(odata, odata2, "StringIO does not agree with original")
+ 
+    print("GridFunction .gf, .gz .dat and StringIO agree with original")   
+
+    mesh2 = mfem.Mesh()
+    mesh.Print("out_test_gz.mesh")
+    mesh2.Load("out_test_gz.mesh")
+    check_mesh(mesh, mesh2, ".mesh does not agree with original")    
+
+    mesh2 = mfem.Mesh()    
+    mesh.Print("out_test_gz.mesh.gz")
+    mesh2.Load("out_test_gz.mesh.gz")
+
+    check_mesh(mesh, mesh2, ".mesh.gz does not agree with original")
+
+    o = io.StringIO()        
+    mesh2 = mfem.Mesh()    
+    mesh.Print(o)
+    mesh2.Load(o)
+    check_mesh(mesh, mesh2, ".mesh.gz does not agree with original")    
+    
+    print("Mesh .mesh, .mesh.gz and StringIO agree with original")   
+
+    print("PASSED")
+
+if __name__=='__main__':
+    run_test()


### PR DESCRIPTION
Pull request following the discussion in https://github.com/mfem/PyMFEM/issues/74.
This pull expand the former update of std::ostream & wrapping to include compressed file. It also apply a similar wrapping approach for std::istream &

1)   Support the filename ends with .gz to create compresed file. This requires MFEM to be built with USE_MFEM_ZLIB. Default (inside setup.py) build script is modified to use this option
```
    gf.Save("out_test_gz.gz")
    gf2 = mfem.GridFunction(mesh, "out_test_gz.gz")
    
    gf.Print("out_test_gz.dat.gz")      # using method inherited from Vector
    gf2.Load("out_test_gz.dat.gz", gf.Size())   # using method inherited from Vector

    mesh.Print("out_test_gz.mesh.gz")
    mesh2.Load("out_test_gz.mesh.gz")
```

2) StringIO can be used to pass data in-memory.
```
    o = io.StringIO()        
    mesh2 = mfem.Mesh()    
    mesh.Print(o)
    mesh2.Load(o)
```
3) DataCollection and VTK is loaded in mfem.ser and mfem.par namespace when importing mfem.
This eliminates the need to load classes manually from underlining python modules.
```
   pd = mfem.ParaViewDataCollection("Example9", mesh)
   pd.SetPrefixPath("ParaView");
   pd.RegisterField("solution", u);
   pd.SetLevelsOfDetail(order);
   pd.SetDataFormat(mfem.VTKFormat_BINARY)
   pd.SetHighOrderOutput(True)
   pd.SetCycle(0)
   pd.SetTime(0.0)
   pd.Save()
```