### PR TITLE
Suppoting Numba compiled Python routine in Function Coefficient 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,7 @@ on:
     branches: [ test ]
   pull_request:
     branches: [ test ]
-    types: [opened]
+    types: [synchronize]
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 [![badge](https://github.com/GLVis/pyglvis/blob/master/examples/ex1.svg "MFEM's Example 1")](https://mybinder.org/v2/gh/GLVis/pyglvis/HEAD?filepath=examples%2Fex1.ipynb)
 [![badge](https://github.com/GLVis/pyglvis/blob/master/examples/ex9.svg "MFEM's Example 9")](https://mybinder.org/v2/gh/GLVis/pyglvis/HEAD?filepath=examples%2Fex9.ipynb)
 
-#  PyMFEM (MFEM Python wrapper)
+#  MFEM + PyMFEM (FEM library)
 
-This package (PyMFEM) is Python wrapper for the MFEM high performance parallel finite element method library.(http://mfem.org/).
+This package provides MFEM and its Python wrapper (PyMFEM). MFEM is a high performance parallel finite element method (FEM) library (http://mfem.org/).
 
 Installer downloads a couple of external libraries and build them.
 By default, "pip install mfem" downloads and builds the serial version of MFEM and PyMFEM.

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -1,4 +1,8 @@
 	<<<  Change Log. >>>
+2021 05.11
+        * NumbaFunction, VectorNumbaFunction, and MatrixNumbaFunction is added
+	  to use Numba JITed python code for mfem function coefficients.
+
 2021 05.07
         * vtk.py and datacollection.py was loaded in mfem.ser and mfem.par namespace properly
 	* istream& wrapping was improved in the same way as ostream&

--- a/docs/manual.txt
+++ b/docs/manual.txt
@@ -310,7 +310,11 @@ to find more details of the MFEM library.
 
               # Assigning (copy) from NumPy array
 	      m = DenseMatrix(3,3)
-	      m.Assign(np.arange(9.).reshape(3,3))
+	      m.Assign(np.arange(9.).reshape(3,3))  # <-- In this case,
+	                                            #     wrapper automatically tranpose
+	                                            #     input matrix so that data is
+						    #     column order. The same is done
+						    #     in GetDataArray()
 	      
               x = DenseTensor(2, 3, 5)
 	      x.Assign(1) # set all 1

--- a/docs/manual.txt
+++ b/docs/manual.txt
@@ -117,6 +117,21 @@ to find more details of the MFEM library.
           Note: the argument is first tested if it can be converted using
 	        np.array(x,  dtype=float)
 
+
+       Using Numba JIT functions for FunctionCoefficients is supported.
+       For example, to use Numba compiled function, one can use
+       GenerateCoefficient mehtod in NumberFunction class as follows.
+
+       >>> from numba import cfunc, carray
+       >>> from mfem.coefficient import scalar_sig
+       >>> sdim = mesh.SpaceDimension()
+       >>> vdim = mesh.Dimension()
+       >>> @cfunc(scalar_sig)
+           def s_func(ptx, sdim):
+           ...    return 2*ptx[0]
+       >>> c = NumbaFunction(s_func, sdim).GenerateCoefficient()
+
+
   4-3) mfem::GridFunction
        GetNodalValues(i) will perform GetNodalValue(Vector(), i) and
        return NumPy array of Vector()

--- a/mfem/_par/coefficient.i
+++ b/mfem/_par/coefficient.i
@@ -151,6 +151,7 @@ namespace mfem {
 }
 
 %include "../../headers/coefficient.hpp"
+%include "../common/numba_coefficient.i"
 
 %feature("director") mfem::VectorPyCoefficientBase;
 %feature("director") mfem::PyCoefficientBase;

--- a/mfem/_par/coefficient.py
+++ b/mfem/_par/coefficient.py
@@ -2005,24 +2005,29 @@ class MatrixNumbaFunction(object):
 _coefficient.MatrixNumbaFunction_swigregister(MatrixNumbaFunction)
 
 
-from numba import cfunc, types, carray
-scalar_sig = types.double(types.CPointer(types.double),
+try:
+    from numba import cfunc, types, carray
+    scalar_sig = types.double(types.CPointer(types.double),
 			  types.intc)
-scalar_sig_t = types.double(types.CPointer(types.double),
+    scalar_sig_t = types.double(types.CPointer(types.double),
 			    types.double,
 			    types.intc)
-vector_sig = types.void(types.CPointer(types.double),
+    vector_sig = types.void(types.CPointer(types.double),
 			types.CPointer(types.double),
 			types.intc,
 			types.intc)
-vector_sig_t = types.void(types.CPointer(types.double),
+    vector_sig_t = types.void(types.CPointer(types.double),
 			  types.double,
                           types.CPointer(types.double),
 			  types.intc,
 			  types.intc)
 
-matrix_scalar = vector_sig
-matrix_scalar_t = vector_sig_t
+    matrix_scalar = vector_sig
+    matrix_scalar_t = vector_sig_t
+except ImportError:
+    pass
+except BaseError:
+    assert False, "Failed setting Numba signatures by an error other than ImportError"
 
 
 def fake_func(x):

--- a/mfem/_par/coefficient.py
+++ b/mfem/_par/coefficient.py
@@ -2022,8 +2022,8 @@ try:
 			  types.intc,
 			  types.intc)
 
-    matrix_scalar = vector_sig
-    matrix_scalar_t = vector_sig_t
+    matrix_sig = vector_sig
+    matrix_sig_t = vector_sig_t
 except ImportError:
     pass
 except BaseError:

--- a/mfem/_par/coefficient.py
+++ b/mfem/_par/coefficient.py
@@ -1874,6 +1874,156 @@ def ComputeGlobalLpNorm(*args):
     """
     return _coefficient.ComputeGlobalLpNorm(*args)
 ComputeGlobalLpNorm = _coefficient.ComputeGlobalLpNorm
+class NumbaFunctionBase(object):
+    r"""Proxy of C++ NumbaFunctionBase class."""
+
+    thisown = property(lambda x: x.this.own(), lambda x, v: x.this.own(v), doc="The membership flag")
+    __repr__ = _swig_repr
+
+    def __init__(self, input, sdim, td):
+        r"""__init__(NumbaFunctionBase self, PyObject * input, int sdim, bool td) -> NumbaFunctionBase"""
+        _coefficient.NumbaFunctionBase_swiginit(self, _coefficient.new_NumbaFunctionBase(input, sdim, td))
+
+    def print_add(self):
+        r"""print_add(NumbaFunctionBase self) -> double"""
+        return _coefficient.NumbaFunctionBase_print_add(self)
+    print_add = _swig_new_instance_method(_coefficient.NumbaFunctionBase_print_add)
+    __swig_destroy__ = _coefficient.delete_NumbaFunctionBase
+
+# Register NumbaFunctionBase in _coefficient:
+_coefficient.NumbaFunctionBase_swigregister(NumbaFunctionBase)
+
+class NumbaFunction(NumbaFunctionBase):
+    r"""Proxy of C++ NumbaFunction class."""
+
+    thisown = property(lambda x: x.this.own(), lambda x, v: x.this.own(v), doc="The membership flag")
+    __repr__ = _swig_repr
+
+    def __init__(self, *args):
+        r"""
+        __init__(NumbaFunction self, PyObject * input, int sdim) -> NumbaFunction
+        __init__(NumbaFunction self, PyObject * input, int sdim, bool td) -> NumbaFunction
+        """
+        _coefficient.NumbaFunction_swiginit(self, _coefficient.new_NumbaFunction(*args))
+
+    def call(self, x):
+        r"""call(NumbaFunction self, Vector x) -> double"""
+        return _coefficient.NumbaFunction_call(self, x)
+    call = _swig_new_instance_method(_coefficient.NumbaFunction_call)
+
+    def callt(self, x, t):
+        r"""callt(NumbaFunction self, Vector x, double t) -> double"""
+        return _coefficient.NumbaFunction_callt(self, x, t)
+    callt = _swig_new_instance_method(_coefficient.NumbaFunction_callt)
+
+    def GenerateCoefficient(self):
+        r"""GenerateCoefficient(NumbaFunction self) -> FunctionCoefficient"""
+        val = _coefficient.NumbaFunction_GenerateCoefficient(self)
+
+        val._link = self
+
+
+        return val
+
+    __swig_destroy__ = _coefficient.delete_NumbaFunction
+
+# Register NumbaFunction in _coefficient:
+_coefficient.NumbaFunction_swigregister(NumbaFunction)
+
+class VectorNumbaFunction(NumbaFunctionBase):
+    r"""Proxy of C++ VectorNumbaFunction class."""
+
+    thisown = property(lambda x: x.this.own(), lambda x, v: x.this.own(v), doc="The membership flag")
+    __repr__ = _swig_repr
+
+    def __init__(self, *args):
+        r"""
+        __init__(VectorNumbaFunction self, PyObject * input, int sdim, int vdim) -> VectorNumbaFunction
+        __init__(VectorNumbaFunction self, PyObject * input, int sdim, int vdim, bool td) -> VectorNumbaFunction
+        """
+        _coefficient.VectorNumbaFunction_swiginit(self, _coefficient.new_VectorNumbaFunction(*args))
+
+    def call(self, x, out):
+        r"""call(VectorNumbaFunction self, Vector x, Vector out)"""
+        return _coefficient.VectorNumbaFunction_call(self, x, out)
+    call = _swig_new_instance_method(_coefficient.VectorNumbaFunction_call)
+
+    def callt(self, x, t, out):
+        r"""callt(VectorNumbaFunction self, Vector x, double t, Vector out)"""
+        return _coefficient.VectorNumbaFunction_callt(self, x, t, out)
+    callt = _swig_new_instance_method(_coefficient.VectorNumbaFunction_callt)
+
+    def GenerateCoefficient(self):
+        r"""GenerateCoefficient(VectorNumbaFunction self) -> VectorFunctionCoefficient"""
+        val = _coefficient.VectorNumbaFunction_GenerateCoefficient(self)
+
+        val._link = self
+
+
+        return val
+
+    __swig_destroy__ = _coefficient.delete_VectorNumbaFunction
+
+# Register VectorNumbaFunction in _coefficient:
+_coefficient.VectorNumbaFunction_swigregister(VectorNumbaFunction)
+
+class MatrixNumbaFunction(object):
+    r"""Proxy of C++ MatrixNumbaFunction class."""
+
+    thisown = property(lambda x: x.this.own(), lambda x, v: x.this.own(v), doc="The membership flag")
+    __repr__ = _swig_repr
+
+    def __init__(self, *args):
+        r"""
+        __init__(MatrixNumbaFunction self, PyObject * input, int sdim, int vdim) -> MatrixNumbaFunction
+        __init__(MatrixNumbaFunction self, PyObject * input, int sdim, int vdim, bool td) -> MatrixNumbaFunction
+        """
+        _coefficient.MatrixNumbaFunction_swiginit(self, _coefficient.new_MatrixNumbaFunction(*args))
+
+    def call(self, x, out):
+        r"""call(MatrixNumbaFunction self, Vector x, DenseMatrix out)"""
+        return _coefficient.MatrixNumbaFunction_call(self, x, out)
+    call = _swig_new_instance_method(_coefficient.MatrixNumbaFunction_call)
+
+    def callt(self, x, t, out):
+        r"""callt(MatrixNumbaFunction self, Vector x, double t, DenseMatrix out)"""
+        return _coefficient.MatrixNumbaFunction_callt(self, x, t, out)
+    callt = _swig_new_instance_method(_coefficient.MatrixNumbaFunction_callt)
+
+    def GenerateCoefficient(self):
+        r"""GenerateCoefficient(MatrixNumbaFunction self) -> MatrixFunctionCoefficient"""
+        val = _coefficient.MatrixNumbaFunction_GenerateCoefficient(self)
+
+        val._link = self
+
+
+        return val
+
+    __swig_destroy__ = _coefficient.delete_MatrixNumbaFunction
+
+# Register MatrixNumbaFunction in _coefficient:
+_coefficient.MatrixNumbaFunction_swigregister(MatrixNumbaFunction)
+
+
+from numba import cfunc, types, carray
+scalar_sig = types.double(types.CPointer(types.double),
+			  types.intc)
+scalar_sig_t = types.double(types.CPointer(types.double),
+			    types.double,
+			    types.intc)
+vector_sig = types.void(types.CPointer(types.double),
+			types.CPointer(types.double),
+			types.intc,
+			types.intc)
+vector_sig_t = types.void(types.CPointer(types.double),
+			  types.double,
+                          types.CPointer(types.double),
+			  types.intc,
+			  types.intc)
+
+matrix_scalar = vector_sig
+matrix_scalar_t = vector_sig_t
+
 
 def fake_func(x):
     r"""fake_func(Vector x) -> double"""

--- a/mfem/_par/coefficient_wrap.cxx
+++ b/mfem/_par/coefficient_wrap.cxx
@@ -3097,98 +3097,102 @@ namespace Swig {
 
 /* -------- TYPES TABLE (BEGIN) -------- */
 
-#define SWIGTYPE_p_PyMFEM__wFILE swig_types[0]
-#define SWIGTYPE_p_char swig_types[1]
-#define SWIGTYPE_p_double swig_types[2]
-#define SWIGTYPE_p_f_double__double swig_types[3]
-#define SWIGTYPE_p_f_double_double__double swig_types[4]
-#define SWIGTYPE_p_f_r_mfem__Vector__double swig_types[5]
-#define SWIGTYPE_p_f_r_mfem__Vector_double__double swig_types[6]
-#define SWIGTYPE_p_mfem__ArrayT_int_t swig_types[7]
-#define SWIGTYPE_p_mfem__Coefficient swig_types[8]
-#define SWIGTYPE_p_mfem__ConstantCoefficient swig_types[9]
-#define SWIGTYPE_p_mfem__CrossCrossCoefficient swig_types[10]
-#define SWIGTYPE_p_mfem__CurlGridFunctionCoefficient swig_types[11]
-#define SWIGTYPE_p_mfem__DeltaCoefficient swig_types[12]
-#define SWIGTYPE_p_mfem__DenseMatrix swig_types[13]
-#define SWIGTYPE_p_mfem__DeterminantCoefficient swig_types[14]
-#define SWIGTYPE_p_mfem__DivergenceGridFunctionCoefficient swig_types[15]
-#define SWIGTYPE_p_mfem__ElementTransformation swig_types[16]
-#define SWIGTYPE_p_mfem__FaceElementTransformations swig_types[17]
-#define SWIGTYPE_p_mfem__FunctionCoefficient swig_types[18]
-#define SWIGTYPE_p_mfem__GradientGridFunctionCoefficient swig_types[19]
-#define SWIGTYPE_p_mfem__GridFunction swig_types[20]
-#define SWIGTYPE_p_mfem__GridFunctionCoefficient swig_types[21]
-#define SWIGTYPE_p_mfem__IdentityMatrixCoefficient swig_types[22]
-#define SWIGTYPE_p_mfem__InnerProductCoefficient swig_types[23]
-#define SWIGTYPE_p_mfem__IntegrationPoint swig_types[24]
-#define SWIGTYPE_p_mfem__IntegrationRule swig_types[25]
-#define SWIGTYPE_p_mfem__InverseMatrixCoefficient swig_types[26]
-#define SWIGTYPE_p_mfem__IsoparametricTransformation swig_types[27]
-#define SWIGTYPE_p_mfem__MatrixArrayCoefficient swig_types[28]
-#define SWIGTYPE_p_mfem__MatrixCoefficient swig_types[29]
-#define SWIGTYPE_p_mfem__MatrixConstantCoefficient swig_types[30]
-#define SWIGTYPE_p_mfem__MatrixFunctionCoefficient swig_types[31]
-#define SWIGTYPE_p_mfem__MatrixPyCoefficientBase swig_types[32]
-#define SWIGTYPE_p_mfem__MatrixRestrictedCoefficient swig_types[33]
-#define SWIGTYPE_p_mfem__MatrixSumCoefficient swig_types[34]
-#define SWIGTYPE_p_mfem__MatrixVectorProductCoefficient swig_types[35]
-#define SWIGTYPE_p_mfem__Mesh swig_types[36]
-#define SWIGTYPE_p_mfem__NormalizedVectorCoefficient swig_types[37]
-#define SWIGTYPE_p_mfem__OuterProductCoefficient swig_types[38]
-#define SWIGTYPE_p_mfem__PWConstCoefficient swig_types[39]
-#define SWIGTYPE_p_mfem__ParMesh swig_types[40]
-#define SWIGTYPE_p_mfem__PowerCoefficient swig_types[41]
-#define SWIGTYPE_p_mfem__ProductCoefficient swig_types[42]
-#define SWIGTYPE_p_mfem__PyCoefficientBase swig_types[43]
-#define SWIGTYPE_p_mfem__QuadratureFunction swig_types[44]
-#define SWIGTYPE_p_mfem__QuadratureFunctionCoefficient swig_types[45]
-#define SWIGTYPE_p_mfem__RatioCoefficient swig_types[46]
-#define SWIGTYPE_p_mfem__RestrictedCoefficient swig_types[47]
-#define SWIGTYPE_p_mfem__ScalarMatrixProductCoefficient swig_types[48]
-#define SWIGTYPE_p_mfem__ScalarVectorProductCoefficient swig_types[49]
-#define SWIGTYPE_p_mfem__SumCoefficient swig_types[50]
-#define SWIGTYPE_p_mfem__TransformedCoefficient swig_types[51]
-#define SWIGTYPE_p_mfem__TransposeMatrixCoefficient swig_types[52]
-#define SWIGTYPE_p_mfem__Vector swig_types[53]
-#define SWIGTYPE_p_mfem__VectorArrayCoefficient swig_types[54]
-#define SWIGTYPE_p_mfem__VectorCoefficient swig_types[55]
-#define SWIGTYPE_p_mfem__VectorConstantCoefficient swig_types[56]
-#define SWIGTYPE_p_mfem__VectorCrossProductCoefficient swig_types[57]
-#define SWIGTYPE_p_mfem__VectorDeltaCoefficient swig_types[58]
-#define SWIGTYPE_p_mfem__VectorFunctionCoefficient swig_types[59]
-#define SWIGTYPE_p_mfem__VectorGridFunctionCoefficient swig_types[60]
-#define SWIGTYPE_p_mfem__VectorPyCoefficientBase swig_types[61]
-#define SWIGTYPE_p_mfem__VectorQuadratureFunctionCoefficient swig_types[62]
-#define SWIGTYPE_p_mfem__VectorRestrictedCoefficient swig_types[63]
-#define SWIGTYPE_p_mfem__VectorRotProductCoefficient swig_types[64]
-#define SWIGTYPE_p_mfem__VectorSumCoefficient swig_types[65]
-#define SWIGTYPE_p_p_mfem__Coefficient swig_types[66]
-#define SWIGTYPE_p_p_mfem__ConstantCoefficient swig_types[67]
-#define SWIGTYPE_p_p_mfem__DeltaCoefficient swig_types[68]
-#define SWIGTYPE_p_p_mfem__DeterminantCoefficient swig_types[69]
-#define SWIGTYPE_p_p_mfem__DivergenceGridFunctionCoefficient swig_types[70]
-#define SWIGTYPE_p_p_mfem__FunctionCoefficient swig_types[71]
-#define SWIGTYPE_p_p_mfem__GridFunctionCoefficient swig_types[72]
-#define SWIGTYPE_p_p_mfem__InnerProductCoefficient swig_types[73]
-#define SWIGTYPE_p_p_mfem__PWConstCoefficient swig_types[74]
-#define SWIGTYPE_p_p_mfem__PowerCoefficient swig_types[75]
-#define SWIGTYPE_p_p_mfem__ProductCoefficient swig_types[76]
-#define SWIGTYPE_p_p_mfem__PyCoefficientBase swig_types[77]
-#define SWIGTYPE_p_p_mfem__QuadratureFunctionCoefficient swig_types[78]
-#define SWIGTYPE_p_p_mfem__RatioCoefficient swig_types[79]
-#define SWIGTYPE_p_p_mfem__RestrictedCoefficient swig_types[80]
-#define SWIGTYPE_p_p_mfem__SumCoefficient swig_types[81]
-#define SWIGTYPE_p_p_mfem__TransformedCoefficient swig_types[82]
-#define SWIGTYPE_p_p_mfem__VectorRotProductCoefficient swig_types[83]
-#define SWIGTYPE_p_std__functionT_double_fmfem__Vector_const_RF_t swig_types[84]
-#define SWIGTYPE_p_std__functionT_double_fmfem__Vector_const_R_doubleF_t swig_types[85]
-#define SWIGTYPE_p_std__functionT_void_fmfem__Vector_const_R_double_mfem__DenseMatrix_RF_t swig_types[86]
-#define SWIGTYPE_p_std__functionT_void_fmfem__Vector_const_R_double_mfem__Vector_RF_t swig_types[87]
-#define SWIGTYPE_p_std__functionT_void_fmfem__Vector_const_R_mfem__DenseMatrix_RF_t swig_types[88]
-#define SWIGTYPE_p_std__functionT_void_fmfem__Vector_const_R_mfem__Vector_RF_t swig_types[89]
-static swig_type_info *swig_types[91];
-static swig_module_info swig_module = {swig_types, 90, 0, 0, 0, 0};
+#define SWIGTYPE_p_MatrixNumbaFunction swig_types[0]
+#define SWIGTYPE_p_NumbaFunction swig_types[1]
+#define SWIGTYPE_p_NumbaFunctionBase swig_types[2]
+#define SWIGTYPE_p_PyMFEM__wFILE swig_types[3]
+#define SWIGTYPE_p_VectorNumbaFunction swig_types[4]
+#define SWIGTYPE_p_char swig_types[5]
+#define SWIGTYPE_p_double swig_types[6]
+#define SWIGTYPE_p_f_double__double swig_types[7]
+#define SWIGTYPE_p_f_double_double__double swig_types[8]
+#define SWIGTYPE_p_f_r_mfem__Vector__double swig_types[9]
+#define SWIGTYPE_p_f_r_mfem__Vector_double__double swig_types[10]
+#define SWIGTYPE_p_mfem__ArrayT_int_t swig_types[11]
+#define SWIGTYPE_p_mfem__Coefficient swig_types[12]
+#define SWIGTYPE_p_mfem__ConstantCoefficient swig_types[13]
+#define SWIGTYPE_p_mfem__CrossCrossCoefficient swig_types[14]
+#define SWIGTYPE_p_mfem__CurlGridFunctionCoefficient swig_types[15]
+#define SWIGTYPE_p_mfem__DeltaCoefficient swig_types[16]
+#define SWIGTYPE_p_mfem__DenseMatrix swig_types[17]
+#define SWIGTYPE_p_mfem__DeterminantCoefficient swig_types[18]
+#define SWIGTYPE_p_mfem__DivergenceGridFunctionCoefficient swig_types[19]
+#define SWIGTYPE_p_mfem__ElementTransformation swig_types[20]
+#define SWIGTYPE_p_mfem__FaceElementTransformations swig_types[21]
+#define SWIGTYPE_p_mfem__FunctionCoefficient swig_types[22]
+#define SWIGTYPE_p_mfem__GradientGridFunctionCoefficient swig_types[23]
+#define SWIGTYPE_p_mfem__GridFunction swig_types[24]
+#define SWIGTYPE_p_mfem__GridFunctionCoefficient swig_types[25]
+#define SWIGTYPE_p_mfem__IdentityMatrixCoefficient swig_types[26]
+#define SWIGTYPE_p_mfem__InnerProductCoefficient swig_types[27]
+#define SWIGTYPE_p_mfem__IntegrationPoint swig_types[28]
+#define SWIGTYPE_p_mfem__IntegrationRule swig_types[29]
+#define SWIGTYPE_p_mfem__InverseMatrixCoefficient swig_types[30]
+#define SWIGTYPE_p_mfem__IsoparametricTransformation swig_types[31]
+#define SWIGTYPE_p_mfem__MatrixArrayCoefficient swig_types[32]
+#define SWIGTYPE_p_mfem__MatrixCoefficient swig_types[33]
+#define SWIGTYPE_p_mfem__MatrixConstantCoefficient swig_types[34]
+#define SWIGTYPE_p_mfem__MatrixFunctionCoefficient swig_types[35]
+#define SWIGTYPE_p_mfem__MatrixPyCoefficientBase swig_types[36]
+#define SWIGTYPE_p_mfem__MatrixRestrictedCoefficient swig_types[37]
+#define SWIGTYPE_p_mfem__MatrixSumCoefficient swig_types[38]
+#define SWIGTYPE_p_mfem__MatrixVectorProductCoefficient swig_types[39]
+#define SWIGTYPE_p_mfem__Mesh swig_types[40]
+#define SWIGTYPE_p_mfem__NormalizedVectorCoefficient swig_types[41]
+#define SWIGTYPE_p_mfem__OuterProductCoefficient swig_types[42]
+#define SWIGTYPE_p_mfem__PWConstCoefficient swig_types[43]
+#define SWIGTYPE_p_mfem__ParMesh swig_types[44]
+#define SWIGTYPE_p_mfem__PowerCoefficient swig_types[45]
+#define SWIGTYPE_p_mfem__ProductCoefficient swig_types[46]
+#define SWIGTYPE_p_mfem__PyCoefficientBase swig_types[47]
+#define SWIGTYPE_p_mfem__QuadratureFunction swig_types[48]
+#define SWIGTYPE_p_mfem__QuadratureFunctionCoefficient swig_types[49]
+#define SWIGTYPE_p_mfem__RatioCoefficient swig_types[50]
+#define SWIGTYPE_p_mfem__RestrictedCoefficient swig_types[51]
+#define SWIGTYPE_p_mfem__ScalarMatrixProductCoefficient swig_types[52]
+#define SWIGTYPE_p_mfem__ScalarVectorProductCoefficient swig_types[53]
+#define SWIGTYPE_p_mfem__SumCoefficient swig_types[54]
+#define SWIGTYPE_p_mfem__TransformedCoefficient swig_types[55]
+#define SWIGTYPE_p_mfem__TransposeMatrixCoefficient swig_types[56]
+#define SWIGTYPE_p_mfem__Vector swig_types[57]
+#define SWIGTYPE_p_mfem__VectorArrayCoefficient swig_types[58]
+#define SWIGTYPE_p_mfem__VectorCoefficient swig_types[59]
+#define SWIGTYPE_p_mfem__VectorConstantCoefficient swig_types[60]
+#define SWIGTYPE_p_mfem__VectorCrossProductCoefficient swig_types[61]
+#define SWIGTYPE_p_mfem__VectorDeltaCoefficient swig_types[62]
+#define SWIGTYPE_p_mfem__VectorFunctionCoefficient swig_types[63]
+#define SWIGTYPE_p_mfem__VectorGridFunctionCoefficient swig_types[64]
+#define SWIGTYPE_p_mfem__VectorPyCoefficientBase swig_types[65]
+#define SWIGTYPE_p_mfem__VectorQuadratureFunctionCoefficient swig_types[66]
+#define SWIGTYPE_p_mfem__VectorRestrictedCoefficient swig_types[67]
+#define SWIGTYPE_p_mfem__VectorRotProductCoefficient swig_types[68]
+#define SWIGTYPE_p_mfem__VectorSumCoefficient swig_types[69]
+#define SWIGTYPE_p_p_mfem__Coefficient swig_types[70]
+#define SWIGTYPE_p_p_mfem__ConstantCoefficient swig_types[71]
+#define SWIGTYPE_p_p_mfem__DeltaCoefficient swig_types[72]
+#define SWIGTYPE_p_p_mfem__DeterminantCoefficient swig_types[73]
+#define SWIGTYPE_p_p_mfem__DivergenceGridFunctionCoefficient swig_types[74]
+#define SWIGTYPE_p_p_mfem__FunctionCoefficient swig_types[75]
+#define SWIGTYPE_p_p_mfem__GridFunctionCoefficient swig_types[76]
+#define SWIGTYPE_p_p_mfem__InnerProductCoefficient swig_types[77]
+#define SWIGTYPE_p_p_mfem__PWConstCoefficient swig_types[78]
+#define SWIGTYPE_p_p_mfem__PowerCoefficient swig_types[79]
+#define SWIGTYPE_p_p_mfem__ProductCoefficient swig_types[80]
+#define SWIGTYPE_p_p_mfem__PyCoefficientBase swig_types[81]
+#define SWIGTYPE_p_p_mfem__QuadratureFunctionCoefficient swig_types[82]
+#define SWIGTYPE_p_p_mfem__RatioCoefficient swig_types[83]
+#define SWIGTYPE_p_p_mfem__RestrictedCoefficient swig_types[84]
+#define SWIGTYPE_p_p_mfem__SumCoefficient swig_types[85]
+#define SWIGTYPE_p_p_mfem__TransformedCoefficient swig_types[86]
+#define SWIGTYPE_p_p_mfem__VectorRotProductCoefficient swig_types[87]
+#define SWIGTYPE_p_std__functionT_double_fmfem__Vector_const_RF_t swig_types[88]
+#define SWIGTYPE_p_std__functionT_double_fmfem__Vector_const_R_doubleF_t swig_types[89]
+#define SWIGTYPE_p_std__functionT_void_fmfem__Vector_const_R_double_mfem__DenseMatrix_RF_t swig_types[90]
+#define SWIGTYPE_p_std__functionT_void_fmfem__Vector_const_R_double_mfem__Vector_RF_t swig_types[91]
+#define SWIGTYPE_p_std__functionT_void_fmfem__Vector_const_R_mfem__DenseMatrix_RF_t swig_types[92]
+#define SWIGTYPE_p_std__functionT_void_fmfem__Vector_const_R_mfem__Vector_RF_t swig_types[93]
+static swig_type_info *swig_types[95];
+static swig_module_info swig_module = {swig_types, 94, 0, 0, 0, 0};
 #define SWIG_TypeQuery(name) SWIG_TypeQueryModule(&swig_module, &swig_module, name)
 #define SWIG_MangledTypeQuery(name) SWIG_MangledTypeQueryModule(&swig_module, &swig_module, name)
 
@@ -3511,6 +3515,159 @@ SWIGINTERNINLINE PyObject*
 {
   return PyBool_FromLong(value ? 1 : 0);
 }
+
+
+class NumbaFunctionBase{
+ protected:
+    void *address_;
+    int  sdim_;
+    bool td_;
+ public:
+    NumbaFunctionBase(PyObject *input, int sdim, bool td): sdim_(sdim), td_(td){
+       PyObject* module = PyImport_ImportModule("numba.core.ccallback");
+       if (!module){
+           PyErr_SetString(PyExc_RuntimeError, "Can not load numba.core.ccallback module");
+           return;
+       }      
+       PyObject* cls = PyObject_GetAttrString(module, "CFunc");
+       if (!cls){
+           PyErr_SetString(PyExc_RuntimeError, "Can not load CFunc");
+           return;
+       }
+       int check = PyObject_IsInstance(input, cls);
+       if (! check){
+           PyErr_SetString(PyExc_RuntimeError, "Input must be numba.core.ccallback.CFunc");
+           return;
+       }
+       PyObject *address = PyObject_GetAttrString(input, "address");
+       void *ptr = PyLong_AsVoidPtr(address); 
+       Py_DECREF(address);
+       address_ = ptr;
+    }
+    double print_add(){
+       std::cout << address_ << '\n';
+       return 0;
+    }
+    virtual ~NumbaFunctionBase(){}    
+};
+
+class NumbaFunction : public NumbaFunctionBase {
+ private:
+    std::function<double(const mfem::Vector &)> obj1;
+    std::function<double(const mfem::Vector &, double t)> obj2;
+
+ public:
+    NumbaFunction(PyObject *input, int sdim):
+       NumbaFunctionBase(input, sdim, false){}
+    
+    NumbaFunction(PyObject *input, int sdim, bool td):
+       NumbaFunctionBase(input, sdim, td){}
+    
+    double call(const mfem::Vector &x){
+      return ((double (*)(double *, int))address_)(x.GetData(), sdim_);
+    }
+    double callt(const mfem::Vector &x, double t){
+      return ((double (*)(double *, double, int))address_)(x.GetData(), t, sdim_);
+    }
+
+    // FunctionCoefficient
+    mfem::FunctionCoefficient* GenerateCoefficient(){
+      using std::placeholders::_1;
+      using std::placeholders::_2;      
+      if (td_) {
+         obj2 = std::bind(&NumbaFunction::callt, this, _1, _2);
+         return new mfem::FunctionCoefficient(obj2);
+      } else {
+         obj1 = std::bind(&NumbaFunction::call, this, _1);
+         return new mfem::FunctionCoefficient(obj1);
+      }
+   }
+};
+ 
+// VectorFunctionCoefficient     
+class VectorNumbaFunction : public NumbaFunctionBase {
+ private:
+  std::function<void(const mfem::Vector &, mfem::Vector &)> obj1;
+  std::function<void(const mfem::Vector &, double, mfem::Vector &)> obj2;
+  int vdim_;
+    
+ public:
+    VectorNumbaFunction(PyObject *input, int sdim, int vdim):
+       NumbaFunctionBase(input, sdim, false), vdim_(vdim){}
+    
+    VectorNumbaFunction(PyObject *input, int sdim, int vdim, bool td):
+       NumbaFunctionBase(input, sdim, td), vdim_(vdim){}
+  
+    void call(const mfem::Vector &x, mfem::Vector &out){
+      return ((void (*) (double *, double *, int, int))address_)(x.GetData(), 
+    							      out.GetData(),
+                                                              sdim_,
+							      vdim_);      
+       
+    }
+    void callt(const mfem::Vector &x, double t, mfem::Vector &out){
+      return ((void (*) (double *, double,  double *, int, int))address_)(x.GetData(),
+							              t,
+								      out.GetData(),
+								      sdim_,
+	 							      vdim_);            
+    }
+
+    mfem::VectorFunctionCoefficient* GenerateCoefficient(){
+      using std::placeholders::_1;
+      using std::placeholders::_2;
+      using std::placeholders::_3;            
+      if (td_) {
+	obj2 = std::bind(&VectorNumbaFunction::callt, this, _1, _2, _3);
+	return new mfem::VectorFunctionCoefficient(vdim_, obj2);
+      } else {
+	obj1 = std::bind(&VectorNumbaFunction::call, this, _1, _2);
+	return new mfem::VectorFunctionCoefficient(vdim_, obj1);
+      }
+   }
+};
+// MatrixFunctionCoefficient
+class MatrixNumbaFunction : NumbaFunctionBase {
+ private:
+  std::function<void(const mfem::Vector &, mfem::DenseMatrix &)> obj1;
+  std::function<void(const mfem::Vector &, double, mfem::DenseMatrix &)> obj2;
+  int vdim_;
+    
+ public:
+    MatrixNumbaFunction(PyObject *input, int sdim, int vdim):
+       NumbaFunctionBase(input, sdim, false), vdim_(vdim){}
+    MatrixNumbaFunction(PyObject *input, int sdim, int vdim, bool td):
+       NumbaFunctionBase(input, sdim, td), vdim_(vdim){}
+
+    void call(const mfem::Vector &x, mfem::DenseMatrix &out){
+      return ((void (*) (double *, double *, int, int))address_)(x.GetData(), 
+    							      out.GetData(),
+                                                              sdim_,
+							      vdim_);      
+       
+    }
+    void callt(const mfem::Vector &x, double t, mfem::DenseMatrix &out){
+      return ((void (*) (double *, double,  double *, int, int))address_)(x.GetData(),
+							              t,
+								      out.GetData(),
+								      sdim_,
+	 							      vdim_);            
+    }
+       
+    mfem::MatrixFunctionCoefficient* GenerateCoefficient(){
+      using std::placeholders::_1;
+      using std::placeholders::_2;
+      using std::placeholders::_3;      
+      if (td_) {
+ 	obj2 = std::bind(&MatrixNumbaFunction::callt, this, _1, _2, _3);
+	return new mfem::MatrixFunctionCoefficient(vdim_, obj2);
+      } else {
+	obj1 = std::bind(&MatrixNumbaFunction::call, this, _1, _2);
+	return new mfem::MatrixFunctionCoefficient(vdim_, obj1);
+      }
+    }
+};
+ 
 
 
 double fake_func(const mfem::Vector &x)
@@ -22613,6 +22770,1209 @@ fail:
 }
 
 
+SWIGINTERN PyObject *_wrap_new_NumbaFunctionBase(PyObject *SWIGUNUSEDPARM(self), PyObject *args, PyObject *kwargs) {
+  PyObject *resultobj = 0;
+  PyObject *arg1 = (PyObject *) 0 ;
+  int arg2 ;
+  bool arg3 ;
+  bool val3 ;
+  int ecode3 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  char * kwnames[] = {
+    (char *)"input",  (char *)"sdim",  (char *)"td",  NULL 
+  };
+  NumbaFunctionBase *result = 0 ;
+  
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OOO:new_NumbaFunctionBase", kwnames, &obj0, &obj1, &obj2)) SWIG_fail;
+  arg1 = obj0;
+  {
+    if ((PyArray_PyIntAsInt(obj1) == -1) && PyErr_Occurred()) {
+      SWIG_exception_fail(SWIG_TypeError, "Input must be integer");
+    };  
+    arg2 = PyArray_PyIntAsInt(obj1);
+  }
+  ecode3 = SWIG_AsVal_bool(obj2, &val3);
+  if (!SWIG_IsOK(ecode3)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode3), "in method '" "new_NumbaFunctionBase" "', argument " "3"" of type '" "bool""'");
+  } 
+  arg3 = static_cast< bool >(val3);
+  {
+    try {
+      result = (NumbaFunctionBase *)new NumbaFunctionBase(arg1,arg2,arg3); 
+    }
+    catch (Swig::DirectorException &e) {
+      SWIG_fail; 
+    }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
+  }
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_NumbaFunctionBase, SWIG_POINTER_NEW |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_NumbaFunctionBase_print_add(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  NumbaFunctionBase *arg1 = (NumbaFunctionBase *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject *swig_obj[1] ;
+  double result;
+  
+  if (!args) SWIG_fail;
+  swig_obj[0] = args;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_NumbaFunctionBase, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "NumbaFunctionBase_print_add" "', argument " "1"" of type '" "NumbaFunctionBase *""'"); 
+  }
+  arg1 = reinterpret_cast< NumbaFunctionBase * >(argp1);
+  {
+    try {
+      result = (double)(arg1)->print_add(); 
+    }
+    catch (Swig::DirectorException &e) {
+      SWIG_fail; 
+    }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
+  }
+  resultobj = SWIG_From_double(static_cast< double >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_delete_NumbaFunctionBase(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  NumbaFunctionBase *arg1 = (NumbaFunctionBase *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject *swig_obj[1] ;
+  
+  if (!args) SWIG_fail;
+  swig_obj[0] = args;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_NumbaFunctionBase, SWIG_POINTER_DISOWN |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "delete_NumbaFunctionBase" "', argument " "1"" of type '" "NumbaFunctionBase *""'"); 
+  }
+  arg1 = reinterpret_cast< NumbaFunctionBase * >(argp1);
+  {
+    try {
+      delete arg1; 
+    }
+    catch (Swig::DirectorException &e) {
+      SWIG_fail; 
+    }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *NumbaFunctionBase_swigregister(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *obj;
+  if (!SWIG_Python_UnpackTuple(args, "swigregister", 1, 1, &obj)) return NULL;
+  SWIG_TypeNewClientData(SWIGTYPE_p_NumbaFunctionBase, SWIG_NewClientData(obj));
+  return SWIG_Py_Void();
+}
+
+SWIGINTERN PyObject *NumbaFunctionBase_swiginit(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  return SWIG_Python_InitShadowInstance(args);
+}
+
+SWIGINTERN PyObject *_wrap_new_NumbaFunction__SWIG_0(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
+  PyObject *resultobj = 0;
+  PyObject *arg1 = (PyObject *) 0 ;
+  int arg2 ;
+  NumbaFunction *result = 0 ;
+  
+  if ((nobjs < 2) || (nobjs > 2)) SWIG_fail;
+  arg1 = swig_obj[0];
+  {
+    if ((PyArray_PyIntAsInt(swig_obj[1]) == -1) && PyErr_Occurred()) {
+      SWIG_exception_fail(SWIG_TypeError, "Input must be integer");
+    };  
+    arg2 = PyArray_PyIntAsInt(swig_obj[1]);
+  }
+  {
+    try {
+      result = (NumbaFunction *)new NumbaFunction(arg1,arg2); 
+    }
+    catch (Swig::DirectorException &e) {
+      SWIG_fail; 
+    }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
+  }
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_NumbaFunction, SWIG_POINTER_NEW |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_new_NumbaFunction__SWIG_1(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
+  PyObject *resultobj = 0;
+  PyObject *arg1 = (PyObject *) 0 ;
+  int arg2 ;
+  bool arg3 ;
+  bool val3 ;
+  int ecode3 = 0 ;
+  NumbaFunction *result = 0 ;
+  
+  if ((nobjs < 3) || (nobjs > 3)) SWIG_fail;
+  arg1 = swig_obj[0];
+  {
+    if ((PyArray_PyIntAsInt(swig_obj[1]) == -1) && PyErr_Occurred()) {
+      SWIG_exception_fail(SWIG_TypeError, "Input must be integer");
+    };  
+    arg2 = PyArray_PyIntAsInt(swig_obj[1]);
+  }
+  ecode3 = SWIG_AsVal_bool(swig_obj[2], &val3);
+  if (!SWIG_IsOK(ecode3)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode3), "in method '" "new_NumbaFunction" "', argument " "3"" of type '" "bool""'");
+  } 
+  arg3 = static_cast< bool >(val3);
+  {
+    try {
+      result = (NumbaFunction *)new NumbaFunction(arg1,arg2,arg3); 
+    }
+    catch (Swig::DirectorException &e) {
+      SWIG_fail; 
+    }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
+  }
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_NumbaFunction, SWIG_POINTER_NEW |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_new_NumbaFunction(PyObject *self, PyObject *args) {
+  Py_ssize_t argc;
+  PyObject *argv[4] = {
+    0
+  };
+  
+  if (!(argc = SWIG_Python_UnpackTuple(args, "new_NumbaFunction", 0, 3, argv))) SWIG_fail;
+  --argc;
+  if (argc == 2) {
+    int _v;
+    _v = (argv[0] != 0);
+    if (_v) {
+      {
+        if ((PyArray_PyIntAsInt(argv[1]) == -1) && PyErr_Occurred()) {
+          PyErr_Clear();
+          _v = 0;
+        } else {
+          _v = 1;    
+        }
+      }
+      if (_v) {
+        return _wrap_new_NumbaFunction__SWIG_0(self, argc, argv);
+      }
+    }
+  }
+  if (argc == 3) {
+    int _v;
+    _v = (argv[0] != 0);
+    if (_v) {
+      {
+        if ((PyArray_PyIntAsInt(argv[1]) == -1) && PyErr_Occurred()) {
+          PyErr_Clear();
+          _v = 0;
+        } else {
+          _v = 1;    
+        }
+      }
+      if (_v) {
+        {
+          int res = SWIG_AsVal_bool(argv[2], NULL);
+          _v = SWIG_CheckState(res);
+        }
+        if (_v) {
+          return _wrap_new_NumbaFunction__SWIG_1(self, argc, argv);
+        }
+      }
+    }
+  }
+  
+fail:
+  SWIG_Python_RaiseOrModifyTypeError("Wrong number or type of arguments for overloaded function 'new_NumbaFunction'.\n"
+    "  Possible C/C++ prototypes are:\n"
+    "    NumbaFunction::NumbaFunction(PyObject *,int)\n"
+    "    NumbaFunction::NumbaFunction(PyObject *,int,bool)\n");
+  return 0;
+}
+
+
+SWIGINTERN PyObject *_wrap_NumbaFunction_call(PyObject *SWIGUNUSEDPARM(self), PyObject *args, PyObject *kwargs) {
+  PyObject *resultobj = 0;
+  NumbaFunction *arg1 = (NumbaFunction *) 0 ;
+  mfem::Vector *arg2 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  char * kwnames[] = {
+    (char *)"self",  (char *)"x",  NULL 
+  };
+  double result;
+  
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OO:NumbaFunction_call", kwnames, &obj0, &obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_NumbaFunction, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "NumbaFunction_call" "', argument " "1"" of type '" "NumbaFunction *""'"); 
+  }
+  arg1 = reinterpret_cast< NumbaFunction * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_mfem__Vector,  0  | 0);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "NumbaFunction_call" "', argument " "2"" of type '" "mfem::Vector const &""'"); 
+  }
+  if (!argp2) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "NumbaFunction_call" "', argument " "2"" of type '" "mfem::Vector const &""'"); 
+  }
+  arg2 = reinterpret_cast< mfem::Vector * >(argp2);
+  {
+    try {
+      result = (double)(arg1)->call((mfem::Vector const &)*arg2); 
+    }
+    catch (Swig::DirectorException &e) {
+      SWIG_fail; 
+    }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
+  }
+  resultobj = SWIG_From_double(static_cast< double >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_NumbaFunction_callt(PyObject *SWIGUNUSEDPARM(self), PyObject *args, PyObject *kwargs) {
+  PyObject *resultobj = 0;
+  NumbaFunction *arg1 = (NumbaFunction *) 0 ;
+  mfem::Vector *arg2 = 0 ;
+  double arg3 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  double val3 ;
+  int ecode3 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  char * kwnames[] = {
+    (char *)"self",  (char *)"x",  (char *)"t",  NULL 
+  };
+  double result;
+  
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OOO:NumbaFunction_callt", kwnames, &obj0, &obj1, &obj2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_NumbaFunction, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "NumbaFunction_callt" "', argument " "1"" of type '" "NumbaFunction *""'"); 
+  }
+  arg1 = reinterpret_cast< NumbaFunction * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_mfem__Vector,  0  | 0);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "NumbaFunction_callt" "', argument " "2"" of type '" "mfem::Vector const &""'"); 
+  }
+  if (!argp2) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "NumbaFunction_callt" "', argument " "2"" of type '" "mfem::Vector const &""'"); 
+  }
+  arg2 = reinterpret_cast< mfem::Vector * >(argp2);
+  ecode3 = SWIG_AsVal_double(obj2, &val3);
+  if (!SWIG_IsOK(ecode3)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode3), "in method '" "NumbaFunction_callt" "', argument " "3"" of type '" "double""'");
+  } 
+  arg3 = static_cast< double >(val3);
+  {
+    try {
+      result = (double)(arg1)->callt((mfem::Vector const &)*arg2,arg3); 
+    }
+    catch (Swig::DirectorException &e) {
+      SWIG_fail; 
+    }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
+  }
+  resultobj = SWIG_From_double(static_cast< double >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_NumbaFunction_GenerateCoefficient(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  NumbaFunction *arg1 = (NumbaFunction *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject *swig_obj[1] ;
+  mfem::FunctionCoefficient *result = 0 ;
+  
+  if (!args) SWIG_fail;
+  swig_obj[0] = args;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_NumbaFunction, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "NumbaFunction_GenerateCoefficient" "', argument " "1"" of type '" "NumbaFunction *""'"); 
+  }
+  arg1 = reinterpret_cast< NumbaFunction * >(argp1);
+  {
+    try {
+      result = (mfem::FunctionCoefficient *)(arg1)->GenerateCoefficient(); 
+    }
+    catch (Swig::DirectorException &e) {
+      SWIG_fail; 
+    }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
+  }
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__FunctionCoefficient, 0 |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_delete_NumbaFunction(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  NumbaFunction *arg1 = (NumbaFunction *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject *swig_obj[1] ;
+  
+  if (!args) SWIG_fail;
+  swig_obj[0] = args;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_NumbaFunction, SWIG_POINTER_DISOWN |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "delete_NumbaFunction" "', argument " "1"" of type '" "NumbaFunction *""'"); 
+  }
+  arg1 = reinterpret_cast< NumbaFunction * >(argp1);
+  {
+    try {
+      delete arg1; 
+    }
+    catch (Swig::DirectorException &e) {
+      SWIG_fail; 
+    }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *NumbaFunction_swigregister(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *obj;
+  if (!SWIG_Python_UnpackTuple(args, "swigregister", 1, 1, &obj)) return NULL;
+  SWIG_TypeNewClientData(SWIGTYPE_p_NumbaFunction, SWIG_NewClientData(obj));
+  return SWIG_Py_Void();
+}
+
+SWIGINTERN PyObject *NumbaFunction_swiginit(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  return SWIG_Python_InitShadowInstance(args);
+}
+
+SWIGINTERN PyObject *_wrap_new_VectorNumbaFunction__SWIG_0(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
+  PyObject *resultobj = 0;
+  PyObject *arg1 = (PyObject *) 0 ;
+  int arg2 ;
+  int arg3 ;
+  VectorNumbaFunction *result = 0 ;
+  
+  if ((nobjs < 3) || (nobjs > 3)) SWIG_fail;
+  arg1 = swig_obj[0];
+  {
+    if ((PyArray_PyIntAsInt(swig_obj[1]) == -1) && PyErr_Occurred()) {
+      SWIG_exception_fail(SWIG_TypeError, "Input must be integer");
+    };  
+    arg2 = PyArray_PyIntAsInt(swig_obj[1]);
+  }
+  {
+    if ((PyArray_PyIntAsInt(swig_obj[2]) == -1) && PyErr_Occurred()) {
+      SWIG_exception_fail(SWIG_TypeError, "Input must be integer");
+    };  
+    arg3 = PyArray_PyIntAsInt(swig_obj[2]);
+  }
+  {
+    try {
+      result = (VectorNumbaFunction *)new VectorNumbaFunction(arg1,arg2,arg3); 
+    }
+    catch (Swig::DirectorException &e) {
+      SWIG_fail; 
+    }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
+  }
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_VectorNumbaFunction, SWIG_POINTER_NEW |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_new_VectorNumbaFunction__SWIG_1(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
+  PyObject *resultobj = 0;
+  PyObject *arg1 = (PyObject *) 0 ;
+  int arg2 ;
+  int arg3 ;
+  bool arg4 ;
+  bool val4 ;
+  int ecode4 = 0 ;
+  VectorNumbaFunction *result = 0 ;
+  
+  if ((nobjs < 4) || (nobjs > 4)) SWIG_fail;
+  arg1 = swig_obj[0];
+  {
+    if ((PyArray_PyIntAsInt(swig_obj[1]) == -1) && PyErr_Occurred()) {
+      SWIG_exception_fail(SWIG_TypeError, "Input must be integer");
+    };  
+    arg2 = PyArray_PyIntAsInt(swig_obj[1]);
+  }
+  {
+    if ((PyArray_PyIntAsInt(swig_obj[2]) == -1) && PyErr_Occurred()) {
+      SWIG_exception_fail(SWIG_TypeError, "Input must be integer");
+    };  
+    arg3 = PyArray_PyIntAsInt(swig_obj[2]);
+  }
+  ecode4 = SWIG_AsVal_bool(swig_obj[3], &val4);
+  if (!SWIG_IsOK(ecode4)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode4), "in method '" "new_VectorNumbaFunction" "', argument " "4"" of type '" "bool""'");
+  } 
+  arg4 = static_cast< bool >(val4);
+  {
+    try {
+      result = (VectorNumbaFunction *)new VectorNumbaFunction(arg1,arg2,arg3,arg4); 
+    }
+    catch (Swig::DirectorException &e) {
+      SWIG_fail; 
+    }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
+  }
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_VectorNumbaFunction, SWIG_POINTER_NEW |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_new_VectorNumbaFunction(PyObject *self, PyObject *args) {
+  Py_ssize_t argc;
+  PyObject *argv[5] = {
+    0
+  };
+  
+  if (!(argc = SWIG_Python_UnpackTuple(args, "new_VectorNumbaFunction", 0, 4, argv))) SWIG_fail;
+  --argc;
+  if (argc == 3) {
+    int _v;
+    _v = (argv[0] != 0);
+    if (_v) {
+      {
+        if ((PyArray_PyIntAsInt(argv[1]) == -1) && PyErr_Occurred()) {
+          PyErr_Clear();
+          _v = 0;
+        } else {
+          _v = 1;    
+        }
+      }
+      if (_v) {
+        {
+          if ((PyArray_PyIntAsInt(argv[2]) == -1) && PyErr_Occurred()) {
+            PyErr_Clear();
+            _v = 0;
+          } else {
+            _v = 1;    
+          }
+        }
+        if (_v) {
+          return _wrap_new_VectorNumbaFunction__SWIG_0(self, argc, argv);
+        }
+      }
+    }
+  }
+  if (argc == 4) {
+    int _v;
+    _v = (argv[0] != 0);
+    if (_v) {
+      {
+        if ((PyArray_PyIntAsInt(argv[1]) == -1) && PyErr_Occurred()) {
+          PyErr_Clear();
+          _v = 0;
+        } else {
+          _v = 1;    
+        }
+      }
+      if (_v) {
+        {
+          if ((PyArray_PyIntAsInt(argv[2]) == -1) && PyErr_Occurred()) {
+            PyErr_Clear();
+            _v = 0;
+          } else {
+            _v = 1;    
+          }
+        }
+        if (_v) {
+          {
+            int res = SWIG_AsVal_bool(argv[3], NULL);
+            _v = SWIG_CheckState(res);
+          }
+          if (_v) {
+            return _wrap_new_VectorNumbaFunction__SWIG_1(self, argc, argv);
+          }
+        }
+      }
+    }
+  }
+  
+fail:
+  SWIG_Python_RaiseOrModifyTypeError("Wrong number or type of arguments for overloaded function 'new_VectorNumbaFunction'.\n"
+    "  Possible C/C++ prototypes are:\n"
+    "    VectorNumbaFunction::VectorNumbaFunction(PyObject *,int,int)\n"
+    "    VectorNumbaFunction::VectorNumbaFunction(PyObject *,int,int,bool)\n");
+  return 0;
+}
+
+
+SWIGINTERN PyObject *_wrap_VectorNumbaFunction_call(PyObject *SWIGUNUSEDPARM(self), PyObject *args, PyObject *kwargs) {
+  PyObject *resultobj = 0;
+  VectorNumbaFunction *arg1 = (VectorNumbaFunction *) 0 ;
+  mfem::Vector *arg2 = 0 ;
+  mfem::Vector *arg3 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  void *argp3 = 0 ;
+  int res3 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  char * kwnames[] = {
+    (char *)"self",  (char *)"x",  (char *)"out",  NULL 
+  };
+  
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OOO:VectorNumbaFunction_call", kwnames, &obj0, &obj1, &obj2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_VectorNumbaFunction, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "VectorNumbaFunction_call" "', argument " "1"" of type '" "VectorNumbaFunction *""'"); 
+  }
+  arg1 = reinterpret_cast< VectorNumbaFunction * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_mfem__Vector,  0  | 0);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "VectorNumbaFunction_call" "', argument " "2"" of type '" "mfem::Vector const &""'"); 
+  }
+  if (!argp2) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "VectorNumbaFunction_call" "', argument " "2"" of type '" "mfem::Vector const &""'"); 
+  }
+  arg2 = reinterpret_cast< mfem::Vector * >(argp2);
+  res3 = SWIG_ConvertPtr(obj2, &argp3, SWIGTYPE_p_mfem__Vector,  0 );
+  if (!SWIG_IsOK(res3)) {
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "VectorNumbaFunction_call" "', argument " "3"" of type '" "mfem::Vector &""'"); 
+  }
+  if (!argp3) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "VectorNumbaFunction_call" "', argument " "3"" of type '" "mfem::Vector &""'"); 
+  }
+  arg3 = reinterpret_cast< mfem::Vector * >(argp3);
+  {
+    try {
+      (arg1)->call((mfem::Vector const &)*arg2,*arg3); 
+    }
+    catch (Swig::DirectorException &e) {
+      SWIG_fail; 
+    }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_VectorNumbaFunction_callt(PyObject *SWIGUNUSEDPARM(self), PyObject *args, PyObject *kwargs) {
+  PyObject *resultobj = 0;
+  VectorNumbaFunction *arg1 = (VectorNumbaFunction *) 0 ;
+  mfem::Vector *arg2 = 0 ;
+  double arg3 ;
+  mfem::Vector *arg4 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  double val3 ;
+  int ecode3 = 0 ;
+  void *argp4 = 0 ;
+  int res4 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  PyObject * obj3 = 0 ;
+  char * kwnames[] = {
+    (char *)"self",  (char *)"x",  (char *)"t",  (char *)"out",  NULL 
+  };
+  
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OOOO:VectorNumbaFunction_callt", kwnames, &obj0, &obj1, &obj2, &obj3)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_VectorNumbaFunction, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "VectorNumbaFunction_callt" "', argument " "1"" of type '" "VectorNumbaFunction *""'"); 
+  }
+  arg1 = reinterpret_cast< VectorNumbaFunction * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_mfem__Vector,  0  | 0);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "VectorNumbaFunction_callt" "', argument " "2"" of type '" "mfem::Vector const &""'"); 
+  }
+  if (!argp2) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "VectorNumbaFunction_callt" "', argument " "2"" of type '" "mfem::Vector const &""'"); 
+  }
+  arg2 = reinterpret_cast< mfem::Vector * >(argp2);
+  ecode3 = SWIG_AsVal_double(obj2, &val3);
+  if (!SWIG_IsOK(ecode3)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode3), "in method '" "VectorNumbaFunction_callt" "', argument " "3"" of type '" "double""'");
+  } 
+  arg3 = static_cast< double >(val3);
+  res4 = SWIG_ConvertPtr(obj3, &argp4, SWIGTYPE_p_mfem__Vector,  0 );
+  if (!SWIG_IsOK(res4)) {
+    SWIG_exception_fail(SWIG_ArgError(res4), "in method '" "VectorNumbaFunction_callt" "', argument " "4"" of type '" "mfem::Vector &""'"); 
+  }
+  if (!argp4) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "VectorNumbaFunction_callt" "', argument " "4"" of type '" "mfem::Vector &""'"); 
+  }
+  arg4 = reinterpret_cast< mfem::Vector * >(argp4);
+  {
+    try {
+      (arg1)->callt((mfem::Vector const &)*arg2,arg3,*arg4); 
+    }
+    catch (Swig::DirectorException &e) {
+      SWIG_fail; 
+    }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_VectorNumbaFunction_GenerateCoefficient(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  VectorNumbaFunction *arg1 = (VectorNumbaFunction *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject *swig_obj[1] ;
+  mfem::VectorFunctionCoefficient *result = 0 ;
+  
+  if (!args) SWIG_fail;
+  swig_obj[0] = args;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_VectorNumbaFunction, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "VectorNumbaFunction_GenerateCoefficient" "', argument " "1"" of type '" "VectorNumbaFunction *""'"); 
+  }
+  arg1 = reinterpret_cast< VectorNumbaFunction * >(argp1);
+  {
+    try {
+      result = (mfem::VectorFunctionCoefficient *)(arg1)->GenerateCoefficient(); 
+    }
+    catch (Swig::DirectorException &e) {
+      SWIG_fail; 
+    }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
+  }
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__VectorFunctionCoefficient, 0 |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_delete_VectorNumbaFunction(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  VectorNumbaFunction *arg1 = (VectorNumbaFunction *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject *swig_obj[1] ;
+  
+  if (!args) SWIG_fail;
+  swig_obj[0] = args;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_VectorNumbaFunction, SWIG_POINTER_DISOWN |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "delete_VectorNumbaFunction" "', argument " "1"" of type '" "VectorNumbaFunction *""'"); 
+  }
+  arg1 = reinterpret_cast< VectorNumbaFunction * >(argp1);
+  {
+    try {
+      delete arg1; 
+    }
+    catch (Swig::DirectorException &e) {
+      SWIG_fail; 
+    }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *VectorNumbaFunction_swigregister(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *obj;
+  if (!SWIG_Python_UnpackTuple(args, "swigregister", 1, 1, &obj)) return NULL;
+  SWIG_TypeNewClientData(SWIGTYPE_p_VectorNumbaFunction, SWIG_NewClientData(obj));
+  return SWIG_Py_Void();
+}
+
+SWIGINTERN PyObject *VectorNumbaFunction_swiginit(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  return SWIG_Python_InitShadowInstance(args);
+}
+
+SWIGINTERN PyObject *_wrap_new_MatrixNumbaFunction__SWIG_0(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
+  PyObject *resultobj = 0;
+  PyObject *arg1 = (PyObject *) 0 ;
+  int arg2 ;
+  int arg3 ;
+  MatrixNumbaFunction *result = 0 ;
+  
+  if ((nobjs < 3) || (nobjs > 3)) SWIG_fail;
+  arg1 = swig_obj[0];
+  {
+    if ((PyArray_PyIntAsInt(swig_obj[1]) == -1) && PyErr_Occurred()) {
+      SWIG_exception_fail(SWIG_TypeError, "Input must be integer");
+    };  
+    arg2 = PyArray_PyIntAsInt(swig_obj[1]);
+  }
+  {
+    if ((PyArray_PyIntAsInt(swig_obj[2]) == -1) && PyErr_Occurred()) {
+      SWIG_exception_fail(SWIG_TypeError, "Input must be integer");
+    };  
+    arg3 = PyArray_PyIntAsInt(swig_obj[2]);
+  }
+  {
+    try {
+      result = (MatrixNumbaFunction *)new MatrixNumbaFunction(arg1,arg2,arg3); 
+    }
+    catch (Swig::DirectorException &e) {
+      SWIG_fail; 
+    }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
+  }
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_MatrixNumbaFunction, SWIG_POINTER_NEW |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_new_MatrixNumbaFunction__SWIG_1(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
+  PyObject *resultobj = 0;
+  PyObject *arg1 = (PyObject *) 0 ;
+  int arg2 ;
+  int arg3 ;
+  bool arg4 ;
+  bool val4 ;
+  int ecode4 = 0 ;
+  MatrixNumbaFunction *result = 0 ;
+  
+  if ((nobjs < 4) || (nobjs > 4)) SWIG_fail;
+  arg1 = swig_obj[0];
+  {
+    if ((PyArray_PyIntAsInt(swig_obj[1]) == -1) && PyErr_Occurred()) {
+      SWIG_exception_fail(SWIG_TypeError, "Input must be integer");
+    };  
+    arg2 = PyArray_PyIntAsInt(swig_obj[1]);
+  }
+  {
+    if ((PyArray_PyIntAsInt(swig_obj[2]) == -1) && PyErr_Occurred()) {
+      SWIG_exception_fail(SWIG_TypeError, "Input must be integer");
+    };  
+    arg3 = PyArray_PyIntAsInt(swig_obj[2]);
+  }
+  ecode4 = SWIG_AsVal_bool(swig_obj[3], &val4);
+  if (!SWIG_IsOK(ecode4)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode4), "in method '" "new_MatrixNumbaFunction" "', argument " "4"" of type '" "bool""'");
+  } 
+  arg4 = static_cast< bool >(val4);
+  {
+    try {
+      result = (MatrixNumbaFunction *)new MatrixNumbaFunction(arg1,arg2,arg3,arg4); 
+    }
+    catch (Swig::DirectorException &e) {
+      SWIG_fail; 
+    }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
+  }
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_MatrixNumbaFunction, SWIG_POINTER_NEW |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_new_MatrixNumbaFunction(PyObject *self, PyObject *args) {
+  Py_ssize_t argc;
+  PyObject *argv[5] = {
+    0
+  };
+  
+  if (!(argc = SWIG_Python_UnpackTuple(args, "new_MatrixNumbaFunction", 0, 4, argv))) SWIG_fail;
+  --argc;
+  if (argc == 3) {
+    int _v;
+    _v = (argv[0] != 0);
+    if (_v) {
+      {
+        if ((PyArray_PyIntAsInt(argv[1]) == -1) && PyErr_Occurred()) {
+          PyErr_Clear();
+          _v = 0;
+        } else {
+          _v = 1;    
+        }
+      }
+      if (_v) {
+        {
+          if ((PyArray_PyIntAsInt(argv[2]) == -1) && PyErr_Occurred()) {
+            PyErr_Clear();
+            _v = 0;
+          } else {
+            _v = 1;    
+          }
+        }
+        if (_v) {
+          return _wrap_new_MatrixNumbaFunction__SWIG_0(self, argc, argv);
+        }
+      }
+    }
+  }
+  if (argc == 4) {
+    int _v;
+    _v = (argv[0] != 0);
+    if (_v) {
+      {
+        if ((PyArray_PyIntAsInt(argv[1]) == -1) && PyErr_Occurred()) {
+          PyErr_Clear();
+          _v = 0;
+        } else {
+          _v = 1;    
+        }
+      }
+      if (_v) {
+        {
+          if ((PyArray_PyIntAsInt(argv[2]) == -1) && PyErr_Occurred()) {
+            PyErr_Clear();
+            _v = 0;
+          } else {
+            _v = 1;    
+          }
+        }
+        if (_v) {
+          {
+            int res = SWIG_AsVal_bool(argv[3], NULL);
+            _v = SWIG_CheckState(res);
+          }
+          if (_v) {
+            return _wrap_new_MatrixNumbaFunction__SWIG_1(self, argc, argv);
+          }
+        }
+      }
+    }
+  }
+  
+fail:
+  SWIG_Python_RaiseOrModifyTypeError("Wrong number or type of arguments for overloaded function 'new_MatrixNumbaFunction'.\n"
+    "  Possible C/C++ prototypes are:\n"
+    "    MatrixNumbaFunction::MatrixNumbaFunction(PyObject *,int,int)\n"
+    "    MatrixNumbaFunction::MatrixNumbaFunction(PyObject *,int,int,bool)\n");
+  return 0;
+}
+
+
+SWIGINTERN PyObject *_wrap_MatrixNumbaFunction_call(PyObject *SWIGUNUSEDPARM(self), PyObject *args, PyObject *kwargs) {
+  PyObject *resultobj = 0;
+  MatrixNumbaFunction *arg1 = (MatrixNumbaFunction *) 0 ;
+  mfem::Vector *arg2 = 0 ;
+  mfem::DenseMatrix *arg3 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  void *argp3 = 0 ;
+  int res3 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  char * kwnames[] = {
+    (char *)"self",  (char *)"x",  (char *)"out",  NULL 
+  };
+  
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OOO:MatrixNumbaFunction_call", kwnames, &obj0, &obj1, &obj2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_MatrixNumbaFunction, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "MatrixNumbaFunction_call" "', argument " "1"" of type '" "MatrixNumbaFunction *""'"); 
+  }
+  arg1 = reinterpret_cast< MatrixNumbaFunction * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_mfem__Vector,  0  | 0);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "MatrixNumbaFunction_call" "', argument " "2"" of type '" "mfem::Vector const &""'"); 
+  }
+  if (!argp2) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "MatrixNumbaFunction_call" "', argument " "2"" of type '" "mfem::Vector const &""'"); 
+  }
+  arg2 = reinterpret_cast< mfem::Vector * >(argp2);
+  res3 = SWIG_ConvertPtr(obj2, &argp3, SWIGTYPE_p_mfem__DenseMatrix,  0 );
+  if (!SWIG_IsOK(res3)) {
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "MatrixNumbaFunction_call" "', argument " "3"" of type '" "mfem::DenseMatrix &""'"); 
+  }
+  if (!argp3) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "MatrixNumbaFunction_call" "', argument " "3"" of type '" "mfem::DenseMatrix &""'"); 
+  }
+  arg3 = reinterpret_cast< mfem::DenseMatrix * >(argp3);
+  {
+    try {
+      (arg1)->call((mfem::Vector const &)*arg2,*arg3); 
+    }
+    catch (Swig::DirectorException &e) {
+      SWIG_fail; 
+    }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_MatrixNumbaFunction_callt(PyObject *SWIGUNUSEDPARM(self), PyObject *args, PyObject *kwargs) {
+  PyObject *resultobj = 0;
+  MatrixNumbaFunction *arg1 = (MatrixNumbaFunction *) 0 ;
+  mfem::Vector *arg2 = 0 ;
+  double arg3 ;
+  mfem::DenseMatrix *arg4 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  double val3 ;
+  int ecode3 = 0 ;
+  void *argp4 = 0 ;
+  int res4 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  PyObject * obj3 = 0 ;
+  char * kwnames[] = {
+    (char *)"self",  (char *)"x",  (char *)"t",  (char *)"out",  NULL 
+  };
+  
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OOOO:MatrixNumbaFunction_callt", kwnames, &obj0, &obj1, &obj2, &obj3)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_MatrixNumbaFunction, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "MatrixNumbaFunction_callt" "', argument " "1"" of type '" "MatrixNumbaFunction *""'"); 
+  }
+  arg1 = reinterpret_cast< MatrixNumbaFunction * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_mfem__Vector,  0  | 0);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "MatrixNumbaFunction_callt" "', argument " "2"" of type '" "mfem::Vector const &""'"); 
+  }
+  if (!argp2) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "MatrixNumbaFunction_callt" "', argument " "2"" of type '" "mfem::Vector const &""'"); 
+  }
+  arg2 = reinterpret_cast< mfem::Vector * >(argp2);
+  ecode3 = SWIG_AsVal_double(obj2, &val3);
+  if (!SWIG_IsOK(ecode3)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode3), "in method '" "MatrixNumbaFunction_callt" "', argument " "3"" of type '" "double""'");
+  } 
+  arg3 = static_cast< double >(val3);
+  res4 = SWIG_ConvertPtr(obj3, &argp4, SWIGTYPE_p_mfem__DenseMatrix,  0 );
+  if (!SWIG_IsOK(res4)) {
+    SWIG_exception_fail(SWIG_ArgError(res4), "in method '" "MatrixNumbaFunction_callt" "', argument " "4"" of type '" "mfem::DenseMatrix &""'"); 
+  }
+  if (!argp4) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "MatrixNumbaFunction_callt" "', argument " "4"" of type '" "mfem::DenseMatrix &""'"); 
+  }
+  arg4 = reinterpret_cast< mfem::DenseMatrix * >(argp4);
+  {
+    try {
+      (arg1)->callt((mfem::Vector const &)*arg2,arg3,*arg4); 
+    }
+    catch (Swig::DirectorException &e) {
+      SWIG_fail; 
+    }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_MatrixNumbaFunction_GenerateCoefficient(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  MatrixNumbaFunction *arg1 = (MatrixNumbaFunction *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject *swig_obj[1] ;
+  mfem::MatrixFunctionCoefficient *result = 0 ;
+  
+  if (!args) SWIG_fail;
+  swig_obj[0] = args;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_MatrixNumbaFunction, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "MatrixNumbaFunction_GenerateCoefficient" "', argument " "1"" of type '" "MatrixNumbaFunction *""'"); 
+  }
+  arg1 = reinterpret_cast< MatrixNumbaFunction * >(argp1);
+  {
+    try {
+      result = (mfem::MatrixFunctionCoefficient *)(arg1)->GenerateCoefficient(); 
+    }
+    catch (Swig::DirectorException &e) {
+      SWIG_fail; 
+    }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
+  }
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__MatrixFunctionCoefficient, 0 |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_delete_MatrixNumbaFunction(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  MatrixNumbaFunction *arg1 = (MatrixNumbaFunction *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject *swig_obj[1] ;
+  
+  if (!args) SWIG_fail;
+  swig_obj[0] = args;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_MatrixNumbaFunction, SWIG_POINTER_DISOWN |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "delete_MatrixNumbaFunction" "', argument " "1"" of type '" "MatrixNumbaFunction *""'"); 
+  }
+  arg1 = reinterpret_cast< MatrixNumbaFunction * >(argp1);
+  {
+    try {
+      delete arg1; 
+    }
+    catch (Swig::DirectorException &e) {
+      SWIG_fail; 
+    }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *MatrixNumbaFunction_swigregister(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *obj;
+  if (!SWIG_Python_UnpackTuple(args, "swigregister", 1, 1, &obj)) return NULL;
+  SWIG_TypeNewClientData(SWIGTYPE_p_MatrixNumbaFunction, SWIG_NewClientData(obj));
+  return SWIG_Py_Void();
+}
+
+SWIGINTERN PyObject *MatrixNumbaFunction_swiginit(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  return SWIG_Python_InitShadowInstance(args);
+}
+
 SWIGINTERN PyObject *_wrap_fake_func(PyObject *SWIGUNUSEDPARM(self), PyObject *args, PyObject *kwargs) {
   PyObject *resultobj = 0;
   mfem::Vector *arg1 = 0 ;
@@ -24437,6 +25797,41 @@ static PyMethodDef SwigMethods[] = {
 		"ComputeGlobalLpNorm(double p, Coefficient coeff, mfem::ParMesh & pmesh, mfem::IntegrationRule const *[] irs) -> double\n"
 		"ComputeGlobalLpNorm(double p, VectorCoefficient coeff, mfem::ParMesh & pmesh, mfem::IntegrationRule const *[] irs) -> double\n"
 		""},
+	 { "new_NumbaFunctionBase", (PyCFunction)(void(*)(void))_wrap_new_NumbaFunctionBase, METH_VARARGS|METH_KEYWORDS, "new_NumbaFunctionBase(PyObject * input, int sdim, bool td) -> NumbaFunctionBase"},
+	 { "NumbaFunctionBase_print_add", _wrap_NumbaFunctionBase_print_add, METH_O, "NumbaFunctionBase_print_add(NumbaFunctionBase self) -> double"},
+	 { "delete_NumbaFunctionBase", _wrap_delete_NumbaFunctionBase, METH_O, "delete_NumbaFunctionBase(NumbaFunctionBase self)"},
+	 { "NumbaFunctionBase_swigregister", NumbaFunctionBase_swigregister, METH_O, NULL},
+	 { "NumbaFunctionBase_swiginit", NumbaFunctionBase_swiginit, METH_VARARGS, NULL},
+	 { "new_NumbaFunction", _wrap_new_NumbaFunction, METH_VARARGS, "\n"
+		"NumbaFunction(PyObject * input, int sdim)\n"
+		"new_NumbaFunction(PyObject * input, int sdim, bool td) -> NumbaFunction\n"
+		""},
+	 { "NumbaFunction_call", (PyCFunction)(void(*)(void))_wrap_NumbaFunction_call, METH_VARARGS|METH_KEYWORDS, "NumbaFunction_call(NumbaFunction self, Vector x) -> double"},
+	 { "NumbaFunction_callt", (PyCFunction)(void(*)(void))_wrap_NumbaFunction_callt, METH_VARARGS|METH_KEYWORDS, "NumbaFunction_callt(NumbaFunction self, Vector x, double t) -> double"},
+	 { "NumbaFunction_GenerateCoefficient", _wrap_NumbaFunction_GenerateCoefficient, METH_O, "NumbaFunction_GenerateCoefficient(NumbaFunction self) -> FunctionCoefficient"},
+	 { "delete_NumbaFunction", _wrap_delete_NumbaFunction, METH_O, "delete_NumbaFunction(NumbaFunction self)"},
+	 { "NumbaFunction_swigregister", NumbaFunction_swigregister, METH_O, NULL},
+	 { "NumbaFunction_swiginit", NumbaFunction_swiginit, METH_VARARGS, NULL},
+	 { "new_VectorNumbaFunction", _wrap_new_VectorNumbaFunction, METH_VARARGS, "\n"
+		"VectorNumbaFunction(PyObject * input, int sdim, int vdim)\n"
+		"new_VectorNumbaFunction(PyObject * input, int sdim, int vdim, bool td) -> VectorNumbaFunction\n"
+		""},
+	 { "VectorNumbaFunction_call", (PyCFunction)(void(*)(void))_wrap_VectorNumbaFunction_call, METH_VARARGS|METH_KEYWORDS, "VectorNumbaFunction_call(VectorNumbaFunction self, Vector x, Vector out)"},
+	 { "VectorNumbaFunction_callt", (PyCFunction)(void(*)(void))_wrap_VectorNumbaFunction_callt, METH_VARARGS|METH_KEYWORDS, "VectorNumbaFunction_callt(VectorNumbaFunction self, Vector x, double t, Vector out)"},
+	 { "VectorNumbaFunction_GenerateCoefficient", _wrap_VectorNumbaFunction_GenerateCoefficient, METH_O, "VectorNumbaFunction_GenerateCoefficient(VectorNumbaFunction self) -> VectorFunctionCoefficient"},
+	 { "delete_VectorNumbaFunction", _wrap_delete_VectorNumbaFunction, METH_O, "delete_VectorNumbaFunction(VectorNumbaFunction self)"},
+	 { "VectorNumbaFunction_swigregister", VectorNumbaFunction_swigregister, METH_O, NULL},
+	 { "VectorNumbaFunction_swiginit", VectorNumbaFunction_swiginit, METH_VARARGS, NULL},
+	 { "new_MatrixNumbaFunction", _wrap_new_MatrixNumbaFunction, METH_VARARGS, "\n"
+		"MatrixNumbaFunction(PyObject * input, int sdim, int vdim)\n"
+		"new_MatrixNumbaFunction(PyObject * input, int sdim, int vdim, bool td) -> MatrixNumbaFunction\n"
+		""},
+	 { "MatrixNumbaFunction_call", (PyCFunction)(void(*)(void))_wrap_MatrixNumbaFunction_call, METH_VARARGS|METH_KEYWORDS, "MatrixNumbaFunction_call(MatrixNumbaFunction self, Vector x, DenseMatrix out)"},
+	 { "MatrixNumbaFunction_callt", (PyCFunction)(void(*)(void))_wrap_MatrixNumbaFunction_callt, METH_VARARGS|METH_KEYWORDS, "MatrixNumbaFunction_callt(MatrixNumbaFunction self, Vector x, double t, DenseMatrix out)"},
+	 { "MatrixNumbaFunction_GenerateCoefficient", _wrap_MatrixNumbaFunction_GenerateCoefficient, METH_O, "MatrixNumbaFunction_GenerateCoefficient(MatrixNumbaFunction self) -> MatrixFunctionCoefficient"},
+	 { "delete_MatrixNumbaFunction", _wrap_delete_MatrixNumbaFunction, METH_O, "delete_MatrixNumbaFunction(MatrixNumbaFunction self)"},
+	 { "MatrixNumbaFunction_swigregister", MatrixNumbaFunction_swigregister, METH_O, NULL},
+	 { "MatrixNumbaFunction_swiginit", MatrixNumbaFunction_swiginit, METH_VARARGS, NULL},
 	 { "fake_func", (PyCFunction)(void(*)(void))_wrap_fake_func, METH_VARARGS|METH_KEYWORDS, "fake_func(Vector x) -> double"},
 	 { "fake_func_vec", (PyCFunction)(void(*)(void))_wrap_fake_func_vec, METH_VARARGS|METH_KEYWORDS, "fake_func_vec(Vector x, Vector Ht)"},
 	 { "fake_func_mat", (PyCFunction)(void(*)(void))_wrap_fake_func_mat, METH_VARARGS|METH_KEYWORDS, "fake_func_mat(Vector x, DenseMatrix Kt)"},
@@ -24961,6 +26356,41 @@ static PyMethodDef SwigMethods_proxydocs[] = {
 		"ComputeGlobalLpNorm(double p, Coefficient coeff, mfem::ParMesh & pmesh, mfem::IntegrationRule const *[] irs) -> double\n"
 		"ComputeGlobalLpNorm(double p, VectorCoefficient coeff, mfem::ParMesh & pmesh, mfem::IntegrationRule const *[] irs) -> double\n"
 		""},
+	 { "new_NumbaFunctionBase", (PyCFunction)(void(*)(void))_wrap_new_NumbaFunctionBase, METH_VARARGS|METH_KEYWORDS, "new_NumbaFunctionBase(PyObject * input, int sdim, bool td) -> NumbaFunctionBase"},
+	 { "NumbaFunctionBase_print_add", _wrap_NumbaFunctionBase_print_add, METH_O, "print_add(NumbaFunctionBase self) -> double"},
+	 { "delete_NumbaFunctionBase", _wrap_delete_NumbaFunctionBase, METH_O, "delete_NumbaFunctionBase(NumbaFunctionBase self)"},
+	 { "NumbaFunctionBase_swigregister", NumbaFunctionBase_swigregister, METH_O, NULL},
+	 { "NumbaFunctionBase_swiginit", NumbaFunctionBase_swiginit, METH_VARARGS, NULL},
+	 { "new_NumbaFunction", _wrap_new_NumbaFunction, METH_VARARGS, "\n"
+		"NumbaFunction(PyObject * input, int sdim)\n"
+		"new_NumbaFunction(PyObject * input, int sdim, bool td) -> NumbaFunction\n"
+		""},
+	 { "NumbaFunction_call", (PyCFunction)(void(*)(void))_wrap_NumbaFunction_call, METH_VARARGS|METH_KEYWORDS, "call(NumbaFunction self, Vector x) -> double"},
+	 { "NumbaFunction_callt", (PyCFunction)(void(*)(void))_wrap_NumbaFunction_callt, METH_VARARGS|METH_KEYWORDS, "callt(NumbaFunction self, Vector x, double t) -> double"},
+	 { "NumbaFunction_GenerateCoefficient", _wrap_NumbaFunction_GenerateCoefficient, METH_O, "GenerateCoefficient(NumbaFunction self) -> FunctionCoefficient"},
+	 { "delete_NumbaFunction", _wrap_delete_NumbaFunction, METH_O, "delete_NumbaFunction(NumbaFunction self)"},
+	 { "NumbaFunction_swigregister", NumbaFunction_swigregister, METH_O, NULL},
+	 { "NumbaFunction_swiginit", NumbaFunction_swiginit, METH_VARARGS, NULL},
+	 { "new_VectorNumbaFunction", _wrap_new_VectorNumbaFunction, METH_VARARGS, "\n"
+		"VectorNumbaFunction(PyObject * input, int sdim, int vdim)\n"
+		"new_VectorNumbaFunction(PyObject * input, int sdim, int vdim, bool td) -> VectorNumbaFunction\n"
+		""},
+	 { "VectorNumbaFunction_call", (PyCFunction)(void(*)(void))_wrap_VectorNumbaFunction_call, METH_VARARGS|METH_KEYWORDS, "call(VectorNumbaFunction self, Vector x, Vector out)"},
+	 { "VectorNumbaFunction_callt", (PyCFunction)(void(*)(void))_wrap_VectorNumbaFunction_callt, METH_VARARGS|METH_KEYWORDS, "callt(VectorNumbaFunction self, Vector x, double t, Vector out)"},
+	 { "VectorNumbaFunction_GenerateCoefficient", _wrap_VectorNumbaFunction_GenerateCoefficient, METH_O, "GenerateCoefficient(VectorNumbaFunction self) -> VectorFunctionCoefficient"},
+	 { "delete_VectorNumbaFunction", _wrap_delete_VectorNumbaFunction, METH_O, "delete_VectorNumbaFunction(VectorNumbaFunction self)"},
+	 { "VectorNumbaFunction_swigregister", VectorNumbaFunction_swigregister, METH_O, NULL},
+	 { "VectorNumbaFunction_swiginit", VectorNumbaFunction_swiginit, METH_VARARGS, NULL},
+	 { "new_MatrixNumbaFunction", _wrap_new_MatrixNumbaFunction, METH_VARARGS, "\n"
+		"MatrixNumbaFunction(PyObject * input, int sdim, int vdim)\n"
+		"new_MatrixNumbaFunction(PyObject * input, int sdim, int vdim, bool td) -> MatrixNumbaFunction\n"
+		""},
+	 { "MatrixNumbaFunction_call", (PyCFunction)(void(*)(void))_wrap_MatrixNumbaFunction_call, METH_VARARGS|METH_KEYWORDS, "call(MatrixNumbaFunction self, Vector x, DenseMatrix out)"},
+	 { "MatrixNumbaFunction_callt", (PyCFunction)(void(*)(void))_wrap_MatrixNumbaFunction_callt, METH_VARARGS|METH_KEYWORDS, "callt(MatrixNumbaFunction self, Vector x, double t, DenseMatrix out)"},
+	 { "MatrixNumbaFunction_GenerateCoefficient", _wrap_MatrixNumbaFunction_GenerateCoefficient, METH_O, "GenerateCoefficient(MatrixNumbaFunction self) -> MatrixFunctionCoefficient"},
+	 { "delete_MatrixNumbaFunction", _wrap_delete_MatrixNumbaFunction, METH_O, "delete_MatrixNumbaFunction(MatrixNumbaFunction self)"},
+	 { "MatrixNumbaFunction_swigregister", MatrixNumbaFunction_swigregister, METH_O, NULL},
+	 { "MatrixNumbaFunction_swiginit", MatrixNumbaFunction_swiginit, METH_VARARGS, NULL},
 	 { "fake_func", (PyCFunction)(void(*)(void))_wrap_fake_func, METH_VARARGS|METH_KEYWORDS, "fake_func(Vector x) -> double"},
 	 { "fake_func_vec", (PyCFunction)(void(*)(void))_wrap_fake_func_vec, METH_VARARGS|METH_KEYWORDS, "fake_func_vec(Vector x, Vector Ht)"},
 	 { "fake_func_mat", (PyCFunction)(void(*)(void))_wrap_fake_func_mat, METH_VARARGS|METH_KEYWORDS, "fake_func_mat(Vector x, DenseMatrix Kt)"},
@@ -24997,6 +26427,15 @@ static PyMethodDef SwigMethods_proxydocs[] = {
 
 /* -------- TYPE CONVERSION AND EQUIVALENCE RULES (BEGIN) -------- */
 
+static void *_p_NumbaFunctionTo_p_NumbaFunctionBase(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((NumbaFunctionBase *)  ((NumbaFunction *) x));
+}
+static void *_p_VectorNumbaFunctionTo_p_NumbaFunctionBase(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((NumbaFunctionBase *)  ((VectorNumbaFunction *) x));
+}
+static void *_p_MatrixNumbaFunctionTo_p_NumbaFunctionBase(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((NumbaFunctionBase *)  ((MatrixNumbaFunction *) x));
+}
 static void *_p_mfem__MatrixConstantCoefficientTo_p_mfem__MatrixCoefficient(void *x, int *SWIGUNUSEDPARM(newmemory)) {
     return (void *)((mfem::MatrixCoefficient *)  ((mfem::MatrixConstantCoefficient *) x));
 }
@@ -25195,7 +26634,11 @@ static void *_p_mfem__IsoparametricTransformationTo_p_mfem__ElementTransformatio
 static void *_p_mfem__FaceElementTransformationsTo_p_mfem__ElementTransformation(void *x, int *SWIGUNUSEDPARM(newmemory)) {
     return (void *)((mfem::ElementTransformation *) (mfem::IsoparametricTransformation *) ((mfem::FaceElementTransformations *) x));
 }
+static swig_type_info _swigt__p_MatrixNumbaFunction = {"_p_MatrixNumbaFunction", "MatrixNumbaFunction *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_NumbaFunction = {"_p_NumbaFunction", "NumbaFunction *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_NumbaFunctionBase = {"_p_NumbaFunctionBase", "NumbaFunctionBase *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_PyMFEM__wFILE = {"_p_PyMFEM__wFILE", "PyMFEM::wFILE *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_VectorNumbaFunction = {"_p_VectorNumbaFunction", "VectorNumbaFunction *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_char = {"_p_char", "char *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_double = {"_p_double", "double *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_f_double__double = {"_p_f_double__double", "double (*)(double)", 0, 0, (void*)0, 0};
@@ -25287,7 +26730,11 @@ static swig_type_info _swigt__p_std__functionT_void_fmfem__Vector_const_R_mfem__
 static swig_type_info _swigt__p_std__functionT_void_fmfem__Vector_const_R_mfem__Vector_RF_t = {"_p_std__functionT_void_fmfem__Vector_const_R_mfem__Vector_RF_t", "std::function< void (mfem::Vector const &,mfem::Vector &) > *", 0, 0, (void*)0, 0};
 
 static swig_type_info *swig_type_initial[] = {
+  &_swigt__p_MatrixNumbaFunction,
+  &_swigt__p_NumbaFunction,
+  &_swigt__p_NumbaFunctionBase,
   &_swigt__p_PyMFEM__wFILE,
+  &_swigt__p_VectorNumbaFunction,
   &_swigt__p_char,
   &_swigt__p_double,
   &_swigt__p_f_double__double,
@@ -25379,7 +26826,11 @@ static swig_type_info *swig_type_initial[] = {
   &_swigt__p_std__functionT_void_fmfem__Vector_const_R_mfem__Vector_RF_t,
 };
 
+static swig_cast_info _swigc__p_MatrixNumbaFunction[] = {  {&_swigt__p_MatrixNumbaFunction, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_NumbaFunction[] = {  {&_swigt__p_NumbaFunction, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_NumbaFunctionBase[] = {  {&_swigt__p_NumbaFunction, _p_NumbaFunctionTo_p_NumbaFunctionBase, 0, 0},  {&_swigt__p_VectorNumbaFunction, _p_VectorNumbaFunctionTo_p_NumbaFunctionBase, 0, 0},  {&_swigt__p_MatrixNumbaFunction, _p_MatrixNumbaFunctionTo_p_NumbaFunctionBase, 0, 0},  {&_swigt__p_NumbaFunctionBase, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_PyMFEM__wFILE[] = {  {&_swigt__p_PyMFEM__wFILE, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_VectorNumbaFunction[] = {  {&_swigt__p_VectorNumbaFunction, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_char[] = {  {&_swigt__p_char, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_double[] = {  {&_swigt__p_double, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_f_double__double[] = {  {&_swigt__p_f_double__double, 0, 0, 0},{0, 0, 0, 0}};
@@ -25471,7 +26922,11 @@ static swig_cast_info _swigc__p_std__functionT_void_fmfem__Vector_const_R_mfem__
 static swig_cast_info _swigc__p_std__functionT_void_fmfem__Vector_const_R_mfem__Vector_RF_t[] = {  {&_swigt__p_std__functionT_void_fmfem__Vector_const_R_mfem__Vector_RF_t, 0, 0, 0},{0, 0, 0, 0}};
 
 static swig_cast_info *swig_cast_initial[] = {
+  _swigc__p_MatrixNumbaFunction,
+  _swigc__p_NumbaFunction,
+  _swigc__p_NumbaFunctionBase,
   _swigc__p_PyMFEM__wFILE,
+  _swigc__p_VectorNumbaFunction,
   _swigc__p_char,
   _swigc__p_double,
   _swigc__p_f_double__double,

--- a/mfem/_ser/coefficient.i
+++ b/mfem/_ser/coefficient.i
@@ -153,6 +153,7 @@ namespace mfem {
 }
 
 %include "../../headers/coefficient.hpp"
+%include "../common/numba_coefficient.i"
 
 %feature("director") mfem::VectorPyCoefficientBase;
 %feature("director") mfem::PyCoefficientBase;
@@ -170,6 +171,7 @@ void fake_func_vec(const mfem::Vector &x, mfem::Vector &Ht)
      Ht(1) = 0.0;
      Ht(2) = 0.0;
 }
+
 void fake_func_mat(const mfem::Vector &x, mfem::DenseMatrix &Kt)
 {
   Kt(0,0) = 1.0;

--- a/mfem/_ser/coefficient.py
+++ b/mfem/_ser/coefficient.py
@@ -1996,8 +1996,8 @@ try:
 			  types.intc,
 			  types.intc)
 
-    matrix_scalar = vector_sig
-    matrix_scalar_t = vector_sig_t
+    matrix_sig = vector_sig
+    matrix_sig_t = vector_sig_t
 except ImportError:
     pass
 except BaseError:

--- a/mfem/_ser/coefficient.py
+++ b/mfem/_ser/coefficient.py
@@ -1979,24 +1979,29 @@ class MatrixNumbaFunction(object):
 _coefficient.MatrixNumbaFunction_swigregister(MatrixNumbaFunction)
 
 
-from numba import cfunc, types, carray
-scalar_sig = types.double(types.CPointer(types.double),
+try:
+    from numba import cfunc, types, carray
+    scalar_sig = types.double(types.CPointer(types.double),
 			  types.intc)
-scalar_sig_t = types.double(types.CPointer(types.double),
+    scalar_sig_t = types.double(types.CPointer(types.double),
 			    types.double,
 			    types.intc)
-vector_sig = types.void(types.CPointer(types.double),
+    vector_sig = types.void(types.CPointer(types.double),
 			types.CPointer(types.double),
 			types.intc,
 			types.intc)
-vector_sig_t = types.void(types.CPointer(types.double),
+    vector_sig_t = types.void(types.CPointer(types.double),
 			  types.double,
                           types.CPointer(types.double),
 			  types.intc,
 			  types.intc)
 
-matrix_scalar = vector_sig
-matrix_scalar_t = vector_sig_t
+    matrix_scalar = vector_sig
+    matrix_scalar_t = vector_sig_t
+except ImportError:
+    pass
+except BaseError:
+    assert False, "Failed setting Numba signatures by an error other than ImportError"
 
 
 def fake_func(x):

--- a/mfem/_ser/coefficient.py
+++ b/mfem/_ser/coefficient.py
@@ -1848,6 +1848,156 @@ def ComputeLpNorm(*args):
     """
     return _coefficient.ComputeLpNorm(*args)
 ComputeLpNorm = _coefficient.ComputeLpNorm
+class NumbaFunctionBase(object):
+    r"""Proxy of C++ NumbaFunctionBase class."""
+
+    thisown = property(lambda x: x.this.own(), lambda x, v: x.this.own(v), doc="The membership flag")
+    __repr__ = _swig_repr
+
+    def __init__(self, input, sdim, td):
+        r"""__init__(NumbaFunctionBase self, PyObject * input, int sdim, bool td) -> NumbaFunctionBase"""
+        _coefficient.NumbaFunctionBase_swiginit(self, _coefficient.new_NumbaFunctionBase(input, sdim, td))
+
+    def print_add(self):
+        r"""print_add(NumbaFunctionBase self) -> double"""
+        return _coefficient.NumbaFunctionBase_print_add(self)
+    print_add = _swig_new_instance_method(_coefficient.NumbaFunctionBase_print_add)
+    __swig_destroy__ = _coefficient.delete_NumbaFunctionBase
+
+# Register NumbaFunctionBase in _coefficient:
+_coefficient.NumbaFunctionBase_swigregister(NumbaFunctionBase)
+
+class NumbaFunction(NumbaFunctionBase):
+    r"""Proxy of C++ NumbaFunction class."""
+
+    thisown = property(lambda x: x.this.own(), lambda x, v: x.this.own(v), doc="The membership flag")
+    __repr__ = _swig_repr
+
+    def __init__(self, *args):
+        r"""
+        __init__(NumbaFunction self, PyObject * input, int sdim) -> NumbaFunction
+        __init__(NumbaFunction self, PyObject * input, int sdim, bool td) -> NumbaFunction
+        """
+        _coefficient.NumbaFunction_swiginit(self, _coefficient.new_NumbaFunction(*args))
+
+    def call(self, x):
+        r"""call(NumbaFunction self, Vector x) -> double"""
+        return _coefficient.NumbaFunction_call(self, x)
+    call = _swig_new_instance_method(_coefficient.NumbaFunction_call)
+
+    def callt(self, x, t):
+        r"""callt(NumbaFunction self, Vector x, double t) -> double"""
+        return _coefficient.NumbaFunction_callt(self, x, t)
+    callt = _swig_new_instance_method(_coefficient.NumbaFunction_callt)
+
+    def GenerateCoefficient(self):
+        r"""GenerateCoefficient(NumbaFunction self) -> FunctionCoefficient"""
+        val = _coefficient.NumbaFunction_GenerateCoefficient(self)
+
+        val._link = self
+
+
+        return val
+
+    __swig_destroy__ = _coefficient.delete_NumbaFunction
+
+# Register NumbaFunction in _coefficient:
+_coefficient.NumbaFunction_swigregister(NumbaFunction)
+
+class VectorNumbaFunction(NumbaFunctionBase):
+    r"""Proxy of C++ VectorNumbaFunction class."""
+
+    thisown = property(lambda x: x.this.own(), lambda x, v: x.this.own(v), doc="The membership flag")
+    __repr__ = _swig_repr
+
+    def __init__(self, *args):
+        r"""
+        __init__(VectorNumbaFunction self, PyObject * input, int sdim, int vdim) -> VectorNumbaFunction
+        __init__(VectorNumbaFunction self, PyObject * input, int sdim, int vdim, bool td) -> VectorNumbaFunction
+        """
+        _coefficient.VectorNumbaFunction_swiginit(self, _coefficient.new_VectorNumbaFunction(*args))
+
+    def call(self, x, out):
+        r"""call(VectorNumbaFunction self, Vector x, Vector out)"""
+        return _coefficient.VectorNumbaFunction_call(self, x, out)
+    call = _swig_new_instance_method(_coefficient.VectorNumbaFunction_call)
+
+    def callt(self, x, t, out):
+        r"""callt(VectorNumbaFunction self, Vector x, double t, Vector out)"""
+        return _coefficient.VectorNumbaFunction_callt(self, x, t, out)
+    callt = _swig_new_instance_method(_coefficient.VectorNumbaFunction_callt)
+
+    def GenerateCoefficient(self):
+        r"""GenerateCoefficient(VectorNumbaFunction self) -> VectorFunctionCoefficient"""
+        val = _coefficient.VectorNumbaFunction_GenerateCoefficient(self)
+
+        val._link = self
+
+
+        return val
+
+    __swig_destroy__ = _coefficient.delete_VectorNumbaFunction
+
+# Register VectorNumbaFunction in _coefficient:
+_coefficient.VectorNumbaFunction_swigregister(VectorNumbaFunction)
+
+class MatrixNumbaFunction(object):
+    r"""Proxy of C++ MatrixNumbaFunction class."""
+
+    thisown = property(lambda x: x.this.own(), lambda x, v: x.this.own(v), doc="The membership flag")
+    __repr__ = _swig_repr
+
+    def __init__(self, *args):
+        r"""
+        __init__(MatrixNumbaFunction self, PyObject * input, int sdim, int vdim) -> MatrixNumbaFunction
+        __init__(MatrixNumbaFunction self, PyObject * input, int sdim, int vdim, bool td) -> MatrixNumbaFunction
+        """
+        _coefficient.MatrixNumbaFunction_swiginit(self, _coefficient.new_MatrixNumbaFunction(*args))
+
+    def call(self, x, out):
+        r"""call(MatrixNumbaFunction self, Vector x, DenseMatrix out)"""
+        return _coefficient.MatrixNumbaFunction_call(self, x, out)
+    call = _swig_new_instance_method(_coefficient.MatrixNumbaFunction_call)
+
+    def callt(self, x, t, out):
+        r"""callt(MatrixNumbaFunction self, Vector x, double t, DenseMatrix out)"""
+        return _coefficient.MatrixNumbaFunction_callt(self, x, t, out)
+    callt = _swig_new_instance_method(_coefficient.MatrixNumbaFunction_callt)
+
+    def GenerateCoefficient(self):
+        r"""GenerateCoefficient(MatrixNumbaFunction self) -> MatrixFunctionCoefficient"""
+        val = _coefficient.MatrixNumbaFunction_GenerateCoefficient(self)
+
+        val._link = self
+
+
+        return val
+
+    __swig_destroy__ = _coefficient.delete_MatrixNumbaFunction
+
+# Register MatrixNumbaFunction in _coefficient:
+_coefficient.MatrixNumbaFunction_swigregister(MatrixNumbaFunction)
+
+
+from numba import cfunc, types, carray
+scalar_sig = types.double(types.CPointer(types.double),
+			  types.intc)
+scalar_sig_t = types.double(types.CPointer(types.double),
+			    types.double,
+			    types.intc)
+vector_sig = types.void(types.CPointer(types.double),
+			types.CPointer(types.double),
+			types.intc,
+			types.intc)
+vector_sig_t = types.void(types.CPointer(types.double),
+			  types.double,
+                          types.CPointer(types.double),
+			  types.intc,
+			  types.intc)
+
+matrix_scalar = vector_sig
+matrix_scalar_t = vector_sig_t
+
 
 def fake_func(x):
     r"""fake_func(Vector x) -> double"""

--- a/mfem/_ser/coefficient_wrap.cxx
+++ b/mfem/_ser/coefficient_wrap.cxx
@@ -3097,97 +3097,101 @@ namespace Swig {
 
 /* -------- TYPES TABLE (BEGIN) -------- */
 
-#define SWIGTYPE_p_PyMFEM__wFILE swig_types[0]
-#define SWIGTYPE_p_char swig_types[1]
-#define SWIGTYPE_p_double swig_types[2]
-#define SWIGTYPE_p_f_double__double swig_types[3]
-#define SWIGTYPE_p_f_double_double__double swig_types[4]
-#define SWIGTYPE_p_f_r_mfem__Vector__double swig_types[5]
-#define SWIGTYPE_p_f_r_mfem__Vector_double__double swig_types[6]
-#define SWIGTYPE_p_mfem__ArrayT_int_t swig_types[7]
-#define SWIGTYPE_p_mfem__Coefficient swig_types[8]
-#define SWIGTYPE_p_mfem__ConstantCoefficient swig_types[9]
-#define SWIGTYPE_p_mfem__CrossCrossCoefficient swig_types[10]
-#define SWIGTYPE_p_mfem__CurlGridFunctionCoefficient swig_types[11]
-#define SWIGTYPE_p_mfem__DeltaCoefficient swig_types[12]
-#define SWIGTYPE_p_mfem__DenseMatrix swig_types[13]
-#define SWIGTYPE_p_mfem__DeterminantCoefficient swig_types[14]
-#define SWIGTYPE_p_mfem__DivergenceGridFunctionCoefficient swig_types[15]
-#define SWIGTYPE_p_mfem__ElementTransformation swig_types[16]
-#define SWIGTYPE_p_mfem__FaceElementTransformations swig_types[17]
-#define SWIGTYPE_p_mfem__FunctionCoefficient swig_types[18]
-#define SWIGTYPE_p_mfem__GradientGridFunctionCoefficient swig_types[19]
-#define SWIGTYPE_p_mfem__GridFunction swig_types[20]
-#define SWIGTYPE_p_mfem__GridFunctionCoefficient swig_types[21]
-#define SWIGTYPE_p_mfem__IdentityMatrixCoefficient swig_types[22]
-#define SWIGTYPE_p_mfem__InnerProductCoefficient swig_types[23]
-#define SWIGTYPE_p_mfem__IntegrationPoint swig_types[24]
-#define SWIGTYPE_p_mfem__IntegrationRule swig_types[25]
-#define SWIGTYPE_p_mfem__InverseMatrixCoefficient swig_types[26]
-#define SWIGTYPE_p_mfem__IsoparametricTransformation swig_types[27]
-#define SWIGTYPE_p_mfem__MatrixArrayCoefficient swig_types[28]
-#define SWIGTYPE_p_mfem__MatrixCoefficient swig_types[29]
-#define SWIGTYPE_p_mfem__MatrixConstantCoefficient swig_types[30]
-#define SWIGTYPE_p_mfem__MatrixFunctionCoefficient swig_types[31]
-#define SWIGTYPE_p_mfem__MatrixPyCoefficientBase swig_types[32]
-#define SWIGTYPE_p_mfem__MatrixRestrictedCoefficient swig_types[33]
-#define SWIGTYPE_p_mfem__MatrixSumCoefficient swig_types[34]
-#define SWIGTYPE_p_mfem__MatrixVectorProductCoefficient swig_types[35]
-#define SWIGTYPE_p_mfem__Mesh swig_types[36]
-#define SWIGTYPE_p_mfem__NormalizedVectorCoefficient swig_types[37]
-#define SWIGTYPE_p_mfem__OuterProductCoefficient swig_types[38]
-#define SWIGTYPE_p_mfem__PWConstCoefficient swig_types[39]
-#define SWIGTYPE_p_mfem__PowerCoefficient swig_types[40]
-#define SWIGTYPE_p_mfem__ProductCoefficient swig_types[41]
-#define SWIGTYPE_p_mfem__PyCoefficientBase swig_types[42]
-#define SWIGTYPE_p_mfem__QuadratureFunction swig_types[43]
-#define SWIGTYPE_p_mfem__QuadratureFunctionCoefficient swig_types[44]
-#define SWIGTYPE_p_mfem__RatioCoefficient swig_types[45]
-#define SWIGTYPE_p_mfem__RestrictedCoefficient swig_types[46]
-#define SWIGTYPE_p_mfem__ScalarMatrixProductCoefficient swig_types[47]
-#define SWIGTYPE_p_mfem__ScalarVectorProductCoefficient swig_types[48]
-#define SWIGTYPE_p_mfem__SumCoefficient swig_types[49]
-#define SWIGTYPE_p_mfem__TransformedCoefficient swig_types[50]
-#define SWIGTYPE_p_mfem__TransposeMatrixCoefficient swig_types[51]
-#define SWIGTYPE_p_mfem__Vector swig_types[52]
-#define SWIGTYPE_p_mfem__VectorArrayCoefficient swig_types[53]
-#define SWIGTYPE_p_mfem__VectorCoefficient swig_types[54]
-#define SWIGTYPE_p_mfem__VectorConstantCoefficient swig_types[55]
-#define SWIGTYPE_p_mfem__VectorCrossProductCoefficient swig_types[56]
-#define SWIGTYPE_p_mfem__VectorDeltaCoefficient swig_types[57]
-#define SWIGTYPE_p_mfem__VectorFunctionCoefficient swig_types[58]
-#define SWIGTYPE_p_mfem__VectorGridFunctionCoefficient swig_types[59]
-#define SWIGTYPE_p_mfem__VectorPyCoefficientBase swig_types[60]
-#define SWIGTYPE_p_mfem__VectorQuadratureFunctionCoefficient swig_types[61]
-#define SWIGTYPE_p_mfem__VectorRestrictedCoefficient swig_types[62]
-#define SWIGTYPE_p_mfem__VectorRotProductCoefficient swig_types[63]
-#define SWIGTYPE_p_mfem__VectorSumCoefficient swig_types[64]
-#define SWIGTYPE_p_p_mfem__Coefficient swig_types[65]
-#define SWIGTYPE_p_p_mfem__ConstantCoefficient swig_types[66]
-#define SWIGTYPE_p_p_mfem__DeltaCoefficient swig_types[67]
-#define SWIGTYPE_p_p_mfem__DeterminantCoefficient swig_types[68]
-#define SWIGTYPE_p_p_mfem__DivergenceGridFunctionCoefficient swig_types[69]
-#define SWIGTYPE_p_p_mfem__FunctionCoefficient swig_types[70]
-#define SWIGTYPE_p_p_mfem__GridFunctionCoefficient swig_types[71]
-#define SWIGTYPE_p_p_mfem__InnerProductCoefficient swig_types[72]
-#define SWIGTYPE_p_p_mfem__PWConstCoefficient swig_types[73]
-#define SWIGTYPE_p_p_mfem__PowerCoefficient swig_types[74]
-#define SWIGTYPE_p_p_mfem__ProductCoefficient swig_types[75]
-#define SWIGTYPE_p_p_mfem__PyCoefficientBase swig_types[76]
-#define SWIGTYPE_p_p_mfem__QuadratureFunctionCoefficient swig_types[77]
-#define SWIGTYPE_p_p_mfem__RatioCoefficient swig_types[78]
-#define SWIGTYPE_p_p_mfem__RestrictedCoefficient swig_types[79]
-#define SWIGTYPE_p_p_mfem__SumCoefficient swig_types[80]
-#define SWIGTYPE_p_p_mfem__TransformedCoefficient swig_types[81]
-#define SWIGTYPE_p_p_mfem__VectorRotProductCoefficient swig_types[82]
-#define SWIGTYPE_p_std__functionT_double_fmfem__Vector_const_RF_t swig_types[83]
-#define SWIGTYPE_p_std__functionT_double_fmfem__Vector_const_R_doubleF_t swig_types[84]
-#define SWIGTYPE_p_std__functionT_void_fmfem__Vector_const_R_double_mfem__DenseMatrix_RF_t swig_types[85]
-#define SWIGTYPE_p_std__functionT_void_fmfem__Vector_const_R_double_mfem__Vector_RF_t swig_types[86]
-#define SWIGTYPE_p_std__functionT_void_fmfem__Vector_const_R_mfem__DenseMatrix_RF_t swig_types[87]
-#define SWIGTYPE_p_std__functionT_void_fmfem__Vector_const_R_mfem__Vector_RF_t swig_types[88]
-static swig_type_info *swig_types[90];
-static swig_module_info swig_module = {swig_types, 89, 0, 0, 0, 0};
+#define SWIGTYPE_p_MatrixNumbaFunction swig_types[0]
+#define SWIGTYPE_p_NumbaFunction swig_types[1]
+#define SWIGTYPE_p_NumbaFunctionBase swig_types[2]
+#define SWIGTYPE_p_PyMFEM__wFILE swig_types[3]
+#define SWIGTYPE_p_VectorNumbaFunction swig_types[4]
+#define SWIGTYPE_p_char swig_types[5]
+#define SWIGTYPE_p_double swig_types[6]
+#define SWIGTYPE_p_f_double__double swig_types[7]
+#define SWIGTYPE_p_f_double_double__double swig_types[8]
+#define SWIGTYPE_p_f_r_mfem__Vector__double swig_types[9]
+#define SWIGTYPE_p_f_r_mfem__Vector_double__double swig_types[10]
+#define SWIGTYPE_p_mfem__ArrayT_int_t swig_types[11]
+#define SWIGTYPE_p_mfem__Coefficient swig_types[12]
+#define SWIGTYPE_p_mfem__ConstantCoefficient swig_types[13]
+#define SWIGTYPE_p_mfem__CrossCrossCoefficient swig_types[14]
+#define SWIGTYPE_p_mfem__CurlGridFunctionCoefficient swig_types[15]
+#define SWIGTYPE_p_mfem__DeltaCoefficient swig_types[16]
+#define SWIGTYPE_p_mfem__DenseMatrix swig_types[17]
+#define SWIGTYPE_p_mfem__DeterminantCoefficient swig_types[18]
+#define SWIGTYPE_p_mfem__DivergenceGridFunctionCoefficient swig_types[19]
+#define SWIGTYPE_p_mfem__ElementTransformation swig_types[20]
+#define SWIGTYPE_p_mfem__FaceElementTransformations swig_types[21]
+#define SWIGTYPE_p_mfem__FunctionCoefficient swig_types[22]
+#define SWIGTYPE_p_mfem__GradientGridFunctionCoefficient swig_types[23]
+#define SWIGTYPE_p_mfem__GridFunction swig_types[24]
+#define SWIGTYPE_p_mfem__GridFunctionCoefficient swig_types[25]
+#define SWIGTYPE_p_mfem__IdentityMatrixCoefficient swig_types[26]
+#define SWIGTYPE_p_mfem__InnerProductCoefficient swig_types[27]
+#define SWIGTYPE_p_mfem__IntegrationPoint swig_types[28]
+#define SWIGTYPE_p_mfem__IntegrationRule swig_types[29]
+#define SWIGTYPE_p_mfem__InverseMatrixCoefficient swig_types[30]
+#define SWIGTYPE_p_mfem__IsoparametricTransformation swig_types[31]
+#define SWIGTYPE_p_mfem__MatrixArrayCoefficient swig_types[32]
+#define SWIGTYPE_p_mfem__MatrixCoefficient swig_types[33]
+#define SWIGTYPE_p_mfem__MatrixConstantCoefficient swig_types[34]
+#define SWIGTYPE_p_mfem__MatrixFunctionCoefficient swig_types[35]
+#define SWIGTYPE_p_mfem__MatrixPyCoefficientBase swig_types[36]
+#define SWIGTYPE_p_mfem__MatrixRestrictedCoefficient swig_types[37]
+#define SWIGTYPE_p_mfem__MatrixSumCoefficient swig_types[38]
+#define SWIGTYPE_p_mfem__MatrixVectorProductCoefficient swig_types[39]
+#define SWIGTYPE_p_mfem__Mesh swig_types[40]
+#define SWIGTYPE_p_mfem__NormalizedVectorCoefficient swig_types[41]
+#define SWIGTYPE_p_mfem__OuterProductCoefficient swig_types[42]
+#define SWIGTYPE_p_mfem__PWConstCoefficient swig_types[43]
+#define SWIGTYPE_p_mfem__PowerCoefficient swig_types[44]
+#define SWIGTYPE_p_mfem__ProductCoefficient swig_types[45]
+#define SWIGTYPE_p_mfem__PyCoefficientBase swig_types[46]
+#define SWIGTYPE_p_mfem__QuadratureFunction swig_types[47]
+#define SWIGTYPE_p_mfem__QuadratureFunctionCoefficient swig_types[48]
+#define SWIGTYPE_p_mfem__RatioCoefficient swig_types[49]
+#define SWIGTYPE_p_mfem__RestrictedCoefficient swig_types[50]
+#define SWIGTYPE_p_mfem__ScalarMatrixProductCoefficient swig_types[51]
+#define SWIGTYPE_p_mfem__ScalarVectorProductCoefficient swig_types[52]
+#define SWIGTYPE_p_mfem__SumCoefficient swig_types[53]
+#define SWIGTYPE_p_mfem__TransformedCoefficient swig_types[54]
+#define SWIGTYPE_p_mfem__TransposeMatrixCoefficient swig_types[55]
+#define SWIGTYPE_p_mfem__Vector swig_types[56]
+#define SWIGTYPE_p_mfem__VectorArrayCoefficient swig_types[57]
+#define SWIGTYPE_p_mfem__VectorCoefficient swig_types[58]
+#define SWIGTYPE_p_mfem__VectorConstantCoefficient swig_types[59]
+#define SWIGTYPE_p_mfem__VectorCrossProductCoefficient swig_types[60]
+#define SWIGTYPE_p_mfem__VectorDeltaCoefficient swig_types[61]
+#define SWIGTYPE_p_mfem__VectorFunctionCoefficient swig_types[62]
+#define SWIGTYPE_p_mfem__VectorGridFunctionCoefficient swig_types[63]
+#define SWIGTYPE_p_mfem__VectorPyCoefficientBase swig_types[64]
+#define SWIGTYPE_p_mfem__VectorQuadratureFunctionCoefficient swig_types[65]
+#define SWIGTYPE_p_mfem__VectorRestrictedCoefficient swig_types[66]
+#define SWIGTYPE_p_mfem__VectorRotProductCoefficient swig_types[67]
+#define SWIGTYPE_p_mfem__VectorSumCoefficient swig_types[68]
+#define SWIGTYPE_p_p_mfem__Coefficient swig_types[69]
+#define SWIGTYPE_p_p_mfem__ConstantCoefficient swig_types[70]
+#define SWIGTYPE_p_p_mfem__DeltaCoefficient swig_types[71]
+#define SWIGTYPE_p_p_mfem__DeterminantCoefficient swig_types[72]
+#define SWIGTYPE_p_p_mfem__DivergenceGridFunctionCoefficient swig_types[73]
+#define SWIGTYPE_p_p_mfem__FunctionCoefficient swig_types[74]
+#define SWIGTYPE_p_p_mfem__GridFunctionCoefficient swig_types[75]
+#define SWIGTYPE_p_p_mfem__InnerProductCoefficient swig_types[76]
+#define SWIGTYPE_p_p_mfem__PWConstCoefficient swig_types[77]
+#define SWIGTYPE_p_p_mfem__PowerCoefficient swig_types[78]
+#define SWIGTYPE_p_p_mfem__ProductCoefficient swig_types[79]
+#define SWIGTYPE_p_p_mfem__PyCoefficientBase swig_types[80]
+#define SWIGTYPE_p_p_mfem__QuadratureFunctionCoefficient swig_types[81]
+#define SWIGTYPE_p_p_mfem__RatioCoefficient swig_types[82]
+#define SWIGTYPE_p_p_mfem__RestrictedCoefficient swig_types[83]
+#define SWIGTYPE_p_p_mfem__SumCoefficient swig_types[84]
+#define SWIGTYPE_p_p_mfem__TransformedCoefficient swig_types[85]
+#define SWIGTYPE_p_p_mfem__VectorRotProductCoefficient swig_types[86]
+#define SWIGTYPE_p_std__functionT_double_fmfem__Vector_const_RF_t swig_types[87]
+#define SWIGTYPE_p_std__functionT_double_fmfem__Vector_const_R_doubleF_t swig_types[88]
+#define SWIGTYPE_p_std__functionT_void_fmfem__Vector_const_R_double_mfem__DenseMatrix_RF_t swig_types[89]
+#define SWIGTYPE_p_std__functionT_void_fmfem__Vector_const_R_double_mfem__Vector_RF_t swig_types[90]
+#define SWIGTYPE_p_std__functionT_void_fmfem__Vector_const_R_mfem__DenseMatrix_RF_t swig_types[91]
+#define SWIGTYPE_p_std__functionT_void_fmfem__Vector_const_R_mfem__Vector_RF_t swig_types[92]
+static swig_type_info *swig_types[94];
+static swig_module_info swig_module = {swig_types, 93, 0, 0, 0, 0};
 #define SWIG_TypeQuery(name) SWIG_TypeQueryModule(&swig_module, &swig_module, name)
 #define SWIG_MangledTypeQuery(name) SWIG_MangledTypeQueryModule(&swig_module, &swig_module, name)
 
@@ -3466,6 +3470,159 @@ SWIGINTERNINLINE PyObject*
 }
 
 
+class NumbaFunctionBase{
+ protected:
+    void *address_;
+    int  sdim_;
+    bool td_;
+ public:
+    NumbaFunctionBase(PyObject *input, int sdim, bool td): sdim_(sdim), td_(td){
+       PyObject* module = PyImport_ImportModule("numba.core.ccallback");
+       if (!module){
+           PyErr_SetString(PyExc_RuntimeError, "Can not load numba.core.ccallback module");
+           return;
+       }      
+       PyObject* cls = PyObject_GetAttrString(module, "CFunc");
+       if (!cls){
+           PyErr_SetString(PyExc_RuntimeError, "Can not load CFunc");
+           return;
+       }
+       int check = PyObject_IsInstance(input, cls);
+       if (! check){
+           PyErr_SetString(PyExc_RuntimeError, "Input must be numba.core.ccallback.CFunc");
+           return;
+       }
+       PyObject *address = PyObject_GetAttrString(input, "address");
+       void *ptr = PyLong_AsVoidPtr(address); 
+       Py_DECREF(address);
+       address_ = ptr;
+    }
+    double print_add(){
+       std::cout << address_ << '\n';
+       return 0;
+    }
+    virtual ~NumbaFunctionBase(){}    
+};
+
+class NumbaFunction : public NumbaFunctionBase {
+ private:
+    std::function<double(const mfem::Vector &)> obj1;
+    std::function<double(const mfem::Vector &, double t)> obj2;
+
+ public:
+    NumbaFunction(PyObject *input, int sdim):
+       NumbaFunctionBase(input, sdim, false){}
+    
+    NumbaFunction(PyObject *input, int sdim, bool td):
+       NumbaFunctionBase(input, sdim, td){}
+    
+    double call(const mfem::Vector &x){
+      return ((double (*)(double *, int))address_)(x.GetData(), sdim_);
+    }
+    double callt(const mfem::Vector &x, double t){
+      return ((double (*)(double *, double, int))address_)(x.GetData(), t, sdim_);
+    }
+
+    // FunctionCoefficient
+    mfem::FunctionCoefficient* GenerateCoefficient(){
+      using std::placeholders::_1;
+      using std::placeholders::_2;      
+      if (td_) {
+         obj2 = std::bind(&NumbaFunction::callt, this, _1, _2);
+         return new mfem::FunctionCoefficient(obj2);
+      } else {
+         obj1 = std::bind(&NumbaFunction::call, this, _1);
+         return new mfem::FunctionCoefficient(obj1);
+      }
+   }
+};
+ 
+// VectorFunctionCoefficient     
+class VectorNumbaFunction : public NumbaFunctionBase {
+ private:
+  std::function<void(const mfem::Vector &, mfem::Vector &)> obj1;
+  std::function<void(const mfem::Vector &, double, mfem::Vector &)> obj2;
+  int vdim_;
+    
+ public:
+    VectorNumbaFunction(PyObject *input, int sdim, int vdim):
+       NumbaFunctionBase(input, sdim, false), vdim_(vdim){}
+    
+    VectorNumbaFunction(PyObject *input, int sdim, int vdim, bool td):
+       NumbaFunctionBase(input, sdim, td), vdim_(vdim){}
+  
+    void call(const mfem::Vector &x, mfem::Vector &out){
+      return ((void (*) (double *, double *, int, int))address_)(x.GetData(), 
+    							      out.GetData(),
+                                                              sdim_,
+							      vdim_);      
+       
+    }
+    void callt(const mfem::Vector &x, double t, mfem::Vector &out){
+      return ((void (*) (double *, double,  double *, int, int))address_)(x.GetData(),
+							              t,
+								      out.GetData(),
+								      sdim_,
+	 							      vdim_);            
+    }
+
+    mfem::VectorFunctionCoefficient* GenerateCoefficient(){
+      using std::placeholders::_1;
+      using std::placeholders::_2;
+      using std::placeholders::_3;            
+      if (td_) {
+	obj2 = std::bind(&VectorNumbaFunction::callt, this, _1, _2, _3);
+	return new mfem::VectorFunctionCoefficient(vdim_, obj2);
+      } else {
+	obj1 = std::bind(&VectorNumbaFunction::call, this, _1, _2);
+	return new mfem::VectorFunctionCoefficient(vdim_, obj1);
+      }
+   }
+};
+// MatrixFunctionCoefficient
+class MatrixNumbaFunction : NumbaFunctionBase {
+ private:
+  std::function<void(const mfem::Vector &, mfem::DenseMatrix &)> obj1;
+  std::function<void(const mfem::Vector &, double, mfem::DenseMatrix &)> obj2;
+  int vdim_;
+    
+ public:
+    MatrixNumbaFunction(PyObject *input, int sdim, int vdim):
+       NumbaFunctionBase(input, sdim, false), vdim_(vdim){}
+    MatrixNumbaFunction(PyObject *input, int sdim, int vdim, bool td):
+       NumbaFunctionBase(input, sdim, td), vdim_(vdim){}
+
+    void call(const mfem::Vector &x, mfem::DenseMatrix &out){
+      return ((void (*) (double *, double *, int, int))address_)(x.GetData(), 
+    							      out.GetData(),
+                                                              sdim_,
+							      vdim_);      
+       
+    }
+    void callt(const mfem::Vector &x, double t, mfem::DenseMatrix &out){
+      return ((void (*) (double *, double,  double *, int, int))address_)(x.GetData(),
+							              t,
+								      out.GetData(),
+								      sdim_,
+	 							      vdim_);            
+    }
+       
+    mfem::MatrixFunctionCoefficient* GenerateCoefficient(){
+      using std::placeholders::_1;
+      using std::placeholders::_2;
+      using std::placeholders::_3;      
+      if (td_) {
+ 	obj2 = std::bind(&MatrixNumbaFunction::callt, this, _1, _2, _3);
+	return new mfem::MatrixFunctionCoefficient(vdim_, obj2);
+      } else {
+	obj1 = std::bind(&MatrixNumbaFunction::call, this, _1, _2);
+	return new mfem::MatrixFunctionCoefficient(vdim_, obj1);
+      }
+    }
+};
+ 
+
+
 /* these fakes are only for define the function signature */
 double fake_func(const mfem::Vector &x)
 {
@@ -3477,6 +3634,7 @@ void fake_func_vec(const mfem::Vector &x, mfem::Vector &Ht)
      Ht(1) = 0.0;
      Ht(2) = 0.0;
 }
+
 void fake_func_mat(const mfem::Vector &x, mfem::DenseMatrix &Kt)
 {
   Kt(0,0) = 1.0;
@@ -24328,6 +24486,1335 @@ fail:
 }
 
 
+SWIGINTERN PyObject *_wrap_new_NumbaFunctionBase(PyObject *SWIGUNUSEDPARM(self), PyObject *args, PyObject *kwargs) {
+  PyObject *resultobj = 0;
+  PyObject *arg1 = (PyObject *) 0 ;
+  int arg2 ;
+  bool arg3 ;
+  bool val3 ;
+  int ecode3 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  char * kwnames[] = {
+    (char *)"input",  (char *)"sdim",  (char *)"td",  NULL 
+  };
+  NumbaFunctionBase *result = 0 ;
+  
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OOO:new_NumbaFunctionBase", kwnames, &obj0, &obj1, &obj2)) SWIG_fail;
+  arg1 = obj0;
+  {
+    if ((PyArray_PyIntAsInt(obj1) == -1) && PyErr_Occurred()) {
+      SWIG_exception_fail(SWIG_TypeError, "Input must be integer");
+    };  
+    arg2 = PyArray_PyIntAsInt(obj1);
+  }
+  ecode3 = SWIG_AsVal_bool(obj2, &val3);
+  if (!SWIG_IsOK(ecode3)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode3), "in method '" "new_NumbaFunctionBase" "', argument " "3"" of type '" "bool""'");
+  } 
+  arg3 = static_cast< bool >(val3);
+  {
+    try {
+      result = (NumbaFunctionBase *)new NumbaFunctionBase(arg1,arg2,arg3);
+    }
+#ifdef  MFEM_USE_EXCEPTIONS
+    catch (mfem::ErrorException &_e) {
+      std::string s("PyMFEM error (mfem::ErrorException): "), s2(_e.what());
+      s = s + s2;    
+      SWIG_exception(SWIG_RuntimeError, s.c_str());
+    }
+#endif
+    
+    catch (Swig::DirectorException &e){
+      SWIG_fail;
+    }    
+    catch (...) {
+      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+    }	 
+  }
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_NumbaFunctionBase, SWIG_POINTER_NEW |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_NumbaFunctionBase_print_add(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  NumbaFunctionBase *arg1 = (NumbaFunctionBase *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject *swig_obj[1] ;
+  double result;
+  
+  if (!args) SWIG_fail;
+  swig_obj[0] = args;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_NumbaFunctionBase, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "NumbaFunctionBase_print_add" "', argument " "1"" of type '" "NumbaFunctionBase *""'"); 
+  }
+  arg1 = reinterpret_cast< NumbaFunctionBase * >(argp1);
+  {
+    try {
+      result = (double)(arg1)->print_add();
+    }
+#ifdef  MFEM_USE_EXCEPTIONS
+    catch (mfem::ErrorException &_e) {
+      std::string s("PyMFEM error (mfem::ErrorException): "), s2(_e.what());
+      s = s + s2;    
+      SWIG_exception(SWIG_RuntimeError, s.c_str());
+    }
+#endif
+    
+    catch (Swig::DirectorException &e){
+      SWIG_fail;
+    }    
+    catch (...) {
+      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+    }	 
+  }
+  resultobj = SWIG_From_double(static_cast< double >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_delete_NumbaFunctionBase(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  NumbaFunctionBase *arg1 = (NumbaFunctionBase *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject *swig_obj[1] ;
+  
+  if (!args) SWIG_fail;
+  swig_obj[0] = args;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_NumbaFunctionBase, SWIG_POINTER_DISOWN |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "delete_NumbaFunctionBase" "', argument " "1"" of type '" "NumbaFunctionBase *""'"); 
+  }
+  arg1 = reinterpret_cast< NumbaFunctionBase * >(argp1);
+  {
+    try {
+      delete arg1;
+    }
+#ifdef  MFEM_USE_EXCEPTIONS
+    catch (mfem::ErrorException &_e) {
+      std::string s("PyMFEM error (mfem::ErrorException): "), s2(_e.what());
+      s = s + s2;    
+      SWIG_exception(SWIG_RuntimeError, s.c_str());
+    }
+#endif
+    
+    catch (Swig::DirectorException &e){
+      SWIG_fail;
+    }    
+    catch (...) {
+      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+    }	 
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *NumbaFunctionBase_swigregister(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *obj;
+  if (!SWIG_Python_UnpackTuple(args, "swigregister", 1, 1, &obj)) return NULL;
+  SWIG_TypeNewClientData(SWIGTYPE_p_NumbaFunctionBase, SWIG_NewClientData(obj));
+  return SWIG_Py_Void();
+}
+
+SWIGINTERN PyObject *NumbaFunctionBase_swiginit(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  return SWIG_Python_InitShadowInstance(args);
+}
+
+SWIGINTERN PyObject *_wrap_new_NumbaFunction__SWIG_0(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
+  PyObject *resultobj = 0;
+  PyObject *arg1 = (PyObject *) 0 ;
+  int arg2 ;
+  NumbaFunction *result = 0 ;
+  
+  if ((nobjs < 2) || (nobjs > 2)) SWIG_fail;
+  arg1 = swig_obj[0];
+  {
+    if ((PyArray_PyIntAsInt(swig_obj[1]) == -1) && PyErr_Occurred()) {
+      SWIG_exception_fail(SWIG_TypeError, "Input must be integer");
+    };  
+    arg2 = PyArray_PyIntAsInt(swig_obj[1]);
+  }
+  {
+    try {
+      result = (NumbaFunction *)new NumbaFunction(arg1,arg2);
+    }
+#ifdef  MFEM_USE_EXCEPTIONS
+    catch (mfem::ErrorException &_e) {
+      std::string s("PyMFEM error (mfem::ErrorException): "), s2(_e.what());
+      s = s + s2;    
+      SWIG_exception(SWIG_RuntimeError, s.c_str());
+    }
+#endif
+    
+    catch (Swig::DirectorException &e){
+      SWIG_fail;
+    }    
+    catch (...) {
+      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+    }	 
+  }
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_NumbaFunction, SWIG_POINTER_NEW |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_new_NumbaFunction__SWIG_1(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
+  PyObject *resultobj = 0;
+  PyObject *arg1 = (PyObject *) 0 ;
+  int arg2 ;
+  bool arg3 ;
+  bool val3 ;
+  int ecode3 = 0 ;
+  NumbaFunction *result = 0 ;
+  
+  if ((nobjs < 3) || (nobjs > 3)) SWIG_fail;
+  arg1 = swig_obj[0];
+  {
+    if ((PyArray_PyIntAsInt(swig_obj[1]) == -1) && PyErr_Occurred()) {
+      SWIG_exception_fail(SWIG_TypeError, "Input must be integer");
+    };  
+    arg2 = PyArray_PyIntAsInt(swig_obj[1]);
+  }
+  ecode3 = SWIG_AsVal_bool(swig_obj[2], &val3);
+  if (!SWIG_IsOK(ecode3)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode3), "in method '" "new_NumbaFunction" "', argument " "3"" of type '" "bool""'");
+  } 
+  arg3 = static_cast< bool >(val3);
+  {
+    try {
+      result = (NumbaFunction *)new NumbaFunction(arg1,arg2,arg3);
+    }
+#ifdef  MFEM_USE_EXCEPTIONS
+    catch (mfem::ErrorException &_e) {
+      std::string s("PyMFEM error (mfem::ErrorException): "), s2(_e.what());
+      s = s + s2;    
+      SWIG_exception(SWIG_RuntimeError, s.c_str());
+    }
+#endif
+    
+    catch (Swig::DirectorException &e){
+      SWIG_fail;
+    }    
+    catch (...) {
+      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+    }	 
+  }
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_NumbaFunction, SWIG_POINTER_NEW |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_new_NumbaFunction(PyObject *self, PyObject *args) {
+  Py_ssize_t argc;
+  PyObject *argv[4] = {
+    0
+  };
+  
+  if (!(argc = SWIG_Python_UnpackTuple(args, "new_NumbaFunction", 0, 3, argv))) SWIG_fail;
+  --argc;
+  if (argc == 2) {
+    int _v;
+    _v = (argv[0] != 0);
+    if (_v) {
+      {
+        if ((PyArray_PyIntAsInt(argv[1]) == -1) && PyErr_Occurred()) {
+          PyErr_Clear();
+          _v = 0;
+        } else {
+          _v = 1;    
+        }
+      }
+      if (_v) {
+        return _wrap_new_NumbaFunction__SWIG_0(self, argc, argv);
+      }
+    }
+  }
+  if (argc == 3) {
+    int _v;
+    _v = (argv[0] != 0);
+    if (_v) {
+      {
+        if ((PyArray_PyIntAsInt(argv[1]) == -1) && PyErr_Occurred()) {
+          PyErr_Clear();
+          _v = 0;
+        } else {
+          _v = 1;    
+        }
+      }
+      if (_v) {
+        {
+          int res = SWIG_AsVal_bool(argv[2], NULL);
+          _v = SWIG_CheckState(res);
+        }
+        if (_v) {
+          return _wrap_new_NumbaFunction__SWIG_1(self, argc, argv);
+        }
+      }
+    }
+  }
+  
+fail:
+  SWIG_Python_RaiseOrModifyTypeError("Wrong number or type of arguments for overloaded function 'new_NumbaFunction'.\n"
+    "  Possible C/C++ prototypes are:\n"
+    "    NumbaFunction::NumbaFunction(PyObject *,int)\n"
+    "    NumbaFunction::NumbaFunction(PyObject *,int,bool)\n");
+  return 0;
+}
+
+
+SWIGINTERN PyObject *_wrap_NumbaFunction_call(PyObject *SWIGUNUSEDPARM(self), PyObject *args, PyObject *kwargs) {
+  PyObject *resultobj = 0;
+  NumbaFunction *arg1 = (NumbaFunction *) 0 ;
+  mfem::Vector *arg2 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  char * kwnames[] = {
+    (char *)"self",  (char *)"x",  NULL 
+  };
+  double result;
+  
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OO:NumbaFunction_call", kwnames, &obj0, &obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_NumbaFunction, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "NumbaFunction_call" "', argument " "1"" of type '" "NumbaFunction *""'"); 
+  }
+  arg1 = reinterpret_cast< NumbaFunction * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_mfem__Vector,  0  | 0);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "NumbaFunction_call" "', argument " "2"" of type '" "mfem::Vector const &""'"); 
+  }
+  if (!argp2) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "NumbaFunction_call" "', argument " "2"" of type '" "mfem::Vector const &""'"); 
+  }
+  arg2 = reinterpret_cast< mfem::Vector * >(argp2);
+  {
+    try {
+      result = (double)(arg1)->call((mfem::Vector const &)*arg2);
+    }
+#ifdef  MFEM_USE_EXCEPTIONS
+    catch (mfem::ErrorException &_e) {
+      std::string s("PyMFEM error (mfem::ErrorException): "), s2(_e.what());
+      s = s + s2;    
+      SWIG_exception(SWIG_RuntimeError, s.c_str());
+    }
+#endif
+    
+    catch (Swig::DirectorException &e){
+      SWIG_fail;
+    }    
+    catch (...) {
+      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+    }	 
+  }
+  resultobj = SWIG_From_double(static_cast< double >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_NumbaFunction_callt(PyObject *SWIGUNUSEDPARM(self), PyObject *args, PyObject *kwargs) {
+  PyObject *resultobj = 0;
+  NumbaFunction *arg1 = (NumbaFunction *) 0 ;
+  mfem::Vector *arg2 = 0 ;
+  double arg3 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  double val3 ;
+  int ecode3 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  char * kwnames[] = {
+    (char *)"self",  (char *)"x",  (char *)"t",  NULL 
+  };
+  double result;
+  
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OOO:NumbaFunction_callt", kwnames, &obj0, &obj1, &obj2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_NumbaFunction, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "NumbaFunction_callt" "', argument " "1"" of type '" "NumbaFunction *""'"); 
+  }
+  arg1 = reinterpret_cast< NumbaFunction * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_mfem__Vector,  0  | 0);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "NumbaFunction_callt" "', argument " "2"" of type '" "mfem::Vector const &""'"); 
+  }
+  if (!argp2) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "NumbaFunction_callt" "', argument " "2"" of type '" "mfem::Vector const &""'"); 
+  }
+  arg2 = reinterpret_cast< mfem::Vector * >(argp2);
+  ecode3 = SWIG_AsVal_double(obj2, &val3);
+  if (!SWIG_IsOK(ecode3)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode3), "in method '" "NumbaFunction_callt" "', argument " "3"" of type '" "double""'");
+  } 
+  arg3 = static_cast< double >(val3);
+  {
+    try {
+      result = (double)(arg1)->callt((mfem::Vector const &)*arg2,arg3);
+    }
+#ifdef  MFEM_USE_EXCEPTIONS
+    catch (mfem::ErrorException &_e) {
+      std::string s("PyMFEM error (mfem::ErrorException): "), s2(_e.what());
+      s = s + s2;    
+      SWIG_exception(SWIG_RuntimeError, s.c_str());
+    }
+#endif
+    
+    catch (Swig::DirectorException &e){
+      SWIG_fail;
+    }    
+    catch (...) {
+      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+    }	 
+  }
+  resultobj = SWIG_From_double(static_cast< double >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_NumbaFunction_GenerateCoefficient(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  NumbaFunction *arg1 = (NumbaFunction *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject *swig_obj[1] ;
+  mfem::FunctionCoefficient *result = 0 ;
+  
+  if (!args) SWIG_fail;
+  swig_obj[0] = args;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_NumbaFunction, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "NumbaFunction_GenerateCoefficient" "', argument " "1"" of type '" "NumbaFunction *""'"); 
+  }
+  arg1 = reinterpret_cast< NumbaFunction * >(argp1);
+  {
+    try {
+      result = (mfem::FunctionCoefficient *)(arg1)->GenerateCoefficient();
+    }
+#ifdef  MFEM_USE_EXCEPTIONS
+    catch (mfem::ErrorException &_e) {
+      std::string s("PyMFEM error (mfem::ErrorException): "), s2(_e.what());
+      s = s + s2;    
+      SWIG_exception(SWIG_RuntimeError, s.c_str());
+    }
+#endif
+    
+    catch (Swig::DirectorException &e){
+      SWIG_fail;
+    }    
+    catch (...) {
+      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+    }	 
+  }
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__FunctionCoefficient, 0 |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_delete_NumbaFunction(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  NumbaFunction *arg1 = (NumbaFunction *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject *swig_obj[1] ;
+  
+  if (!args) SWIG_fail;
+  swig_obj[0] = args;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_NumbaFunction, SWIG_POINTER_DISOWN |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "delete_NumbaFunction" "', argument " "1"" of type '" "NumbaFunction *""'"); 
+  }
+  arg1 = reinterpret_cast< NumbaFunction * >(argp1);
+  {
+    try {
+      delete arg1;
+    }
+#ifdef  MFEM_USE_EXCEPTIONS
+    catch (mfem::ErrorException &_e) {
+      std::string s("PyMFEM error (mfem::ErrorException): "), s2(_e.what());
+      s = s + s2;    
+      SWIG_exception(SWIG_RuntimeError, s.c_str());
+    }
+#endif
+    
+    catch (Swig::DirectorException &e){
+      SWIG_fail;
+    }    
+    catch (...) {
+      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+    }	 
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *NumbaFunction_swigregister(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *obj;
+  if (!SWIG_Python_UnpackTuple(args, "swigregister", 1, 1, &obj)) return NULL;
+  SWIG_TypeNewClientData(SWIGTYPE_p_NumbaFunction, SWIG_NewClientData(obj));
+  return SWIG_Py_Void();
+}
+
+SWIGINTERN PyObject *NumbaFunction_swiginit(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  return SWIG_Python_InitShadowInstance(args);
+}
+
+SWIGINTERN PyObject *_wrap_new_VectorNumbaFunction__SWIG_0(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
+  PyObject *resultobj = 0;
+  PyObject *arg1 = (PyObject *) 0 ;
+  int arg2 ;
+  int arg3 ;
+  VectorNumbaFunction *result = 0 ;
+  
+  if ((nobjs < 3) || (nobjs > 3)) SWIG_fail;
+  arg1 = swig_obj[0];
+  {
+    if ((PyArray_PyIntAsInt(swig_obj[1]) == -1) && PyErr_Occurred()) {
+      SWIG_exception_fail(SWIG_TypeError, "Input must be integer");
+    };  
+    arg2 = PyArray_PyIntAsInt(swig_obj[1]);
+  }
+  {
+    if ((PyArray_PyIntAsInt(swig_obj[2]) == -1) && PyErr_Occurred()) {
+      SWIG_exception_fail(SWIG_TypeError, "Input must be integer");
+    };  
+    arg3 = PyArray_PyIntAsInt(swig_obj[2]);
+  }
+  {
+    try {
+      result = (VectorNumbaFunction *)new VectorNumbaFunction(arg1,arg2,arg3);
+    }
+#ifdef  MFEM_USE_EXCEPTIONS
+    catch (mfem::ErrorException &_e) {
+      std::string s("PyMFEM error (mfem::ErrorException): "), s2(_e.what());
+      s = s + s2;    
+      SWIG_exception(SWIG_RuntimeError, s.c_str());
+    }
+#endif
+    
+    catch (Swig::DirectorException &e){
+      SWIG_fail;
+    }    
+    catch (...) {
+      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+    }	 
+  }
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_VectorNumbaFunction, SWIG_POINTER_NEW |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_new_VectorNumbaFunction__SWIG_1(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
+  PyObject *resultobj = 0;
+  PyObject *arg1 = (PyObject *) 0 ;
+  int arg2 ;
+  int arg3 ;
+  bool arg4 ;
+  bool val4 ;
+  int ecode4 = 0 ;
+  VectorNumbaFunction *result = 0 ;
+  
+  if ((nobjs < 4) || (nobjs > 4)) SWIG_fail;
+  arg1 = swig_obj[0];
+  {
+    if ((PyArray_PyIntAsInt(swig_obj[1]) == -1) && PyErr_Occurred()) {
+      SWIG_exception_fail(SWIG_TypeError, "Input must be integer");
+    };  
+    arg2 = PyArray_PyIntAsInt(swig_obj[1]);
+  }
+  {
+    if ((PyArray_PyIntAsInt(swig_obj[2]) == -1) && PyErr_Occurred()) {
+      SWIG_exception_fail(SWIG_TypeError, "Input must be integer");
+    };  
+    arg3 = PyArray_PyIntAsInt(swig_obj[2]);
+  }
+  ecode4 = SWIG_AsVal_bool(swig_obj[3], &val4);
+  if (!SWIG_IsOK(ecode4)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode4), "in method '" "new_VectorNumbaFunction" "', argument " "4"" of type '" "bool""'");
+  } 
+  arg4 = static_cast< bool >(val4);
+  {
+    try {
+      result = (VectorNumbaFunction *)new VectorNumbaFunction(arg1,arg2,arg3,arg4);
+    }
+#ifdef  MFEM_USE_EXCEPTIONS
+    catch (mfem::ErrorException &_e) {
+      std::string s("PyMFEM error (mfem::ErrorException): "), s2(_e.what());
+      s = s + s2;    
+      SWIG_exception(SWIG_RuntimeError, s.c_str());
+    }
+#endif
+    
+    catch (Swig::DirectorException &e){
+      SWIG_fail;
+    }    
+    catch (...) {
+      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+    }	 
+  }
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_VectorNumbaFunction, SWIG_POINTER_NEW |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_new_VectorNumbaFunction(PyObject *self, PyObject *args) {
+  Py_ssize_t argc;
+  PyObject *argv[5] = {
+    0
+  };
+  
+  if (!(argc = SWIG_Python_UnpackTuple(args, "new_VectorNumbaFunction", 0, 4, argv))) SWIG_fail;
+  --argc;
+  if (argc == 3) {
+    int _v;
+    _v = (argv[0] != 0);
+    if (_v) {
+      {
+        if ((PyArray_PyIntAsInt(argv[1]) == -1) && PyErr_Occurred()) {
+          PyErr_Clear();
+          _v = 0;
+        } else {
+          _v = 1;    
+        }
+      }
+      if (_v) {
+        {
+          if ((PyArray_PyIntAsInt(argv[2]) == -1) && PyErr_Occurred()) {
+            PyErr_Clear();
+            _v = 0;
+          } else {
+            _v = 1;    
+          }
+        }
+        if (_v) {
+          return _wrap_new_VectorNumbaFunction__SWIG_0(self, argc, argv);
+        }
+      }
+    }
+  }
+  if (argc == 4) {
+    int _v;
+    _v = (argv[0] != 0);
+    if (_v) {
+      {
+        if ((PyArray_PyIntAsInt(argv[1]) == -1) && PyErr_Occurred()) {
+          PyErr_Clear();
+          _v = 0;
+        } else {
+          _v = 1;    
+        }
+      }
+      if (_v) {
+        {
+          if ((PyArray_PyIntAsInt(argv[2]) == -1) && PyErr_Occurred()) {
+            PyErr_Clear();
+            _v = 0;
+          } else {
+            _v = 1;    
+          }
+        }
+        if (_v) {
+          {
+            int res = SWIG_AsVal_bool(argv[3], NULL);
+            _v = SWIG_CheckState(res);
+          }
+          if (_v) {
+            return _wrap_new_VectorNumbaFunction__SWIG_1(self, argc, argv);
+          }
+        }
+      }
+    }
+  }
+  
+fail:
+  SWIG_Python_RaiseOrModifyTypeError("Wrong number or type of arguments for overloaded function 'new_VectorNumbaFunction'.\n"
+    "  Possible C/C++ prototypes are:\n"
+    "    VectorNumbaFunction::VectorNumbaFunction(PyObject *,int,int)\n"
+    "    VectorNumbaFunction::VectorNumbaFunction(PyObject *,int,int,bool)\n");
+  return 0;
+}
+
+
+SWIGINTERN PyObject *_wrap_VectorNumbaFunction_call(PyObject *SWIGUNUSEDPARM(self), PyObject *args, PyObject *kwargs) {
+  PyObject *resultobj = 0;
+  VectorNumbaFunction *arg1 = (VectorNumbaFunction *) 0 ;
+  mfem::Vector *arg2 = 0 ;
+  mfem::Vector *arg3 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  void *argp3 = 0 ;
+  int res3 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  char * kwnames[] = {
+    (char *)"self",  (char *)"x",  (char *)"out",  NULL 
+  };
+  
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OOO:VectorNumbaFunction_call", kwnames, &obj0, &obj1, &obj2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_VectorNumbaFunction, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "VectorNumbaFunction_call" "', argument " "1"" of type '" "VectorNumbaFunction *""'"); 
+  }
+  arg1 = reinterpret_cast< VectorNumbaFunction * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_mfem__Vector,  0  | 0);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "VectorNumbaFunction_call" "', argument " "2"" of type '" "mfem::Vector const &""'"); 
+  }
+  if (!argp2) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "VectorNumbaFunction_call" "', argument " "2"" of type '" "mfem::Vector const &""'"); 
+  }
+  arg2 = reinterpret_cast< mfem::Vector * >(argp2);
+  res3 = SWIG_ConvertPtr(obj2, &argp3, SWIGTYPE_p_mfem__Vector,  0 );
+  if (!SWIG_IsOK(res3)) {
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "VectorNumbaFunction_call" "', argument " "3"" of type '" "mfem::Vector &""'"); 
+  }
+  if (!argp3) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "VectorNumbaFunction_call" "', argument " "3"" of type '" "mfem::Vector &""'"); 
+  }
+  arg3 = reinterpret_cast< mfem::Vector * >(argp3);
+  {
+    try {
+      (arg1)->call((mfem::Vector const &)*arg2,*arg3);
+    }
+#ifdef  MFEM_USE_EXCEPTIONS
+    catch (mfem::ErrorException &_e) {
+      std::string s("PyMFEM error (mfem::ErrorException): "), s2(_e.what());
+      s = s + s2;    
+      SWIG_exception(SWIG_RuntimeError, s.c_str());
+    }
+#endif
+    
+    catch (Swig::DirectorException &e){
+      SWIG_fail;
+    }    
+    catch (...) {
+      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+    }	 
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_VectorNumbaFunction_callt(PyObject *SWIGUNUSEDPARM(self), PyObject *args, PyObject *kwargs) {
+  PyObject *resultobj = 0;
+  VectorNumbaFunction *arg1 = (VectorNumbaFunction *) 0 ;
+  mfem::Vector *arg2 = 0 ;
+  double arg3 ;
+  mfem::Vector *arg4 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  double val3 ;
+  int ecode3 = 0 ;
+  void *argp4 = 0 ;
+  int res4 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  PyObject * obj3 = 0 ;
+  char * kwnames[] = {
+    (char *)"self",  (char *)"x",  (char *)"t",  (char *)"out",  NULL 
+  };
+  
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OOOO:VectorNumbaFunction_callt", kwnames, &obj0, &obj1, &obj2, &obj3)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_VectorNumbaFunction, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "VectorNumbaFunction_callt" "', argument " "1"" of type '" "VectorNumbaFunction *""'"); 
+  }
+  arg1 = reinterpret_cast< VectorNumbaFunction * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_mfem__Vector,  0  | 0);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "VectorNumbaFunction_callt" "', argument " "2"" of type '" "mfem::Vector const &""'"); 
+  }
+  if (!argp2) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "VectorNumbaFunction_callt" "', argument " "2"" of type '" "mfem::Vector const &""'"); 
+  }
+  arg2 = reinterpret_cast< mfem::Vector * >(argp2);
+  ecode3 = SWIG_AsVal_double(obj2, &val3);
+  if (!SWIG_IsOK(ecode3)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode3), "in method '" "VectorNumbaFunction_callt" "', argument " "3"" of type '" "double""'");
+  } 
+  arg3 = static_cast< double >(val3);
+  res4 = SWIG_ConvertPtr(obj3, &argp4, SWIGTYPE_p_mfem__Vector,  0 );
+  if (!SWIG_IsOK(res4)) {
+    SWIG_exception_fail(SWIG_ArgError(res4), "in method '" "VectorNumbaFunction_callt" "', argument " "4"" of type '" "mfem::Vector &""'"); 
+  }
+  if (!argp4) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "VectorNumbaFunction_callt" "', argument " "4"" of type '" "mfem::Vector &""'"); 
+  }
+  arg4 = reinterpret_cast< mfem::Vector * >(argp4);
+  {
+    try {
+      (arg1)->callt((mfem::Vector const &)*arg2,arg3,*arg4);
+    }
+#ifdef  MFEM_USE_EXCEPTIONS
+    catch (mfem::ErrorException &_e) {
+      std::string s("PyMFEM error (mfem::ErrorException): "), s2(_e.what());
+      s = s + s2;    
+      SWIG_exception(SWIG_RuntimeError, s.c_str());
+    }
+#endif
+    
+    catch (Swig::DirectorException &e){
+      SWIG_fail;
+    }    
+    catch (...) {
+      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+    }	 
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_VectorNumbaFunction_GenerateCoefficient(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  VectorNumbaFunction *arg1 = (VectorNumbaFunction *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject *swig_obj[1] ;
+  mfem::VectorFunctionCoefficient *result = 0 ;
+  
+  if (!args) SWIG_fail;
+  swig_obj[0] = args;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_VectorNumbaFunction, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "VectorNumbaFunction_GenerateCoefficient" "', argument " "1"" of type '" "VectorNumbaFunction *""'"); 
+  }
+  arg1 = reinterpret_cast< VectorNumbaFunction * >(argp1);
+  {
+    try {
+      result = (mfem::VectorFunctionCoefficient *)(arg1)->GenerateCoefficient();
+    }
+#ifdef  MFEM_USE_EXCEPTIONS
+    catch (mfem::ErrorException &_e) {
+      std::string s("PyMFEM error (mfem::ErrorException): "), s2(_e.what());
+      s = s + s2;    
+      SWIG_exception(SWIG_RuntimeError, s.c_str());
+    }
+#endif
+    
+    catch (Swig::DirectorException &e){
+      SWIG_fail;
+    }    
+    catch (...) {
+      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+    }	 
+  }
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__VectorFunctionCoefficient, 0 |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_delete_VectorNumbaFunction(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  VectorNumbaFunction *arg1 = (VectorNumbaFunction *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject *swig_obj[1] ;
+  
+  if (!args) SWIG_fail;
+  swig_obj[0] = args;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_VectorNumbaFunction, SWIG_POINTER_DISOWN |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "delete_VectorNumbaFunction" "', argument " "1"" of type '" "VectorNumbaFunction *""'"); 
+  }
+  arg1 = reinterpret_cast< VectorNumbaFunction * >(argp1);
+  {
+    try {
+      delete arg1;
+    }
+#ifdef  MFEM_USE_EXCEPTIONS
+    catch (mfem::ErrorException &_e) {
+      std::string s("PyMFEM error (mfem::ErrorException): "), s2(_e.what());
+      s = s + s2;    
+      SWIG_exception(SWIG_RuntimeError, s.c_str());
+    }
+#endif
+    
+    catch (Swig::DirectorException &e){
+      SWIG_fail;
+    }    
+    catch (...) {
+      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+    }	 
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *VectorNumbaFunction_swigregister(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *obj;
+  if (!SWIG_Python_UnpackTuple(args, "swigregister", 1, 1, &obj)) return NULL;
+  SWIG_TypeNewClientData(SWIGTYPE_p_VectorNumbaFunction, SWIG_NewClientData(obj));
+  return SWIG_Py_Void();
+}
+
+SWIGINTERN PyObject *VectorNumbaFunction_swiginit(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  return SWIG_Python_InitShadowInstance(args);
+}
+
+SWIGINTERN PyObject *_wrap_new_MatrixNumbaFunction__SWIG_0(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
+  PyObject *resultobj = 0;
+  PyObject *arg1 = (PyObject *) 0 ;
+  int arg2 ;
+  int arg3 ;
+  MatrixNumbaFunction *result = 0 ;
+  
+  if ((nobjs < 3) || (nobjs > 3)) SWIG_fail;
+  arg1 = swig_obj[0];
+  {
+    if ((PyArray_PyIntAsInt(swig_obj[1]) == -1) && PyErr_Occurred()) {
+      SWIG_exception_fail(SWIG_TypeError, "Input must be integer");
+    };  
+    arg2 = PyArray_PyIntAsInt(swig_obj[1]);
+  }
+  {
+    if ((PyArray_PyIntAsInt(swig_obj[2]) == -1) && PyErr_Occurred()) {
+      SWIG_exception_fail(SWIG_TypeError, "Input must be integer");
+    };  
+    arg3 = PyArray_PyIntAsInt(swig_obj[2]);
+  }
+  {
+    try {
+      result = (MatrixNumbaFunction *)new MatrixNumbaFunction(arg1,arg2,arg3);
+    }
+#ifdef  MFEM_USE_EXCEPTIONS
+    catch (mfem::ErrorException &_e) {
+      std::string s("PyMFEM error (mfem::ErrorException): "), s2(_e.what());
+      s = s + s2;    
+      SWIG_exception(SWIG_RuntimeError, s.c_str());
+    }
+#endif
+    
+    catch (Swig::DirectorException &e){
+      SWIG_fail;
+    }    
+    catch (...) {
+      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+    }	 
+  }
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_MatrixNumbaFunction, SWIG_POINTER_NEW |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_new_MatrixNumbaFunction__SWIG_1(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
+  PyObject *resultobj = 0;
+  PyObject *arg1 = (PyObject *) 0 ;
+  int arg2 ;
+  int arg3 ;
+  bool arg4 ;
+  bool val4 ;
+  int ecode4 = 0 ;
+  MatrixNumbaFunction *result = 0 ;
+  
+  if ((nobjs < 4) || (nobjs > 4)) SWIG_fail;
+  arg1 = swig_obj[0];
+  {
+    if ((PyArray_PyIntAsInt(swig_obj[1]) == -1) && PyErr_Occurred()) {
+      SWIG_exception_fail(SWIG_TypeError, "Input must be integer");
+    };  
+    arg2 = PyArray_PyIntAsInt(swig_obj[1]);
+  }
+  {
+    if ((PyArray_PyIntAsInt(swig_obj[2]) == -1) && PyErr_Occurred()) {
+      SWIG_exception_fail(SWIG_TypeError, "Input must be integer");
+    };  
+    arg3 = PyArray_PyIntAsInt(swig_obj[2]);
+  }
+  ecode4 = SWIG_AsVal_bool(swig_obj[3], &val4);
+  if (!SWIG_IsOK(ecode4)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode4), "in method '" "new_MatrixNumbaFunction" "', argument " "4"" of type '" "bool""'");
+  } 
+  arg4 = static_cast< bool >(val4);
+  {
+    try {
+      result = (MatrixNumbaFunction *)new MatrixNumbaFunction(arg1,arg2,arg3,arg4);
+    }
+#ifdef  MFEM_USE_EXCEPTIONS
+    catch (mfem::ErrorException &_e) {
+      std::string s("PyMFEM error (mfem::ErrorException): "), s2(_e.what());
+      s = s + s2;    
+      SWIG_exception(SWIG_RuntimeError, s.c_str());
+    }
+#endif
+    
+    catch (Swig::DirectorException &e){
+      SWIG_fail;
+    }    
+    catch (...) {
+      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+    }	 
+  }
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_MatrixNumbaFunction, SWIG_POINTER_NEW |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_new_MatrixNumbaFunction(PyObject *self, PyObject *args) {
+  Py_ssize_t argc;
+  PyObject *argv[5] = {
+    0
+  };
+  
+  if (!(argc = SWIG_Python_UnpackTuple(args, "new_MatrixNumbaFunction", 0, 4, argv))) SWIG_fail;
+  --argc;
+  if (argc == 3) {
+    int _v;
+    _v = (argv[0] != 0);
+    if (_v) {
+      {
+        if ((PyArray_PyIntAsInt(argv[1]) == -1) && PyErr_Occurred()) {
+          PyErr_Clear();
+          _v = 0;
+        } else {
+          _v = 1;    
+        }
+      }
+      if (_v) {
+        {
+          if ((PyArray_PyIntAsInt(argv[2]) == -1) && PyErr_Occurred()) {
+            PyErr_Clear();
+            _v = 0;
+          } else {
+            _v = 1;    
+          }
+        }
+        if (_v) {
+          return _wrap_new_MatrixNumbaFunction__SWIG_0(self, argc, argv);
+        }
+      }
+    }
+  }
+  if (argc == 4) {
+    int _v;
+    _v = (argv[0] != 0);
+    if (_v) {
+      {
+        if ((PyArray_PyIntAsInt(argv[1]) == -1) && PyErr_Occurred()) {
+          PyErr_Clear();
+          _v = 0;
+        } else {
+          _v = 1;    
+        }
+      }
+      if (_v) {
+        {
+          if ((PyArray_PyIntAsInt(argv[2]) == -1) && PyErr_Occurred()) {
+            PyErr_Clear();
+            _v = 0;
+          } else {
+            _v = 1;    
+          }
+        }
+        if (_v) {
+          {
+            int res = SWIG_AsVal_bool(argv[3], NULL);
+            _v = SWIG_CheckState(res);
+          }
+          if (_v) {
+            return _wrap_new_MatrixNumbaFunction__SWIG_1(self, argc, argv);
+          }
+        }
+      }
+    }
+  }
+  
+fail:
+  SWIG_Python_RaiseOrModifyTypeError("Wrong number or type of arguments for overloaded function 'new_MatrixNumbaFunction'.\n"
+    "  Possible C/C++ prototypes are:\n"
+    "    MatrixNumbaFunction::MatrixNumbaFunction(PyObject *,int,int)\n"
+    "    MatrixNumbaFunction::MatrixNumbaFunction(PyObject *,int,int,bool)\n");
+  return 0;
+}
+
+
+SWIGINTERN PyObject *_wrap_MatrixNumbaFunction_call(PyObject *SWIGUNUSEDPARM(self), PyObject *args, PyObject *kwargs) {
+  PyObject *resultobj = 0;
+  MatrixNumbaFunction *arg1 = (MatrixNumbaFunction *) 0 ;
+  mfem::Vector *arg2 = 0 ;
+  mfem::DenseMatrix *arg3 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  void *argp3 = 0 ;
+  int res3 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  char * kwnames[] = {
+    (char *)"self",  (char *)"x",  (char *)"out",  NULL 
+  };
+  
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OOO:MatrixNumbaFunction_call", kwnames, &obj0, &obj1, &obj2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_MatrixNumbaFunction, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "MatrixNumbaFunction_call" "', argument " "1"" of type '" "MatrixNumbaFunction *""'"); 
+  }
+  arg1 = reinterpret_cast< MatrixNumbaFunction * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_mfem__Vector,  0  | 0);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "MatrixNumbaFunction_call" "', argument " "2"" of type '" "mfem::Vector const &""'"); 
+  }
+  if (!argp2) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "MatrixNumbaFunction_call" "', argument " "2"" of type '" "mfem::Vector const &""'"); 
+  }
+  arg2 = reinterpret_cast< mfem::Vector * >(argp2);
+  res3 = SWIG_ConvertPtr(obj2, &argp3, SWIGTYPE_p_mfem__DenseMatrix,  0 );
+  if (!SWIG_IsOK(res3)) {
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "MatrixNumbaFunction_call" "', argument " "3"" of type '" "mfem::DenseMatrix &""'"); 
+  }
+  if (!argp3) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "MatrixNumbaFunction_call" "', argument " "3"" of type '" "mfem::DenseMatrix &""'"); 
+  }
+  arg3 = reinterpret_cast< mfem::DenseMatrix * >(argp3);
+  {
+    try {
+      (arg1)->call((mfem::Vector const &)*arg2,*arg3);
+    }
+#ifdef  MFEM_USE_EXCEPTIONS
+    catch (mfem::ErrorException &_e) {
+      std::string s("PyMFEM error (mfem::ErrorException): "), s2(_e.what());
+      s = s + s2;    
+      SWIG_exception(SWIG_RuntimeError, s.c_str());
+    }
+#endif
+    
+    catch (Swig::DirectorException &e){
+      SWIG_fail;
+    }    
+    catch (...) {
+      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+    }	 
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_MatrixNumbaFunction_callt(PyObject *SWIGUNUSEDPARM(self), PyObject *args, PyObject *kwargs) {
+  PyObject *resultobj = 0;
+  MatrixNumbaFunction *arg1 = (MatrixNumbaFunction *) 0 ;
+  mfem::Vector *arg2 = 0 ;
+  double arg3 ;
+  mfem::DenseMatrix *arg4 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  double val3 ;
+  int ecode3 = 0 ;
+  void *argp4 = 0 ;
+  int res4 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  PyObject * obj3 = 0 ;
+  char * kwnames[] = {
+    (char *)"self",  (char *)"x",  (char *)"t",  (char *)"out",  NULL 
+  };
+  
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OOOO:MatrixNumbaFunction_callt", kwnames, &obj0, &obj1, &obj2, &obj3)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_MatrixNumbaFunction, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "MatrixNumbaFunction_callt" "', argument " "1"" of type '" "MatrixNumbaFunction *""'"); 
+  }
+  arg1 = reinterpret_cast< MatrixNumbaFunction * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_mfem__Vector,  0  | 0);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "MatrixNumbaFunction_callt" "', argument " "2"" of type '" "mfem::Vector const &""'"); 
+  }
+  if (!argp2) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "MatrixNumbaFunction_callt" "', argument " "2"" of type '" "mfem::Vector const &""'"); 
+  }
+  arg2 = reinterpret_cast< mfem::Vector * >(argp2);
+  ecode3 = SWIG_AsVal_double(obj2, &val3);
+  if (!SWIG_IsOK(ecode3)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode3), "in method '" "MatrixNumbaFunction_callt" "', argument " "3"" of type '" "double""'");
+  } 
+  arg3 = static_cast< double >(val3);
+  res4 = SWIG_ConvertPtr(obj3, &argp4, SWIGTYPE_p_mfem__DenseMatrix,  0 );
+  if (!SWIG_IsOK(res4)) {
+    SWIG_exception_fail(SWIG_ArgError(res4), "in method '" "MatrixNumbaFunction_callt" "', argument " "4"" of type '" "mfem::DenseMatrix &""'"); 
+  }
+  if (!argp4) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "MatrixNumbaFunction_callt" "', argument " "4"" of type '" "mfem::DenseMatrix &""'"); 
+  }
+  arg4 = reinterpret_cast< mfem::DenseMatrix * >(argp4);
+  {
+    try {
+      (arg1)->callt((mfem::Vector const &)*arg2,arg3,*arg4);
+    }
+#ifdef  MFEM_USE_EXCEPTIONS
+    catch (mfem::ErrorException &_e) {
+      std::string s("PyMFEM error (mfem::ErrorException): "), s2(_e.what());
+      s = s + s2;    
+      SWIG_exception(SWIG_RuntimeError, s.c_str());
+    }
+#endif
+    
+    catch (Swig::DirectorException &e){
+      SWIG_fail;
+    }    
+    catch (...) {
+      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+    }	 
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_MatrixNumbaFunction_GenerateCoefficient(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  MatrixNumbaFunction *arg1 = (MatrixNumbaFunction *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject *swig_obj[1] ;
+  mfem::MatrixFunctionCoefficient *result = 0 ;
+  
+  if (!args) SWIG_fail;
+  swig_obj[0] = args;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_MatrixNumbaFunction, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "MatrixNumbaFunction_GenerateCoefficient" "', argument " "1"" of type '" "MatrixNumbaFunction *""'"); 
+  }
+  arg1 = reinterpret_cast< MatrixNumbaFunction * >(argp1);
+  {
+    try {
+      result = (mfem::MatrixFunctionCoefficient *)(arg1)->GenerateCoefficient();
+    }
+#ifdef  MFEM_USE_EXCEPTIONS
+    catch (mfem::ErrorException &_e) {
+      std::string s("PyMFEM error (mfem::ErrorException): "), s2(_e.what());
+      s = s + s2;    
+      SWIG_exception(SWIG_RuntimeError, s.c_str());
+    }
+#endif
+    
+    catch (Swig::DirectorException &e){
+      SWIG_fail;
+    }    
+    catch (...) {
+      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+    }	 
+  }
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__MatrixFunctionCoefficient, 0 |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_delete_MatrixNumbaFunction(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  MatrixNumbaFunction *arg1 = (MatrixNumbaFunction *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject *swig_obj[1] ;
+  
+  if (!args) SWIG_fail;
+  swig_obj[0] = args;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_MatrixNumbaFunction, SWIG_POINTER_DISOWN |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "delete_MatrixNumbaFunction" "', argument " "1"" of type '" "MatrixNumbaFunction *""'"); 
+  }
+  arg1 = reinterpret_cast< MatrixNumbaFunction * >(argp1);
+  {
+    try {
+      delete arg1;
+    }
+#ifdef  MFEM_USE_EXCEPTIONS
+    catch (mfem::ErrorException &_e) {
+      std::string s("PyMFEM error (mfem::ErrorException): "), s2(_e.what());
+      s = s + s2;    
+      SWIG_exception(SWIG_RuntimeError, s.c_str());
+    }
+#endif
+    
+    catch (Swig::DirectorException &e){
+      SWIG_fail;
+    }    
+    catch (...) {
+      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+    }	 
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *MatrixNumbaFunction_swigregister(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *obj;
+  if (!SWIG_Python_UnpackTuple(args, "swigregister", 1, 1, &obj)) return NULL;
+  SWIG_TypeNewClientData(SWIGTYPE_p_MatrixNumbaFunction, SWIG_NewClientData(obj));
+  return SWIG_Py_Void();
+}
+
+SWIGINTERN PyObject *MatrixNumbaFunction_swiginit(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  return SWIG_Python_InitShadowInstance(args);
+}
+
 SWIGINTERN PyObject *_wrap_fake_func(PyObject *SWIGUNUSEDPARM(self), PyObject *args, PyObject *kwargs) {
   PyObject *resultobj = 0;
   mfem::Vector *arg1 = 0 ;
@@ -26265,6 +27752,41 @@ static PyMethodDef SwigMethods[] = {
 		"ComputeLpNorm(double p, Coefficient coeff, mfem::Mesh & mesh, mfem::IntegrationRule const *[] irs) -> double\n"
 		"ComputeLpNorm(double p, VectorCoefficient coeff, mfem::Mesh & mesh, mfem::IntegrationRule const *[] irs) -> double\n"
 		""},
+	 { "new_NumbaFunctionBase", (PyCFunction)(void(*)(void))_wrap_new_NumbaFunctionBase, METH_VARARGS|METH_KEYWORDS, "new_NumbaFunctionBase(PyObject * input, int sdim, bool td) -> NumbaFunctionBase"},
+	 { "NumbaFunctionBase_print_add", _wrap_NumbaFunctionBase_print_add, METH_O, "NumbaFunctionBase_print_add(NumbaFunctionBase self) -> double"},
+	 { "delete_NumbaFunctionBase", _wrap_delete_NumbaFunctionBase, METH_O, "delete_NumbaFunctionBase(NumbaFunctionBase self)"},
+	 { "NumbaFunctionBase_swigregister", NumbaFunctionBase_swigregister, METH_O, NULL},
+	 { "NumbaFunctionBase_swiginit", NumbaFunctionBase_swiginit, METH_VARARGS, NULL},
+	 { "new_NumbaFunction", _wrap_new_NumbaFunction, METH_VARARGS, "\n"
+		"NumbaFunction(PyObject * input, int sdim)\n"
+		"new_NumbaFunction(PyObject * input, int sdim, bool td) -> NumbaFunction\n"
+		""},
+	 { "NumbaFunction_call", (PyCFunction)(void(*)(void))_wrap_NumbaFunction_call, METH_VARARGS|METH_KEYWORDS, "NumbaFunction_call(NumbaFunction self, Vector x) -> double"},
+	 { "NumbaFunction_callt", (PyCFunction)(void(*)(void))_wrap_NumbaFunction_callt, METH_VARARGS|METH_KEYWORDS, "NumbaFunction_callt(NumbaFunction self, Vector x, double t) -> double"},
+	 { "NumbaFunction_GenerateCoefficient", _wrap_NumbaFunction_GenerateCoefficient, METH_O, "NumbaFunction_GenerateCoefficient(NumbaFunction self) -> FunctionCoefficient"},
+	 { "delete_NumbaFunction", _wrap_delete_NumbaFunction, METH_O, "delete_NumbaFunction(NumbaFunction self)"},
+	 { "NumbaFunction_swigregister", NumbaFunction_swigregister, METH_O, NULL},
+	 { "NumbaFunction_swiginit", NumbaFunction_swiginit, METH_VARARGS, NULL},
+	 { "new_VectorNumbaFunction", _wrap_new_VectorNumbaFunction, METH_VARARGS, "\n"
+		"VectorNumbaFunction(PyObject * input, int sdim, int vdim)\n"
+		"new_VectorNumbaFunction(PyObject * input, int sdim, int vdim, bool td) -> VectorNumbaFunction\n"
+		""},
+	 { "VectorNumbaFunction_call", (PyCFunction)(void(*)(void))_wrap_VectorNumbaFunction_call, METH_VARARGS|METH_KEYWORDS, "VectorNumbaFunction_call(VectorNumbaFunction self, Vector x, Vector out)"},
+	 { "VectorNumbaFunction_callt", (PyCFunction)(void(*)(void))_wrap_VectorNumbaFunction_callt, METH_VARARGS|METH_KEYWORDS, "VectorNumbaFunction_callt(VectorNumbaFunction self, Vector x, double t, Vector out)"},
+	 { "VectorNumbaFunction_GenerateCoefficient", _wrap_VectorNumbaFunction_GenerateCoefficient, METH_O, "VectorNumbaFunction_GenerateCoefficient(VectorNumbaFunction self) -> VectorFunctionCoefficient"},
+	 { "delete_VectorNumbaFunction", _wrap_delete_VectorNumbaFunction, METH_O, "delete_VectorNumbaFunction(VectorNumbaFunction self)"},
+	 { "VectorNumbaFunction_swigregister", VectorNumbaFunction_swigregister, METH_O, NULL},
+	 { "VectorNumbaFunction_swiginit", VectorNumbaFunction_swiginit, METH_VARARGS, NULL},
+	 { "new_MatrixNumbaFunction", _wrap_new_MatrixNumbaFunction, METH_VARARGS, "\n"
+		"MatrixNumbaFunction(PyObject * input, int sdim, int vdim)\n"
+		"new_MatrixNumbaFunction(PyObject * input, int sdim, int vdim, bool td) -> MatrixNumbaFunction\n"
+		""},
+	 { "MatrixNumbaFunction_call", (PyCFunction)(void(*)(void))_wrap_MatrixNumbaFunction_call, METH_VARARGS|METH_KEYWORDS, "MatrixNumbaFunction_call(MatrixNumbaFunction self, Vector x, DenseMatrix out)"},
+	 { "MatrixNumbaFunction_callt", (PyCFunction)(void(*)(void))_wrap_MatrixNumbaFunction_callt, METH_VARARGS|METH_KEYWORDS, "MatrixNumbaFunction_callt(MatrixNumbaFunction self, Vector x, double t, DenseMatrix out)"},
+	 { "MatrixNumbaFunction_GenerateCoefficient", _wrap_MatrixNumbaFunction_GenerateCoefficient, METH_O, "MatrixNumbaFunction_GenerateCoefficient(MatrixNumbaFunction self) -> MatrixFunctionCoefficient"},
+	 { "delete_MatrixNumbaFunction", _wrap_delete_MatrixNumbaFunction, METH_O, "delete_MatrixNumbaFunction(MatrixNumbaFunction self)"},
+	 { "MatrixNumbaFunction_swigregister", MatrixNumbaFunction_swigregister, METH_O, NULL},
+	 { "MatrixNumbaFunction_swiginit", MatrixNumbaFunction_swiginit, METH_VARARGS, NULL},
 	 { "fake_func", (PyCFunction)(void(*)(void))_wrap_fake_func, METH_VARARGS|METH_KEYWORDS, "fake_func(Vector x) -> double"},
 	 { "fake_func_vec", (PyCFunction)(void(*)(void))_wrap_fake_func_vec, METH_VARARGS|METH_KEYWORDS, "fake_func_vec(Vector x, Vector Ht)"},
 	 { "fake_func_mat", (PyCFunction)(void(*)(void))_wrap_fake_func_mat, METH_VARARGS|METH_KEYWORDS, "fake_func_mat(Vector x, DenseMatrix Kt)"},
@@ -26785,6 +28307,41 @@ static PyMethodDef SwigMethods_proxydocs[] = {
 		"ComputeLpNorm(double p, Coefficient coeff, mfem::Mesh & mesh, mfem::IntegrationRule const *[] irs) -> double\n"
 		"ComputeLpNorm(double p, VectorCoefficient coeff, mfem::Mesh & mesh, mfem::IntegrationRule const *[] irs) -> double\n"
 		""},
+	 { "new_NumbaFunctionBase", (PyCFunction)(void(*)(void))_wrap_new_NumbaFunctionBase, METH_VARARGS|METH_KEYWORDS, "new_NumbaFunctionBase(PyObject * input, int sdim, bool td) -> NumbaFunctionBase"},
+	 { "NumbaFunctionBase_print_add", _wrap_NumbaFunctionBase_print_add, METH_O, "print_add(NumbaFunctionBase self) -> double"},
+	 { "delete_NumbaFunctionBase", _wrap_delete_NumbaFunctionBase, METH_O, "delete_NumbaFunctionBase(NumbaFunctionBase self)"},
+	 { "NumbaFunctionBase_swigregister", NumbaFunctionBase_swigregister, METH_O, NULL},
+	 { "NumbaFunctionBase_swiginit", NumbaFunctionBase_swiginit, METH_VARARGS, NULL},
+	 { "new_NumbaFunction", _wrap_new_NumbaFunction, METH_VARARGS, "\n"
+		"NumbaFunction(PyObject * input, int sdim)\n"
+		"new_NumbaFunction(PyObject * input, int sdim, bool td) -> NumbaFunction\n"
+		""},
+	 { "NumbaFunction_call", (PyCFunction)(void(*)(void))_wrap_NumbaFunction_call, METH_VARARGS|METH_KEYWORDS, "call(NumbaFunction self, Vector x) -> double"},
+	 { "NumbaFunction_callt", (PyCFunction)(void(*)(void))_wrap_NumbaFunction_callt, METH_VARARGS|METH_KEYWORDS, "callt(NumbaFunction self, Vector x, double t) -> double"},
+	 { "NumbaFunction_GenerateCoefficient", _wrap_NumbaFunction_GenerateCoefficient, METH_O, "GenerateCoefficient(NumbaFunction self) -> FunctionCoefficient"},
+	 { "delete_NumbaFunction", _wrap_delete_NumbaFunction, METH_O, "delete_NumbaFunction(NumbaFunction self)"},
+	 { "NumbaFunction_swigregister", NumbaFunction_swigregister, METH_O, NULL},
+	 { "NumbaFunction_swiginit", NumbaFunction_swiginit, METH_VARARGS, NULL},
+	 { "new_VectorNumbaFunction", _wrap_new_VectorNumbaFunction, METH_VARARGS, "\n"
+		"VectorNumbaFunction(PyObject * input, int sdim, int vdim)\n"
+		"new_VectorNumbaFunction(PyObject * input, int sdim, int vdim, bool td) -> VectorNumbaFunction\n"
+		""},
+	 { "VectorNumbaFunction_call", (PyCFunction)(void(*)(void))_wrap_VectorNumbaFunction_call, METH_VARARGS|METH_KEYWORDS, "call(VectorNumbaFunction self, Vector x, Vector out)"},
+	 { "VectorNumbaFunction_callt", (PyCFunction)(void(*)(void))_wrap_VectorNumbaFunction_callt, METH_VARARGS|METH_KEYWORDS, "callt(VectorNumbaFunction self, Vector x, double t, Vector out)"},
+	 { "VectorNumbaFunction_GenerateCoefficient", _wrap_VectorNumbaFunction_GenerateCoefficient, METH_O, "GenerateCoefficient(VectorNumbaFunction self) -> VectorFunctionCoefficient"},
+	 { "delete_VectorNumbaFunction", _wrap_delete_VectorNumbaFunction, METH_O, "delete_VectorNumbaFunction(VectorNumbaFunction self)"},
+	 { "VectorNumbaFunction_swigregister", VectorNumbaFunction_swigregister, METH_O, NULL},
+	 { "VectorNumbaFunction_swiginit", VectorNumbaFunction_swiginit, METH_VARARGS, NULL},
+	 { "new_MatrixNumbaFunction", _wrap_new_MatrixNumbaFunction, METH_VARARGS, "\n"
+		"MatrixNumbaFunction(PyObject * input, int sdim, int vdim)\n"
+		"new_MatrixNumbaFunction(PyObject * input, int sdim, int vdim, bool td) -> MatrixNumbaFunction\n"
+		""},
+	 { "MatrixNumbaFunction_call", (PyCFunction)(void(*)(void))_wrap_MatrixNumbaFunction_call, METH_VARARGS|METH_KEYWORDS, "call(MatrixNumbaFunction self, Vector x, DenseMatrix out)"},
+	 { "MatrixNumbaFunction_callt", (PyCFunction)(void(*)(void))_wrap_MatrixNumbaFunction_callt, METH_VARARGS|METH_KEYWORDS, "callt(MatrixNumbaFunction self, Vector x, double t, DenseMatrix out)"},
+	 { "MatrixNumbaFunction_GenerateCoefficient", _wrap_MatrixNumbaFunction_GenerateCoefficient, METH_O, "GenerateCoefficient(MatrixNumbaFunction self) -> MatrixFunctionCoefficient"},
+	 { "delete_MatrixNumbaFunction", _wrap_delete_MatrixNumbaFunction, METH_O, "delete_MatrixNumbaFunction(MatrixNumbaFunction self)"},
+	 { "MatrixNumbaFunction_swigregister", MatrixNumbaFunction_swigregister, METH_O, NULL},
+	 { "MatrixNumbaFunction_swiginit", MatrixNumbaFunction_swiginit, METH_VARARGS, NULL},
 	 { "fake_func", (PyCFunction)(void(*)(void))_wrap_fake_func, METH_VARARGS|METH_KEYWORDS, "fake_func(Vector x) -> double"},
 	 { "fake_func_vec", (PyCFunction)(void(*)(void))_wrap_fake_func_vec, METH_VARARGS|METH_KEYWORDS, "fake_func_vec(Vector x, Vector Ht)"},
 	 { "fake_func_mat", (PyCFunction)(void(*)(void))_wrap_fake_func_mat, METH_VARARGS|METH_KEYWORDS, "fake_func_mat(Vector x, DenseMatrix Kt)"},
@@ -26821,6 +28378,15 @@ static PyMethodDef SwigMethods_proxydocs[] = {
 
 /* -------- TYPE CONVERSION AND EQUIVALENCE RULES (BEGIN) -------- */
 
+static void *_p_NumbaFunctionTo_p_NumbaFunctionBase(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((NumbaFunctionBase *)  ((NumbaFunction *) x));
+}
+static void *_p_VectorNumbaFunctionTo_p_NumbaFunctionBase(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((NumbaFunctionBase *)  ((VectorNumbaFunction *) x));
+}
+static void *_p_MatrixNumbaFunctionTo_p_NumbaFunctionBase(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((NumbaFunctionBase *)  ((MatrixNumbaFunction *) x));
+}
 static void *_p_mfem__MatrixConstantCoefficientTo_p_mfem__MatrixCoefficient(void *x, int *SWIGUNUSEDPARM(newmemory)) {
     return (void *)((mfem::MatrixCoefficient *)  ((mfem::MatrixConstantCoefficient *) x));
 }
@@ -27019,7 +28585,11 @@ static void *_p_mfem__IsoparametricTransformationTo_p_mfem__ElementTransformatio
 static void *_p_mfem__FaceElementTransformationsTo_p_mfem__ElementTransformation(void *x, int *SWIGUNUSEDPARM(newmemory)) {
     return (void *)((mfem::ElementTransformation *) (mfem::IsoparametricTransformation *) ((mfem::FaceElementTransformations *) x));
 }
+static swig_type_info _swigt__p_MatrixNumbaFunction = {"_p_MatrixNumbaFunction", "MatrixNumbaFunction *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_NumbaFunction = {"_p_NumbaFunction", "NumbaFunction *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_NumbaFunctionBase = {"_p_NumbaFunctionBase", "NumbaFunctionBase *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_PyMFEM__wFILE = {"_p_PyMFEM__wFILE", "PyMFEM::wFILE *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_VectorNumbaFunction = {"_p_VectorNumbaFunction", "VectorNumbaFunction *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_char = {"_p_char", "char *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_double = {"_p_double", "double *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_f_double__double = {"_p_f_double__double", "double (*)(double)", 0, 0, (void*)0, 0};
@@ -27110,7 +28680,11 @@ static swig_type_info _swigt__p_std__functionT_void_fmfem__Vector_const_R_mfem__
 static swig_type_info _swigt__p_std__functionT_void_fmfem__Vector_const_R_mfem__Vector_RF_t = {"_p_std__functionT_void_fmfem__Vector_const_R_mfem__Vector_RF_t", "std::function< void (mfem::Vector const &,mfem::Vector &) > *", 0, 0, (void*)0, 0};
 
 static swig_type_info *swig_type_initial[] = {
+  &_swigt__p_MatrixNumbaFunction,
+  &_swigt__p_NumbaFunction,
+  &_swigt__p_NumbaFunctionBase,
   &_swigt__p_PyMFEM__wFILE,
+  &_swigt__p_VectorNumbaFunction,
   &_swigt__p_char,
   &_swigt__p_double,
   &_swigt__p_f_double__double,
@@ -27201,7 +28775,11 @@ static swig_type_info *swig_type_initial[] = {
   &_swigt__p_std__functionT_void_fmfem__Vector_const_R_mfem__Vector_RF_t,
 };
 
+static swig_cast_info _swigc__p_MatrixNumbaFunction[] = {  {&_swigt__p_MatrixNumbaFunction, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_NumbaFunction[] = {  {&_swigt__p_NumbaFunction, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_NumbaFunctionBase[] = {  {&_swigt__p_NumbaFunction, _p_NumbaFunctionTo_p_NumbaFunctionBase, 0, 0},  {&_swigt__p_VectorNumbaFunction, _p_VectorNumbaFunctionTo_p_NumbaFunctionBase, 0, 0},  {&_swigt__p_MatrixNumbaFunction, _p_MatrixNumbaFunctionTo_p_NumbaFunctionBase, 0, 0},  {&_swigt__p_NumbaFunctionBase, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_PyMFEM__wFILE[] = {  {&_swigt__p_PyMFEM__wFILE, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_VectorNumbaFunction[] = {  {&_swigt__p_VectorNumbaFunction, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_char[] = {  {&_swigt__p_char, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_double[] = {  {&_swigt__p_double, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_f_double__double[] = {  {&_swigt__p_f_double__double, 0, 0, 0},{0, 0, 0, 0}};
@@ -27292,7 +28870,11 @@ static swig_cast_info _swigc__p_std__functionT_void_fmfem__Vector_const_R_mfem__
 static swig_cast_info _swigc__p_std__functionT_void_fmfem__Vector_const_R_mfem__Vector_RF_t[] = {  {&_swigt__p_std__functionT_void_fmfem__Vector_const_R_mfem__Vector_RF_t, 0, 0, 0},{0, 0, 0, 0}};
 
 static swig_cast_info *swig_cast_initial[] = {
+  _swigc__p_MatrixNumbaFunction,
+  _swigc__p_NumbaFunction,
+  _swigc__p_NumbaFunctionBase,
   _swigc__p_PyMFEM__wFILE,
+  _swigc__p_VectorNumbaFunction,
   _swigc__p_char,
   _swigc__p_double,
   _swigc__p_f_double__double,

--- a/mfem/common/chypre.py
+++ b/mfem/common/chypre.py
@@ -1,6 +1,6 @@
 '''
   CHypre (Complex Hypre)
-  
+
   CHypreVec : ParVector
   CHypreMat : ParCSR
 
@@ -17,22 +17,23 @@
 '''
 import numpy as np
 from numbers import Number
-from scipy.sparse  import csr_matrix, coo_matrix, lil_matrix
+from scipy.sparse import csr_matrix, coo_matrix, lil_matrix
 from mfem.common.parcsr_extra import *
 
 # DO NOT IMPORT MPI in Global, sicne some routins will be used
 # in serial mode too.
 try:
-   import mfem.par
-   MFEM_PAR = True
-except:
-   MFEM_PAR = False
+    import mfem.par
+    MFEM_PAR = True
+except BaseException:
+    MFEM_PAR = False
+
 
 class CHypreVec(list):
-    def __init__(self, r = None, i = None, horizontal = False):
-        list.__init__(self, [None]*2)
+    def __init__(self, r=None, i=None, horizontal=False):
+        list.__init__(self, [None] * 2)
         self._horizontal = horizontal
-        
+
         if isinstance(r, np.ndarray):
             self[0] = ToHypreParVec(r)
         else:
@@ -49,88 +50,93 @@ class CHypreVec(list):
             part = self[1].GetPartitioningArray()
         else:
             return "CHypreVec (empty)"
-        return "CHypreVec"+str(self.shape)+"["+str(part[1]-part[0])+"]"
-            
+        return "CHypreVec" + str(self.shape) + \
+            "[" + str(part[1] - part[0]) + "]"
+
     @property
     def imag(self):
         return self[1]
+
     @imag.setter
     def imag(self, value):
-        self[1]  = value
+        self[1] = value
+
     @property
     def real(self):
         return self[0]
+
     @real.setter
     def real(self, value):
-        self[0]  = value
+        self[0] = value
+
     @property
     def shape(self):
         if self[0] is not None:
-           size = self[0].GlobalSize()
+            size = self[0].GlobalSize()
         elif self[1] is not None:
-           size = self[1].GlobalSize()
+            size = self[1].GlobalSize()
         else:
-           size = 0.0
-       
+            size = 0.0
+
         if self._horizontal:
             return 1, size
         else:
             return size, 1
-            
+
     def isComplex(self):
         return not (self[1] is None)
-     
+
     def GetPartitioningArray(self):
         if self[0] is not None:
             part = self[0].GetPartitioningArray()
             part[2] = self[0].GlobalSize()
-        elif self[1] is not None:         
-            prat =  self[1].GetPartitioningArray()
-            part[2] = self[1].GlobalSize()         
+        elif self[1] is not None:
+            prat = self[1].GetPartitioningArray()
+            part[2] = self[1].GlobalSize()
         else:
             raise ValueError("CHypreVec is empty")
         return part
-     
+
     def __imul__(self, other):
         if isinstance(other, CHypreVec):
-           assert False, "CHypreVec *= vector is not supported. Use dot"
+            assert False, "CHypreVec *= vector is not supported. Use dot"
         elif np.iscomplexobj(other):
-           other = complex(other)
-           i = other.imag
-           r = other.real
-           
-           if self[0] is not None and self[0] is not None:
-               rr = self[0].GetDataArray()*r - self[1].GetDataArray()*i
-               ii = self[0].GetDataArray()*i + self[1].GetDataArray()*r
-               self[0] = ToHypreParVec(rr)
-               self[1] = ToHypreParVec(ii)
-               
-           elif self[0] is not None:
-               if i != 0.:
-                   self[1] = ToHypreParVec(i*self[0].GetDataArray())
-               if r != 0.:
-                   self[0] *= r
-               else:
-                   self[0] = None
-                   
-           elif self[1] is not None:
-               if i != 0.:
-                   self[0] = ToHypreParVec(-i*self[1].GetDataArray())
-               if r != 0.:
-                   self[1] *= r
-               else:
-                   self[1] = None
-                   
-           else:
-               passself[0] = None
+            other = complex(other)
+            i = other.imag
+            r = other.real
+
+            if self[0] is not None and self[0] is not None:
+                rr = self[0].GetDataArray() * r - self[1].GetDataArray() * i
+                ii = self[0].GetDataArray() * i + self[1].GetDataArray() * r
+                self[0] = ToHypreParVec(rr)
+                self[1] = ToHypreParVec(ii)
+
+            elif self[0] is not None:
+                if i != 0.:
+                    self[1] = ToHypreParVec(i * self[0].GetDataArray())
+                if r != 0.:
+                    self[0] *= r
+                else:
+                    self[0] = None
+
+            elif self[1] is not None:
+                if i != 0.:
+                    self[0] = ToHypreParVec(-i * self[1].GetDataArray())
+                if r != 0.:
+                    self[1] *= r
+                else:
+                    self[1] = None
+
+            else:
+                passself[0] = None
         else:
-           other = float(other)        
-           if self[0] is not None:
-               self[0] *= other
-           if self[1] is not None:
-               self[1] *= other
+            other = float(other)
+            if self[0] is not None:
+                self[0] *= other
+            if self[1] is not None:
+                self[1] *= other
         return self
-     
+
     def __mul__(self, other):
         if isinstance(other, CHypreVec):
             assert False, "CHypreVec *= vector is not supported. Use dot"
@@ -143,20 +149,20 @@ class CHypreVec(list):
             i = 0.0
         rdata = self[0].GetDataArray() if self[0] is not None else 0
         idata = self[1].GetDataArray() if self[1] is not None else 0
-           
-        rr = rdata*r - idata*i
-        ii = rdata*i + idata*r
+
+        rr = rdata * r - idata * i
+        ii = rdata * i + idata * r
 
         # note: for the real part we keep it even if it is zero
         #       so that it conservs vector size information
-        rr = ToHypreParVec(rr) 
-        ii = ToHypreParVec(ii) if np.count_nonzero(ii) != 0 else None           
-              
+        rr = ToHypreParVec(rr)
+        ii = ToHypreParVec(ii) if np.count_nonzero(ii) != 0 else None
+
         return CHypreVec(rr, ii, horizontal=self._horizontal)
-     
+
     def __add__(self, other):
         assert self._horizontal == other._horizontal, "can not add vertical and hirozontal vector"
-       
+
         if self[0] is not None and other[0] is not None:
             data = self[0].GetDataArray() + other[0].GetDataArray()
             r = ToHypreParVec(data)
@@ -179,7 +185,7 @@ class CHypreVec(list):
             i = ToHypreParVec(data)
         else:
             i = None
-        return CHypreVec(r, i, horizontal = self._horizontal)
+        return CHypreVec(r, i, horizontal=self._horizontal)
 
     def __sub__(self, other):
         assert self._horizontal == other._horizontal, "can not add vertical and hirozontal vector"
@@ -205,29 +211,29 @@ class CHypreVec(list):
             i = ToHypreParVec(data)
         else:
             i = None
-        return CHypreVec(r, i, horizontal = self._horizontal)
-     
+        return CHypreVec(r, i, horizontal=self._horizontal)
+
     def dot(self, other):
         if isinstance(other, CHypreVec):
-            return InnerProductComplex(self, other)            
+            return InnerProductComplex(self, other)
         elif (isinstance(other, CHypreMat) and
-            self._horizontal):
+              self._horizontal):
             ret = other.transpose().dot(self)
             ret._horizontal = True
             return ret
         else:
             raise ValueError(
-                  "CHypreVec::dot supports Vec*Vec (InnerProduct) and (Mat^t*Vec)^t ")
+                "CHypreVec::dot supports Vec*Vec (InnerProduct) and (Mat^t*Vec)^t ")
 
-    
     def set_element(self, i, v):
         part = self.GetPartitioningArray()
         if part[0] <= i and i < part[1]:
             v = complex(v)
             if self[0] is not None:
                 self[0][int(i - part[0])] = v.real
-            if self[1] is not None:            
+            if self[1] is not None:
                 self[1][int(i - part[0])] = v.imag
+
     def get_element(self, i):
         part = self.GetPartitioningArray()
         if part[0] <= i and i < part[1]:
@@ -235,22 +241,23 @@ class CHypreVec(list):
                 r = self[0][int(i - part[0])]
             else:
                 r = 0
-            if self[1] is not None:            
-                return r + 1j*self[1][int(i - part[0])]
+            if self[1] is not None:
+                return r + 1j * self[1][int(i - part[0])]
             else:
                 return r
+
     def copy_element(self, tdof, vec):
         for i in tdof:
             v = vec.get_element(i)
             self.set_element(i, v)
-    '''            
+    '''
     def gather(self):
         from mpi4py import MPI
         myid = MPI.COMM_WORLD.rank
         vecr = 0.0; veci = 0.0
         if self[0] is not None:
            vecr  = gather_vector(self[0].GetDataArray(), MPI.DOUBLE)
-        if self[1] is not None:        
+        if self[1] is not None:
            veci = gather_vector(self[1].GetDataArray(), MPI.DOUBLE)
 
         if myid == 0:
@@ -258,17 +265,18 @@ class CHypreVec(list):
                 return vecr
             else:
                 return vecr + 1j*veci
-    '''        
+    '''
+
     def get_squaremat_from_right(self):
         '''
         squre matrix which can be multipled from the right of self.
         '''
         if not self._horizontal:
             raise ValueError("Vector orientation is not right")
-        
+
         part = self.GetPartitioningArray()
-        return SquareCHypreMat(part, real = (self[1] is None))
-    
+        return SquareCHypreMat(part, real=(self[1] is None))
+
     def transpose(self):
         self._horizontal = not self._horizontal
         return self
@@ -279,27 +287,31 @@ class CHypreVec(list):
         data = v.GetDataArray()
         part = v.GetPartitioningArray()
         for i in idx:
-            if i >= part[1]:continue                
-            if i < part[0]:continue
+            if i >= part[1]:
+                continue
+            if i < part[0]:
+                continue
             data[i - part[0]] = 0
-            
+
         ret = ToHypreParVec(data)
         ret.SetOwnership(ownership)
         v.SetOwnership(0)
-        return  ret
-        
+        return ret
+
     def resetCol(self, idx):
         if self._horizontal:
             if self[0] is not None:
                 self[0] = self._do_reset(self[0], idx)
             if self[1] is not None:
                 self[1] = self._do_reset(self[1], idx)
-        else:            
-            if 0 in idx: self *= 0.0
-            
+        else:
+            if 0 in idx:
+                self *= 0.0
+
     def resetRow(self, idx):
         if self._horizontal:
-            if 0 in idx: self *= 0.0
+            if 0 in idx:
+                self *= 0.0
         else:
             if self[0] is not None:
                 self[0] = self._do_reset(self[0], idx)
@@ -307,57 +319,61 @@ class CHypreVec(list):
                 self[1] = self._do_reset(self[1], idx)
 
     def _do_select(self, v, lidx):
-        # ownership is transferrd to a new vector.       
-        ownership = v.GetOwnership()       
+        # ownership is transferrd to a new vector.
+        ownership = v.GetOwnership()
         data = v.GetDataArray()
         data2 = data[lidx]
         ret = ToHypreParVec(data2)
         ret.SetOwnership(ownership)
         v.SetOwnership(0)
-        return  ret
+        return ret
 
     def selectRows(self, idx):
         '''
         idx is global index
         '''
         if self._horizontal:
-            if not 0 in idx: raise ValueError("VectorSize becomes zero")
+            if not 0 in idx:
+                raise ValueError("VectorSize becomes zero")
             return self
 
-        part = self.GetPartitioningArray()                        
+        part = self.GetPartitioningArray()
         idx = idx[idx >= part[0]]
         idx = idx[idx < part[1]]
         lidx = idx - part[0]
 
-        r = None; i = None        
+        r = None
+        i = None
         if not self._horizontal:
             if self[0] is not None:
                 r = self._do_select(self[0], lidx)
             if self[1] is not None:
                 i = self._do_select(self[1], lidx)
-        return CHypreVec(r, i, horizontal = self._horizontal)
-     
+        return CHypreVec(r, i, horizontal=self._horizontal)
+
     def selectCols(self, idx):
         '''
         idx is global index
         '''
         if not self._horizontal:
-            if not 0 in idx: raise ValueError("VectorSize becomes zero")
+            if not 0 in idx:
+                raise ValueError("VectorSize becomes zero")
             return self
-         
-        part = self.GetPartitioningArray()                        
+
+        part = self.GetPartitioningArray()
         idx = idx[idx >= part[0]]
         idx = idx[idx < part[1]]
         lidx = idx - part[0]
 
-        r = None; i = None
+        r = None
+        i = None
         if self._horizontal:
             if self[0] is not None:
                 r = self._do_select(self[0], lidx)
             if self[1] is not None:
                 i = self._do_select(self[1], lidx)
-        return CHypreVec(r, i, horizontal = self._horizontal)
-     
+        return CHypreVec(r, i, horizontal=self._horizontal)
+
     def GlobalVector(self):
         '''
         Here it is reimplmente using MPI allgather.
@@ -367,30 +383,30 @@ class CHypreVec(list):
         def gather_allvector(data):
             from mfem.common.mpi_dtype import get_mpi_datatype
             from mpi4py import MPI
-       
+
             mpi_data_type = get_mpi_datatype(data)
-            myid     = MPI.COMM_WORLD.rank
+            myid = MPI.COMM_WORLD.rank
             rcounts = data.shape[0]
             rcounts = np.array(MPI.COMM_WORLD.allgather(rcounts))
 
-            for x in data.shape[1:]: rcounts = rcounts * x        
+            for x in data.shape[1:]:
+                rcounts = rcounts * x
             cm = np.hstack((0, np.cumsum(rcounts)))
-            disps = list(cm[:-1])        
-            length =  cm[-1]
+            disps = list(cm[:-1])
+            length = cm[-1]
             recvbuf = np.empty([length], dtype=data.dtype)
             recvdata = [recvbuf, rcounts, disps, mpi_data_type]
-            senddata = [data.flatten(), data.flatten().shape[0]]        
+            senddata = [data.flatten(), data.flatten().shape[0]]
             MPI.COMM_WORLD.Allgatherv(senddata, recvdata)
             return recvbuf.reshape(-1, *data.shape[1:])
 
- 
         if self[0] is not None:
             v1 = gather_allvector(self[0].GetDataArray().copy())
         else:
             v1 = 0.0
         if self[1] is not None:
-            v2 = gather_allvector(self[1].GetDataArray().copy())           
-            v1 = v1 + 1j*v2
+            v2 = gather_allvector(self[1].GetDataArray().copy())
+            v1 = v1 + 1j * v2
         return v1
 
     def toarray(self):
@@ -401,63 +417,64 @@ class CHypreVec(list):
             v = self[0].GetDataArray()
         else:
             v = 0.0
-        if self[1] is not None:            
-            v = v + 1j*self[1].GetDataArray()
+        if self[1] is not None:
+            v = v + 1j * self[1].GetDataArray()
         return v
 
     def isAllZero(self):
         return any(self.GlobalVector())
-     
+
     def get_global_coo(self):
         data = self[0].GetDataArray()
         if self[1] is not None:
-            data = data + 1j*self[1].GetDataArray()
-        gcoo = coo_matrix(self.shape, dtype = data.dtype)
+            data = data + 1j * self[1].GetDataArray()
+        gcoo = coo_matrix(self.shape, dtype=data.dtype)
         gcoo.data = data
-        part = self.GetPartitioningArray()        
+        part = self.GetPartitioningArray()
         if self._horizontal:
-            gcoo.row  = np.zeros(len(data))
-            gcoo.col  = np.arange(len(data))+ part[0]
+            gcoo.row = np.zeros(len(data))
+            gcoo.col = np.arange(len(data)) + part[0]
         else:
-            gcoo.col  = np.zeros(len(data))
-            gcoo.row  = np.arange(len(data))+ part[0]
+            gcoo.col = np.zeros(len(data))
+            gcoo.row = np.arange(len(data)) + part[0]
         return gcoo
 
     def true_nnz(self):
         '''
         more expensive version which reports nnz after
         eliminating all zero entries
-        I can not use @property, since ScipyCoo can't 
+        I can not use @property, since ScipyCoo can't
         have @property (class inherited from ndarray)
         '''
         data = self[0].GetDataArray()
         if self[1] is not None:
-            data = data + 1j*self[1].GetDataArray()
+            data = data + 1j * self[1].GetDataArray()
         local_nnz = np.sum(data == 0.)
 
         from mpi4py import MPI
-        comm     = MPI.COMM_WORLD     
+        comm = MPI.COMM_WORLD
         nnz = comm.allgather(local_nnz)
         return nnz
-     
-    @property     
+
+    @property
     def isHypre(self):
         return True
 
+
 class CHypreMat(list):
-    def __init__(self, r = None, i = None, col_starts = None):
-        list.__init__(self, [None]*2)
+    def __init__(self, r=None, i=None, col_starts=None):
+        list.__init__(self, [None] * 2)
         if isinstance(r, csr_matrix):
-            self[0] = ToHypreParCSR(r, col_starts = col_starts)
+            self[0] = ToHypreParCSR(r, col_starts=col_starts)
         elif isinstance(r, mfem.par.HypreParMatrix):
             self[0] = r
         elif r is None:
-            self[0] = r           
+            self[0] = r
         else:
             assert False, "unknonw matrix element"
         if isinstance(i, csr_matrix):
-            self[1] = ToHypreParCSR(i, col_starts = col_starts)
-        elif isinstance(i, mfem.par.HypreParMatrix):            
+            self[1] = ToHypreParCSR(i, col_starts=col_starts)
+        elif isinstance(i, mfem.par.HypreParMatrix):
             self[1] = i
         elif i is None:
             self[1] = i
@@ -465,58 +482,79 @@ class CHypreMat(list):
             assert False, "unknonw matrix element"
 
     def GetOwns(self):
-        flags = [None]*6
+        flags = [None] * 6
         if self[0] is not None:
-           flags[0] = self[0].OwnsDiag()
-           flags[1] = self[0].OwnsOffd()
-           flags[2] = self[0].OwnsColMap()
+            flags[0] = self[0].OwnsDiag()
+            flags[1] = self[0].OwnsOffd()
+            flags[2] = self[0].OwnsColMap()
         if self[1] is not None:
-           flags[3] = self[1].OwnsDiag()
-           flags[4] = self[1].OwnsOffd()
-           flags[5] = self[1].OwnsColMap()
+            flags[3] = self[1].OwnsDiag()
+            flags[4] = self[1].OwnsOffd()
+            flags[5] = self[1].OwnsColMap()
         return flags
-           
+
     def __repr__(self):
-        return "CHypreMat"+str(self.shape) +"["+str(self.lshape)+"]"
-    
+        return "CHypreMat" + str(self.shape) + "[" + str(self.lshape) + "]"
+
     def isComplex(self):
         return not (self[1] is None)
 
-    def __mul__(self, other): # A * B or A * v
+    def __mul__(self, other):  # A * B or A * v
         if isinstance(other, CHypreMat):
             return CHypreMat(*ParMultComplex(self, other))
         elif isinstance(other, CHypreVec):
-            v =  CHypreVec(*ParMultVecComplex(self, other))
+            v = CHypreVec(*ParMultVecComplex(self, other))
             v._horizontal = other._horizontal
             return v
         elif isinstance(other, Number):
-            if self[0] is not None:
-               R = mfem.par.Add(other, self[0], 0.0, self[0])
-               R.CopyRowStarts()
-               R.CopyColStarts()
+            if np.iscomplexobj(other):
+                other = complex(other)
+                r = other.real
+                i = other.imag
             else:
-               R = None
-            if self[1] is not None:
-               I = mfem.par.Add(other, self[1], 0.0, self[1])
-               I.CopyRowStarts()
-               I.CopyColStarts()
+                r = other
+                i = 0
+            if self[0] is not None and self[1] is not None:
+                R = mfem.par.Add(r, self[0], -i, self[1])
+                I = mfem.par.Add(i, self[0], r, self[1])
+            elif self[0] is not None:
+                #R = mfem.par.Add(r, self[0], 0.0, self[0])
+                R = mfem.par.Add(r, self[0], 0.0, self[0])
+                if i != 0.0:
+                    I = mfem.par.Add(i, self[0], 0.0, self[0])
+                else:
+                    I = None
+            elif self[1] is not None:
+                if r != 0.0:
+                    I = mfem.par.Add(r, self[1], 0.0, self[1])
+                else:
+                    I = None
+                R = mfem.par.Add(-i, self[1], 0.0, self[1])
             else:
-               I = None
+                assert False, "this mode is not supported"
+                R = None
+                I = None
+            if R is not None:
+                R.CopyRowStarts()
+                R.CopyColStarts()
+            if I is not None:
+                I.CopyRowStarts()
+                I.CopyColStarts()
             return CHypreMat(R, I)
         raise ValueError("argument should be CHypreMat/Vec")
-    
+
     def __rmul__(self, other):
         if not isinstance(other, CHypreMat):
-             raise ValueError(
-                   "argument should be CHypreMat")
+            raise ValueError(
+                "argument should be CHypreMat")
         return CHypreMat(*ParMultComplex(other, self))
-        
-    def __add__(self, other): #A + B
+
+    def __add__(self, other):  # A + B
         if not isinstance(other, CHypreMat):
-             raise ValueError(
-                   "argument should be CHypreMat")
-        if self[0] is not None and other[0] is not None:            
-            r =  ParAdd(self[0], other[0])
+            raise ValueError(
+                "argument should be CHypreMat")
+        if self[0] is not None and other[0] is not None:
+            r = ParAdd(self[0], other[0])
         elif self[0] is not None:
             r = ToHypreParCSR(ToScipyCoo(self[0]).tocsr())
         elif other[0] is not None:
@@ -524,7 +562,7 @@ class CHypreMat(list):
         else:
             r = None
         if self[1] is not None and other[1] is not None:
-            i =  ParAdd(self[1], other[1])           
+            i = ParAdd(self[1], other[1])
 #            i =  mfem.par.add_hypre(1.0, self[1], 1.0, other[1])
         elif self[1] is not None:
             i = ToHypreParCSR(ToScipyCoo(self[1]).tocsr())
@@ -532,88 +570,92 @@ class CHypreMat(list):
             i = ToHypreParCSR(ToScipyCoo(other[1]).tocsr())
         else:
             i = None
-            
+
         if r is not None:
-           r.CopyRowStarts()
-           r.CopyColStarts()
+            r.CopyRowStarts()
+            r.CopyColStarts()
         if i is not None:
-           i.CopyRowStarts()
-           i.CopyColStarts()
+            i.CopyRowStarts()
+            i.CopyColStarts()
 
-        return CHypreMat(r, i)        
+        return CHypreMat(r, i)
 
-    def __sub__(self, other): #A - B
+    def __sub__(self, other):  # A - B
         if not isinstance(other, CHypreMat):
-             raise ValueError(
-                   "argument should be CHypreMat")
+            raise ValueError(
+                "argument should be CHypreMat")
         if self[0] is not None and other[0] is not None:
             other[0] *= -1
-            r =  ParAdd(self[0], other[0])
-            other[0] *= -1            
+            r = ParAdd(self[0], other[0])
+            other[0] *= -1
         elif self[0] is not None:
-            r = ToHypreParCSR(ToScipyCoo(self[0]).tocsr())           
+            r = ToHypreParCSR(ToScipyCoo(self[0]).tocsr())
         elif other[0] is not None:
-            r = mfem.par.Add(-1, othe[0], 0.0, other[0])                      
+            r = mfem.par.Add(-1, othe[0], 0.0, other[0])
         else:
             r = None
         if self[1] is not None and other[1] is not None:
-            other[1] *= -1           
-            i =  ParAdd(self[1], other[1])
-            other[1] *= -1                       
+            other[1] *= -1
+            i = ParAdd(self[1], other[1])
+            other[1] *= -1
         elif self[1] is not None:
-            i = ToHypreParCSR(ToScipyCoo(self[1]).tocsr())           
+            i = ToHypreParCSR(ToScipyCoo(self[1]).tocsr())
         elif other[1] is not None:
-            i = mfem.par.Add(-1, othe[1], 0.0, other[1])           
+            i = mfem.par.Add(-1, othe[1], 0.0, other[1])
         else:
             i = None
 
         if r is not None:
-           r.CopyRowStarts()
-           r.CopyColStarts()
+            r.CopyRowStarts()
+            r.CopyColStarts()
         if i is not None:
-           i.CopyRowStarts()
-           i.CopyColStarts()
-           
-        return CHypreMat(r, i)        
-       
-    def __neg__(self): #-B
-       r = None; i = None
-       if self[0] is not None:
-           r = mfem.par.Add(-1, self[0], 0.0, self[0])
-           r.CopyRowStarts()
-           r.CopyColStarts()
-       if self[1] is not None:
-           i = mfem.par.Add(-1, self[1], 0.0, self[0])
-           i.CopyRowStarts()
-           i.CopyColStarts()
-           
-       return CHypreMat(r, i)
+            i.CopyRowStarts()
+            i.CopyColStarts()
 
+        return CHypreMat(r, i)
+
+    def __neg__(self):  # -B
+        r = None
+        i = None
+        if self[0] is not None:
+            r = mfem.par.Add(-1, self[0], 0.0, self[0])
+            r.CopyRowStarts()
+            r.CopyColStarts()
+        if self[1] is not None:
+            i = mfem.par.Add(-1, self[1], 0.0, self[0])
+            i.CopyRowStarts()
+            i.CopyColStarts()
+
+        return CHypreMat(r, i)
 
     @property
     def imag(self):
         return self[1]
+
     @imag.setter
     def imag(self, value):
-        self[1]  = value
+        self[1] = value
+
     @property
     def real(self):
         return self[0]
+
     @real.setter
     def real(self, value):
-        self[0]  = value
+        self[0] = value
 
     def GetColPartArray(self):
         if self[0] is not None:
             return self[0].GetColPartArray()
         else:
-            return self[1].GetColPartArray()        
+            return self[1].GetColPartArray()
+
     def GetRowPartArray(self):
         if self[0] is not None:
             return self[0].GetRowPartArray()
         else:
-            return self[1].GetRowPartArray()        
-        
+            return self[1].GetRowPartArray()
+
     def __imul__(self, other):
         if self[0] is not None:
             self[0] *= other
@@ -623,7 +665,7 @@ class CHypreMat(list):
 
     def dot(self, other):
         return self.__mul__(other)
-    
+
     def transpose(self):
         '''
         transpose of matrix
@@ -632,36 +674,37 @@ class CHypreMat(list):
         R = self[0].Transpose() if self[0] is not None else None
         I = self[1].Transpose() if self[1] is not None else None
         return CHypreMat(R, I)
-        #return CHypreMat(self[0].Transpose(), self[1].Transpose())
+        # return CHypreMat(self[0].Transpose(), self[1].Transpose())
 
-    def conj(self, inplace = True):
+    def conj(self, inplace=True):
         '''
         complex conjugate
           if copy is on, imaginary part becomes different object
         '''
-        if self[1] is None: return self
-        
+        if self[1] is None:
+            return self
+
         if not inplace:
-           self[1] = ToHypreParCSR(-ToScipyCoo(self[1]).tocsr())
+            self[1] = ToHypreParCSR(-ToScipyCoo(self[1]).tocsr())
         else:
-           self[1] *= -1.0
+            self[1] *= -1.0
         return self
 
     def rap(self, B):
         '''
         B^* A B
         '''
-        ret = B.conj().transpose()*self
+        ret = B.conj().transpose() * self
         ret = ret * (B.conj())
         # this should put B back to original
         return ret
 
-    def setDiag(self, idx, value = 1.0):
+    def setDiag(self, idx, value=1.0):
         if self[0] is not None:
-            self[0] = ResetHypreDiag(self[0], idx, value = float(value))
-        if self[1] is not None:            
-            self[1] = ResetHypreDiag(self[1], idx, value = float(np.imag(value)))
-            
+            self[0] = ResetHypreDiag(self[0], idx, value=float(value))
+        if self[1] is not None:
+            self[1] = ResetHypreDiag(self[1], idx, value=float(np.imag(value)))
+
     def resetCol(self, idx, inplace=True):
         if self[0] is not None:
             r = ResetHypreCol(self[0], idx)
@@ -672,11 +715,12 @@ class CHypreMat(list):
         else:
             i = None
         if inplace:
-            self[0]=r; self[1]=i
+            self[0] = r
+            self[1] = i
             return self
         else:
-            return  CHypreMat(r, i)
-            
+            return CHypreMat(r, i)
+
     def resetRow(self, idx, inplace=True):
         if self[0] is not None:
             r = ResetHypreRow(self[0], idx)
@@ -687,20 +731,21 @@ class CHypreMat(list):
         else:
             i = None
         if inplace:
-            self[0]=r; self[1]=i
+            self[0] = r
+            self[1] = i
             return self
         else:
-            return  CHypreMat(r, i)
-            
+            return CHypreMat(r, i)
+
     def selectRows(self, idx):
         '''
         idx is global index
         '''
         rpart = self[0].GetRowPartArray()
-        rpart[2] = self[0].GetGlobalNumRows()            
+        rpart[2] = self[0].GetGlobalNumRows()
         cpart = self[0].GetColPartArray()
         cpart[2] = self[0].GetGlobalNumCols()
-        
+
         idx = idx[idx >= rpart[0]]
         idx = idx[idx < rpart[1]]
         idx = idx - rpart[0]
@@ -708,15 +753,15 @@ class CHypreMat(list):
         csr = ToScipyCoo(self[0]).tocsr()
 
         csr = csr[idx, :]
-        r = ToHypreParCSR(csr, col_starts = cpart)
+        r = ToHypreParCSR(csr, col_starts=cpart)
         if self[1] is not None:
-           csr = ToScipyCoo(self[1]).tocsr()
-           csr = csr[idx, :]
-           i = ToHypreParCSR(csr, col_starts =cpart)
+            csr = ToScipyCoo(self[1]).tocsr()
+            csr = csr[idx, :]
+            i = ToHypreParCSR(csr, col_starts=cpart)
         else:
-           i = None
+            i = None
         return CHypreMat(r, i)
-       
+
     def selectCols(self, idx):
         '''
         idx is global index
@@ -725,21 +770,21 @@ class CHypreMat(list):
         cpart[2] = self[0].GetGlobalNumCols()
         rpart = self[0].GetRowPartArray()
         rpart[2] = self[0].GetGlobalNumRows()
-        
+
         idx = idx[idx >= cpart[0]]
         idx = idx[idx < cpart[1]]
         idx = idx - cpart[0]
 
-        mat = self.transpose()        
+        mat = self.transpose()
         csr = ToScipyCoo(mat[0]).tocsr()
         csr = csr[idx, :]
-        r = ToHypreParCSR(csr, col_starts = rpart)
+        r = ToHypreParCSR(csr, col_starts=rpart)
         if self[1] is not None:
-           csr = ToScipyCoo(mat[1]).tocsr()
-           csr = csr[idx, :]
-           i = ToHypreParCSR(csr, col_starts =rpart)
+            csr = ToScipyCoo(mat[1]).tocsr()
+            csr = csr[idx, :]
+            i = ToHypreParCSR(csr, col_starts=rpart)
         else:
-           i = None
+            i = None
         mat = CHypreMat(r, i).transpose()
         '''
         if (cpart == rpart).all():
@@ -750,13 +795,15 @@ class CHypreMat(list):
               mat[1] = ToHypreParCSR(csr, col_starts =rpart)
         '''
         return mat
-    
+
     @property
     def nnz(self):
         if self[0] is not None and self[1] is not None:
             return self[0].NNZ(), self[1].NNZ()
-        if self[0] is not None: return self[0].NNZ()
-        if self[1] is not None: return self[1].NNZ()
+        if self[0] is not None:
+            return self[0].NNZ()
+        if self[1] is not None:
+            return self[1].NNZ()
 
     def true_nnz(self):
         '''
@@ -764,7 +811,7 @@ class CHypreMat(list):
         eliminating all zero entries
         '''
         #coo = self.get_local_coo()
-        if self[0] is not None:        
+        if self[0] is not None:
             nnz0, tnnz0 = self[0].get_local_true_nnz()
         else:
             nnz0 = 0
@@ -774,7 +821,7 @@ class CHypreMat(list):
         else:
             nnz1 = 0
             tnnz1 = 0
-        #print nnz0, tnnz0, nnz1, tnnz1
+        # print nnz0, tnnz0, nnz1, tnnz1
         return tnnz0, tnnz1
 
     def m(self):
@@ -782,43 +829,51 @@ class CHypreMat(list):
         return global row number: two number should be the same
         '''
         ans = []
-        if self[0] is not None: ans.append(self[0].M())
-        if self[1] is not None: ans.append(self[1].M())
+        if self[0] is not None:
+            ans.append(self[0].M())
+        if self[1] is not None:
+            ans.append(self[1].M())
 
         if len(ans) == 2 and ans[0] != ans[1]:
-            raise ValueError("data format error, real and imag should have same size")
+            raise ValueError(
+                "data format error, real and imag should have same size")
         return ans[0]
-    
+
     def n(self):
         '''
         return global col number: two number should be the same
         '''
         ans = []
-        if self[0] is not None: ans.append(self[0].N())
-        if self[1] is not None: ans.append(self[1].N())
+        if self[0] is not None:
+            ans.append(self[0].N())
+        if self[1] is not None:
+            ans.append(self[1].N())
         if len(ans) == 2 and ans[0] != ans[1]:
-            raise ValueError("data format error, real and imag should have same size")
+            raise ValueError(
+                "data format error, real and imag should have same size")
         return ans[0]
+
     @property
     def shape(self):
         if self[0] is not None:
             return (self[0].GetGlobalNumRows(), self[0].GetGlobalNumCols())
-        elif self[1] is not None:        
+        elif self[1] is not None:
             return (self[1].GetGlobalNumRows(), self[1].GetGlobalNumCols())
         else:
-            return (0,0)
+            return (0, 0)
+
     @property
     def lshape(self):
         if self[0] is not None:
             return (self[0].GetNumRows(), self[0].GetNumCols())
-        elif self[1] is not None:        
+        elif self[1] is not None:
             return (self[1].GetNumRows(), self[1].GetNumCols())
         else:
-            return (0,0)
+            return (0, 0)
 
     def get_local_coo(self):
         if self.isComplex():
-            return (ToScipyCoo(self[0]) + 1j*ToScipyCoo(self[1])).tocoo()
+            return (ToScipyCoo(self[0]) + 1j * ToScipyCoo(self[1])).tocoo()
         else:
             return ToScipyCoo(self[0])
 
@@ -827,10 +882,10 @@ class CHypreMat(list):
         gcoo = coo_matrix(self.shape)
         gcoo.data = lcoo.data
 
-        gcoo.row  = lcoo.row + self.GetRowPartArray()[0]
-        gcoo.col  = lcoo.col
+        gcoo.row = lcoo.row + self.GetRowPartArray()[0]
+        gcoo.col = lcoo.col
         return gcoo
-        
+
     def get_squaremat_from_right(self):
         '''
         squre matrix which can be multipled from the right of self.
@@ -841,11 +896,11 @@ class CHypreMat(list):
             part[2] = self[0].GetGlobalNumCols()
         elif self[1] is not None:
             part = self[1].GetColPartArray()
-            part[2] = self[1].GetGlobalNumCols()            
+            part[2] = self[1].GetGlobalNumCols()
         else:
             raise ValueError("CHypreMat is empty")
-        return SquareCHypreMat(part, real = (self[1] is None))
-     
+        return SquareCHypreMat(part, real=(self[1] is None))
+
     def elimination_matrix(self, idx):
         #  # local version
         #  ret = lil_matrix((len(nonzeros), self.shape[0]))
@@ -858,28 +913,29 @@ class CHypreMat(list):
         idx = idx[idx >= rpart[0]]
         idx = idx[idx < rpart[1]]
         idx = idx - rpart[0]
-        
+
         shape = (len(idx), self.shape[1])
-        #print shape, idx + rpart[0]
-        elil =  lil_matrix(shape)
+        # print shape, idx + rpart[0]
+        elil = lil_matrix(shape)
         for i, j in enumerate(idx):
-           elil[i, j + rpart[0]] = 1
-       
-        r = ToHypreParCSR(elil.tocsr(), col_starts =cpart)
+            elil[i, j + rpart[0]] = 1
+
+        r = ToHypreParCSR(elil.tocsr(), col_starts=cpart)
         return CHypreMat(r, None)
-     
+
     def eliminate_RowsCols(self, tdof, inplace=False):
-        # note: tdof is a valued viewed in each node. MyTDoF offset is subtracted
+        # note: tdof is a valued viewed in each node. MyTDoF offset is
+        # subtracted
         tdof1 = mfem.par.intArray(tdof)
         if not inplace:
             #print("inplace flag off copying ParCSR")
-            if self[0] is not None:           
-                r =  ToHypreParCSR(ToScipyCoo(self[0]).tocsr())
+            if self[0] is not None:
+                r = ToHypreParCSR(ToScipyCoo(self[0]).tocsr())
 
             else:
                 r = None
-            if self[1] is not None:           
-                i =  ToHypreParCSR(ToScipyCoo(self[1]).tocsr())
+            if self[1] is not None:
+                i = ToHypreParCSR(ToScipyCoo(self[1]).tocsr())
 
             else:
                 i = None
@@ -897,58 +953,62 @@ class CHypreMat(list):
             Aei = target[1].EliminateRowsCols(tdof1)
             Aei.CopyRowStarts()
             Aei.CopyColStarts()
-            row0 = Aei.GetRowPartArray()[0]            
+            row0 = Aei.GetRowPartArray()[0]
         else:
             Aei = None
-        target.setDiag([x+row0 for x in tdof], value = 1.0)
+        target.setDiag([x + row0 for x in tdof], value=1.0)
         mat = CHypreMat(Aer, Aei)
-        #print mat.get_local_coo()
+        # print mat.get_local_coo()
         return mat, target
-     
-    @property     
+
+    @property
     def isHypre(self):
         return True
-    
+
+
 def SquareCHypreMat(part, real=False):
     from scipy.sparse import csr_matrix
-    lr = part[1]-part[0]
-    c  = part[2]
+    lr = part[1] - part[0]
+    c = part[2]
     m1 = csr_matrix((lr, c))
     if real:
-       m2 = None
+        m2 = None
     else:
-       m2 = csr_matrix((lr, c))
+        m2 = csr_matrix((lr, c))
     return CHypreMat(m1, m2)
 
-def Array2CHypreVec(array, part = None, horizontal = False):
+
+def Array2CHypreVec(array, part=None, horizontal=False):
     '''
-    convert array in rank =0 to 
+    convert array in rank =0 to
     distributed Hypre 1D Matrix (size = m x 1)
     '''
-    from mpi4py import MPI    
+    from mpi4py import MPI
     isComplex = MPI.COMM_WORLD.bcast(np.iscomplexobj(array), root=0)
     if isComplex:
-       if array is None:
-           rarray = None
-           iarray = None
-       else:
-           rarray= array.real
-           iarray= array.imag
-       return  CHypreVec(Array2HypreVec(rarray, part),
+        if array is None:
+            rarray = None
+            iarray = None
+        else:
+            rarray = array.real
+            iarray = array.imag
+        return CHypreVec(Array2HypreVec(rarray, part),
                          Array2HypreVec(iarray, part), horizontal=horizontal)
     else:
-       if array is None:
-           rarray = None
-       else:
-           rarray= array
-       return CHypreVec(Array2HypreVec(rarray, part), None, horizontal=horizontal)
+        if array is None:
+            rarray = None
+        else:
+            rarray = array
+        return CHypreVec(Array2HypreVec(rarray, part),
+                         None, horizontal=horizontal)
+
 
 def CHypreVec2Array(array):
     from mpi4py import MPI
-    myid     = MPI.COMM_WORLD.rank
-    
+    myid = MPI.COMM_WORLD.rank
+
     if array[0] is not None:
-        r= HypreVec2Array(array[0])
+        r = HypreVec2Array(array[0])
     else:
         if myid == 0:
             r = 0.0
@@ -962,18 +1022,20 @@ def CHypreVec2Array(array):
         return r
     else:
         if myid == 0:
-            return r + 1j*i            
+            return r + 1j * i
         else:
             return None
-        
+
+
 def CHypreMat2Coo(mat):
     print("CHYPREMat2Coo: deprecated,  Use class method !!!!")
     if mat.isComplex():
-         return ToScipyCoo(mat.real) + 1j*ToScipyCoo(mat.imag)
+        return ToScipyCoo(mat.real) + 1j * ToScipyCoo(mat.imag)
     else:
-         return ToScipyCoo(mat.real)
+        return ToScipyCoo(mat.real)
 
-def LF2PyVec(rlf, ilf = None, horizontal= False):
+
+def LF2PyVec(rlf, ilf=None, horizontal=False):
     if MFEM_PAR:
         '''
         From ParLF to CHypreVec
@@ -982,126 +1044,135 @@ def LF2PyVec(rlf, ilf = None, horizontal= False):
         rv.thisown = True
         if ilf is not None:
             iv = ilf.ParallelAssemble()
-            iv.thisown = True            
+            iv.thisown = True
         else:
             iv = None
-        return CHypreVec(rv, iv, horizontal = horizontal)
+        return CHypreVec(rv, iv, horizontal=horizontal)
     else:
-        b1 = rlf.GetDataArray().copy()#; rlf.thisown = False
+        b1 = rlf.GetDataArray().copy()  # ; rlf.thisown = False
         if ilf is not None:
-           b2 = ilf.GetDataArray()#; ilf.thisown = False
-           b1 = b1+1j*b2
+            b2 = ilf.GetDataArray()  # ; ilf.thisown = False
+            b1 = b1 + 1j * b2
         if horizontal:
-           return b1.reshape((1, -1))               
-        else:
-           return b1.reshape((-1, 1))
-       
-LinearForm2PyVector = LF2PyVec
-
-def MfemVec2PyVec(rlf, ilf = None, horizontal= False):
-    b1 = rlf.GetDataArray().copy()#; rlf.thisown = False
-    if ilf is not None:
-       b2 = ilf.GetDataArray()#; ilf.thisown = False
-    else:
-       b2 = None
-       
-    if MFEM_PAR:
-        b1 = ToHypreParVec(b1)
-        if b2 is not None:
-           b2 = ToHypreParVec(b2)
-        return CHypreVec(b1, b2, horizontal = horizontal)           
-    else:
-        if b2 is not None: b1 = b1+1j*b2
-        if horizontal:
-            return b1.reshape((1, -1))               
+            return b1.reshape((1, -1))
         else:
             return b1.reshape((-1, 1))
 
-def Array2PyVec(array, part = None, horizontal= False):
+
+LinearForm2PyVector = LF2PyVec
+
+
+def MfemVec2PyVec(rlf, ilf=None, horizontal=False):
+    b1 = rlf.GetDataArray().copy()  # ; rlf.thisown = False
+    if ilf is not None:
+        b2 = ilf.GetDataArray()  # ; ilf.thisown = False
+    else:
+        b2 = None
+
+    if MFEM_PAR:
+        b1 = ToHypreParVec(b1)
+        if b2 is not None:
+            b2 = ToHypreParVec(b2)
+        return CHypreVec(b1, b2, horizontal=horizontal)
+    else:
+        if b2 is not None:
+            b1 = b1 + 1j * b2
+        if horizontal:
+            return b1.reshape((1, -1))
+        else:
+            return b1.reshape((-1, 1))
+
+
+def Array2PyVec(array, part=None, horizontal=False):
     '''
-    convert array in rank = 0  to 
+    convert array in rank = 0  to
     distributed Hypre 1D Matrix (size = m x 1)
     '''
-      
+
     if MFEM_PAR:
-        return Array2CHypreVec(array, part = part, horizontal=horizontal)       
+        return Array2CHypreVec(array, part=part, horizontal=horizontal)
     else:
         if horizontal:
-            return array.reshape((1, -1))               
+            return array.reshape((1, -1))
         else:
             return array.reshape((-1, 1))
 
-         
-def BF2PyMat(rbf, ibf = None, finalize = False):
+
+def BF2PyMat(rbf, ibf=None, finalize=False):
     '''
-    Convert pair of BilinearForms to CHypreMat or 
+    Convert pair of BilinearForms to CHypreMat or
     ScipySparsematrix
     '''
     if finalize:
         rbf.Finalize()
-        if ibf is not None: ibf.Finalize()
-        
-    if MFEM_PAR:
-        M1 =  rbf.ParallelAssemble()
-        M1.thisown = True        
         if ibf is not None:
-            M2 =  ibf.ParallelAssemble()
-            M2.thisown = True                    
+            ibf.Finalize()
+
+    if MFEM_PAR:
+        M1 = rbf.ParallelAssemble()
+        M1.thisown = True
+        if ibf is not None:
+            M2 = ibf.ParallelAssemble()
+            M2.thisown = True
         else:
             M2 = None
-        return CHypreMat(M1,  M2)
+        return CHypreMat(M1, M2)
     else:
-        from mfem.common.sparse_utils import sparsemat_to_scipycsr        
-        M1 =  rbf.SpMat()        
-        if ibf is None:        
-            return sparsemat_to_scipycsr(M1, dtype = float)
+        from mfem.common.sparse_utils import sparsemat_to_scipycsr
+        M1 = rbf.SpMat()
+        if ibf is None:
+            return sparsemat_to_scipycsr(M1, dtype=float)
         if ibf is not None:
-            M2 =  ibf.SpMat()
-            m1 = sparsemat_to_scipycsr(M1, dtype = float).tolil()
-            m2 = sparsemat_to_scipycsr(M2, dtype = complex).tolil()
-            m = m1 + 1j*m2
+            M2 = ibf.SpMat()
+            m1 = sparsemat_to_scipycsr(M1, dtype=float).tolil()
+            m2 = sparsemat_to_scipycsr(M2, dtype=complex).tolil()
+            m = m1 + 1j * m2
             m = m.tocsr()
         return m
 
+
 BilinearForm2PyMatix = BF2PyMat
 
-def MfemMat2PyMat(M1, M2 = None):
+
+def MfemMat2PyMat(M1, M2=None):
     '''
-    Convert pair of SpMat/HypreParCSR to CHypreMat or 
-    ScipySparsematrix. This is simpler version of BF2PyMat, only 
+    Convert pair of SpMat/HypreParCSR to CHypreMat or
+    ScipySparsematrix. This is simpler version of BF2PyMat, only
     difference is it skippes convertion from BF to Matrix.
     '''
     from mfem.common.sparse_utils import sparsemat_to_scipycsr
     if MFEM_PAR:
-        return CHypreMat(M1,  M2)
+        return CHypreMat(M1, M2)
     else:
-        if M2 is None:        
-            return sparsemat_to_scipycsr(M1, dtype = float)
+        if M2 is None:
+            return sparsemat_to_scipycsr(M1, dtype=float)
         else:
-            m1 = sparsemat_to_scipycsr(M1, dtype = float).tolil()
-            m2 = sparsemat_to_scipycsr(M2, dtype = complex).tolil()
-            m = m1 + 1j*m2
+            m1 = sparsemat_to_scipycsr(M1, dtype=float).tolil()
+            m2 = sparsemat_to_scipycsr(M2, dtype=complex).tolil()
+            m = m1 + 1j * m2
             m = m.tocsr()
             return m
 
-def EmptySquarePyMat(m, col_starts = None):
-    from scipy.sparse import csr_matrix       
+
+def EmptySquarePyMat(m, col_starts=None):
+    from scipy.sparse import csr_matrix
     if MFEM_PAR:
         if col_starts is None:
-           col_starts = get_assumed_patitioning(m)
-        rows =  col_starts[1] - col_starts[0]
+            col_starts = get_assumed_patitioning(m)
+        rows = col_starts[1] - col_starts[0]
         m1 = csr_matrix((rows, m))
         return CHypreMat(m1, None, )
     else:
         from scipy.sparse import csr_matrix
         return csr_matrix((m, m))
 
-def IdentityPyMat(m, col_starts = None, diag=1.0):
+
+def IdentityPyMat(m, col_starts=None, diag=1.0):
     from scipy.sparse import coo_matrix, lil_matrix
     if MFEM_PAR:
         if col_starts is None:
-           col_starts = get_assumed_patitioning(m)
-        rows =  col_starts[1] - col_starts[0]
+            col_starts = get_assumed_patitioning(m)
+        rows = col_starts[1] - col_starts[0]
 
         if np.iscomplexobj(diag):
             real = diag.real
@@ -1109,79 +1180,79 @@ def IdentityPyMat(m, col_starts = None, diag=1.0):
         else:
             real = float(np.real(diag))
             imag = 0.0
-        #if real != 0.0:
+        # if real != 0.0:
         m1 = lil_matrix((rows, m))
         for i in range(rows):
-            m1[i, i+col_starts[0]] = real
-        m1 = m1.tocsr() 
+            m1[i, i + col_starts[0]] = real
+        m1 = m1.tocsr()
 
         if imag != 0.0:
             m2 = lil_matrix((rows, m))
             for i in range(rows):
-                m2[i, i+col_starts[0]] = imag
-            m2 = m2.tocsr() 
+                m2[i, i + col_starts[0]] = imag
+            m2 = m2.tocsr()
         else:
             m2 = None
         return CHypreMat(m1, m2, )
     else:
         m1 = coo_matrix((m, m))
-        m1.setdiag(np.zeros(m)+diag)
+        m1.setdiag(np.zeros(m) + diag)
         return m1.tocsr()
 
-def HStackPyVec(vecs, col_starts = None):
+
+def HStackPyVec(vecs, col_starts=None):
     '''
-    horizontally stack vertical vectors to generate 
+    horizontally stack vertical vectors to generate
     PyMat
     '''
-    from scipy.sparse import csr_matrix    
+    from scipy.sparse import csr_matrix
     if MFEM_PAR:
-        from mpi4py import MPI   
-        comm     = MPI.COMM_WORLD     
+        from mpi4py import MPI
+        comm = MPI.COMM_WORLD
         rows = vecs[0].GetPartitioningArray()
         if col_starts is None:
-            col_starts = get_assumed_patitioning(len(vecs))        
+            col_starts = get_assumed_patitioning(len(vecs))
 
         isComplex = any([v.isComplex() for v in vecs])
         mat = np.hstack([np.atleast_2d(v.toarray()).transpose() for v in vecs])
         if isComplex:
             m1 = csr_matrix(mat.real)
-            m2 = csr_matrix(mat.imag)           
+            m2 = csr_matrix(mat.imag)
         else:
             m1 = csr_matrix(mat)
             m2 = None
-        ret = CHypreMat(m1, m2, col_starts = col_starts)
+        ret = CHypreMat(m1, m2, col_starts=col_starts)
         return ret
     else:
         return csr_matrix(np.hstack(vecs))
 
-def PyVec2PyMat(vec, col_starts = None):
+
+def PyVec2PyMat(vec, col_starts=None):
     from scipy.sparse import csr_matrix
     if MFEM_PAR:
         '''
         vec must be vertical
         '''
         assert not vec._horizontal, "PyVec must be vertical"
-        
-        from mpi4py import MPI   
-        comm     = MPI.COMM_WORLD     
+
+        from mpi4py import MPI
+        comm = MPI.COMM_WORLD
         rows = vec.GetPartitioningArray()
         if col_starts is None:
-            col_starts = get_assumed_patitioning(1)        
+            col_starts = get_assumed_patitioning(1)
 
         isComplex = vec.isComplex()
         mat = np.atleast_2d(vec.toarray()).transpose()
-        
+
         if isComplex:
             m1 = csr_matrix(mat.real)
-            m2 = csr_matrix(mat.imag)           
+            m2 = csr_matrix(mat.imag)
         else:
             m1 = csr_matrix(mat)
             m2 = None
-        #print m1.shape 
-        ret = CHypreMat(m1, m2, col_starts = col_starts)
-        #print "returning", ret,
+        # print m1.shape
+        ret = CHypreMat(m1, m2, col_starts=col_starts)
+        # print "returning", ret,
         return ret
     else:
         return csr_matrix(vec)
-
-

--- a/mfem/common/numba_coefficient.i
+++ b/mfem/common/numba_coefficient.i
@@ -230,22 +230,27 @@ class MatrixNumbaFunction : NumbaFunctionBase {
 %newobject MatrixNumbaFunction::GenerateCoefficientT;
 
 %pythoncode %{
-from numba import cfunc, types, carray
-scalar_sig = types.double(types.CPointer(types.double),
+try:
+    from numba import cfunc, types, carray
+    scalar_sig = types.double(types.CPointer(types.double),
 			  types.intc)
-scalar_sig_t = types.double(types.CPointer(types.double),
+    scalar_sig_t = types.double(types.CPointer(types.double),
 			    types.double,
 			    types.intc)
-vector_sig = types.void(types.CPointer(types.double),
+    vector_sig = types.void(types.CPointer(types.double),
 			types.CPointer(types.double),
 			types.intc,
 			types.intc)
-vector_sig_t = types.void(types.CPointer(types.double),
+    vector_sig_t = types.void(types.CPointer(types.double),
 			  types.double,
                           types.CPointer(types.double),
 			  types.intc,
 			  types.intc)
   
-matrix_scalar = vector_sig
-matrix_scalar_t = vector_sig_t
+    matrix_scalar = vector_sig
+    matrix_scalar_t = vector_sig_t
+except ImportError:
+    pass
+except BaseError:
+    assert False, "Failed setting Numba signatures by an error other than ImportError"
 %}

--- a/mfem/common/numba_coefficient.i
+++ b/mfem/common/numba_coefficient.i
@@ -27,10 +27,10 @@ c = NumbaFunction(s_func, sdim, True).GenerateCoefficient()
 
 @cfunc(vector_sig):
 def v_func(ptx, out, sdim, vdim)
-    out_array = carray(out, (m, ))
+    out_array = carray(out, (vdim, ))
     for i in range(m):
         out_array[i] = x+i
-    return out_array
+
 c = VectorNumbaFunction(v_func, sdim, ndim).GenerateCoeficient()
 
 @cfunc(vector_sig_t):
@@ -247,8 +247,8 @@ try:
 			  types.intc,
 			  types.intc)
   
-    matrix_scalar = vector_sig
-    matrix_scalar_t = vector_sig_t
+    matrix_sig = vector_sig
+    matrix_sig_t = vector_sig_t
 except ImportError:
     pass
 except BaseError:

--- a/mfem/common/numba_coefficient.i
+++ b/mfem/common/numba_coefficient.i
@@ -1,0 +1,251 @@
+/*
+# 
+#  using numba JIT function for mfem::FunctionCoefficient
+#
+from numba import cfunc, carray
+
+from mfem.coefficient import (scalar_sig,
+                              scalar_sig_t,
+                              vector_sig,
+                              vector_sig_t,
+                              matrix_sig,
+                              matrix_sig_t,
+
+sdim = mesh.SpaceDimension()
+vdim = mesh.Dimension()
+
+@cfunc(scalar_sig)
+def s_func(ptx, sdim):
+    return 2*ptx[0]
+
+c = NumbaFunction(s_func, sdim).GenerateCoefficient()
+
+@cfunc(scalar_sig_t)
+def s_func_t(ptx, t, sdim):
+    return 2*ptx[0]
+c = NumbaFunction(s_func, sdim, True).GenerateCoefficient()
+
+@cfunc(vector_sig):
+def v_func(ptx, out, sdim, vdim)
+    out_array = carray(out, (m, ))
+    for i in range(m):
+        out_array[i] = x+i
+    return out_array
+c = VectorNumbaFunction(v_func, sdim, ndim).GenerateCoeficient()
+
+@cfunc(vector_sig_t):
+def v_func(ptx, t, out, sdim, vdim):
+    out_array = carray(out, (vdim, ))
+    for i in range(vdim):
+        out_array[i] = x+i
+c = VectorNumbaFunction(v_func, sdim, ndim, True).GenerateCoefficient()
+
+@cfunc(matrix_sig):
+def m_func(ptx, out, sdim, vdim):
+    out_array = carray(out, (vdim, vdim))
+    for i in range(ndim):
+        for j in range(ndim):
+            out_array[i, j] = i*m + j
+c = MatrixNumbaFunction(m_func, sdim, ndim).GenerateCoefficient()
+
+@cfunc(matrix_sig_t):
+def m_func(ptx, t, out, sdim, vdim):
+    out_array = carray(out, (vdim, vdim))
+    for i in range(vdim):
+        for j in range(vdim):
+            out_array[i, j] = i*m + j
+c = MatrixNumbaFunction(m_func, sdim, ndim, True).GenerateCoefficient()
+
+*/
+
+%pythonappend  NumbaFunction::GenerateCoefficient %{
+    val._link = self
+%}
+%pythonappend  VectorNumbaFunction::GenerateCoefficient %{
+    val._link = self
+%}
+%pythonappend  MatrixNumbaFunction::GenerateCoefficient %{
+    val._link = self
+%}
+
+%inline %{
+class NumbaFunctionBase{
+ protected:
+    void *address_;
+    int  sdim_;
+    bool td_;
+ public:
+    NumbaFunctionBase(PyObject *input, int sdim, bool td): sdim_(sdim), td_(td){
+       PyObject* module = PyImport_ImportModule("numba.core.ccallback");
+       if (!module){
+           PyErr_SetString(PyExc_RuntimeError, "Can not load numba.core.ccallback module");
+           return;
+       }      
+       PyObject* cls = PyObject_GetAttrString(module, "CFunc");
+       if (!cls){
+           PyErr_SetString(PyExc_RuntimeError, "Can not load CFunc");
+           return;
+       }
+       int check = PyObject_IsInstance(input, cls);
+       if (! check){
+           PyErr_SetString(PyExc_RuntimeError, "Input must be numba.core.ccallback.CFunc");
+           return;
+       }
+       PyObject *address = PyObject_GetAttrString(input, "address");
+       void *ptr = PyLong_AsVoidPtr(address); 
+       Py_DECREF(address);
+       address_ = ptr;
+    }
+    double print_add(){
+       std::cout << address_ << '\n';
+       return 0;
+    }
+    virtual ~NumbaFunctionBase(){}    
+};
+
+class NumbaFunction : public NumbaFunctionBase {
+ private:
+    std::function<double(const mfem::Vector &)> obj1;
+    std::function<double(const mfem::Vector &, double t)> obj2;
+
+ public:
+    NumbaFunction(PyObject *input, int sdim):
+       NumbaFunctionBase(input, sdim, false){}
+    
+    NumbaFunction(PyObject *input, int sdim, bool td):
+       NumbaFunctionBase(input, sdim, td){}
+    
+    double call(const mfem::Vector &x){
+      return ((double (*)(double *, int))address_)(x.GetData(), sdim_);
+    }
+    double callt(const mfem::Vector &x, double t){
+      return ((double (*)(double *, double, int))address_)(x.GetData(), t, sdim_);
+    }
+
+    // FunctionCoefficient
+    mfem::FunctionCoefficient* GenerateCoefficient(){
+      using std::placeholders::_1;
+      using std::placeholders::_2;      
+      if (td_) {
+         obj2 = std::bind(&NumbaFunction::callt, this, _1, _2);
+         return new mfem::FunctionCoefficient(obj2);
+      } else {
+         obj1 = std::bind(&NumbaFunction::call, this, _1);
+         return new mfem::FunctionCoefficient(obj1);
+      }
+   }
+};
+ 
+// VectorFunctionCoefficient     
+class VectorNumbaFunction : public NumbaFunctionBase {
+ private:
+  std::function<void(const mfem::Vector &, mfem::Vector &)> obj1;
+  std::function<void(const mfem::Vector &, double, mfem::Vector &)> obj2;
+  int vdim_;
+    
+ public:
+    VectorNumbaFunction(PyObject *input, int sdim, int vdim):
+       NumbaFunctionBase(input, sdim, false), vdim_(vdim){}
+    
+    VectorNumbaFunction(PyObject *input, int sdim, int vdim, bool td):
+       NumbaFunctionBase(input, sdim, td), vdim_(vdim){}
+  
+    void call(const mfem::Vector &x, mfem::Vector &out){
+      return ((void (*) (double *, double *, int, int))address_)(x.GetData(), 
+    							      out.GetData(),
+                                                              sdim_,
+							      vdim_);      
+       
+    }
+    void callt(const mfem::Vector &x, double t, mfem::Vector &out){
+      return ((void (*) (double *, double,  double *, int, int))address_)(x.GetData(),
+							              t,
+								      out.GetData(),
+								      sdim_,
+	 							      vdim_);            
+    }
+
+    mfem::VectorFunctionCoefficient* GenerateCoefficient(){
+      using std::placeholders::_1;
+      using std::placeholders::_2;
+      using std::placeholders::_3;            
+      if (td_) {
+	obj2 = std::bind(&VectorNumbaFunction::callt, this, _1, _2, _3);
+	return new mfem::VectorFunctionCoefficient(vdim_, obj2);
+      } else {
+	obj1 = std::bind(&VectorNumbaFunction::call, this, _1, _2);
+	return new mfem::VectorFunctionCoefficient(vdim_, obj1);
+      }
+   }
+};
+// MatrixFunctionCoefficient
+class MatrixNumbaFunction : NumbaFunctionBase {
+ private:
+  std::function<void(const mfem::Vector &, mfem::DenseMatrix &)> obj1;
+  std::function<void(const mfem::Vector &, double, mfem::DenseMatrix &)> obj2;
+  int vdim_;
+    
+ public:
+    MatrixNumbaFunction(PyObject *input, int sdim, int vdim):
+       NumbaFunctionBase(input, sdim, false), vdim_(vdim){}
+    MatrixNumbaFunction(PyObject *input, int sdim, int vdim, bool td):
+       NumbaFunctionBase(input, sdim, td), vdim_(vdim){}
+
+    void call(const mfem::Vector &x, mfem::DenseMatrix &out){
+      return ((void (*) (double *, double *, int, int))address_)(x.GetData(), 
+    							      out.GetData(),
+                                                              sdim_,
+							      vdim_);      
+       
+    }
+    void callt(const mfem::Vector &x, double t, mfem::DenseMatrix &out){
+      return ((void (*) (double *, double,  double *, int, int))address_)(x.GetData(),
+							              t,
+								      out.GetData(),
+								      sdim_,
+	 							      vdim_);            
+    }
+       
+    mfem::MatrixFunctionCoefficient* GenerateCoefficient(){
+      using std::placeholders::_1;
+      using std::placeholders::_2;
+      using std::placeholders::_3;      
+      if (td_) {
+ 	obj2 = std::bind(&MatrixNumbaFunction::callt, this, _1, _2, _3);
+	return new mfem::MatrixFunctionCoefficient(vdim_, obj2);
+      } else {
+	obj1 = std::bind(&MatrixNumbaFunction::call, this, _1, _2);
+	return new mfem::MatrixFunctionCoefficient(vdim_, obj1);
+      }
+    }
+};
+ 
+%}
+
+%newobject NumbaFunction::GenerateCoefficient;
+%newobject NumbaFunction::GenerateCoefficientT;
+%newobject VectorNumbaFunction::GenerateCoefficient;
+%newobject VectorNumbaFunction::GenerateCoefficientT;
+%newobject MatrixNumbaFunction::GenerateCoefficient;
+%newobject MatrixNumbaFunction::GenerateCoefficientT;
+
+%pythoncode %{
+from numba import cfunc, types, carray
+scalar_sig = types.double(types.CPointer(types.double),
+			  types.intc)
+scalar_sig_t = types.double(types.CPointer(types.double),
+			    types.double,
+			    types.intc)
+vector_sig = types.void(types.CPointer(types.double),
+			types.CPointer(types.double),
+			types.intc,
+			types.intc)
+vector_sig_t = types.void(types.CPointer(types.double),
+			  types.double,
+                          types.CPointer(types.double),
+			  types.intc,
+			  types.intc)
+  
+matrix_scalar = vector_sig
+matrix_scalar_t = vector_sig_t
+%}

--- a/test/test_gz.py
+++ b/test/test_gz.py
@@ -6,38 +6,41 @@ import numpy as np
 import io
 from mfem import path as mfem_path
 
-if len(sys.argv) > 1 and sys.argv[1] == '-p':   
+if len(sys.argv) > 1 and sys.argv[1] == '-p':
     import mfem.par as mfem
     use_parallel = True
     from mfem.common.mpi_debug import nicePrint as print
     from mpi4py import MPI
-    myid  = MPI.COMM_WORLD.rank
-    
+    myid = MPI.COMM_WORLD.rank
+
 else:
     import mfem.ser as mfem
     use_parallel = False
     myid = 0
 
+
 def check(a, b, msg):
     assert len(a) == len(b), msg
-    assert np.sum(np.abs(a-b)) == 0, msg
-    
+    assert np.sum(np.abs(a - b)) == 0, msg
+
+
 def check_mesh(m1, m2, msg):
     assert m1.GetNE() == m2.GetNE(), msg
-    assert m1.GetNBE() == m2.GetNBE(), msg    
-    assert m1.GetNV() == m2.GetNV(), msg    
-    
+    assert m1.GetNBE() == m2.GetNBE(), msg
+    assert m1.GetNV() == m2.GetNV(), msg
+
+
 def run_test():
     #meshfile = expanduser(join(mfem_path, 'data', 'semi_circle.mesh'))
     meshfile = "../data/amr-quad.mesh"
     mesh = mfem.Mesh(meshfile, 1, 1)
     dim = mesh.Dimension()
-    sdim = mesh.SpaceDimension()    
+    sdim = mesh.SpaceDimension()
     fec = mfem.H1_FECollection(1, dim)
     fespace = mfem.FiniteElementSpace(mesh, fec, 1)
-    print('Number of finite element unknowns: '+
+    print('Number of finite element unknowns: ' +
           str(fespace.GetTrueVSize()))
-    
+
     c = mfem.ConstantCoefficient(1.0)
     gf = mfem.GridFunction(fespace)
     gf.ProjectCoefficient(c)
@@ -48,55 +51,68 @@ def run_test():
     gf2 = mfem.GridFunction(mesh, "out_test_gz.gf")
     odata2 = gf2.GetDataArray().copy()
     check(odata, odata2, "text file does not agree with original")
-    
+
     gf.Save("out_test_gz.gz")
+    gf2.Assign(0.0)
     gf2 = mfem.GridFunction(mesh, "out_test_gz.gz")
     odata2 = gf2.GetDataArray().copy()
     check(odata, odata2, ".gz file does not agree with original")
-    
+
     gf.Print("out_test_gz.dat")
+    gf2.Assign(0.0)
     gf2.Load("out_test_gz.dat", gf.Size())
     odata2 = gf2.GetDataArray().copy()
     check(odata, odata2, ".dat file does not agree with original")
 
     gf.Print("out_test_gz.dat.gz")
+    gf2.Assign(0.0)
     gf2.Load("out_test_gz.dat.gz", gf.Size())
     odata2 = gf2.GetDataArray().copy()
-    check(odata, odata2, ".dat file does not agree with original")
-    
-    
+    check(odata, odata2, ".dat file does not agree with original (gz)")
+
+    import gzip
+    import io
+    gf.Print("out_test_gz.dat2.gz")
+    with gzip.open("out_test_gz.dat2.gz", 'rt') as f:
+        sio = io.StringIO(f.read())
+    gf3 = mfem.GridFunction(fespace)
+    gf3.Load(sio, gf.Size())
+    odata3 = gf3.GetDataArray().copy()
+    check(odata, odata3, ".dat file does not agree with original(gz-io)")
+
     c = mfem.ConstantCoefficient(2.0)
     gf.ProjectCoefficient(c)
     odata = gf.GetDataArray().copy()
-    
-    o = io.StringIO()    
+
+    o = io.StringIO()
     gf.Print(o)
     gf2.Load(o, gf.Size())
     odata2 = gf2.GetDataArray().copy()
     check(odata, odata2, "StringIO does not agree with original")
- 
-    print("GridFunction .gf, .gz .dat and StringIO agree with original")   
+
+    print("GridFunction .gf, .gz .dat and StringIO agree with original")
 
     mesh2 = mfem.Mesh()
     mesh.Print("out_test_gz.mesh")
     mesh2.Load("out_test_gz.mesh")
-    check_mesh(mesh, mesh2, ".mesh does not agree with original")    
+    check_mesh(mesh, mesh2, ".mesh does not agree with original")
 
-    mesh2 = mfem.Mesh()    
+    mesh2 = mfem.Mesh()
     mesh.Print("out_test_gz.mesh.gz")
     mesh2.Load("out_test_gz.mesh.gz")
 
     check_mesh(mesh, mesh2, ".mesh.gz does not agree with original")
 
-    o = io.StringIO()        
-    mesh2 = mfem.Mesh()    
+    o = io.StringIO()
+    mesh2 = mfem.Mesh()
     mesh.Print(o)
     mesh2.Load(o)
-    check_mesh(mesh, mesh2, ".mesh.gz does not agree with original")    
-    
-    print("Mesh .mesh, .mesh.gz and StringIO agree with original")   
+    check_mesh(mesh, mesh2, ".mesh.gz does not agree with original")
+
+    print("Mesh .mesh, .mesh.gz and StringIO agree with original")
 
     print("PASSED")
 
-if __name__=='__main__':
+
+if __name__ == '__main__':
     run_test()

--- a/test/test_numba.py
+++ b/test/test_numba.py
@@ -1,0 +1,44 @@
+from __future__ import print_function
+import os
+from os.path import expanduser, join
+import sys
+import io
+from mfem import path as mfem_path
+import numba
+
+if len(sys.argv) > 1 and sys.argv[1] == '-p':   
+    import mfem.par as mfem
+    use_parallel = True
+    from mfem.common.mpi_debug import nicePrint as print
+    from mpi4py import MPI
+    myid  = MPI.COMM_WORLD.rank
+    
+else:
+    import mfem.ser as mfem
+    use_parallel = False
+    myid = 0
+
+from numba import cfunc, carray    
+
+@cfunc(mfem.scalar_sig)
+def s_func(ptx, sdim):
+    return 2
+
+def run_test():
+    #meshfile = expanduser(join(mfem_path, 'data', 'semi_circle.mesh'))
+    mesh = mfem.Mesh(6, 6, "TRIANGLE")
+    dim = mesh.Dimension()
+    sdim = mesh.SpaceDimension()    
+    fec = mfem.H1_FECollection(1, dim)
+    fespace = mfem.FiniteElementSpace(mesh, fec, 1)
+    print('Number of finite element unknowns: '+
+          str(fespace.GetTrueVSize()))
+
+    c = mfem.NumbaFunction(s_func, sdim).GenerateCoefficient()    
+    gf = mfem.GridFunction(fespace)
+    gf.ProjectCoefficient(c)
+
+    gf.Print()
+if __name__=='__main__':
+    run_test()
+    

--- a/test/test_numba.py
+++ b/test/test_numba.py
@@ -1,44 +1,202 @@
 from __future__ import print_function
+from numba import cfunc, farray, carray
 import os
 from os.path import expanduser, join
 import sys
 import io
 from mfem import path as mfem_path
+import numpy as np
 import numba
+import time
 
-if len(sys.argv) > 1 and sys.argv[1] == '-p':   
+if len(sys.argv) > 1 and sys.argv[1] == '-p':
     import mfem.par as mfem
     use_parallel = True
     from mfem.common.mpi_debug import nicePrint as print
     from mpi4py import MPI
-    myid  = MPI.COMM_WORLD.rank
-    
+    myid = MPI.COMM_WORLD.rank
+
 else:
     import mfem.ser as mfem
     use_parallel = False
     myid = 0
 
-from numba import cfunc, carray    
+
+class s_coeff(mfem.PyCoefficient):
+    def __init__(self):
+        mfem.PyCoefficient.__init__(self)
+
+    def EvalValue(self, p):
+        return p[0]
+
+
+class v_coeff(mfem.VectorPyCoefficient):
+    def __init__(self, dim):
+        mfem.VectorPyCoefficient.__init__(self, dim)
+
+    def EvalValue(self, p):
+        return (p[0], p[1], p[2])
+
+
+class m_coeff(mfem.MatrixPyCoefficient):
+    def __init__(self, dim):
+        mfem.MatrixPyCoefficient.__init__(self, dim)
+
+    def EvalValue(self, p):
+        return np.array([[p[0], p[1], p[2]],
+                         [0.0, p[1], p[2]],
+                         [0.0, 0.0, p[2]]])
+
 
 @cfunc(mfem.scalar_sig)
 def s_func(ptx, sdim):
-    return 2
+    return ptx[0]
+
+
+@cfunc(mfem.vector_sig)
+def v_func(ptx, out, sdim, vdim):
+    out_array = carray(out, (vdim, ))
+    for i in range(sdim):
+        out_array[i] = ptx[i]
+
+
+@cfunc(mfem.matrix_sig)
+def m_func(ptx, out, sdim, vdim):
+    # we use farray to assign the data like above.
+    out_array = farray(out, (vdim, vdim))
+    out_array[0, 0] = ptx[0]
+    out_array[0, 1] = ptx[1]
+    out_array[0, 2] = ptx[2]
+    out_array[1, 0] = 0.0
+    out_array[1, 1] = ptx[1]
+    out_array[1, 2] = ptx[2]
+    out_array[2, 0] = 0.0
+    out_array[2, 1] = 0.0
+    out_array[2, 2] = ptx[2]
+    '''
+    accessing the array linearly does not speed up.
+    out_array = carray(out, (vdim * vdim, ))
+    out_array[0] = ptx[0]
+    out_array[1] = 0.0
+    out_array[2] = 0.0
+    out_array[3] = ptx[1]
+    out_array[4] = ptx[1]
+    out_array[5] = 0.0
+    out_array[6] = ptx[2]
+    out_array[7] = ptx[2]
+    out_array[8] = ptx[2]
+    '''
+
+def check(a, b, msg):
+    assert len(a) == len(b), msg
+    assert np.sum(np.abs(a - b)) == 0, msg
+
 
 def run_test():
     #meshfile = expanduser(join(mfem_path, 'data', 'semi_circle.mesh'))
-    mesh = mfem.Mesh(6, 6, "TRIANGLE")
+    mesh = mfem.Mesh(30, 30, 30, "TETRAHEDRON")
+    mesh.ReorientTetMesh()
+
+    order = 2
+
     dim = mesh.Dimension()
-    sdim = mesh.SpaceDimension()    
-    fec = mfem.H1_FECollection(1, dim)
-    fespace = mfem.FiniteElementSpace(mesh, fec, 1)
-    print('Number of finite element unknowns: '+
-          str(fespace.GetTrueVSize()))
+    sdim = mesh.SpaceDimension()
+    fec1 = mfem.H1_FECollection(order, dim)
+    fespace1 = mfem.FiniteElementSpace(mesh, fec1, 1)
 
-    c = mfem.NumbaFunction(s_func, sdim).GenerateCoefficient()    
-    gf = mfem.GridFunction(fespace)
-    gf.ProjectCoefficient(c)
+    fec2 = mfem.ND_FECollection(order, dim)
+    fespace2 = mfem.FiniteElementSpace(mesh, fec2, 1)
 
-    gf.Print()
-if __name__=='__main__':
+    print("Element order :", order)
+
+    print('Number of H1 finite element unknowns: ' +
+          str(fespace1.GetTrueVSize()))
+    print('Number of ND finite element unknowns: ' +
+          str(fespace2.GetTrueVSize()))
+
+    print("Checking scalar")
+
+    gf = mfem.GridFunction(fespace1)
+    c1 = mfem.NumbaFunction(s_func, sdim).GenerateCoefficient()
+    c2 = s_coeff()
+
+    gf.Assign(0.0)
+    start = time.time()
+    gf.ProjectCoefficient(c1)
+    end = time.time()
+    data1 = gf.GetDataArray().copy()
+    print("Numba time (scalar)", end - start)
+
+    gf.Assign(0.0)
+    start = time.time()
+    gf.ProjectCoefficient(c2)
+    end = time.time()
+    data2 = gf.GetDataArray().copy()
+    print("Python time (scalar)", end - start)
+
+    check(data1, data2, "scalar coefficient does not agree with original")
+
+    print("Checking vector")
+    gf = mfem.GridFunction(fespace2)
+    c3 = mfem.VectorNumbaFunction(v_func, sdim, dim).GenerateCoefficient()
+    c4 = v_coeff(dim)
+
+    gf.Assign(0.0)
+    start = time.time()
+    gf.ProjectCoefficient(c3)
+    end = time.time()
+    data1 = gf.GetDataArray().copy()
+    print("Numba time (vector)", end - start)
+
+    gf.Assign(0.0)
+    start = time.time()
+    gf.ProjectCoefficient(c4)
+    end = time.time()
+    data2 = gf.GetDataArray().copy()
+    print("Python time (vector)", end - start)
+
+    check(data1, data2, "vector coefficient does not agree with original")
+
+    print("Checking matrix")
+    a1 = mfem.BilinearForm(fespace2)
+    a2 = mfem.BilinearForm(fespace2)
+    c4 = mfem.MatrixNumbaFunction(m_func, sdim, dim).GenerateCoefficient()
+    c5 = m_coeff(dim)
+
+    a1.AddDomainIntegrator(mfem.VectorFEMassIntegrator(c4))
+    a2.AddDomainIntegrator(mfem.VectorFEMassIntegrator(c5))
+
+    start = time.time()
+    a1.Assemble()
+    end = time.time()
+    a1.Finalize()
+    M1 = a1.SpMat()
+
+    print("Numba time (matrix)", end - start)
+
+    start = time.time()
+    a2.Assemble()
+    end = time.time()
+    a2.Finalize()
+    M2 = a2.SpMat()
+    print("Python time (matrix)", end - start)
+
+    #from mfem.commmon.sparse_utils import sparsemat_to_scipycsr
+    #csr1 = sparsemat_to_scipycsr(M1, float)
+    #csr2 = sparsemat_to_scipycsr(M2, float)
+
+    check(M1.GetDataArray(),
+          M2.GetDataArray(),
+          "matrix coefficient does not agree with original")
+    check(M1.GetIArray(),
+          M2.GetIArray(),
+          "matrix coefficient does not agree with original")
+    check(M1.GetJArray(),
+          M2.GetJArray(),
+          "matrix coefficient does not agree with original")
+
+    print("PASSED")
+
+
+if __name__ == '__main__':
     run_test()
-    


### PR DESCRIPTION
This pull add an option to use Numba JIT (just-in-time) compiled Python routine in Function 
Coefficient. Compared to the existing wrapper, which uses the SWIG director mechanism,  Numba JIT
realizes much faster coefficient evaluation, while keeping the convenience of writing a coefficient 
in Python

To-Do:
   complete test routine
   add a few more example
   test it in a larger scale simulation.
