### PR TITLE
Compressed io fix

### DIFF
--- a/.github/workflows/release_binary.yml
+++ b/.github/workflows/release_binary.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   vm:
     runs-on: ubuntu-latest
-    container: quay.io/pypa/manylinux2010_x86_64    
+    container: quay.io/pypa/manylinux2014_x86_64
     steps:
       - name: build_sdist
         run: |
@@ -41,7 +41,7 @@ jobs:
         pythonpath: ["cp36-cp36m", "cp37-cp37m", "cp38-cp38", "cp39-cp39"]
  
     runs-on: ubuntu-latest
-    container: quay.io/pypa/manylinux2010_x86_64
+    container: quay.io/pypa/manylinux2014_x86_64
     #container: node:10.16-jessie
     steps:
       - name: build package
@@ -63,6 +63,7 @@ jobs:
           fi	  
           CWD=$PWD
           ls -l 
+          yum install -y zlib-devel
           python3 setup.py install
           rm -rf dist/*
           python3 setup.py bdist_wheel

--- a/.github/workflows/testrelease_binary.yml
+++ b/.github/workflows/testrelease_binary.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   vm:
     runs-on: ubuntu-latest
-    container: quay.io/pypa/manylinux2010_x86_64    
+    container: quay.io/pypa/manylinux2014_x86_64
     steps:
       - name: build_sdist
         run: |
@@ -32,7 +32,7 @@ jobs:
           python3 setup.py sdist
           ls -l dist/
           python3 -m twine upload --repository-url https://test.pypi.org/legacy/ --password ${{ secrets.TEST_PYPI_TOKEN }} --username __token__ --verbose dist/*
-          #python3 -m twine upload --password ${{ secrets.PYPI_TOKEN }} --username __token__ --verbose dist/*   	  
+          #python3 -m twine upload --password ${{ secrets.PYPI_TOKEN }} --username __token__ --verbose dist/*
   container:
     needs: vm
     strategy:
@@ -41,7 +41,7 @@ jobs:
         pythonpath: ["cp36-cp36m", "cp37-cp37m", "cp38-cp38", "cp39-cp39"]
  
     runs-on: ubuntu-latest
-    container: quay.io/pypa/manylinux2010_x86_64
+    container: quay.io/pypa/manylinux2014_x86_64
     #container: node:10.16-jessie
     steps:
       - name: build package
@@ -62,7 +62,8 @@ jobs:
              pip3 install -r requirements.txt
           fi	  
           CWD=$PWD
-          ls -l 
+          ls -l
+          yum install -y zlib-devel
           python3 setup.py install
           rm -rf dist/*
           python3 setup.py bdist_wheel

--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -3,5 +3,5 @@ numpy>=1.20.0; python_version>="3.7"
 scipy>=1.5.2
 six>1.13.0
 matplotlib
-mfem
+mfem==4.2.0.15
 glvis

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -1,4 +1,7 @@
 	<<<  Change Log. >>>
+2021 05.19
+        * Fixed std::istream & wrapping not to return the lenght of data. This fixes
+	  the constructors such as mfem::Mesh(std::stream &)
 2021 05.07
         * vtk.py and datacollection.py was loaded in mfem.ser and mfem.par namespace properly
 	* istream& wrapping was improved in the same way as ostream&

--- a/mfem/__init__.py
+++ b/mfem/__init__.py
@@ -20,4 +20,4 @@ def debug_print(message):
 
     print(message)
 
-__version__ = '4.2.0.15'
+__version__ = '4.2.0.16'

--- a/mfem/__init__.py
+++ b/mfem/__init__.py
@@ -20,6 +20,4 @@ def debug_print(message):
 
     print(message)
 
-__version__ = '4.2.0.14'
-
-
+__version__ = '4.2.0.15'

--- a/mfem/_par/array.py
+++ b/mfem/_par/array.py
@@ -348,6 +348,16 @@ class intArray(object):
         return _array.intArray_Print(self, *args)
     Print = _swig_new_instance_method(_array.intArray_Print)
 
+    def PrintGZ(self, file, precision=8):
+        r"""PrintGZ(intArray self, char const * file, int precision=8)"""
+        return _array.intArray_PrintGZ(self, file, precision)
+    PrintGZ = _swig_new_instance_method(_array.intArray_PrintGZ)
+
+    def SaveGZ(self, file, precision=8):
+        r"""SaveGZ(intArray self, char const * file, int precision=8)"""
+        return _array.intArray_SaveGZ(self, file, precision)
+    SaveGZ = _swig_new_instance_method(_array.intArray_SaveGZ)
+
     def Save(self, *args):
         r"""
         Save(intArray self, std::ostream & out, int fmt=0)
@@ -642,6 +652,16 @@ class doubleArray(object):
         """
         return _array.doubleArray_Print(self, *args)
     Print = _swig_new_instance_method(_array.doubleArray_Print)
+
+    def PrintGZ(self, file, precision=8):
+        r"""PrintGZ(doubleArray self, char const * file, int precision=8)"""
+        return _array.doubleArray_PrintGZ(self, file, precision)
+    PrintGZ = _swig_new_instance_method(_array.doubleArray_PrintGZ)
+
+    def SaveGZ(self, file, precision=8):
+        r"""SaveGZ(doubleArray self, char const * file, int precision=8)"""
+        return _array.doubleArray_SaveGZ(self, file, precision)
+    SaveGZ = _swig_new_instance_method(_array.doubleArray_SaveGZ)
 
     def Save(self, *args):
         r"""

--- a/mfem/_par/array_wrap.cxx
+++ b/mfem/_par/array_wrap.cxx
@@ -3148,6 +3148,17 @@ SWIGINTERN void mfem_Array_Sl_int_Sg__Print__SWIG_1(mfem::Array< int > *self,cha
   self -> Print(ofile);
   ofile.close();
   }
+SWIGINTERN void mfem_Array_Sl_int_Sg__PrintGZ(mfem::Array< int > *self,char const *file,int precision=8){
+  mfem::ofgzstream *ofile = new mfem::ofgzstream(file, true);
+  if (!ofile)
+     {
+        std::cerr << "\nCan not produce output file: " << file << '\n' << std::endl;
+        return;
+      }
+  ofile ->precision(precision);  
+  self -> Print(*ofile);
+  delete ofile;
+  }
 SWIGINTERN void mfem_Array_Sl_int_Sg__Save__SWIG_1(mfem::Array< int > *self,char const *file,int precision=8){
   std::ofstream ofile(file);
   if (!ofile)
@@ -3158,6 +3169,18 @@ SWIGINTERN void mfem_Array_Sl_int_Sg__Save__SWIG_1(mfem::Array< int > *self,char
   ofile.precision(precision);    
   self -> Save(ofile);
   ofile.close();
+  }
+SWIGINTERN void mfem_Array_Sl_int_Sg__SaveGZ(mfem::Array< int > *self,char const *file,int precision=8){
+  mfem::ofgzstream *ofile = new mfem::ofgzstream(file, true);
+  
+  if (!ofile)
+     {
+        std::cerr << "\nCan not produce output file: " << file << '\n' << std::endl;
+        return;
+      }
+  ofile -> precision(precision);  
+  self -> Save(*ofile);
+  delete ofile;
   }
 SWIGINTERN void mfem_Array_Sl_int_Sg__Save__SWIG_2(mfem::Array< int > *self){
   self -> Save(std::cout);
@@ -3186,6 +3209,17 @@ SWIGINTERN void mfem_Array_Sl_double_Sg__Print__SWIG_1(mfem::Array< double > *se
   self -> Print(ofile);
   ofile.close();
   }
+SWIGINTERN void mfem_Array_Sl_double_Sg__PrintGZ(mfem::Array< double > *self,char const *file,int precision=8){
+  mfem::ofgzstream *ofile = new mfem::ofgzstream(file, true);
+  if (!ofile)
+     {
+        std::cerr << "\nCan not produce output file: " << file << '\n' << std::endl;
+        return;
+      }
+  ofile ->precision(precision);  
+  self -> Print(*ofile);
+  delete ofile;
+  }
 SWIGINTERN void mfem_Array_Sl_double_Sg__Save__SWIG_1(mfem::Array< double > *self,char const *file,int precision=8){
   std::ofstream ofile(file);
   if (!ofile)
@@ -3196,6 +3230,18 @@ SWIGINTERN void mfem_Array_Sl_double_Sg__Save__SWIG_1(mfem::Array< double > *sel
   ofile.precision(precision);    
   self -> Save(ofile);
   ofile.close();
+  }
+SWIGINTERN void mfem_Array_Sl_double_Sg__SaveGZ(mfem::Array< double > *self,char const *file,int precision=8){
+  mfem::ofgzstream *ofile = new mfem::ofgzstream(file, true);
+  
+  if (!ofile)
+     {
+        std::cerr << "\nCan not produce output file: " << file << '\n' << std::endl;
+        return;
+      }
+  ofile -> precision(precision);  
+  self -> Save(*ofile);
+  delete ofile;
   }
 SWIGINTERN void mfem_Array_Sl_double_Sg__Save__SWIG_2(mfem::Array< double > *self){
   self -> Save(std::cout);
@@ -5531,14 +5577,20 @@ SWIGINTERN PyObject *_wrap_intArray_Load__SWIG_0(PyObject *SWIGUNUSEDPARM(self),
       }
     }
     if (stream2 == 0){
-      if (temp2->isGZ()){
-        in_gz2 = new mfem::ifgzstream(temp2->getFilename());
-        arg2 = in_gz2;
-      } else {
-        in_txt2.open(temp2->getFilename(), std::ifstream::in);
-        in_txt2.precision(temp2->getPrecision());
-        arg2 = &in_txt2;
-      }
+      /*
+            if (temp2->isGZ()){
+        	 in_gz2 = new mfem::ifgzstream(temp2->getFilename());
+               arg2 = in_gz2;
+            } else {
+        	 in_txt2.open(temp2->getFilename(), std::ifstream::in);
+               in_txt2.precision(temp2->getPrecision());
+               arg2 = &in_txt2;
+            }
+           */
+      /* this will auto-detect the input file type */
+      in_gz2 = new mfem::ifgzstream(temp2->getFilename());
+      arg2 = in_gz2;
+      
       if (temp2->isTemporary()){
         delete temp2;
       }
@@ -5570,18 +5622,6 @@ SWIGINTERN PyObject *_wrap_intArray_Load__SWIG_0(PyObject *SWIGUNUSEDPARM(self),
     }	 
   }
   resultobj = SWIG_Py_Void();
-  {
-    if (stream2) {
-      ret2 = PyLong_FromSsize_t(len2);
-      if (PyErr_Occurred()) {
-        PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
-        return NULL;
-      }
-      delete stream2;    
-      Py_XDECREF(resultobj);   /* Blow away any previous result */
-      resultobj = ret2;    
-    }
-  }
   {
     if (!stream2) {
       if (temp2) {
@@ -5678,14 +5718,20 @@ SWIGINTERN PyObject *_wrap_intArray_Load__SWIG_1(PyObject *SWIGUNUSEDPARM(self),
       }
     }
     if (stream3 == 0){
-      if (temp3->isGZ()){
-        in_gz3 = new mfem::ifgzstream(temp3->getFilename());
-        arg3 = in_gz3;
-      } else {
-        in_txt3.open(temp3->getFilename(), std::ifstream::in);
-        in_txt3.precision(temp3->getPrecision());
-        arg3 = &in_txt3;
-      }
+      /*
+            if (temp3->isGZ()){
+        	 in_gz3 = new mfem::ifgzstream(temp3->getFilename());
+               arg3 = in_gz3;
+            } else {
+        	 in_txt3.open(temp3->getFilename(), std::ifstream::in);
+               in_txt3.precision(temp3->getPrecision());
+               arg3 = &in_txt3;
+            }
+           */
+      /* this will auto-detect the input file type */
+      in_gz3 = new mfem::ifgzstream(temp3->getFilename());
+      arg3 = in_gz3;
+      
       if (temp3->isTemporary()){
         delete temp3;
       }
@@ -5710,18 +5756,6 @@ SWIGINTERN PyObject *_wrap_intArray_Load__SWIG_1(PyObject *SWIGUNUSEDPARM(self),
     }	 
   }
   resultobj = SWIG_Py_Void();
-  {
-    if (stream3) {
-      ret3 = PyLong_FromSsize_t(len3);
-      if (PyErr_Occurred()) {
-        PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
-        return NULL;
-      }
-      delete stream3;    
-      Py_XDECREF(resultobj);   /* Blow away any previous result */
-      resultobj = ret3;    
-    }
-  }
   {
     if (!stream3) {
       if (temp3) {
@@ -7068,6 +7102,68 @@ fail:
 }
 
 
+SWIGINTERN PyObject *_wrap_intArray_PrintGZ(PyObject *SWIGUNUSEDPARM(self), PyObject *args, PyObject *kwargs) {
+  PyObject *resultobj = 0;
+  mfem::Array< int > *arg1 = (mfem::Array< int > *) 0 ;
+  char *arg2 = (char *) 0 ;
+  int arg3 = (int) 8 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int res2 ;
+  char *buf2 = 0 ;
+  int alloc2 = 0 ;
+  int val3 ;
+  int ecode3 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  char * kwnames[] = {
+    (char *)"self",  (char *)"file",  (char *)"precision",  NULL 
+  };
+  
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OO|O:intArray_PrintGZ", kwnames, &obj0, &obj1, &obj2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_mfem__ArrayT_int_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "intArray_PrintGZ" "', argument " "1"" of type '" "mfem::Array< int > *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::Array< int > * >(argp1);
+  res2 = SWIG_AsCharPtrAndSize(obj1, &buf2, NULL, &alloc2);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "intArray_PrintGZ" "', argument " "2"" of type '" "char const *""'");
+  }
+  arg2 = reinterpret_cast< char * >(buf2);
+  if (obj2) {
+    ecode3 = SWIG_AsVal_int(obj2, &val3);
+    if (!SWIG_IsOK(ecode3)) {
+      SWIG_exception_fail(SWIG_ArgError(ecode3), "in method '" "intArray_PrintGZ" "', argument " "3"" of type '" "int""'");
+    } 
+    arg3 = static_cast< int >(val3);
+  }
+  {
+    try {
+      mfem_Array_Sl_int_Sg__PrintGZ(arg1,(char const *)arg2,arg3);
+    }
+#ifdef  MFEM_USE_EXCEPTIONS
+    catch (mfem::ErrorException &_e) {
+      std::string s("PyMFEM error (mfem::ErrorException): "), s2(_e.what());
+      s = s + s2;    
+      SWIG_exception(SWIG_RuntimeError, s.c_str());
+    }
+#endif
+    
+    catch (...) {
+      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+    }	 
+  }
+  resultobj = SWIG_Py_Void();
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return resultobj;
+fail:
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return NULL;
+}
+
+
 SWIGINTERN PyObject *_wrap_intArray_Save__SWIG_1(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
   PyObject *resultobj = 0;
   mfem::Array< int > *arg1 = (mfem::Array< int > *) 0 ;
@@ -7102,6 +7198,68 @@ SWIGINTERN PyObject *_wrap_intArray_Save__SWIG_1(PyObject *SWIGUNUSEDPARM(self),
   {
     try {
       mfem_Array_Sl_int_Sg__Save__SWIG_1(arg1,(char const *)arg2,arg3);
+    }
+#ifdef  MFEM_USE_EXCEPTIONS
+    catch (mfem::ErrorException &_e) {
+      std::string s("PyMFEM error (mfem::ErrorException): "), s2(_e.what());
+      s = s + s2;    
+      SWIG_exception(SWIG_RuntimeError, s.c_str());
+    }
+#endif
+    
+    catch (...) {
+      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+    }	 
+  }
+  resultobj = SWIG_Py_Void();
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return resultobj;
+fail:
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_intArray_SaveGZ(PyObject *SWIGUNUSEDPARM(self), PyObject *args, PyObject *kwargs) {
+  PyObject *resultobj = 0;
+  mfem::Array< int > *arg1 = (mfem::Array< int > *) 0 ;
+  char *arg2 = (char *) 0 ;
+  int arg3 = (int) 8 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int res2 ;
+  char *buf2 = 0 ;
+  int alloc2 = 0 ;
+  int val3 ;
+  int ecode3 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  char * kwnames[] = {
+    (char *)"self",  (char *)"file",  (char *)"precision",  NULL 
+  };
+  
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OO|O:intArray_SaveGZ", kwnames, &obj0, &obj1, &obj2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_mfem__ArrayT_int_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "intArray_SaveGZ" "', argument " "1"" of type '" "mfem::Array< int > *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::Array< int > * >(argp1);
+  res2 = SWIG_AsCharPtrAndSize(obj1, &buf2, NULL, &alloc2);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "intArray_SaveGZ" "', argument " "2"" of type '" "char const *""'");
+  }
+  arg2 = reinterpret_cast< char * >(buf2);
+  if (obj2) {
+    ecode3 = SWIG_AsVal_int(obj2, &val3);
+    if (!SWIG_IsOK(ecode3)) {
+      SWIG_exception_fail(SWIG_ArgError(ecode3), "in method '" "intArray_SaveGZ" "', argument " "3"" of type '" "int""'");
+    } 
+    arg3 = static_cast< int >(val3);
+  }
+  {
+    try {
+      mfem_Array_Sl_int_Sg__SaveGZ(arg1,(char const *)arg2,arg3);
     }
 #ifdef  MFEM_USE_EXCEPTIONS
     catch (mfem::ErrorException &_e) {
@@ -9596,14 +9754,20 @@ SWIGINTERN PyObject *_wrap_doubleArray_Load__SWIG_0(PyObject *SWIGUNUSEDPARM(sel
       }
     }
     if (stream2 == 0){
-      if (temp2->isGZ()){
-        in_gz2 = new mfem::ifgzstream(temp2->getFilename());
-        arg2 = in_gz2;
-      } else {
-        in_txt2.open(temp2->getFilename(), std::ifstream::in);
-        in_txt2.precision(temp2->getPrecision());
-        arg2 = &in_txt2;
-      }
+      /*
+            if (temp2->isGZ()){
+        	 in_gz2 = new mfem::ifgzstream(temp2->getFilename());
+               arg2 = in_gz2;
+            } else {
+        	 in_txt2.open(temp2->getFilename(), std::ifstream::in);
+               in_txt2.precision(temp2->getPrecision());
+               arg2 = &in_txt2;
+            }
+           */
+      /* this will auto-detect the input file type */
+      in_gz2 = new mfem::ifgzstream(temp2->getFilename());
+      arg2 = in_gz2;
+      
       if (temp2->isTemporary()){
         delete temp2;
       }
@@ -9635,18 +9799,6 @@ SWIGINTERN PyObject *_wrap_doubleArray_Load__SWIG_0(PyObject *SWIGUNUSEDPARM(sel
     }	 
   }
   resultobj = SWIG_Py_Void();
-  {
-    if (stream2) {
-      ret2 = PyLong_FromSsize_t(len2);
-      if (PyErr_Occurred()) {
-        PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
-        return NULL;
-      }
-      delete stream2;    
-      Py_XDECREF(resultobj);   /* Blow away any previous result */
-      resultobj = ret2;    
-    }
-  }
   {
     if (!stream2) {
       if (temp2) {
@@ -9743,14 +9895,20 @@ SWIGINTERN PyObject *_wrap_doubleArray_Load__SWIG_1(PyObject *SWIGUNUSEDPARM(sel
       }
     }
     if (stream3 == 0){
-      if (temp3->isGZ()){
-        in_gz3 = new mfem::ifgzstream(temp3->getFilename());
-        arg3 = in_gz3;
-      } else {
-        in_txt3.open(temp3->getFilename(), std::ifstream::in);
-        in_txt3.precision(temp3->getPrecision());
-        arg3 = &in_txt3;
-      }
+      /*
+            if (temp3->isGZ()){
+        	 in_gz3 = new mfem::ifgzstream(temp3->getFilename());
+               arg3 = in_gz3;
+            } else {
+        	 in_txt3.open(temp3->getFilename(), std::ifstream::in);
+               in_txt3.precision(temp3->getPrecision());
+               arg3 = &in_txt3;
+            }
+           */
+      /* this will auto-detect the input file type */
+      in_gz3 = new mfem::ifgzstream(temp3->getFilename());
+      arg3 = in_gz3;
+      
       if (temp3->isTemporary()){
         delete temp3;
       }
@@ -9775,18 +9933,6 @@ SWIGINTERN PyObject *_wrap_doubleArray_Load__SWIG_1(PyObject *SWIGUNUSEDPARM(sel
     }	 
   }
   resultobj = SWIG_Py_Void();
-  {
-    if (stream3) {
-      ret3 = PyLong_FromSsize_t(len3);
-      if (PyErr_Occurred()) {
-        PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
-        return NULL;
-      }
-      delete stream3;    
-      Py_XDECREF(resultobj);   /* Blow away any previous result */
-      resultobj = ret3;    
-    }
-  }
   {
     if (!stream3) {
       if (temp3) {
@@ -11133,6 +11279,68 @@ fail:
 }
 
 
+SWIGINTERN PyObject *_wrap_doubleArray_PrintGZ(PyObject *SWIGUNUSEDPARM(self), PyObject *args, PyObject *kwargs) {
+  PyObject *resultobj = 0;
+  mfem::Array< double > *arg1 = (mfem::Array< double > *) 0 ;
+  char *arg2 = (char *) 0 ;
+  int arg3 = (int) 8 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int res2 ;
+  char *buf2 = 0 ;
+  int alloc2 = 0 ;
+  int val3 ;
+  int ecode3 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  char * kwnames[] = {
+    (char *)"self",  (char *)"file",  (char *)"precision",  NULL 
+  };
+  
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OO|O:doubleArray_PrintGZ", kwnames, &obj0, &obj1, &obj2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_mfem__ArrayT_double_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "doubleArray_PrintGZ" "', argument " "1"" of type '" "mfem::Array< double > *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::Array< double > * >(argp1);
+  res2 = SWIG_AsCharPtrAndSize(obj1, &buf2, NULL, &alloc2);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "doubleArray_PrintGZ" "', argument " "2"" of type '" "char const *""'");
+  }
+  arg2 = reinterpret_cast< char * >(buf2);
+  if (obj2) {
+    ecode3 = SWIG_AsVal_int(obj2, &val3);
+    if (!SWIG_IsOK(ecode3)) {
+      SWIG_exception_fail(SWIG_ArgError(ecode3), "in method '" "doubleArray_PrintGZ" "', argument " "3"" of type '" "int""'");
+    } 
+    arg3 = static_cast< int >(val3);
+  }
+  {
+    try {
+      mfem_Array_Sl_double_Sg__PrintGZ(arg1,(char const *)arg2,arg3);
+    }
+#ifdef  MFEM_USE_EXCEPTIONS
+    catch (mfem::ErrorException &_e) {
+      std::string s("PyMFEM error (mfem::ErrorException): "), s2(_e.what());
+      s = s + s2;    
+      SWIG_exception(SWIG_RuntimeError, s.c_str());
+    }
+#endif
+    
+    catch (...) {
+      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+    }	 
+  }
+  resultobj = SWIG_Py_Void();
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return resultobj;
+fail:
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return NULL;
+}
+
+
 SWIGINTERN PyObject *_wrap_doubleArray_Save__SWIG_1(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
   PyObject *resultobj = 0;
   mfem::Array< double > *arg1 = (mfem::Array< double > *) 0 ;
@@ -11167,6 +11375,68 @@ SWIGINTERN PyObject *_wrap_doubleArray_Save__SWIG_1(PyObject *SWIGUNUSEDPARM(sel
   {
     try {
       mfem_Array_Sl_double_Sg__Save__SWIG_1(arg1,(char const *)arg2,arg3);
+    }
+#ifdef  MFEM_USE_EXCEPTIONS
+    catch (mfem::ErrorException &_e) {
+      std::string s("PyMFEM error (mfem::ErrorException): "), s2(_e.what());
+      s = s + s2;    
+      SWIG_exception(SWIG_RuntimeError, s.c_str());
+    }
+#endif
+    
+    catch (...) {
+      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+    }	 
+  }
+  resultobj = SWIG_Py_Void();
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return resultobj;
+fail:
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_doubleArray_SaveGZ(PyObject *SWIGUNUSEDPARM(self), PyObject *args, PyObject *kwargs) {
+  PyObject *resultobj = 0;
+  mfem::Array< double > *arg1 = (mfem::Array< double > *) 0 ;
+  char *arg2 = (char *) 0 ;
+  int arg3 = (int) 8 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int res2 ;
+  char *buf2 = 0 ;
+  int alloc2 = 0 ;
+  int val3 ;
+  int ecode3 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  char * kwnames[] = {
+    (char *)"self",  (char *)"file",  (char *)"precision",  NULL 
+  };
+  
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OO|O:doubleArray_SaveGZ", kwnames, &obj0, &obj1, &obj2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_mfem__ArrayT_double_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "doubleArray_SaveGZ" "', argument " "1"" of type '" "mfem::Array< double > *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::Array< double > * >(argp1);
+  res2 = SWIG_AsCharPtrAndSize(obj1, &buf2, NULL, &alloc2);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "doubleArray_SaveGZ" "', argument " "2"" of type '" "char const *""'");
+  }
+  arg2 = reinterpret_cast< char * >(buf2);
+  if (obj2) {
+    ecode3 = SWIG_AsVal_int(obj2, &val3);
+    if (!SWIG_IsOK(ecode3)) {
+      SWIG_exception_fail(SWIG_ArgError(ecode3), "in method '" "doubleArray_SaveGZ" "', argument " "3"" of type '" "int""'");
+    } 
+    arg3 = static_cast< int >(val3);
+  }
+  {
+    try {
+      mfem_Array_Sl_double_Sg__SaveGZ(arg1,(char const *)arg2,arg3);
     }
 #ifdef  MFEM_USE_EXCEPTIONS
     catch (mfem::ErrorException &_e) {
@@ -11840,6 +12110,8 @@ static PyMethodDef SwigMethods[] = {
 		"intArray_Print(intArray self, std::ostream & out=mfem::out, int width=4)\n"
 		"intArray_Print(intArray self, char const * file, int precision=8)\n"
 		""},
+	 { "intArray_PrintGZ", (PyCFunction)(void(*)(void))_wrap_intArray_PrintGZ, METH_VARARGS|METH_KEYWORDS, "intArray_PrintGZ(intArray self, char const * file, int precision=8)"},
+	 { "intArray_SaveGZ", (PyCFunction)(void(*)(void))_wrap_intArray_SaveGZ, METH_VARARGS|METH_KEYWORDS, "intArray_SaveGZ(intArray self, char const * file, int precision=8)"},
 	 { "intArray_Save", _wrap_intArray_Save, METH_VARARGS, "\n"
 		"intArray_Save(intArray self, std::ostream & out, int fmt=0)\n"
 		"intArray_Save(intArray self, char const * file, int precision=8)\n"
@@ -11935,6 +12207,8 @@ static PyMethodDef SwigMethods[] = {
 		"doubleArray_Print(doubleArray self, std::ostream & out=mfem::out, int width=4)\n"
 		"doubleArray_Print(doubleArray self, char const * file, int precision=8)\n"
 		""},
+	 { "doubleArray_PrintGZ", (PyCFunction)(void(*)(void))_wrap_doubleArray_PrintGZ, METH_VARARGS|METH_KEYWORDS, "doubleArray_PrintGZ(doubleArray self, char const * file, int precision=8)"},
+	 { "doubleArray_SaveGZ", (PyCFunction)(void(*)(void))_wrap_doubleArray_SaveGZ, METH_VARARGS|METH_KEYWORDS, "doubleArray_SaveGZ(doubleArray self, char const * file, int precision=8)"},
 	 { "doubleArray_Save", _wrap_doubleArray_Save, METH_VARARGS, "\n"
 		"doubleArray_Save(doubleArray self, std::ostream & out, int fmt=0)\n"
 		"doubleArray_Save(doubleArray self, char const * file, int precision=8)\n"
@@ -12046,6 +12320,8 @@ static PyMethodDef SwigMethods_proxydocs[] = {
 		"Print(intArray self, std::ostream & out=mfem::out, int width=4)\n"
 		"Print(intArray self, char const * file, int precision=8)\n"
 		""},
+	 { "intArray_PrintGZ", (PyCFunction)(void(*)(void))_wrap_intArray_PrintGZ, METH_VARARGS|METH_KEYWORDS, "PrintGZ(intArray self, char const * file, int precision=8)"},
+	 { "intArray_SaveGZ", (PyCFunction)(void(*)(void))_wrap_intArray_SaveGZ, METH_VARARGS|METH_KEYWORDS, "SaveGZ(intArray self, char const * file, int precision=8)"},
 	 { "intArray_Save", _wrap_intArray_Save, METH_VARARGS, "\n"
 		"Save(intArray self, std::ostream & out, int fmt=0)\n"
 		"Save(intArray self, char const * file, int precision=8)\n"
@@ -12141,6 +12417,8 @@ static PyMethodDef SwigMethods_proxydocs[] = {
 		"Print(doubleArray self, std::ostream & out=mfem::out, int width=4)\n"
 		"Print(doubleArray self, char const * file, int precision=8)\n"
 		""},
+	 { "doubleArray_PrintGZ", (PyCFunction)(void(*)(void))_wrap_doubleArray_PrintGZ, METH_VARARGS|METH_KEYWORDS, "PrintGZ(doubleArray self, char const * file, int precision=8)"},
+	 { "doubleArray_SaveGZ", (PyCFunction)(void(*)(void))_wrap_doubleArray_SaveGZ, METH_VARARGS|METH_KEYWORDS, "SaveGZ(doubleArray self, char const * file, int precision=8)"},
 	 { "doubleArray_Save", _wrap_doubleArray_Save, METH_VARARGS, "\n"
 		"Save(doubleArray self, std::ostream & out, int fmt=0)\n"
 		"Save(doubleArray self, char const * file, int precision=8)\n"

--- a/mfem/_par/blockmatrix.py
+++ b/mfem/_par/blockmatrix.py
@@ -233,6 +233,11 @@ class BlockMatrix(mfem._par.matrix.AbstractSparseMatrix):
         return _blockmatrix.BlockMatrix_PrintMatlab(self, *args)
     PrintMatlab = _swig_new_instance_method(_blockmatrix.BlockMatrix_PrintMatlab)
 
+    def PrintMatlabGZ(self, file, precision=8):
+        r"""PrintMatlabGZ(BlockMatrix self, char const * file, int precision=8)"""
+        return _blockmatrix.BlockMatrix_PrintMatlabGZ(self, file, precision)
+    PrintMatlabGZ = _swig_new_instance_method(_blockmatrix.BlockMatrix_PrintMatlabGZ)
+
 # Register BlockMatrix in _blockmatrix:
 _blockmatrix.BlockMatrix_swigregister(BlockMatrix)
 

--- a/mfem/_par/blockmatrix_wrap.cxx
+++ b/mfem/_par/blockmatrix_wrap.cxx
@@ -3548,6 +3548,17 @@ SWIGINTERN void mfem_BlockMatrix_PrintMatlab__SWIG_1(mfem::BlockMatrix *self,cha
   self -> PrintMatlab(ofile);
   ofile.close();
   }
+SWIGINTERN void mfem_BlockMatrix_PrintMatlabGZ(mfem::BlockMatrix *self,char const *file,int precision=8){
+  mfem::ofgzstream *ofile = new mfem::ofgzstream(file, true);
+  if (!ofile)
+     {
+        std::cerr << "\nCan not produce output file: " << file << '\n' << std::endl;
+        return;
+      }
+  ofile ->precision(precision);  
+  self -> PrintMatlab(*ofile);
+  delete ofile;
+  }
 
 
 /* ---------------------------------------------------
@@ -5632,6 +5643,64 @@ fail:
 }
 
 
+SWIGINTERN PyObject *_wrap_BlockMatrix_PrintMatlabGZ(PyObject *SWIGUNUSEDPARM(self), PyObject *args, PyObject *kwargs) {
+  PyObject *resultobj = 0;
+  mfem::BlockMatrix *arg1 = (mfem::BlockMatrix *) 0 ;
+  char *arg2 = (char *) 0 ;
+  int arg3 = (int) 8 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int res2 ;
+  char *buf2 = 0 ;
+  int alloc2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  char * kwnames[] = {
+    (char *)"self",  (char *)"file",  (char *)"precision",  NULL 
+  };
+  
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OO|O:BlockMatrix_PrintMatlabGZ", kwnames, &obj0, &obj1, &obj2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_mfem__BlockMatrix, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "BlockMatrix_PrintMatlabGZ" "', argument " "1"" of type '" "mfem::BlockMatrix *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::BlockMatrix * >(argp1);
+  res2 = SWIG_AsCharPtrAndSize(obj1, &buf2, NULL, &alloc2);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "BlockMatrix_PrintMatlabGZ" "', argument " "2"" of type '" "char const *""'");
+  }
+  arg2 = reinterpret_cast< char * >(buf2);
+  if (obj2) {
+    {
+      if ((PyArray_PyIntAsInt(obj2) == -1) && PyErr_Occurred()) {
+        SWIG_exception_fail(SWIG_TypeError, "Input must be integer");
+      };  
+      arg3 = PyArray_PyIntAsInt(obj2);
+    }
+  }
+  {
+    try {
+      mfem_BlockMatrix_PrintMatlabGZ(arg1,(char const *)arg2,arg3); 
+    }
+    catch (Swig::DirectorException &e) {
+      SWIG_fail; 
+    }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
+  }
+  resultobj = SWIG_Py_Void();
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return resultobj;
+fail:
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return NULL;
+}
+
+
 SWIGINTERN PyObject *BlockMatrix_swigregister(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *obj;
   if (!SWIG_Python_UnpackTuple(args, "swigregister", 1, 1, &obj)) return NULL;
@@ -5695,6 +5764,7 @@ static PyMethodDef SwigMethods[] = {
 		"BlockMatrix_PrintMatlab(BlockMatrix self, std::ostream & os=mfem::out)\n"
 		"BlockMatrix_PrintMatlab(BlockMatrix self, char const * file, int precision=8)\n"
 		""},
+	 { "BlockMatrix_PrintMatlabGZ", (PyCFunction)(void(*)(void))_wrap_BlockMatrix_PrintMatlabGZ, METH_VARARGS|METH_KEYWORDS, "BlockMatrix_PrintMatlabGZ(BlockMatrix self, char const * file, int precision=8)"},
 	 { "BlockMatrix_swigregister", BlockMatrix_swigregister, METH_O, NULL},
 	 { "BlockMatrix_swiginit", BlockMatrix_swiginit, METH_VARARGS, NULL},
 	 { NULL, NULL, 0, NULL }
@@ -5752,6 +5822,7 @@ static PyMethodDef SwigMethods_proxydocs[] = {
 		"PrintMatlab(BlockMatrix self, std::ostream & os=mfem::out)\n"
 		"PrintMatlab(BlockMatrix self, char const * file, int precision=8)\n"
 		""},
+	 { "BlockMatrix_PrintMatlabGZ", (PyCFunction)(void(*)(void))_wrap_BlockMatrix_PrintMatlabGZ, METH_VARARGS|METH_KEYWORDS, "PrintMatlabGZ(BlockMatrix self, char const * file, int precision=8)"},
 	 { "BlockMatrix_swigregister", BlockMatrix_swigregister, METH_O, NULL},
 	 { "BlockMatrix_swiginit", BlockMatrix_swiginit, METH_VARARGS, NULL},
 	 { NULL, NULL, 0, NULL }

--- a/mfem/_par/communication.py
+++ b/mfem/_par/communication.py
@@ -221,6 +221,11 @@ class GroupTopology(object):
         return _communication.GroupTopology_Save(self, *args)
     Save = _swig_new_instance_method(_communication.GroupTopology_Save)
 
+    def SaveGZ(self, file, precision=8):
+        r"""SaveGZ(GroupTopology self, char const * file, int precision=8)"""
+        return _communication.GroupTopology_SaveGZ(self, file, precision)
+    SaveGZ = _swig_new_instance_method(_communication.GroupTopology_SaveGZ)
+
 # Register GroupTopology in _communication:
 _communication.GroupTopology_swigregister(GroupTopology)
 
@@ -287,6 +292,11 @@ class GroupCommunicator(object):
         """
         return _communication.GroupCommunicator_PrintInfo(self, *args)
     PrintInfo = _swig_new_instance_method(_communication.GroupCommunicator_PrintInfo)
+
+    def PrintInfoGZ(self, file, precision=8):
+        r"""PrintInfoGZ(GroupCommunicator self, char const * file, int precision=8)"""
+        return _communication.GroupCommunicator_PrintInfoGZ(self, file, precision)
+    PrintInfoGZ = _swig_new_instance_method(_communication.GroupCommunicator_PrintInfoGZ)
 
 # Register GroupCommunicator in _communication:
 _communication.GroupCommunicator_swigregister(GroupCommunicator)

--- a/mfem/_par/communication_wrap.cxx
+++ b/mfem/_par/communication_wrap.cxx
@@ -3029,6 +3029,17 @@ SWIGINTERN void mfem_GroupTopology_Save__SWIG_1(mfem::GroupTopology *self,char c
   self -> Save(ofile);
   ofile.close();
   }
+SWIGINTERN void mfem_GroupTopology_SaveGZ(mfem::GroupTopology *self,char const *file,int precision=8){
+  mfem::ofgzstream *ofile = new mfem::ofgzstream(file, true);
+  if (!ofile)
+     {
+        std::cerr << "\nCan not produce output file: " << file << '\n' << std::endl;
+        return;
+      }
+  ofile ->precision(precision);  
+  self -> Save(*ofile);
+  delete ofile;
+  }
 
 #include <limits.h>
 #if !defined(SWIG_NO_LLONG_MAX)
@@ -3190,6 +3201,17 @@ SWIGINTERN void mfem_GroupCommunicator_PrintInfo__SWIG_1(mfem::GroupCommunicator
   ofile.precision(precision);  
   self -> PrintInfo(ofile);
   ofile.close();
+  }
+SWIGINTERN void mfem_GroupCommunicator_PrintInfoGZ(mfem::GroupCommunicator *self,char const *file,int precision=8){
+  mfem::ofgzstream *ofile = new mfem::ofgzstream(file, true);
+  if (!ofile)
+     {
+        std::cerr << "\nCan not produce output file: " << file << '\n' << std::endl;
+        return;
+      }
+  ofile ->precision(precision);  
+  self -> PrintInfo(*ofile);
+  delete ofile;
   }
 #ifdef __cplusplus
 extern "C" {
@@ -4450,14 +4472,20 @@ SWIGINTERN PyObject *_wrap_GroupTopology_Load(PyObject *SWIGUNUSEDPARM(self), Py
       }
     }
     if (stream2 == 0){
-      if (temp2->isGZ()){
-        in_gz2 = new mfem::ifgzstream(temp2->getFilename());
-        arg2 = in_gz2;
-      } else {
-        in_txt2.open(temp2->getFilename(), std::ifstream::in);
-        in_txt2.precision(temp2->getPrecision());
-        arg2 = &in_txt2;
-      }
+      /*
+            if (temp2->isGZ()){
+        	 in_gz2 = new mfem::ifgzstream(temp2->getFilename());
+               arg2 = in_gz2;
+            } else {
+        	 in_txt2.open(temp2->getFilename(), std::ifstream::in);
+               in_txt2.precision(temp2->getPrecision());
+               arg2 = &in_txt2;
+            }
+           */
+      /* this will auto-detect the input file type */
+      in_gz2 = new mfem::ifgzstream(temp2->getFilename());
+      arg2 = in_gz2;
+      
       if (temp2->isTemporary()){
         delete temp2;
       }
@@ -4482,18 +4510,6 @@ SWIGINTERN PyObject *_wrap_GroupTopology_Load(PyObject *SWIGUNUSEDPARM(self), Py
     }	 
   }
   resultobj = SWIG_Py_Void();
-  {
-    if (stream2) {
-      ret2 = PyLong_FromSsize_t(len2);
-      if (PyErr_Occurred()) {
-        PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
-        return NULL;
-      }
-      delete stream2;    
-      Py_XDECREF(resultobj);   /* Blow away any previous result */
-      resultobj = ret2;    
-    }
-  }
   {
     if (!stream2) {
       if (temp2) {
@@ -4743,6 +4759,67 @@ fail:
     "    mfem::GroupTopology::Save(std::ostream &) const\n"
     "    mfem::GroupTopology::Save(char const *,int)\n");
   return 0;
+}
+
+
+SWIGINTERN PyObject *_wrap_GroupTopology_SaveGZ(PyObject *SWIGUNUSEDPARM(self), PyObject *args, PyObject *kwargs) {
+  PyObject *resultobj = 0;
+  mfem::GroupTopology *arg1 = (mfem::GroupTopology *) 0 ;
+  char *arg2 = (char *) 0 ;
+  int arg3 = (int) 8 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int res2 ;
+  char *buf2 = 0 ;
+  int alloc2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  char * kwnames[] = {
+    (char *)"self",  (char *)"file",  (char *)"precision",  NULL 
+  };
+  
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OO|O:GroupTopology_SaveGZ", kwnames, &obj0, &obj1, &obj2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_mfem__GroupTopology, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "GroupTopology_SaveGZ" "', argument " "1"" of type '" "mfem::GroupTopology *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::GroupTopology * >(argp1);
+  res2 = SWIG_AsCharPtrAndSize(obj1, &buf2, NULL, &alloc2);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "GroupTopology_SaveGZ" "', argument " "2"" of type '" "char const *""'");
+  }
+  arg2 = reinterpret_cast< char * >(buf2);
+  if (obj2) {
+    {
+      if ((PyArray_PyIntAsInt(obj2) == -1) && PyErr_Occurred()) {
+        SWIG_exception_fail(SWIG_TypeError, "Input must be integer");
+      };  
+      arg3 = PyArray_PyIntAsInt(obj2);
+    }
+  }
+  {
+    try {
+      mfem_GroupTopology_SaveGZ(arg1,(char const *)arg2,arg3);
+    }
+#ifdef  MFEM_USE_EXCEPTIONS
+    catch (mfem::ErrorException &_e) {
+      std::string s("PyMFEM error (mfem::ErrorException): "), s2(_e.what());
+      s = s + s2;    
+      SWIG_exception(SWIG_RuntimeError, s.c_str());
+    }
+#endif
+    
+    catch (...) {
+      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+    }	 
+  }
+  resultobj = SWIG_Py_Void();
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return resultobj;
+fail:
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return NULL;
 }
 
 
@@ -5585,6 +5662,67 @@ fail:
 }
 
 
+SWIGINTERN PyObject *_wrap_GroupCommunicator_PrintInfoGZ(PyObject *SWIGUNUSEDPARM(self), PyObject *args, PyObject *kwargs) {
+  PyObject *resultobj = 0;
+  mfem::GroupCommunicator *arg1 = (mfem::GroupCommunicator *) 0 ;
+  char *arg2 = (char *) 0 ;
+  int arg3 = (int) 8 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int res2 ;
+  char *buf2 = 0 ;
+  int alloc2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  char * kwnames[] = {
+    (char *)"self",  (char *)"file",  (char *)"precision",  NULL 
+  };
+  
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OO|O:GroupCommunicator_PrintInfoGZ", kwnames, &obj0, &obj1, &obj2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_mfem__GroupCommunicator, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "GroupCommunicator_PrintInfoGZ" "', argument " "1"" of type '" "mfem::GroupCommunicator *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::GroupCommunicator * >(argp1);
+  res2 = SWIG_AsCharPtrAndSize(obj1, &buf2, NULL, &alloc2);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "GroupCommunicator_PrintInfoGZ" "', argument " "2"" of type '" "char const *""'");
+  }
+  arg2 = reinterpret_cast< char * >(buf2);
+  if (obj2) {
+    {
+      if ((PyArray_PyIntAsInt(obj2) == -1) && PyErr_Occurred()) {
+        SWIG_exception_fail(SWIG_TypeError, "Input must be integer");
+      };  
+      arg3 = PyArray_PyIntAsInt(obj2);
+    }
+  }
+  {
+    try {
+      mfem_GroupCommunicator_PrintInfoGZ(arg1,(char const *)arg2,arg3);
+    }
+#ifdef  MFEM_USE_EXCEPTIONS
+    catch (mfem::ErrorException &_e) {
+      std::string s("PyMFEM error (mfem::ErrorException): "), s2(_e.what());
+      s = s + s2;    
+      SWIG_exception(SWIG_RuntimeError, s.c_str());
+    }
+#endif
+    
+    catch (...) {
+      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+    }	 
+  }
+  resultobj = SWIG_Py_Void();
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return resultobj;
+fail:
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return NULL;
+}
+
+
 SWIGINTERN PyObject *GroupCommunicator_swigregister(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *obj;
   if (!SWIG_Python_UnpackTuple(args, "swigregister", 1, 1, &obj)) return NULL;
@@ -5677,6 +5815,7 @@ static PyMethodDef SwigMethods[] = {
 		"GroupTopology_Save(GroupTopology self, std::ostream & out)\n"
 		"GroupTopology_Save(GroupTopology self, char const * file, int precision=8)\n"
 		""},
+	 { "GroupTopology_SaveGZ", (PyCFunction)(void(*)(void))_wrap_GroupTopology_SaveGZ, METH_VARARGS|METH_KEYWORDS, "GroupTopology_SaveGZ(GroupTopology self, char const * file, int precision=8)"},
 	 { "GroupTopology_swigregister", GroupTopology_swigregister, METH_O, NULL},
 	 { "GroupTopology_swiginit", GroupTopology_swiginit, METH_VARARGS, NULL},
 	 { "new_GroupCommunicator", (PyCFunction)(void(*)(void))_wrap_new_GroupCommunicator, METH_VARARGS|METH_KEYWORDS, "new_GroupCommunicator(GroupTopology gt, mfem::GroupCommunicator::Mode m=byNeighbor) -> GroupCommunicator"},
@@ -5698,6 +5837,7 @@ static PyMethodDef SwigMethods[] = {
 		"GroupCommunicator_PrintInfo(GroupCommunicator self, std::ostream & out=mfem::out)\n"
 		"GroupCommunicator_PrintInfo(GroupCommunicator self, char const * file, int precision=8)\n"
 		""},
+	 { "GroupCommunicator_PrintInfoGZ", (PyCFunction)(void(*)(void))_wrap_GroupCommunicator_PrintInfoGZ, METH_VARARGS|METH_KEYWORDS, "GroupCommunicator_PrintInfoGZ(GroupCommunicator self, char const * file, int precision=8)"},
 	 { "GroupCommunicator_swigregister", GroupCommunicator_swigregister, METH_O, NULL},
 	 { "GroupCommunicator_swiginit", GroupCommunicator_swiginit, METH_VARARGS, NULL},
 	 { "ReorderRanksZCurve", (PyCFunction)(void(*)(void))_wrap_ReorderRanksZCurve, METH_VARARGS|METH_KEYWORDS, "ReorderRanksZCurve(MPI_Comm comm) -> MPI_Comm"},
@@ -5743,6 +5883,7 @@ static PyMethodDef SwigMethods_proxydocs[] = {
 		"Save(GroupTopology self, std::ostream & out)\n"
 		"Save(GroupTopology self, char const * file, int precision=8)\n"
 		""},
+	 { "GroupTopology_SaveGZ", (PyCFunction)(void(*)(void))_wrap_GroupTopology_SaveGZ, METH_VARARGS|METH_KEYWORDS, "SaveGZ(GroupTopology self, char const * file, int precision=8)"},
 	 { "GroupTopology_swigregister", GroupTopology_swigregister, METH_O, NULL},
 	 { "GroupTopology_swiginit", GroupTopology_swiginit, METH_VARARGS, NULL},
 	 { "new_GroupCommunicator", (PyCFunction)(void(*)(void))_wrap_new_GroupCommunicator, METH_VARARGS|METH_KEYWORDS, "new_GroupCommunicator(GroupTopology gt, mfem::GroupCommunicator::Mode m=byNeighbor) -> GroupCommunicator"},
@@ -5764,6 +5905,7 @@ static PyMethodDef SwigMethods_proxydocs[] = {
 		"PrintInfo(GroupCommunicator self, std::ostream & out=mfem::out)\n"
 		"PrintInfo(GroupCommunicator self, char const * file, int precision=8)\n"
 		""},
+	 { "GroupCommunicator_PrintInfoGZ", (PyCFunction)(void(*)(void))_wrap_GroupCommunicator_PrintInfoGZ, METH_VARARGS|METH_KEYWORDS, "PrintInfoGZ(GroupCommunicator self, char const * file, int precision=8)"},
 	 { "GroupCommunicator_swigregister", GroupCommunicator_swigregister, METH_O, NULL},
 	 { "GroupCommunicator_swiginit", GroupCommunicator_swiginit, METH_VARARGS, NULL},
 	 { "ReorderRanksZCurve", (PyCFunction)(void(*)(void))_wrap_ReorderRanksZCurve, METH_VARARGS|METH_KEYWORDS, "ReorderRanksZCurve(MPI_Comm comm) -> MPI_Comm"},

--- a/mfem/_par/densemat.py
+++ b/mfem/_par/densemat.py
@@ -621,6 +621,11 @@ class DenseMatrix(mfem._par.matrix.Matrix):
         return _densemat.DenseMatrix_Print(self, *args)
     Print = _swig_new_instance_method(_densemat.DenseMatrix_Print)
 
+    def PrintGZ(self, file, precision=8):
+        r"""PrintGZ(DenseMatrix self, char const * file, int precision=8)"""
+        return _densemat.DenseMatrix_PrintGZ(self, file, precision)
+    PrintGZ = _swig_new_instance_method(_densemat.DenseMatrix_PrintGZ)
+
     def PrintT(self, *args):
         r"""
         PrintT(DenseMatrix self, std::ostream & out=mfem::out, int width_=4)
@@ -629,6 +634,11 @@ class DenseMatrix(mfem._par.matrix.Matrix):
         return _densemat.DenseMatrix_PrintT(self, *args)
     PrintT = _swig_new_instance_method(_densemat.DenseMatrix_PrintT)
 
+    def PrintTGZ(self, file, precision=8):
+        r"""PrintTGZ(DenseMatrix self, char const * file, int precision=8)"""
+        return _densemat.DenseMatrix_PrintTGZ(self, file, precision)
+    PrintTGZ = _swig_new_instance_method(_densemat.DenseMatrix_PrintTGZ)
+
     def PrintMatlab(self, *args):
         r"""
         PrintMatlab(DenseMatrix self, std::ostream & out=mfem::out)
@@ -636,6 +646,11 @@ class DenseMatrix(mfem._par.matrix.Matrix):
         """
         return _densemat.DenseMatrix_PrintMatlab(self, *args)
     PrintMatlab = _swig_new_instance_method(_densemat.DenseMatrix_PrintMatlab)
+
+    def PrintMatlabGZ(self, file, precision=8):
+        r"""PrintMatlabGZ(DenseMatrix self, char const * file, int precision=8)"""
+        return _densemat.DenseMatrix_PrintMatlabGZ(self, file, precision)
+    PrintMatlabGZ = _swig_new_instance_method(_densemat.DenseMatrix_PrintMatlabGZ)
 
 # Register DenseMatrix in _densemat:
 _densemat.DenseMatrix_swigregister(DenseMatrix)

--- a/mfem/_par/densemat_wrap.cxx
+++ b/mfem/_par/densemat_wrap.cxx
@@ -3637,6 +3637,17 @@ SWIGINTERN void mfem_DenseMatrix_Print__SWIG_1(mfem::DenseMatrix *self,char cons
   self -> Print(ofile);
   ofile.close();
   }
+SWIGINTERN void mfem_DenseMatrix_PrintGZ(mfem::DenseMatrix *self,char const *file,int precision=8){
+  mfem::ofgzstream *ofile = new mfem::ofgzstream(file, true);
+  if (!ofile)
+     {
+        std::cerr << "\nCan not produce output file: " << file << '\n' << std::endl;
+        return;
+      }
+  ofile ->precision(precision);  
+  self -> Print(*ofile);
+  delete ofile;
+  }
 SWIGINTERN void mfem_DenseMatrix_PrintT__SWIG_1(mfem::DenseMatrix *self,char const *file,int precision=8){
   std::ofstream ofile(file);
   if (!ofile)
@@ -3648,6 +3659,17 @@ SWIGINTERN void mfem_DenseMatrix_PrintT__SWIG_1(mfem::DenseMatrix *self,char con
   self -> PrintT(ofile);
   ofile.close();
   }
+SWIGINTERN void mfem_DenseMatrix_PrintTGZ(mfem::DenseMatrix *self,char const *file,int precision=8){
+  mfem::ofgzstream *ofile = new mfem::ofgzstream(file, true);
+  if (!ofile)
+     {
+        std::cerr << "\nCan not produce output file: " << file << '\n' << std::endl;
+        return;
+      }
+  ofile ->precision(precision);  
+  self -> PrintT(*ofile);
+  delete ofile;
+  }
 SWIGINTERN void mfem_DenseMatrix_PrintMatlab__SWIG_1(mfem::DenseMatrix *self,char const *file,int precision=8){
   std::ofstream ofile(file);
   if (!ofile)
@@ -3658,6 +3680,17 @@ SWIGINTERN void mfem_DenseMatrix_PrintMatlab__SWIG_1(mfem::DenseMatrix *self,cha
   ofile.precision(precision);  
   self -> PrintMatlab(ofile);
   ofile.close();
+  }
+SWIGINTERN void mfem_DenseMatrix_PrintMatlabGZ(mfem::DenseMatrix *self,char const *file,int precision=8){
+  mfem::ofgzstream *ofile = new mfem::ofgzstream(file, true);
+  if (!ofile)
+     {
+        std::cerr << "\nCan not produce output file: " << file << '\n' << std::endl;
+        return;
+      }
+  ofile ->precision(precision);  
+  self -> PrintMatlab(*ofile);
+  delete ofile;
   }
 SWIGINTERN void mfem_DenseTensor_Assign(mfem::DenseTensor *self,double const c){
     (* self) = c;
@@ -11495,6 +11528,64 @@ fail:
 }
 
 
+SWIGINTERN PyObject *_wrap_DenseMatrix_PrintGZ(PyObject *SWIGUNUSEDPARM(self), PyObject *args, PyObject *kwargs) {
+  PyObject *resultobj = 0;
+  mfem::DenseMatrix *arg1 = (mfem::DenseMatrix *) 0 ;
+  char *arg2 = (char *) 0 ;
+  int arg3 = (int) 8 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int res2 ;
+  char *buf2 = 0 ;
+  int alloc2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  char * kwnames[] = {
+    (char *)"self",  (char *)"file",  (char *)"precision",  NULL 
+  };
+  
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OO|O:DenseMatrix_PrintGZ", kwnames, &obj0, &obj1, &obj2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_mfem__DenseMatrix, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "DenseMatrix_PrintGZ" "', argument " "1"" of type '" "mfem::DenseMatrix *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::DenseMatrix * >(argp1);
+  res2 = SWIG_AsCharPtrAndSize(obj1, &buf2, NULL, &alloc2);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "DenseMatrix_PrintGZ" "', argument " "2"" of type '" "char const *""'");
+  }
+  arg2 = reinterpret_cast< char * >(buf2);
+  if (obj2) {
+    {
+      if ((PyArray_PyIntAsInt(obj2) == -1) && PyErr_Occurred()) {
+        SWIG_exception_fail(SWIG_TypeError, "Input must be integer");
+      };  
+      arg3 = PyArray_PyIntAsInt(obj2);
+    }
+  }
+  {
+    try {
+      mfem_DenseMatrix_PrintGZ(arg1,(char const *)arg2,arg3); 
+    }
+    catch (Swig::DirectorException &e) {
+      SWIG_fail; 
+    }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
+  }
+  resultobj = SWIG_Py_Void();
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return resultobj;
+fail:
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return NULL;
+}
+
+
 SWIGINTERN PyObject *_wrap_DenseMatrix_PrintT__SWIG_1(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
   PyObject *resultobj = 0;
   mfem::DenseMatrix *arg1 = (mfem::DenseMatrix *) 0 ;
@@ -11646,6 +11737,64 @@ fail:
 }
 
 
+SWIGINTERN PyObject *_wrap_DenseMatrix_PrintTGZ(PyObject *SWIGUNUSEDPARM(self), PyObject *args, PyObject *kwargs) {
+  PyObject *resultobj = 0;
+  mfem::DenseMatrix *arg1 = (mfem::DenseMatrix *) 0 ;
+  char *arg2 = (char *) 0 ;
+  int arg3 = (int) 8 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int res2 ;
+  char *buf2 = 0 ;
+  int alloc2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  char * kwnames[] = {
+    (char *)"self",  (char *)"file",  (char *)"precision",  NULL 
+  };
+  
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OO|O:DenseMatrix_PrintTGZ", kwnames, &obj0, &obj1, &obj2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_mfem__DenseMatrix, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "DenseMatrix_PrintTGZ" "', argument " "1"" of type '" "mfem::DenseMatrix *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::DenseMatrix * >(argp1);
+  res2 = SWIG_AsCharPtrAndSize(obj1, &buf2, NULL, &alloc2);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "DenseMatrix_PrintTGZ" "', argument " "2"" of type '" "char const *""'");
+  }
+  arg2 = reinterpret_cast< char * >(buf2);
+  if (obj2) {
+    {
+      if ((PyArray_PyIntAsInt(obj2) == -1) && PyErr_Occurred()) {
+        SWIG_exception_fail(SWIG_TypeError, "Input must be integer");
+      };  
+      arg3 = PyArray_PyIntAsInt(obj2);
+    }
+  }
+  {
+    try {
+      mfem_DenseMatrix_PrintTGZ(arg1,(char const *)arg2,arg3); 
+    }
+    catch (Swig::DirectorException &e) {
+      SWIG_fail; 
+    }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
+  }
+  resultobj = SWIG_Py_Void();
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return resultobj;
+fail:
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return NULL;
+}
+
+
 SWIGINTERN PyObject *_wrap_DenseMatrix_PrintMatlab__SWIG_1(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
   PyObject *resultobj = 0;
   mfem::DenseMatrix *arg1 = (mfem::DenseMatrix *) 0 ;
@@ -11781,6 +11930,64 @@ fail:
     "    mfem::DenseMatrix::PrintMatlab(std::ostream &) const\n"
     "    mfem::DenseMatrix::PrintMatlab(char const *,int)\n");
   return 0;
+}
+
+
+SWIGINTERN PyObject *_wrap_DenseMatrix_PrintMatlabGZ(PyObject *SWIGUNUSEDPARM(self), PyObject *args, PyObject *kwargs) {
+  PyObject *resultobj = 0;
+  mfem::DenseMatrix *arg1 = (mfem::DenseMatrix *) 0 ;
+  char *arg2 = (char *) 0 ;
+  int arg3 = (int) 8 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int res2 ;
+  char *buf2 = 0 ;
+  int alloc2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  char * kwnames[] = {
+    (char *)"self",  (char *)"file",  (char *)"precision",  NULL 
+  };
+  
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OO|O:DenseMatrix_PrintMatlabGZ", kwnames, &obj0, &obj1, &obj2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_mfem__DenseMatrix, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "DenseMatrix_PrintMatlabGZ" "', argument " "1"" of type '" "mfem::DenseMatrix *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::DenseMatrix * >(argp1);
+  res2 = SWIG_AsCharPtrAndSize(obj1, &buf2, NULL, &alloc2);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "DenseMatrix_PrintMatlabGZ" "', argument " "2"" of type '" "char const *""'");
+  }
+  arg2 = reinterpret_cast< char * >(buf2);
+  if (obj2) {
+    {
+      if ((PyArray_PyIntAsInt(obj2) == -1) && PyErr_Occurred()) {
+        SWIG_exception_fail(SWIG_TypeError, "Input must be integer");
+      };  
+      arg3 = PyArray_PyIntAsInt(obj2);
+    }
+  }
+  {
+    try {
+      mfem_DenseMatrix_PrintMatlabGZ(arg1,(char const *)arg2,arg3); 
+    }
+    catch (Swig::DirectorException &e) {
+      SWIG_fail; 
+    }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
+  }
+  resultobj = SWIG_Py_Void();
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return resultobj;
+fail:
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return NULL;
 }
 
 
@@ -17840,14 +18047,17 @@ static PyMethodDef SwigMethods[] = {
 		"DenseMatrix_Print(DenseMatrix self, std::ostream & out=mfem::out, int width_=4)\n"
 		"DenseMatrix_Print(DenseMatrix self, char const * file, int precision=8)\n"
 		""},
+	 { "DenseMatrix_PrintGZ", (PyCFunction)(void(*)(void))_wrap_DenseMatrix_PrintGZ, METH_VARARGS|METH_KEYWORDS, "DenseMatrix_PrintGZ(DenseMatrix self, char const * file, int precision=8)"},
 	 { "DenseMatrix_PrintT", _wrap_DenseMatrix_PrintT, METH_VARARGS, "\n"
 		"DenseMatrix_PrintT(DenseMatrix self, std::ostream & out=mfem::out, int width_=4)\n"
 		"DenseMatrix_PrintT(DenseMatrix self, char const * file, int precision=8)\n"
 		""},
+	 { "DenseMatrix_PrintTGZ", (PyCFunction)(void(*)(void))_wrap_DenseMatrix_PrintTGZ, METH_VARARGS|METH_KEYWORDS, "DenseMatrix_PrintTGZ(DenseMatrix self, char const * file, int precision=8)"},
 	 { "DenseMatrix_PrintMatlab", _wrap_DenseMatrix_PrintMatlab, METH_VARARGS, "\n"
 		"DenseMatrix_PrintMatlab(DenseMatrix self, std::ostream & out=mfem::out)\n"
 		"DenseMatrix_PrintMatlab(DenseMatrix self, char const * file, int precision=8)\n"
 		""},
+	 { "DenseMatrix_PrintMatlabGZ", (PyCFunction)(void(*)(void))_wrap_DenseMatrix_PrintMatlabGZ, METH_VARARGS|METH_KEYWORDS, "DenseMatrix_PrintMatlabGZ(DenseMatrix self, char const * file, int precision=8)"},
 	 { "DenseMatrix_swigregister", DenseMatrix_swigregister, METH_O, NULL},
 	 { "DenseMatrix_swiginit", DenseMatrix_swiginit, METH_VARARGS, NULL},
 	 { "LinearSolve", (PyCFunction)(void(*)(void))_wrap_LinearSolve, METH_VARARGS|METH_KEYWORDS, "LinearSolve(DenseMatrix A, double * X, double TOL=1.e-9) -> bool"},
@@ -18162,14 +18372,17 @@ static PyMethodDef SwigMethods_proxydocs[] = {
 		"Print(DenseMatrix self, std::ostream & out=mfem::out, int width_=4)\n"
 		"Print(DenseMatrix self, char const * file, int precision=8)\n"
 		""},
+	 { "DenseMatrix_PrintGZ", (PyCFunction)(void(*)(void))_wrap_DenseMatrix_PrintGZ, METH_VARARGS|METH_KEYWORDS, "PrintGZ(DenseMatrix self, char const * file, int precision=8)"},
 	 { "DenseMatrix_PrintT", _wrap_DenseMatrix_PrintT, METH_VARARGS, "\n"
 		"PrintT(DenseMatrix self, std::ostream & out=mfem::out, int width_=4)\n"
 		"PrintT(DenseMatrix self, char const * file, int precision=8)\n"
 		""},
+	 { "DenseMatrix_PrintTGZ", (PyCFunction)(void(*)(void))_wrap_DenseMatrix_PrintTGZ, METH_VARARGS|METH_KEYWORDS, "PrintTGZ(DenseMatrix self, char const * file, int precision=8)"},
 	 { "DenseMatrix_PrintMatlab", _wrap_DenseMatrix_PrintMatlab, METH_VARARGS, "\n"
 		"PrintMatlab(DenseMatrix self, std::ostream & out=mfem::out)\n"
 		"PrintMatlab(DenseMatrix self, char const * file, int precision=8)\n"
 		""},
+	 { "DenseMatrix_PrintMatlabGZ", (PyCFunction)(void(*)(void))_wrap_DenseMatrix_PrintMatlabGZ, METH_VARARGS|METH_KEYWORDS, "PrintMatlabGZ(DenseMatrix self, char const * file, int precision=8)"},
 	 { "DenseMatrix_swigregister", DenseMatrix_swigregister, METH_O, NULL},
 	 { "DenseMatrix_swiginit", DenseMatrix_swiginit, METH_VARARGS, NULL},
 	 { "LinearSolve", (PyCFunction)(void(*)(void))_wrap_LinearSolve, METH_VARARGS|METH_KEYWORDS, "LinearSolve(DenseMatrix A, double * X, double TOL=1.e-9) -> bool"},

--- a/mfem/_par/fespace.i
+++ b/mfem/_par/fespace.i
@@ -57,49 +57,49 @@ INT_DEFAULT_NEGATIVE_ONE(int component = -1)
 def GetBdrElementVDofs(self, i):
     from  .array import intArray
     vdofs = intArray()
-    _fespace.FiniteElementSpace_GetBdrElementVDofs(self, i, vdofs)
+    $action(self, i, vdofs)
     return vdofs.ToList()
 %}
 %feature("shadow") mfem::FiniteElementSpace::GetElementVDofs %{
 def GetElementVDofs(self, i):
     from  .array import intArray
     vdofs = intArray()
-    _fespace.FiniteElementSpace_GetElementVDofs(self, i, vdofs)
+    $action(self, i, vdofs)
     return vdofs.ToList()
 %}
 %feature("shadow") mfem::FiniteElementSpace::GetFaceVDofs %{
 def GetFaceVDofs(self, i):
     from  .array import intArray
     vdofs = intArray()
-    _fespace.FiniteElementSpace_GetFaceVDofs(self, i, vdofs)
+    $action(self, i, vdofs)
     return vdofs.ToList()
 %}
 %feature("shadow") mfem::FiniteElementSpace::GetEdgeVDofs %{
 def GetEdgeVDofs(self, i):
     from  .array import intArray
     vdofs = intArray()
-    _fespace.FiniteElementSpace_GetEdgeVDofs(self, i, vdofs)
+    $action(self, i, vdofs)
     return vdofs.ToList()
 %}
 %feature("shadow") mfem::FiniteElementSpace::GetVertexVDofs %{
 def GetVertexVDofs(self, i):
     from  .array import intArray
     vdofs = intArray()
-    _fespace.FiniteElementSpace_GetVertexVDofs(self, i, vdofs)
+    $action(self, i, vdofs)
     return vdofs.ToList()
 %}
 %feature("shadow") mfem::FiniteElementSpace::GetElementInteriorVDofs %{
 def GetElementInteriorVDofs(self, i):
     from  .array import intArray
     vdofs = intArray()
-    _fespace.FiniteElementSpace_GetElementInteriorVDofs(self, i, vdofs)
+    $action(self, i, vdofs)
     return vdofs.ToList()
 %}
 %feature("shadow") mfem::FiniteElementSpace::GetEdgeInteriorVDofs %{
 def GetEdgeInteriorVDofs(self, i):
     from  .array import intArray
     vdofs = intArray()
-    _fespace.FiniteElementSpace_GetEdgeInteriorVDofs(self, i, vdofs)
+    $action(self, i, vdofs)
     return vdofs.ToList()
 %}
 
@@ -108,49 +108,49 @@ def GetEdgeInteriorVDofs(self, i):
 def GetBdrElementDofs(self, i):
     from  .array import intArray
     vdofs = intArray()
-    _fespace.FiniteElementSpace_GetBdrElementDofs(self, i, vdofs)
+    $action(self, i, vdofs)
     return vdofs.ToList()
 %}
 %feature("shadow") mfem::FiniteElementSpace::GetElementDofs %{
 def GetElementDofs(self, i):
     from  .array import intArray
     vdofs = intArray()
-    _fespace.FiniteElementSpace_GetElementDofs(self, i, vdofs)
+    $action(self, i, vdofs)
     return vdofs.ToList()
 %}
 %feature("shadow") mfem::FiniteElementSpace::GetFaceDofs %{
 def GetFaceDofs(self, i):
     from  .array import intArray
     vdofs = intArray()
-    _fespace.FiniteElementSpace_GetFaceDofs(self, i, vdofs)
+    $action(self, i, vdofs)
     return vdofs.ToList()
 %}
 %feature("shadow") mfem::FiniteElementSpace::GetEdgeDofs %{
 def GetEdgeDofs(self, i):
     from  .array import intArray
     vdofs = intArray()
-    _fespace.FiniteElementSpace_GetEdgeDofs(self, i, vdofs)
+    $action(self, i, vdofs)
     return vdofs.ToList()
 %}
 %feature("shadow") mfem::FiniteElementSpace::GetVertexDofs %{
 def GetVertexDofs(self, i):
     from  .array import intArray
     vdofs = intArray()
-    _fespace.FiniteElementSpace_GetVertexDofs(self, i, vdofs)
+    $action(self, i, vdofs)
     return vdofs.ToList()
 %}
 %feature("shadow") mfem::FiniteElementSpace::GetElementInteriorDofs %{
 def GetElementInteriorDofs(self, i):
     from  .array import intArray
     vdofs = intArray()
-    _fespace.FiniteElementSpace_GetElementInteriorDofs(self, i, vdofs)
+    $action(self, i, vdofs)
     return vdofs.ToList()
 %}
 %feature("shadow") mfem::FiniteElementSpace::GetEdgeInteriorDofs %{
 def GetEdgeInteriorDofs(self, i):
     from  .array import intArray
     vdofs = intArray()
-    _fespace.FiniteElementSpace_GetEdgeInteriorDofs(self, i, vdofs)
+    $action(self, i, vdofs)
     return vdofs.ToList()
 %}
 

--- a/mfem/_par/fespace.py
+++ b/mfem/_par/fespace.py
@@ -659,6 +659,11 @@ class FiniteElementSpace(object):
     Load = _swig_new_instance_method(_fespace.FiniteElementSpace_Load)
     __swig_destroy__ = _fespace.delete_FiniteElementSpace
 
+    def SaveGZ(self, file, precision=8):
+        r"""SaveGZ(FiniteElementSpace self, char const * file, int precision=8)"""
+        return _fespace.FiniteElementSpace_SaveGZ(self, file, precision)
+    SaveGZ = _swig_new_instance_method(_fespace.FiniteElementSpace_SaveGZ)
+
     def Save(self, *args):
         r"""
         Save(FiniteElementSpace self, std::ostream & out)
@@ -719,6 +724,11 @@ class QuadratureSpace(object):
         r"""GetElementIntRule(QuadratureSpace self, int idx) -> IntegrationRule"""
         return _fespace.QuadratureSpace_GetElementIntRule(self, idx)
     GetElementIntRule = _swig_new_instance_method(_fespace.QuadratureSpace_GetElementIntRule)
+
+    def SaveGZ(self, file, precision=8):
+        r"""SaveGZ(QuadratureSpace self, char const * file, int precision=8)"""
+        return _fespace.QuadratureSpace_SaveGZ(self, file, precision)
+    SaveGZ = _swig_new_instance_method(_fespace.QuadratureSpace_SaveGZ)
 
     def Save(self, *args):
         r"""

--- a/mfem/_par/fespace_wrap.cxx
+++ b/mfem/_par/fespace_wrap.cxx
@@ -3824,6 +3824,18 @@ SWIGINTERN void mfem_FiniteElementSpace_Save__SWIG_1(mfem::FiniteElementSpace *s
   self -> Save(ofile);
   ofile.close();
   }
+SWIGINTERN void mfem_FiniteElementSpace_SaveGZ(mfem::FiniteElementSpace *self,char const *file,int precision=8){
+  mfem::ofgzstream *ofile = new mfem::ofgzstream(file, true);
+  
+  if (!ofile)
+     {
+        std::cerr << "\nCan not produce output file: " << file << '\n' << std::endl;
+        return;
+      }
+  ofile -> precision(precision);  
+  self -> Save(*ofile);
+  delete ofile;
+  }
 SWIGINTERN void mfem_FiniteElementSpace_Save__SWIG_2(mfem::FiniteElementSpace *self){
   self -> Save(std::cout);
   }
@@ -3837,6 +3849,18 @@ SWIGINTERN void mfem_QuadratureSpace_Save__SWIG_1(mfem::QuadratureSpace *self,ch
   ofile.precision(precision);    
   self -> Save(ofile);
   ofile.close();
+  }
+SWIGINTERN void mfem_QuadratureSpace_SaveGZ(mfem::QuadratureSpace *self,char const *file,int precision=8){
+  mfem::ofgzstream *ofile = new mfem::ofgzstream(file, true);
+  
+  if (!ofile)
+     {
+        std::cerr << "\nCan not produce output file: " << file << '\n' << std::endl;
+        return;
+      }
+  ofile -> precision(precision);  
+  self -> Save(*ofile);
+  delete ofile;
   }
 SWIGINTERN void mfem_QuadratureSpace_Save__SWIG_2(mfem::QuadratureSpace *self){
   self -> Save(std::cout);
@@ -9019,14 +9043,20 @@ SWIGINTERN PyObject *_wrap_FiniteElementSpace_Load(PyObject *SWIGUNUSEDPARM(self
       }
     }
     if (stream3 == 0){
-      if (temp3->isGZ()){
-        in_gz3 = new mfem::ifgzstream(temp3->getFilename());
-        arg3 = in_gz3;
-      } else {
-        in_txt3.open(temp3->getFilename(), std::ifstream::in);
-        in_txt3.precision(temp3->getPrecision());
-        arg3 = &in_txt3;
-      }
+      /*
+            if (temp3->isGZ()){
+        	 in_gz3 = new mfem::ifgzstream(temp3->getFilename());
+               arg3 = in_gz3;
+            } else {
+        	 in_txt3.open(temp3->getFilename(), std::ifstream::in);
+               in_txt3.precision(temp3->getPrecision());
+               arg3 = &in_txt3;
+            }
+           */
+      /* this will auto-detect the input file type */
+      in_gz3 = new mfem::ifgzstream(temp3->getFilename());
+      arg3 = in_gz3;
+      
       if (temp3->isTemporary()){
         delete temp3;
       }
@@ -9048,18 +9078,6 @@ SWIGINTERN PyObject *_wrap_FiniteElementSpace_Load(PyObject *SWIGUNUSEDPARM(self
     //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__FiniteElementCollection, 0 |  0 );
-  {
-    if (stream3) {
-      ret3 = PyLong_FromSsize_t(len3);
-      if (PyErr_Occurred()) {
-        PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
-        return NULL;
-      }
-      delete stream3;    
-      Py_XDECREF(resultobj);   /* Blow away any previous result */
-      resultobj = ret3;    
-    }
-  }
   {
     if (!stream3) {
       if (temp3) {
@@ -9153,6 +9171,64 @@ SWIGINTERN PyObject *_wrap_FiniteElementSpace_Save__SWIG_1(PyObject *SWIGUNUSEDP
   {
     try {
       mfem_FiniteElementSpace_Save__SWIG_1(arg1,(char const *)arg2,arg3); 
+    }
+    catch (Swig::DirectorException &e) {
+      SWIG_fail; 
+    }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
+  }
+  resultobj = SWIG_Py_Void();
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return resultobj;
+fail:
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_FiniteElementSpace_SaveGZ(PyObject *SWIGUNUSEDPARM(self), PyObject *args, PyObject *kwargs) {
+  PyObject *resultobj = 0;
+  mfem::FiniteElementSpace *arg1 = (mfem::FiniteElementSpace *) 0 ;
+  char *arg2 = (char *) 0 ;
+  int arg3 = (int) 8 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int res2 ;
+  char *buf2 = 0 ;
+  int alloc2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  char * kwnames[] = {
+    (char *)"self",  (char *)"file",  (char *)"precision",  NULL 
+  };
+  
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OO|O:FiniteElementSpace_SaveGZ", kwnames, &obj0, &obj1, &obj2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_mfem__FiniteElementSpace, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "FiniteElementSpace_SaveGZ" "', argument " "1"" of type '" "mfem::FiniteElementSpace *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::FiniteElementSpace * >(argp1);
+  res2 = SWIG_AsCharPtrAndSize(obj1, &buf2, NULL, &alloc2);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "FiniteElementSpace_SaveGZ" "', argument " "2"" of type '" "char const *""'");
+  }
+  arg2 = reinterpret_cast< char * >(buf2);
+  if (obj2) {
+    {
+      if ((PyArray_PyIntAsInt(obj2) == -1) && PyErr_Occurred()) {
+        SWIG_exception_fail(SWIG_TypeError, "Input must be integer");
+      };  
+      arg3 = PyArray_PyIntAsInt(obj2);
+    }
+  }
+  {
+    try {
+      mfem_FiniteElementSpace_SaveGZ(arg1,(char const *)arg2,arg3); 
     }
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
@@ -9411,14 +9487,20 @@ SWIGINTERN PyObject *_wrap_new_QuadratureSpace__SWIG_1(PyObject *SWIGUNUSEDPARM(
       }
     }
     if (stream2 == 0){
-      if (temp2->isGZ()){
-        in_gz2 = new mfem::ifgzstream(temp2->getFilename());
-        arg2 = in_gz2;
-      } else {
-        in_txt2.open(temp2->getFilename(), std::ifstream::in);
-        in_txt2.precision(temp2->getPrecision());
-        arg2 = &in_txt2;
-      }
+      /*
+            if (temp2->isGZ()){
+        	 in_gz2 = new mfem::ifgzstream(temp2->getFilename());
+               arg2 = in_gz2;
+            } else {
+        	 in_txt2.open(temp2->getFilename(), std::ifstream::in);
+               in_txt2.precision(temp2->getPrecision());
+               arg2 = &in_txt2;
+            }
+           */
+      /* this will auto-detect the input file type */
+      in_gz2 = new mfem::ifgzstream(temp2->getFilename());
+      arg2 = in_gz2;
+      
       if (temp2->isTemporary()){
         delete temp2;
       }
@@ -9440,18 +9522,6 @@ SWIGINTERN PyObject *_wrap_new_QuadratureSpace__SWIG_1(PyObject *SWIGUNUSEDPARM(
     //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__QuadratureSpace, SWIG_POINTER_NEW |  0 );
-  {
-    if (stream2) {
-      ret2 = PyLong_FromSsize_t(len2);
-      if (PyErr_Occurred()) {
-        PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
-        return NULL;
-      }
-      delete stream2;    
-      Py_XDECREF(resultobj);   /* Blow away any previous result */
-      resultobj = ret2;    
-    }
-  }
   {
     if (!stream2) {
       if (temp2) {
@@ -9904,6 +9974,64 @@ SWIGINTERN PyObject *_wrap_QuadratureSpace_Save__SWIG_1(PyObject *SWIGUNUSEDPARM
   {
     try {
       mfem_QuadratureSpace_Save__SWIG_1(arg1,(char const *)arg2,arg3); 
+    }
+    catch (Swig::DirectorException &e) {
+      SWIG_fail; 
+    }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
+  }
+  resultobj = SWIG_Py_Void();
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return resultobj;
+fail:
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_QuadratureSpace_SaveGZ(PyObject *SWIGUNUSEDPARM(self), PyObject *args, PyObject *kwargs) {
+  PyObject *resultobj = 0;
+  mfem::QuadratureSpace *arg1 = (mfem::QuadratureSpace *) 0 ;
+  char *arg2 = (char *) 0 ;
+  int arg3 = (int) 8 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int res2 ;
+  char *buf2 = 0 ;
+  int alloc2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  char * kwnames[] = {
+    (char *)"self",  (char *)"file",  (char *)"precision",  NULL 
+  };
+  
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OO|O:QuadratureSpace_SaveGZ", kwnames, &obj0, &obj1, &obj2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_mfem__QuadratureSpace, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "QuadratureSpace_SaveGZ" "', argument " "1"" of type '" "mfem::QuadratureSpace *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::QuadratureSpace * >(argp1);
+  res2 = SWIG_AsCharPtrAndSize(obj1, &buf2, NULL, &alloc2);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "QuadratureSpace_SaveGZ" "', argument " "2"" of type '" "char const *""'");
+  }
+  arg2 = reinterpret_cast< char * >(buf2);
+  if (obj2) {
+    {
+      if ((PyArray_PyIntAsInt(obj2) == -1) && PyErr_Occurred()) {
+        SWIG_exception_fail(SWIG_TypeError, "Input must be integer");
+      };  
+      arg3 = PyArray_PyIntAsInt(obj2);
+    }
+  }
+  {
+    try {
+      mfem_QuadratureSpace_SaveGZ(arg1,(char const *)arg2,arg3); 
     }
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
@@ -10834,6 +10962,7 @@ static PyMethodDef SwigMethods[] = {
 	 { "FiniteElementSpace_IsDGSpace", _wrap_FiniteElementSpace_IsDGSpace, METH_O, "FiniteElementSpace_IsDGSpace(FiniteElementSpace self) -> bool"},
 	 { "FiniteElementSpace_Load", (PyCFunction)(void(*)(void))_wrap_FiniteElementSpace_Load, METH_VARARGS|METH_KEYWORDS, "FiniteElementSpace_Load(FiniteElementSpace self, Mesh m, std::istream & input) -> FiniteElementCollection"},
 	 { "delete_FiniteElementSpace", _wrap_delete_FiniteElementSpace, METH_O, "delete_FiniteElementSpace(FiniteElementSpace self)"},
+	 { "FiniteElementSpace_SaveGZ", (PyCFunction)(void(*)(void))_wrap_FiniteElementSpace_SaveGZ, METH_VARARGS|METH_KEYWORDS, "FiniteElementSpace_SaveGZ(FiniteElementSpace self, char const * file, int precision=8)"},
 	 { "FiniteElementSpace_Save", _wrap_FiniteElementSpace_Save, METH_VARARGS, "\n"
 		"FiniteElementSpace_Save(FiniteElementSpace self, std::ostream & out)\n"
 		"FiniteElementSpace_Save(FiniteElementSpace self, char const * file, int precision=8)\n"
@@ -10850,6 +10979,7 @@ static PyMethodDef SwigMethods[] = {
 	 { "QuadratureSpace_GetMesh", _wrap_QuadratureSpace_GetMesh, METH_O, "QuadratureSpace_GetMesh(QuadratureSpace self) -> Mesh"},
 	 { "QuadratureSpace_GetNE", _wrap_QuadratureSpace_GetNE, METH_O, "QuadratureSpace_GetNE(QuadratureSpace self) -> int"},
 	 { "QuadratureSpace_GetElementIntRule", (PyCFunction)(void(*)(void))_wrap_QuadratureSpace_GetElementIntRule, METH_VARARGS|METH_KEYWORDS, "QuadratureSpace_GetElementIntRule(QuadratureSpace self, int idx) -> IntegrationRule"},
+	 { "QuadratureSpace_SaveGZ", (PyCFunction)(void(*)(void))_wrap_QuadratureSpace_SaveGZ, METH_VARARGS|METH_KEYWORDS, "QuadratureSpace_SaveGZ(QuadratureSpace self, char const * file, int precision=8)"},
 	 { "QuadratureSpace_Save", _wrap_QuadratureSpace_Save, METH_VARARGS, "\n"
 		"QuadratureSpace_Save(QuadratureSpace self, std::ostream & out)\n"
 		"QuadratureSpace_Save(QuadratureSpace self, char const * file, int precision=8)\n"
@@ -11000,6 +11130,7 @@ static PyMethodDef SwigMethods_proxydocs[] = {
 	 { "FiniteElementSpace_IsDGSpace", _wrap_FiniteElementSpace_IsDGSpace, METH_O, "IsDGSpace(FiniteElementSpace self) -> bool"},
 	 { "FiniteElementSpace_Load", (PyCFunction)(void(*)(void))_wrap_FiniteElementSpace_Load, METH_VARARGS|METH_KEYWORDS, "Load(FiniteElementSpace self, Mesh m, std::istream & input) -> FiniteElementCollection"},
 	 { "delete_FiniteElementSpace", _wrap_delete_FiniteElementSpace, METH_O, "delete_FiniteElementSpace(FiniteElementSpace self)"},
+	 { "FiniteElementSpace_SaveGZ", (PyCFunction)(void(*)(void))_wrap_FiniteElementSpace_SaveGZ, METH_VARARGS|METH_KEYWORDS, "SaveGZ(FiniteElementSpace self, char const * file, int precision=8)"},
 	 { "FiniteElementSpace_Save", _wrap_FiniteElementSpace_Save, METH_VARARGS, "\n"
 		"Save(FiniteElementSpace self, std::ostream & out)\n"
 		"Save(FiniteElementSpace self, char const * file, int precision=8)\n"
@@ -11016,6 +11147,7 @@ static PyMethodDef SwigMethods_proxydocs[] = {
 	 { "QuadratureSpace_GetMesh", _wrap_QuadratureSpace_GetMesh, METH_O, "GetMesh(QuadratureSpace self) -> Mesh"},
 	 { "QuadratureSpace_GetNE", _wrap_QuadratureSpace_GetNE, METH_O, "GetNE(QuadratureSpace self) -> int"},
 	 { "QuadratureSpace_GetElementIntRule", (PyCFunction)(void(*)(void))_wrap_QuadratureSpace_GetElementIntRule, METH_VARARGS|METH_KEYWORDS, "GetElementIntRule(QuadratureSpace self, int idx) -> IntegrationRule"},
+	 { "QuadratureSpace_SaveGZ", (PyCFunction)(void(*)(void))_wrap_QuadratureSpace_SaveGZ, METH_VARARGS|METH_KEYWORDS, "SaveGZ(QuadratureSpace self, char const * file, int precision=8)"},
 	 { "QuadratureSpace_Save", _wrap_QuadratureSpace_Save, METH_VARARGS, "\n"
 		"Save(QuadratureSpace self, std::ostream & out)\n"
 		"Save(QuadratureSpace self, char const * file, int precision=8)\n"

--- a/mfem/_par/gridfunc.i
+++ b/mfem/_par/gridfunc.i
@@ -54,11 +54,11 @@ def GetNodalValues(self, *args):
     from .vector import Vector
     if len(args) == 1:
         vec = Vector()
-        _gridfunc.GridFunction_GetNodalValues(self, vec, args[0])
+        $action(self, vec, args[0])
         vec.thisown = 0
         return vec.GetDataArray()
     else:
-        return _gridfunc.GridFunction_GetNodalValues(self, *args)
+        return $action(self, *args)
 %}
 
 %typemap(in) const mfem::IntegrationRule *irs[]{

--- a/mfem/_par/gridfunc.py
+++ b/mfem/_par/gridfunc.py
@@ -572,6 +572,11 @@ class GridFunction(mfem._par.vector.Vector):
         return _gridfunc.GridFunction_Save(self, *args)
     Save = _swig_new_instance_method(_gridfunc.GridFunction_Save)
 
+    def SaveGZ(self, file, precision=8):
+        r"""SaveGZ(GridFunction self, char const * file, int precision=8)"""
+        return _gridfunc.GridFunction_SaveGZ(self, file, precision)
+    SaveGZ = _swig_new_instance_method(_gridfunc.GridFunction_SaveGZ)
+
 # Register GridFunction in _gridfunc:
 _gridfunc.GridFunction_swigregister(GridFunction)
 
@@ -649,6 +654,11 @@ class QuadratureFunction(mfem._par.vector.Vector):
         """
         return _gridfunc.QuadratureFunction_Save(self, *args)
     Save = _swig_new_instance_method(_gridfunc.QuadratureFunction_Save)
+
+    def SaveGZ(self, file, precision=8):
+        r"""SaveGZ(QuadratureFunction self, char const * file, int precision=8)"""
+        return _gridfunc.QuadratureFunction_SaveGZ(self, file, precision)
+    SaveGZ = _swig_new_instance_method(_gridfunc.QuadratureFunction_SaveGZ)
 
 # Register QuadratureFunction in _gridfunc:
 _gridfunc.QuadratureFunction_swigregister(QuadratureFunction)

--- a/mfem/_par/gridfunc_wrap.cxx
+++ b/mfem/_par/gridfunc_wrap.cxx
@@ -3826,6 +3826,17 @@ SWIGINTERN void mfem_GridFunction_Save__SWIG_1(mfem::GridFunction *self,char con
   self -> Save(ofile);
   ofile.close();
   }
+SWIGINTERN void mfem_GridFunction_SaveGZ(mfem::GridFunction *self,char const *file,int precision=8){
+  mfem::ofgzstream *ofile = new mfem::ofgzstream(file, true);
+  if (!ofile)
+     {
+        std::cerr << "\nCan not produce output file: " << file << '\n' << std::endl;
+        return;
+      }
+  ofile ->precision(precision);  
+  self -> Save(*ofile);
+  delete ofile;
+  }
 
 SWIGINTERNINLINE PyObject*
   SWIG_From_bool  (bool value)
@@ -3843,6 +3854,17 @@ SWIGINTERN void mfem_QuadratureFunction_Save__SWIG_1(mfem::QuadratureFunction *s
   ofile.precision(precision);  
   self -> Save(ofile);
   ofile.close();
+  }
+SWIGINTERN void mfem_QuadratureFunction_SaveGZ(mfem::QuadratureFunction *self,char const *file,int precision=8){
+  mfem::ofgzstream *ofile = new mfem::ofgzstream(file, true);
+  if (!ofile)
+     {
+        std::cerr << "\nCan not produce output file: " << file << '\n' << std::endl;
+        return;
+      }
+  ofile ->precision(precision);  
+  self -> Save(*ofile);
+  delete ofile;
   }
 
 
@@ -4053,14 +4075,20 @@ SWIGINTERN PyObject *_wrap_new_GridFunction__SWIG_4(PyObject *SWIGUNUSEDPARM(sel
       }
     }
     if (stream2 == 0){
-      if (temp2->isGZ()){
-        in_gz2 = new mfem::ifgzstream(temp2->getFilename());
-        arg2 = in_gz2;
-      } else {
-        in_txt2.open(temp2->getFilename(), std::ifstream::in);
-        in_txt2.precision(temp2->getPrecision());
-        arg2 = &in_txt2;
-      }
+      /*
+            if (temp2->isGZ()){
+        	 in_gz2 = new mfem::ifgzstream(temp2->getFilename());
+               arg2 = in_gz2;
+            } else {
+        	 in_txt2.open(temp2->getFilename(), std::ifstream::in);
+               in_txt2.precision(temp2->getPrecision());
+               arg2 = &in_txt2;
+            }
+           */
+      /* this will auto-detect the input file type */
+      in_gz2 = new mfem::ifgzstream(temp2->getFilename());
+      arg2 = in_gz2;
+      
       if (temp2->isTemporary()){
         delete temp2;
       }
@@ -4082,18 +4110,6 @@ SWIGINTERN PyObject *_wrap_new_GridFunction__SWIG_4(PyObject *SWIGUNUSEDPARM(sel
     //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__GridFunction, SWIG_POINTER_NEW |  0 );
-  {
-    if (stream2) {
-      ret2 = PyLong_FromSsize_t(len2);
-      if (PyErr_Occurred()) {
-        PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
-        return NULL;
-      }
-      delete stream2;    
-      Py_XDECREF(resultobj);   /* Blow away any previous result */
-      resultobj = ret2;    
-    }
-  }
   {
     if (!stream2) {
       if (temp2) {
@@ -13554,6 +13570,64 @@ fail:
 }
 
 
+SWIGINTERN PyObject *_wrap_GridFunction_SaveGZ(PyObject *SWIGUNUSEDPARM(self), PyObject *args, PyObject *kwargs) {
+  PyObject *resultobj = 0;
+  mfem::GridFunction *arg1 = (mfem::GridFunction *) 0 ;
+  char *arg2 = (char *) 0 ;
+  int arg3 = (int) 8 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int res2 ;
+  char *buf2 = 0 ;
+  int alloc2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  char * kwnames[] = {
+    (char *)"self",  (char *)"file",  (char *)"precision",  NULL 
+  };
+  
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OO|O:GridFunction_SaveGZ", kwnames, &obj0, &obj1, &obj2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_mfem__GridFunction, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "GridFunction_SaveGZ" "', argument " "1"" of type '" "mfem::GridFunction *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::GridFunction * >(argp1);
+  res2 = SWIG_AsCharPtrAndSize(obj1, &buf2, NULL, &alloc2);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "GridFunction_SaveGZ" "', argument " "2"" of type '" "char const *""'");
+  }
+  arg2 = reinterpret_cast< char * >(buf2);
+  if (obj2) {
+    {
+      if ((PyArray_PyIntAsInt(obj2) == -1) && PyErr_Occurred()) {
+        SWIG_exception_fail(SWIG_TypeError, "Input must be integer");
+      };  
+      arg3 = PyArray_PyIntAsInt(obj2);
+    }
+  }
+  {
+    try {
+      mfem_GridFunction_SaveGZ(arg1,(char const *)arg2,arg3); 
+    }
+    catch (Swig::DirectorException &e) {
+      SWIG_fail; 
+    }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
+  }
+  resultobj = SWIG_Py_Void();
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return resultobj;
+fail:
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return NULL;
+}
+
+
 SWIGINTERN PyObject *GridFunction_swigregister(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *obj;
   if (!SWIG_Python_UnpackTuple(args, "swigregister", 1, 1, &obj)) return NULL;
@@ -13920,14 +13994,20 @@ SWIGINTERN PyObject *_wrap_new_QuadratureFunction__SWIG_4(PyObject *SWIGUNUSEDPA
       }
     }
     if (stream2 == 0){
-      if (temp2->isGZ()){
-        in_gz2 = new mfem::ifgzstream(temp2->getFilename());
-        arg2 = in_gz2;
-      } else {
-        in_txt2.open(temp2->getFilename(), std::ifstream::in);
-        in_txt2.precision(temp2->getPrecision());
-        arg2 = &in_txt2;
-      }
+      /*
+            if (temp2->isGZ()){
+        	 in_gz2 = new mfem::ifgzstream(temp2->getFilename());
+               arg2 = in_gz2;
+            } else {
+        	 in_txt2.open(temp2->getFilename(), std::ifstream::in);
+               in_txt2.precision(temp2->getPrecision());
+               arg2 = &in_txt2;
+            }
+           */
+      /* this will auto-detect the input file type */
+      in_gz2 = new mfem::ifgzstream(temp2->getFilename());
+      arg2 = in_gz2;
+      
       if (temp2->isTemporary()){
         delete temp2;
       }
@@ -13949,18 +14029,6 @@ SWIGINTERN PyObject *_wrap_new_QuadratureFunction__SWIG_4(PyObject *SWIGUNUSEDPA
     //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__QuadratureFunction, SWIG_POINTER_NEW |  0 );
-  {
-    if (stream2) {
-      ret2 = PyLong_FromSsize_t(len2);
-      if (PyErr_Occurred()) {
-        PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
-        return NULL;
-      }
-      delete stream2;    
-      Py_XDECREF(resultobj);   /* Blow away any previous result */
-      resultobj = ret2;    
-    }
-  }
   {
     if (!stream2) {
       if (temp2) {
@@ -15331,6 +15399,64 @@ fail:
 }
 
 
+SWIGINTERN PyObject *_wrap_QuadratureFunction_SaveGZ(PyObject *SWIGUNUSEDPARM(self), PyObject *args, PyObject *kwargs) {
+  PyObject *resultobj = 0;
+  mfem::QuadratureFunction *arg1 = (mfem::QuadratureFunction *) 0 ;
+  char *arg2 = (char *) 0 ;
+  int arg3 = (int) 8 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int res2 ;
+  char *buf2 = 0 ;
+  int alloc2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  char * kwnames[] = {
+    (char *)"self",  (char *)"file",  (char *)"precision",  NULL 
+  };
+  
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OO|O:QuadratureFunction_SaveGZ", kwnames, &obj0, &obj1, &obj2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_mfem__QuadratureFunction, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "QuadratureFunction_SaveGZ" "', argument " "1"" of type '" "mfem::QuadratureFunction *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::QuadratureFunction * >(argp1);
+  res2 = SWIG_AsCharPtrAndSize(obj1, &buf2, NULL, &alloc2);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "QuadratureFunction_SaveGZ" "', argument " "2"" of type '" "char const *""'");
+  }
+  arg2 = reinterpret_cast< char * >(buf2);
+  if (obj2) {
+    {
+      if ((PyArray_PyIntAsInt(obj2) == -1) && PyErr_Occurred()) {
+        SWIG_exception_fail(SWIG_TypeError, "Input must be integer");
+      };  
+      arg3 = PyArray_PyIntAsInt(obj2);
+    }
+  }
+  {
+    try {
+      mfem_QuadratureFunction_SaveGZ(arg1,(char const *)arg2,arg3); 
+    }
+    catch (Swig::DirectorException &e) {
+      SWIG_fail; 
+    }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
+  }
+  resultobj = SWIG_Py_Void();
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return resultobj;
+fail:
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return NULL;
+}
+
+
 SWIGINTERN PyObject *QuadratureFunction_swigregister(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *obj;
   if (!SWIG_Python_UnpackTuple(args, "swigregister", 1, 1, &obj)) return NULL;
@@ -16153,6 +16279,7 @@ static PyMethodDef SwigMethods[] = {
 		"GridFunction_Save(GridFunction self, std::ostream & out)\n"
 		"GridFunction_Save(GridFunction self, char const * file, int precision=8)\n"
 		""},
+	 { "GridFunction_SaveGZ", (PyCFunction)(void(*)(void))_wrap_GridFunction_SaveGZ, METH_VARARGS|METH_KEYWORDS, "GridFunction_SaveGZ(GridFunction self, char const * file, int precision=8)"},
 	 { "GridFunction_swigregister", GridFunction_swigregister, METH_O, NULL},
 	 { "GridFunction_swiginit", GridFunction_swiginit, METH_VARARGS, NULL},
 	 { "new_QuadratureFunction", _wrap_new_QuadratureFunction, METH_VARARGS, "\n"
@@ -16185,6 +16312,7 @@ static PyMethodDef SwigMethods[] = {
 		"QuadratureFunction_Save(QuadratureFunction self, std::ostream & out)\n"
 		"QuadratureFunction_Save(QuadratureFunction self, char const * file, int precision=8)\n"
 		""},
+	 { "QuadratureFunction_SaveGZ", (PyCFunction)(void(*)(void))_wrap_QuadratureFunction_SaveGZ, METH_VARARGS|METH_KEYWORDS, "QuadratureFunction_SaveGZ(QuadratureFunction self, char const * file, int precision=8)"},
 	 { "QuadratureFunction_swigregister", QuadratureFunction_swigregister, METH_O, NULL},
 	 { "QuadratureFunction_swiginit", QuadratureFunction_swiginit, METH_VARARGS, NULL},
 	 { "__lshift__", _wrap___lshift__, METH_VARARGS, "\n"
@@ -16382,6 +16510,7 @@ static PyMethodDef SwigMethods_proxydocs[] = {
 		"Save(GridFunction self, std::ostream & out)\n"
 		"Save(GridFunction self, char const * file, int precision=8)\n"
 		""},
+	 { "GridFunction_SaveGZ", (PyCFunction)(void(*)(void))_wrap_GridFunction_SaveGZ, METH_VARARGS|METH_KEYWORDS, "SaveGZ(GridFunction self, char const * file, int precision=8)"},
 	 { "GridFunction_swigregister", GridFunction_swigregister, METH_O, NULL},
 	 { "GridFunction_swiginit", GridFunction_swiginit, METH_VARARGS, NULL},
 	 { "new_QuadratureFunction", _wrap_new_QuadratureFunction, METH_VARARGS, "\n"
@@ -16414,6 +16543,7 @@ static PyMethodDef SwigMethods_proxydocs[] = {
 		"Save(QuadratureFunction self, std::ostream & out)\n"
 		"Save(QuadratureFunction self, char const * file, int precision=8)\n"
 		""},
+	 { "QuadratureFunction_SaveGZ", (PyCFunction)(void(*)(void))_wrap_QuadratureFunction_SaveGZ, METH_VARARGS|METH_KEYWORDS, "SaveGZ(QuadratureFunction self, char const * file, int precision=8)"},
 	 { "QuadratureFunction_swigregister", QuadratureFunction_swigregister, METH_O, NULL},
 	 { "QuadratureFunction_swiginit", QuadratureFunction_swiginit, METH_VARARGS, NULL},
 	 { "__lshift__", _wrap___lshift__, METH_VARARGS, "\n"

--- a/mfem/_par/hypre.py
+++ b/mfem/_par/hypre.py
@@ -505,6 +505,11 @@ class HypreParMatrix(mfem._par.operators.Operator):
         return _hypre.HypreParMatrix_PrintCommPkg(self, *args)
     PrintCommPkg = _swig_new_instance_method(_hypre.HypreParMatrix_PrintCommPkg)
 
+    def PrintCommPkgGZ(self, file, precision=8):
+        r"""PrintCommPkgGZ(HypreParMatrix self, char const * file, int precision=8)"""
+        return _hypre.HypreParMatrix_PrintCommPkgGZ(self, file, precision)
+    PrintCommPkgGZ = _swig_new_instance_method(_hypre.HypreParMatrix_PrintCommPkgGZ)
+
 # Register HypreParMatrix in _hypre:
 _hypre.HypreParMatrix_swigregister(HypreParMatrix)
 

--- a/mfem/_par/hypre_wrap.cxx
+++ b/mfem/_par/hypre_wrap.cxx
@@ -4001,6 +4001,17 @@ SWIGINTERN void mfem_HypreParMatrix_PrintCommPkg__SWIG_1(mfem::HypreParMatrix *s
   self -> PrintCommPkg(ofile);
   ofile.close();
   }
+SWIGINTERN void mfem_HypreParMatrix_PrintCommPkgGZ(mfem::HypreParMatrix *self,char const *file,int precision=8){
+  mfem::ofgzstream *ofile = new mfem::ofgzstream(file, true);
+  if (!ofile)
+     {
+        std::cerr << "\nCan not produce output file: " << file << '\n' << std::endl;
+        return;
+      }
+  ofile ->precision(precision);  
+  self -> PrintCommPkg(*ofile);
+  delete ofile;
+  }
 
 SWIGINTERN int
 SWIG_AsVal_int (PyObject * obj, int *val)
@@ -9901,6 +9912,64 @@ fail:
     "    mfem::HypreParMatrix::PrintCommPkg(std::ostream &) const\n"
     "    mfem::HypreParMatrix::PrintCommPkg(char const *,int)\n");
   return 0;
+}
+
+
+SWIGINTERN PyObject *_wrap_HypreParMatrix_PrintCommPkgGZ(PyObject *SWIGUNUSEDPARM(self), PyObject *args, PyObject *kwargs) {
+  PyObject *resultobj = 0;
+  mfem::HypreParMatrix *arg1 = (mfem::HypreParMatrix *) 0 ;
+  char *arg2 = (char *) 0 ;
+  int arg3 = (int) 8 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int res2 ;
+  char *buf2 = 0 ;
+  int alloc2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  char * kwnames[] = {
+    (char *)"self",  (char *)"file",  (char *)"precision",  NULL 
+  };
+  
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OO|O:HypreParMatrix_PrintCommPkgGZ", kwnames, &obj0, &obj1, &obj2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_mfem__HypreParMatrix, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "HypreParMatrix_PrintCommPkgGZ" "', argument " "1"" of type '" "mfem::HypreParMatrix *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::HypreParMatrix * >(argp1);
+  res2 = SWIG_AsCharPtrAndSize(obj1, &buf2, NULL, &alloc2);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "HypreParMatrix_PrintCommPkgGZ" "', argument " "2"" of type '" "char const *""'");
+  }
+  arg2 = reinterpret_cast< char * >(buf2);
+  if (obj2) {
+    {
+      if ((PyArray_PyIntAsInt(obj2) == -1) && PyErr_Occurred()) {
+        SWIG_exception_fail(SWIG_TypeError, "Input must be integer");
+      };  
+      arg3 = PyArray_PyIntAsInt(obj2);
+    }
+  }
+  {
+    try {
+      mfem_HypreParMatrix_PrintCommPkgGZ(arg1,(char const *)arg2,arg3); 
+    }
+    catch (Swig::DirectorException &e) {
+      SWIG_fail; 
+    }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
+  }
+  resultobj = SWIG_Py_Void();
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return resultobj;
+fail:
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return NULL;
 }
 
 
@@ -17715,6 +17784,7 @@ static PyMethodDef SwigMethods[] = {
 		"HypreParMatrix_PrintCommPkg(HypreParMatrix self, std::ostream & out=out)\n"
 		"HypreParMatrix_PrintCommPkg(HypreParMatrix self, char const * file, int precision=8)\n"
 		""},
+	 { "HypreParMatrix_PrintCommPkgGZ", (PyCFunction)(void(*)(void))_wrap_HypreParMatrix_PrintCommPkgGZ, METH_VARARGS|METH_KEYWORDS, "HypreParMatrix_PrintCommPkgGZ(HypreParMatrix self, char const * file, int precision=8)"},
 	 { "HypreParMatrix_swigregister", HypreParMatrix_swigregister, METH_O, NULL},
 	 { "HypreParMatrix_swiginit", HypreParMatrix_swiginit, METH_VARARGS, NULL},
 	 { "ParMult", (PyCFunction)(void(*)(void))_wrap_ParMult, METH_VARARGS|METH_KEYWORDS, "ParMult(HypreParMatrix A, HypreParMatrix B, bool own_matrix=False) -> HypreParMatrix"},
@@ -18056,6 +18126,7 @@ static PyMethodDef SwigMethods_proxydocs[] = {
 		"PrintCommPkg(HypreParMatrix self, std::ostream & out=out)\n"
 		"PrintCommPkg(HypreParMatrix self, char const * file, int precision=8)\n"
 		""},
+	 { "HypreParMatrix_PrintCommPkgGZ", (PyCFunction)(void(*)(void))_wrap_HypreParMatrix_PrintCommPkgGZ, METH_VARARGS|METH_KEYWORDS, "PrintCommPkgGZ(HypreParMatrix self, char const * file, int precision=8)"},
 	 { "HypreParMatrix_swigregister", HypreParMatrix_swigregister, METH_O, NULL},
 	 { "HypreParMatrix_swiginit", HypreParMatrix_swiginit, METH_VARARGS, NULL},
 	 { "ParMult", (PyCFunction)(void(*)(void))_wrap_ParMult, METH_VARARGS|METH_KEYWORDS, "ParMult(HypreParMatrix A, HypreParMatrix B, bool own_matrix=False) -> HypreParMatrix"},

--- a/mfem/_par/matrix.py
+++ b/mfem/_par/matrix.py
@@ -111,6 +111,11 @@ class Matrix(mfem._par.operators.Operator):
         return _matrix.Matrix_Print(self, *args)
     Print = _swig_new_instance_method(_matrix.Matrix_Print)
 
+    def PrintGZ(self, file, precision=8):
+        r"""PrintGZ(Matrix self, char const * file, int precision=8)"""
+        return _matrix.Matrix_PrintGZ(self, file, precision)
+    PrintGZ = _swig_new_instance_method(_matrix.Matrix_PrintGZ)
+
 # Register Matrix in _matrix:
 _matrix.Matrix_swigregister(Matrix)
 

--- a/mfem/_par/matrix_wrap.cxx
+++ b/mfem/_par/matrix_wrap.cxx
@@ -3382,6 +3382,17 @@ SWIGINTERN void mfem_Matrix_Print__SWIG_1(mfem::Matrix *self,char const *file,in
   self -> Print(ofile);
   ofile.close();
   }
+SWIGINTERN void mfem_Matrix_PrintGZ(mfem::Matrix *self,char const *file,int precision=8){
+  mfem::ofgzstream *ofile = new mfem::ofgzstream(file, true);
+  if (!ofile)
+     {
+        std::cerr << "\nCan not produce output file: " << file << '\n' << std::endl;
+        return;
+      }
+  ofile ->precision(precision);  
+  self -> Print(*ofile);
+  delete ofile;
+  }
 
 SWIGINTERNINLINE PyObject*
   SWIG_From_int  (int value)
@@ -4060,6 +4071,64 @@ fail:
 }
 
 
+SWIGINTERN PyObject *_wrap_Matrix_PrintGZ(PyObject *SWIGUNUSEDPARM(self), PyObject *args, PyObject *kwargs) {
+  PyObject *resultobj = 0;
+  mfem::Matrix *arg1 = (mfem::Matrix *) 0 ;
+  char *arg2 = (char *) 0 ;
+  int arg3 = (int) 8 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int res2 ;
+  char *buf2 = 0 ;
+  int alloc2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  char * kwnames[] = {
+    (char *)"self",  (char *)"file",  (char *)"precision",  NULL 
+  };
+  
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OO|O:Matrix_PrintGZ", kwnames, &obj0, &obj1, &obj2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_mfem__Matrix, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "Matrix_PrintGZ" "', argument " "1"" of type '" "mfem::Matrix *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::Matrix * >(argp1);
+  res2 = SWIG_AsCharPtrAndSize(obj1, &buf2, NULL, &alloc2);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "Matrix_PrintGZ" "', argument " "2"" of type '" "char const *""'");
+  }
+  arg2 = reinterpret_cast< char * >(buf2);
+  if (obj2) {
+    {
+      if ((PyArray_PyIntAsInt(obj2) == -1) && PyErr_Occurred()) {
+        SWIG_exception_fail(SWIG_TypeError, "Input must be integer");
+      };  
+      arg3 = PyArray_PyIntAsInt(obj2);
+    }
+  }
+  {
+    try {
+      mfem_Matrix_PrintGZ(arg1,(char const *)arg2,arg3); 
+    }
+    catch (Swig::DirectorException &e) {
+      SWIG_fail; 
+    }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
+  }
+  resultobj = SWIG_Py_Void();
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return resultobj;
+fail:
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return NULL;
+}
+
+
 SWIGINTERN PyObject *Matrix_swigregister(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *obj;
   if (!SWIG_Python_UnpackTuple(args, "swigregister", 1, 1, &obj)) return NULL;
@@ -4577,6 +4646,7 @@ static PyMethodDef SwigMethods[] = {
 		"Matrix_Print(Matrix self, std::ostream & out=mfem::out, int width_=4)\n"
 		"Matrix_Print(Matrix self, char const * file, int precision=8)\n"
 		""},
+	 { "Matrix_PrintGZ", (PyCFunction)(void(*)(void))_wrap_Matrix_PrintGZ, METH_VARARGS|METH_KEYWORDS, "Matrix_PrintGZ(Matrix self, char const * file, int precision=8)"},
 	 { "Matrix_swigregister", Matrix_swigregister, METH_O, NULL},
 	 { "delete_MatrixInverse", _wrap_delete_MatrixInverse, METH_O, "delete_MatrixInverse(MatrixInverse self)"},
 	 { "MatrixInverse_swigregister", MatrixInverse_swigregister, METH_O, NULL},
@@ -4607,6 +4677,7 @@ static PyMethodDef SwigMethods_proxydocs[] = {
 		"Print(Matrix self, std::ostream & out=mfem::out, int width_=4)\n"
 		"Print(Matrix self, char const * file, int precision=8)\n"
 		""},
+	 { "Matrix_PrintGZ", (PyCFunction)(void(*)(void))_wrap_Matrix_PrintGZ, METH_VARARGS|METH_KEYWORDS, "PrintGZ(Matrix self, char const * file, int precision=8)"},
 	 { "Matrix_swigregister", Matrix_swigregister, METH_O, NULL},
 	 { "delete_MatrixInverse", _wrap_delete_MatrixInverse, METH_O, "delete_MatrixInverse(MatrixInverse self)"},
 	 { "MatrixInverse_swigregister", MatrixInverse_swigregister, METH_O, NULL},

--- a/mfem/_par/mesh.i
+++ b/mfem/_par/mesh.i
@@ -158,7 +158,7 @@ if (!SWIG_IsOK(res2)){
 def GetBdrElementVertices(self, i):
     from  .array import intArray
     ivert = intArray()
-    _mesh.Mesh_GetBdrElementVertices(self, i, ivert)
+    $action(self, i, ivert)
     return ivert.ToList()
 %}
 
@@ -167,7 +167,7 @@ def GetBdrElementAdjacentElement(self, bdr_el):
     from mfem.par import intp
     el = intp()
     info = intp()  
-    _mesh.Mesh_GetBdrElementAdjacentElement(self, bdr_el, el, info)
+    $action(self, bdr_el, el, info)
     return el.value(), info.value()
 %}
 
@@ -175,7 +175,7 @@ def GetBdrElementAdjacentElement(self, bdr_el):
 def GetElementVertices(self, i):
     from  .array import intArray
     ivert = intArray()
-    _mesh.Mesh_GetElementVertices(self, i, ivert)
+    $action(self, i, ivert)
     return ivert.ToList()
 %}
 
@@ -184,7 +184,7 @@ def GetElementEdges(self, i):
     from  .array import intArray
     ia = intArray()
     ib = intArray()      
-    _mesh.Mesh_GetElementEdges(self, i, ia, ib)
+    $action(self, i, ia, ib)
     return ia.ToList(), ib.ToList()      
 %} 
 
@@ -193,7 +193,7 @@ def GetBdrElementEdges(self, i):
     from  .array import intArray
     ia = intArray()
     ib = intArray()      
-    _mesh.Mesh_GetBdrElementEdges(self, i, ia, ib)
+    $action(self, i, ia, ib)
     return ia.ToList(), ib.ToList()
 %} 
 
@@ -202,7 +202,7 @@ def GetFaceEdges(self, i):
     from  .array import intArray
     ia = intArray()
     ib = intArray()      
-    _mesh.Mesh_GetFaceEdges(self, i, ia, ib)
+    $action(self, i, ia, ib)
     return ia.ToList(), ib.ToList()
 %}
 
@@ -210,7 +210,7 @@ def GetFaceEdges(self, i):
 def GetEdgeVertices(self, i):
     from  .array import intArray
     ia = intArray()
-    _mesh.Mesh_GetEdgeVertices(self, i, ia)
+    $action(self, i, ia)
     return ia.ToList()
 %}
 
@@ -218,7 +218,7 @@ def GetEdgeVertices(self, i):
 def GetFaceVertices(self, i):
     from  .array import intArray
     ia = intArray()
-    _mesh.Mesh_GetFaceVertices(self, i, ia)
+    $action(self, i, ia)
     return ia.ToList()
 %}
 
@@ -227,7 +227,7 @@ def GetElementFaces(self, i):
     from  .array import intArray
     ia = intArray()
     ib = intArray()      
-    _mesh.Mesh_GetElementFaces(self, i, ia, ib)
+    $action(self, i, ia, ib)
     return ia.ToList(), ib.ToList()
 %}
 
@@ -236,7 +236,7 @@ def GetBoundingBox(self, ref = 2):
     from  .vector import Vector
     min = Vector()
     max = Vector()      
-    _mesh.Mesh_GetBoundingBox(self, min, max, ref)      
+    $action(self, min, max, ref)      
     return min.GetDataArray().copy(), max.GetDataArray().copy()
 %}
 %feature("shadow") mfem::Mesh::GetFaceElements %{
@@ -251,28 +251,28 @@ def GetFaceElements(self, Face):
 def GetElementTransformation(self, i):
     from mfem.par import IsoparametricTransformation
     Tr = IsoparametricTransformation()
-    _mesh.Mesh_GetElementTransformation(self, i, Tr)
+    $action(self, i, Tr)
     return Tr
 %}
 %feature("shadow") mfem::Mesh::GetBdrElementTransformation %{
 def GetBdrElementTransformation(self, i):
     from mfem.par import IsoparametricTransformation
     Tr = IsoparametricTransformation()
-    _mesh.Mesh_GetBdrElementTransformation(self, i, Tr)
+    $action(self, i, Tr)
     return Tr
 %}
 %feature("shadow") mfem::Mesh::GetFaceTransformation %{
 def GetFaceTransformation(self, i):
     from mfem.par import IsoparametricTransformation
     Tr = IsoparametricTransformation()
-    _mesh.Mesh_GetFaceTransformation(self, i, Tr)
+    $action(self, i, Tr)
     return Tr
 %}
 %feature("shadow") mfem::Mesh::GetEdgeTransformation %{
 def GetEdgeTransformation(self, i):
     from mfem.par import IsoparametricTransformation
     Tr = IsoparametricTransformation()
-    _mesh.Mesh_GetEdgeTransformation(self, i, Tr)
+    $action(self, i, Tr)
     return Tr
 %}
 %feature("shadow") mfem::Mesh::GetFaceInfos %{
@@ -281,7 +281,7 @@ def GetFaceInfos(self, i):
     Elem1 = intp()
     Elem2 = intp()  
   
-    _mesh.Mesh_GetFaceInfos(self, i, Elem1, Elem2)
+    $action(self, i, Elem1, Elem2)
     return Elem1.value(), Elem2.value()
 %}
 %feature("shadow") mfem::Mesh::FindPoints %{
@@ -295,7 +295,7 @@ def FindPoints(self, pp, warn=True, inv_trans=None):
     M.Assign(pp)
     elem_ids = mfem.intArray()
     int_points = mfem.IntegrationPointArray()
-    count = _mesh.Mesh_FindPoints(self, M, elem_ids, int_points, warn, inv_trans)      
+    count = $action(self, M, elem_ids, int_points, warn, inv_trans)      
     elem_ids = elem_ids.ToList()
     return count, elem_ids, int_points
 %}
@@ -312,7 +312,7 @@ def CartesianPartitioning(self, nxyz, return_list=False):
         warnings.warn("CartesianPartitioning argument should be iterable",
 		      DeprecationWarning,)
 
-    r = _mesh.Mesh_CartesianPartitioning(self, dd)
+    r = $action(self, dd)
 
     if not return_list:
         return r

--- a/mfem/_par/mesh.py
+++ b/mfem/_par/mesh.py
@@ -1154,6 +1154,11 @@ class Mesh(object):
         return _mesh.Mesh_PrintInfo(self, *args)
     PrintInfo = _swig_new_instance_method(_mesh.Mesh_PrintInfo)
 
+    def PrintInfoGZ(self, file, precision=8):
+        r"""PrintInfoGZ(Mesh self, char const * file, int precision=8)"""
+        return _mesh.Mesh_PrintInfoGZ(self, file, precision)
+    PrintInfoGZ = _swig_new_instance_method(_mesh.Mesh_PrintInfoGZ)
+
     def Print(self, *args):
         r"""
         Print(Mesh self, std::ostream & out=out)
@@ -1161,6 +1166,11 @@ class Mesh(object):
         """
         return _mesh.Mesh_Print(self, *args)
     Print = _swig_new_instance_method(_mesh.Mesh_Print)
+
+    def PrintGZ(self, file, precision=8):
+        r"""PrintGZ(Mesh self, char const * file, int precision=8)"""
+        return _mesh.Mesh_PrintGZ(self, file, precision)
+    PrintGZ = _swig_new_instance_method(_mesh.Mesh_PrintGZ)
 
     def PrintXG(self, *args):
         r"""
@@ -1170,6 +1180,11 @@ class Mesh(object):
         return _mesh.Mesh_PrintXG(self, *args)
     PrintXG = _swig_new_instance_method(_mesh.Mesh_PrintXG)
 
+    def PrintXGGZ(self, file, precision=8):
+        r"""PrintXGGZ(Mesh self, char const * file, int precision=8)"""
+        return _mesh.Mesh_PrintXGGZ(self, file, precision)
+    PrintXGGZ = _swig_new_instance_method(_mesh.Mesh_PrintXGGZ)
+
     def PrintVTK(self, *args):
         r"""
         PrintVTK(Mesh self, std::ostream & out)
@@ -1178,6 +1193,11 @@ class Mesh(object):
         """
         return _mesh.Mesh_PrintVTK(self, *args)
     PrintVTK = _swig_new_instance_method(_mesh.Mesh_PrintVTK)
+
+    def PrintVTKGZ(self, file, precision=8):
+        r"""PrintVTKGZ(Mesh self, char const * file, int precision=8)"""
+        return _mesh.Mesh_PrintVTKGZ(self, file, precision)
+    PrintVTKGZ = _swig_new_instance_method(_mesh.Mesh_PrintVTKGZ)
 
 # Register Mesh in _mesh:
 _mesh.Mesh_swigregister(Mesh)

--- a/mfem/_par/mesh_wrap.cxx
+++ b/mfem/_par/mesh_wrap.cxx
@@ -3972,6 +3972,17 @@ SWIGINTERN void mfem_Mesh_PrintInfo__SWIG_1(mfem::Mesh *self,char const *file,in
   self -> PrintInfo(ofile);
   ofile.close();
   }
+SWIGINTERN void mfem_Mesh_PrintInfoGZ(mfem::Mesh *self,char const *file,int precision=8){
+  mfem::ofgzstream *ofile = new mfem::ofgzstream(file, true);
+  if (!ofile)
+     {
+        std::cerr << "\nCan not produce output file: " << file << '\n' << std::endl;
+        return;
+      }
+  ofile ->precision(precision);  
+  self -> PrintInfo(*ofile);
+  delete ofile;
+  }
 SWIGINTERN void mfem_Mesh_Print__SWIG_1(mfem::Mesh *self,char const *file,int precision=8){
   std::ofstream ofile(file);
   if (!ofile)
@@ -3982,6 +3993,17 @@ SWIGINTERN void mfem_Mesh_Print__SWIG_1(mfem::Mesh *self,char const *file,int pr
   ofile.precision(precision);  
   self -> Print(ofile);
   ofile.close();
+  }
+SWIGINTERN void mfem_Mesh_PrintGZ(mfem::Mesh *self,char const *file,int precision=8){
+  mfem::ofgzstream *ofile = new mfem::ofgzstream(file, true);
+  if (!ofile)
+     {
+        std::cerr << "\nCan not produce output file: " << file << '\n' << std::endl;
+        return;
+      }
+  ofile ->precision(precision);  
+  self -> Print(*ofile);
+  delete ofile;
   }
 SWIGINTERN void mfem_Mesh_PrintXG__SWIG_1(mfem::Mesh *self,char const *file,int precision=8){
   std::ofstream ofile(file);
@@ -3994,6 +4016,17 @@ SWIGINTERN void mfem_Mesh_PrintXG__SWIG_1(mfem::Mesh *self,char const *file,int 
   self -> PrintXG(ofile);
   ofile.close();
   }
+SWIGINTERN void mfem_Mesh_PrintXGGZ(mfem::Mesh *self,char const *file,int precision=8){
+  mfem::ofgzstream *ofile = new mfem::ofgzstream(file, true);
+  if (!ofile)
+     {
+        std::cerr << "\nCan not produce output file: " << file << '\n' << std::endl;
+        return;
+      }
+  ofile ->precision(precision);  
+  self -> PrintXG(*ofile);
+  delete ofile;
+  }
 SWIGINTERN void mfem_Mesh_PrintVTK__SWIG_2(mfem::Mesh *self,char const *file,int precision=8){
   std::ofstream ofile(file);
   if (!ofile)
@@ -4004,6 +4037,17 @@ SWIGINTERN void mfem_Mesh_PrintVTK__SWIG_2(mfem::Mesh *self,char const *file,int
   ofile.precision(precision);  
   self -> PrintVTK(ofile);
   ofile.close();
+  }
+SWIGINTERN void mfem_Mesh_PrintVTKGZ(mfem::Mesh *self,char const *file,int precision=8){
+  mfem::ofgzstream *ofile = new mfem::ofgzstream(file, true);
+  if (!ofile)
+     {
+        std::cerr << "\nCan not produce output file: " << file << '\n' << std::endl;
+        return;
+      }
+  ofile ->precision(precision);  
+  self -> PrintVTK(*ofile);
+  delete ofile;
   }
 
 
@@ -8575,14 +8619,20 @@ SWIGINTERN PyObject *_wrap_new_Mesh__SWIG_9(PyObject *SWIGUNUSEDPARM(self), Py_s
       }
     }
     if (stream1 == 0){
-      if (temp1->isGZ()){
-        in_gz1 = new mfem::ifgzstream(temp1->getFilename());
-        arg1 = in_gz1;
-      } else {
-        in_txt1.open(temp1->getFilename(), std::ifstream::in);
-        in_txt1.precision(temp1->getPrecision());
-        arg1 = &in_txt1;
-      }
+      /*
+            if (temp1->isGZ()){
+        	 in_gz1 = new mfem::ifgzstream(temp1->getFilename());
+               arg1 = in_gz1;
+            } else {
+        	 in_txt1.open(temp1->getFilename(), std::ifstream::in);
+               in_txt1.precision(temp1->getPrecision());
+               arg1 = &in_txt1;
+            }
+           */
+      /* this will auto-detect the input file type */
+      in_gz1 = new mfem::ifgzstream(temp1->getFilename());
+      arg1 = in_gz1;
+      
       if (temp1->isTemporary()){
         delete temp1;
       }
@@ -8627,18 +8677,6 @@ SWIGINTERN PyObject *_wrap_new_Mesh__SWIG_9(PyObject *SWIGUNUSEDPARM(self), Py_s
     //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__Mesh, SWIG_POINTER_NEW |  0 );
-  {
-    if (stream1) {
-      ret1 = PyLong_FromSsize_t(len1);
-      if (PyErr_Occurred()) {
-        PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
-        return NULL;
-      }
-      delete stream1;    
-      Py_XDECREF(resultobj);   /* Blow away any previous result */
-      resultobj = ret1;    
-    }
-  }
   {
     if (!stream1) {
       if (temp1) {
@@ -8827,14 +8865,20 @@ SWIGINTERN PyObject *_wrap_Mesh_Load(PyObject *SWIGUNUSEDPARM(self), PyObject *a
       }
     }
     if (stream2 == 0){
-      if (temp2->isGZ()){
-        in_gz2 = new mfem::ifgzstream(temp2->getFilename());
-        arg2 = in_gz2;
-      } else {
-        in_txt2.open(temp2->getFilename(), std::ifstream::in);
-        in_txt2.precision(temp2->getPrecision());
-        arg2 = &in_txt2;
-      }
+      /*
+            if (temp2->isGZ()){
+        	 in_gz2 = new mfem::ifgzstream(temp2->getFilename());
+               arg2 = in_gz2;
+            } else {
+        	 in_txt2.open(temp2->getFilename(), std::ifstream::in);
+               in_txt2.precision(temp2->getPrecision());
+               arg2 = &in_txt2;
+            }
+           */
+      /* this will auto-detect the input file type */
+      in_gz2 = new mfem::ifgzstream(temp2->getFilename());
+      arg2 = in_gz2;
+      
       if (temp2->isTemporary()){
         delete temp2;
       }
@@ -8879,18 +8923,6 @@ SWIGINTERN PyObject *_wrap_Mesh_Load(PyObject *SWIGUNUSEDPARM(self), PyObject *a
     //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
-  {
-    if (stream2) {
-      ret2 = PyLong_FromSsize_t(len2);
-      if (PyErr_Occurred()) {
-        PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
-        return NULL;
-      }
-      delete stream2;    
-      Py_XDECREF(resultobj);   /* Blow away any previous result */
-      resultobj = ret2;    
-    }
-  }
   {
     if (!stream2) {
       if (temp2) {
@@ -20129,6 +20161,64 @@ fail:
 }
 
 
+SWIGINTERN PyObject *_wrap_Mesh_PrintInfoGZ(PyObject *SWIGUNUSEDPARM(self), PyObject *args, PyObject *kwargs) {
+  PyObject *resultobj = 0;
+  mfem::Mesh *arg1 = (mfem::Mesh *) 0 ;
+  char *arg2 = (char *) 0 ;
+  int arg3 = (int) 8 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int res2 ;
+  char *buf2 = 0 ;
+  int alloc2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  char * kwnames[] = {
+    (char *)"self",  (char *)"file",  (char *)"precision",  NULL 
+  };
+  
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OO|O:Mesh_PrintInfoGZ", kwnames, &obj0, &obj1, &obj2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_mfem__Mesh, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "Mesh_PrintInfoGZ" "', argument " "1"" of type '" "mfem::Mesh *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::Mesh * >(argp1);
+  res2 = SWIG_AsCharPtrAndSize(obj1, &buf2, NULL, &alloc2);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "Mesh_PrintInfoGZ" "', argument " "2"" of type '" "char const *""'");
+  }
+  arg2 = reinterpret_cast< char * >(buf2);
+  if (obj2) {
+    {
+      if ((PyArray_PyIntAsInt(obj2) == -1) && PyErr_Occurred()) {
+        SWIG_exception_fail(SWIG_TypeError, "Input must be integer");
+      };  
+      arg3 = PyArray_PyIntAsInt(obj2);
+    }
+  }
+  {
+    try {
+      mfem_Mesh_PrintInfoGZ(arg1,(char const *)arg2,arg3); 
+    }
+    catch (Swig::DirectorException &e) {
+      SWIG_fail; 
+    }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
+  }
+  resultobj = SWIG_Py_Void();
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return resultobj;
+fail:
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return NULL;
+}
+
+
 SWIGINTERN PyObject *_wrap_Mesh_Print__SWIG_1(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
   PyObject *resultobj = 0;
   mfem::Mesh *arg1 = (mfem::Mesh *) 0 ;
@@ -20267,6 +20357,64 @@ fail:
 }
 
 
+SWIGINTERN PyObject *_wrap_Mesh_PrintGZ(PyObject *SWIGUNUSEDPARM(self), PyObject *args, PyObject *kwargs) {
+  PyObject *resultobj = 0;
+  mfem::Mesh *arg1 = (mfem::Mesh *) 0 ;
+  char *arg2 = (char *) 0 ;
+  int arg3 = (int) 8 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int res2 ;
+  char *buf2 = 0 ;
+  int alloc2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  char * kwnames[] = {
+    (char *)"self",  (char *)"file",  (char *)"precision",  NULL 
+  };
+  
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OO|O:Mesh_PrintGZ", kwnames, &obj0, &obj1, &obj2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_mfem__Mesh, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "Mesh_PrintGZ" "', argument " "1"" of type '" "mfem::Mesh *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::Mesh * >(argp1);
+  res2 = SWIG_AsCharPtrAndSize(obj1, &buf2, NULL, &alloc2);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "Mesh_PrintGZ" "', argument " "2"" of type '" "char const *""'");
+  }
+  arg2 = reinterpret_cast< char * >(buf2);
+  if (obj2) {
+    {
+      if ((PyArray_PyIntAsInt(obj2) == -1) && PyErr_Occurred()) {
+        SWIG_exception_fail(SWIG_TypeError, "Input must be integer");
+      };  
+      arg3 = PyArray_PyIntAsInt(obj2);
+    }
+  }
+  {
+    try {
+      mfem_Mesh_PrintGZ(arg1,(char const *)arg2,arg3); 
+    }
+    catch (Swig::DirectorException &e) {
+      SWIG_fail; 
+    }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
+  }
+  resultobj = SWIG_Py_Void();
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return resultobj;
+fail:
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return NULL;
+}
+
+
 SWIGINTERN PyObject *_wrap_Mesh_PrintXG__SWIG_1(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
   PyObject *resultobj = 0;
   mfem::Mesh *arg1 = (mfem::Mesh *) 0 ;
@@ -20402,6 +20550,64 @@ fail:
     "    mfem::Mesh::PrintXG(std::ostream &) const\n"
     "    mfem::Mesh::PrintXG(char const *,int)\n");
   return 0;
+}
+
+
+SWIGINTERN PyObject *_wrap_Mesh_PrintXGGZ(PyObject *SWIGUNUSEDPARM(self), PyObject *args, PyObject *kwargs) {
+  PyObject *resultobj = 0;
+  mfem::Mesh *arg1 = (mfem::Mesh *) 0 ;
+  char *arg2 = (char *) 0 ;
+  int arg3 = (int) 8 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int res2 ;
+  char *buf2 = 0 ;
+  int alloc2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  char * kwnames[] = {
+    (char *)"self",  (char *)"file",  (char *)"precision",  NULL 
+  };
+  
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OO|O:Mesh_PrintXGGZ", kwnames, &obj0, &obj1, &obj2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_mfem__Mesh, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "Mesh_PrintXGGZ" "', argument " "1"" of type '" "mfem::Mesh *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::Mesh * >(argp1);
+  res2 = SWIG_AsCharPtrAndSize(obj1, &buf2, NULL, &alloc2);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "Mesh_PrintXGGZ" "', argument " "2"" of type '" "char const *""'");
+  }
+  arg2 = reinterpret_cast< char * >(buf2);
+  if (obj2) {
+    {
+      if ((PyArray_PyIntAsInt(obj2) == -1) && PyErr_Occurred()) {
+        SWIG_exception_fail(SWIG_TypeError, "Input must be integer");
+      };  
+      arg3 = PyArray_PyIntAsInt(obj2);
+    }
+  }
+  {
+    try {
+      mfem_Mesh_PrintXGGZ(arg1,(char const *)arg2,arg3); 
+    }
+    catch (Swig::DirectorException &e) {
+      SWIG_fail; 
+    }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
+  }
+  resultobj = SWIG_Py_Void();
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return resultobj;
+fail:
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return NULL;
 }
 
 
@@ -20600,6 +20806,64 @@ fail:
     "    mfem::Mesh::PrintVTK(std::ostream &,int,int)\n"
     "    mfem::Mesh::PrintVTK(char const *,int)\n");
   return 0;
+}
+
+
+SWIGINTERN PyObject *_wrap_Mesh_PrintVTKGZ(PyObject *SWIGUNUSEDPARM(self), PyObject *args, PyObject *kwargs) {
+  PyObject *resultobj = 0;
+  mfem::Mesh *arg1 = (mfem::Mesh *) 0 ;
+  char *arg2 = (char *) 0 ;
+  int arg3 = (int) 8 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int res2 ;
+  char *buf2 = 0 ;
+  int alloc2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  char * kwnames[] = {
+    (char *)"self",  (char *)"file",  (char *)"precision",  NULL 
+  };
+  
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OO|O:Mesh_PrintVTKGZ", kwnames, &obj0, &obj1, &obj2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_mfem__Mesh, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "Mesh_PrintVTKGZ" "', argument " "1"" of type '" "mfem::Mesh *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::Mesh * >(argp1);
+  res2 = SWIG_AsCharPtrAndSize(obj1, &buf2, NULL, &alloc2);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "Mesh_PrintVTKGZ" "', argument " "2"" of type '" "char const *""'");
+  }
+  arg2 = reinterpret_cast< char * >(buf2);
+  if (obj2) {
+    {
+      if ((PyArray_PyIntAsInt(obj2) == -1) && PyErr_Occurred()) {
+        SWIG_exception_fail(SWIG_TypeError, "Input must be integer");
+      };  
+      arg3 = PyArray_PyIntAsInt(obj2);
+    }
+  }
+  {
+    try {
+      mfem_Mesh_PrintVTKGZ(arg1,(char const *)arg2,arg3); 
+    }
+    catch (Swig::DirectorException &e) {
+      SWIG_fail; 
+    }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
+  }
+  resultobj = SWIG_Py_Void();
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return resultobj;
+fail:
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return NULL;
 }
 
 
@@ -22585,19 +22849,23 @@ static PyMethodDef SwigMethods[] = {
 		"Mesh_PrintInfo(Mesh self, std::ostream & out=out)\n"
 		"Mesh_PrintInfo(Mesh self, char const * file, int precision=8)\n"
 		""},
+	 { "Mesh_PrintInfoGZ", (PyCFunction)(void(*)(void))_wrap_Mesh_PrintInfoGZ, METH_VARARGS|METH_KEYWORDS, "Mesh_PrintInfoGZ(Mesh self, char const * file, int precision=8)"},
 	 { "Mesh_Print", _wrap_Mesh_Print, METH_VARARGS, "\n"
 		"Mesh_Print(Mesh self, std::ostream & out=out)\n"
 		"Mesh_Print(Mesh self, char const * file, int precision=8)\n"
 		""},
+	 { "Mesh_PrintGZ", (PyCFunction)(void(*)(void))_wrap_Mesh_PrintGZ, METH_VARARGS|METH_KEYWORDS, "Mesh_PrintGZ(Mesh self, char const * file, int precision=8)"},
 	 { "Mesh_PrintXG", _wrap_Mesh_PrintXG, METH_VARARGS, "\n"
 		"Mesh_PrintXG(Mesh self, std::ostream & out=out)\n"
 		"Mesh_PrintXG(Mesh self, char const * file, int precision=8)\n"
 		""},
+	 { "Mesh_PrintXGGZ", (PyCFunction)(void(*)(void))_wrap_Mesh_PrintXGGZ, METH_VARARGS|METH_KEYWORDS, "Mesh_PrintXGGZ(Mesh self, char const * file, int precision=8)"},
 	 { "Mesh_PrintVTK", _wrap_Mesh_PrintVTK, METH_VARARGS, "\n"
 		"Mesh_PrintVTK(Mesh self, std::ostream & out)\n"
 		"Mesh_PrintVTK(Mesh self, std::ostream & out, int ref, int field_data=0)\n"
 		"Mesh_PrintVTK(Mesh self, char const * file, int precision=8)\n"
 		""},
+	 { "Mesh_PrintVTKGZ", (PyCFunction)(void(*)(void))_wrap_Mesh_PrintVTKGZ, METH_VARARGS|METH_KEYWORDS, "Mesh_PrintVTKGZ(Mesh self, char const * file, int precision=8)"},
 	 { "Mesh_swigregister", Mesh_swigregister, METH_O, NULL},
 	 { "Mesh_swiginit", Mesh_swiginit, METH_VARARGS, NULL},
 	 { "__lshift__", _wrap___lshift__, METH_VARARGS, "\n"
@@ -22946,19 +23214,23 @@ static PyMethodDef SwigMethods_proxydocs[] = {
 		"PrintInfo(Mesh self, std::ostream & out=out)\n"
 		"PrintInfo(Mesh self, char const * file, int precision=8)\n"
 		""},
+	 { "Mesh_PrintInfoGZ", (PyCFunction)(void(*)(void))_wrap_Mesh_PrintInfoGZ, METH_VARARGS|METH_KEYWORDS, "PrintInfoGZ(Mesh self, char const * file, int precision=8)"},
 	 { "Mesh_Print", _wrap_Mesh_Print, METH_VARARGS, "\n"
 		"Print(Mesh self, std::ostream & out=out)\n"
 		"Print(Mesh self, char const * file, int precision=8)\n"
 		""},
+	 { "Mesh_PrintGZ", (PyCFunction)(void(*)(void))_wrap_Mesh_PrintGZ, METH_VARARGS|METH_KEYWORDS, "PrintGZ(Mesh self, char const * file, int precision=8)"},
 	 { "Mesh_PrintXG", _wrap_Mesh_PrintXG, METH_VARARGS, "\n"
 		"PrintXG(Mesh self, std::ostream & out=out)\n"
 		"PrintXG(Mesh self, char const * file, int precision=8)\n"
 		""},
+	 { "Mesh_PrintXGGZ", (PyCFunction)(void(*)(void))_wrap_Mesh_PrintXGGZ, METH_VARARGS|METH_KEYWORDS, "PrintXGGZ(Mesh self, char const * file, int precision=8)"},
 	 { "Mesh_PrintVTK", _wrap_Mesh_PrintVTK, METH_VARARGS, "\n"
 		"PrintVTK(Mesh self, std::ostream & out)\n"
 		"PrintVTK(Mesh self, std::ostream & out, int ref, int field_data=0)\n"
 		"PrintVTK(Mesh self, char const * file, int precision=8)\n"
 		""},
+	 { "Mesh_PrintVTKGZ", (PyCFunction)(void(*)(void))_wrap_Mesh_PrintVTKGZ, METH_VARARGS|METH_KEYWORDS, "PrintVTKGZ(Mesh self, char const * file, int precision=8)"},
 	 { "Mesh_swigregister", Mesh_swigregister, METH_O, NULL},
 	 { "Mesh_swiginit", Mesh_swiginit, METH_VARARGS, NULL},
 	 { "__lshift__", _wrap___lshift__, METH_VARARGS, "\n"

--- a/mfem/_par/ncmesh.py
+++ b/mfem/_par/ncmesh.py
@@ -371,6 +371,11 @@ class NCMesh(object):
         return _ncmesh.NCMesh_PrintMemoryDetail(self)
     PrintMemoryDetail = _swig_new_instance_method(_ncmesh.NCMesh_PrintMemoryDetail)
 
+    def PrintVertexParentsGZ(self, file, precision=8):
+        r"""PrintVertexParentsGZ(NCMesh self, char const * file, int precision=8)"""
+        return _ncmesh.NCMesh_PrintVertexParentsGZ(self, file, precision)
+    PrintVertexParentsGZ = _swig_new_instance_method(_ncmesh.NCMesh_PrintVertexParentsGZ)
+
     def PrintVertexParents(self, *args):
         r"""
         PrintVertexParents(NCMesh self, std::ostream & out)
@@ -379,6 +384,11 @@ class NCMesh(object):
         """
         return _ncmesh.NCMesh_PrintVertexParents(self, *args)
     PrintVertexParents = _swig_new_instance_method(_ncmesh.NCMesh_PrintVertexParents)
+
+    def PrintCoarseElementsGZ(self, file, precision=8):
+        r"""PrintCoarseElementsGZ(NCMesh self, char const * file, int precision=8)"""
+        return _ncmesh.NCMesh_PrintCoarseElementsGZ(self, file, precision)
+    PrintCoarseElementsGZ = _swig_new_instance_method(_ncmesh.NCMesh_PrintCoarseElementsGZ)
 
     def PrintCoarseElements(self, *args):
         r"""
@@ -396,6 +406,11 @@ class NCMesh(object):
         """
         return _ncmesh.NCMesh_PrintStats(self, *args)
     PrintStats = _swig_new_instance_method(_ncmesh.NCMesh_PrintStats)
+
+    def PrintStatsGZ(self, file, precision=8):
+        r"""PrintStatsGZ(NCMesh self, char const * file, int precision=8)"""
+        return _ncmesh.NCMesh_PrintStatsGZ(self, file, precision)
+    PrintStatsGZ = _swig_new_instance_method(_ncmesh.NCMesh_PrintStatsGZ)
 
 # Register NCMesh in _ncmesh:
 _ncmesh.NCMesh_swigregister(NCMesh)

--- a/mfem/_par/ncmesh_wrap.cxx
+++ b/mfem/_par/ncmesh_wrap.cxx
@@ -3623,6 +3623,18 @@ SWIGINTERN void mfem_NCMesh_PrintVertexParents__SWIG_1(mfem::NCMesh *self,char c
   self -> PrintVertexParents(ofile);
   ofile.close();
   }
+SWIGINTERN void mfem_NCMesh_PrintVertexParentsGZ(mfem::NCMesh *self,char const *file,int precision=8){
+  mfem::ofgzstream *ofile = new mfem::ofgzstream(file, true);
+  
+  if (!ofile)
+     {
+        std::cerr << "\nCan not produce output file: " << file << '\n' << std::endl;
+        return;
+      }
+  ofile -> precision(precision);  
+  self -> PrintVertexParents(*ofile);
+  delete ofile;
+  }
 SWIGINTERN void mfem_NCMesh_PrintVertexParents__SWIG_2(mfem::NCMesh *self){
   self -> PrintVertexParents(std::cout);
   }
@@ -3637,6 +3649,18 @@ SWIGINTERN void mfem_NCMesh_PrintCoarseElements__SWIG_1(mfem::NCMesh *self,char 
   self -> PrintCoarseElements(ofile);
   ofile.close();
   }
+SWIGINTERN void mfem_NCMesh_PrintCoarseElementsGZ(mfem::NCMesh *self,char const *file,int precision=8){
+  mfem::ofgzstream *ofile = new mfem::ofgzstream(file, true);
+  
+  if (!ofile)
+     {
+        std::cerr << "\nCan not produce output file: " << file << '\n' << std::endl;
+        return;
+      }
+  ofile -> precision(precision);  
+  self -> PrintCoarseElements(*ofile);
+  delete ofile;
+  }
 SWIGINTERN void mfem_NCMesh_PrintCoarseElements__SWIG_2(mfem::NCMesh *self){
   self -> PrintCoarseElements(std::cout);
   }
@@ -3650,6 +3674,17 @@ SWIGINTERN void mfem_NCMesh_PrintStats__SWIG_1(mfem::NCMesh *self,char const *fi
   ofile.precision(precision);  
   self -> PrintStats(ofile);
   ofile.close();
+  }
+SWIGINTERN void mfem_NCMesh_PrintStatsGZ(mfem::NCMesh *self,char const *file,int precision=8){
+  mfem::ofgzstream *ofile = new mfem::ofgzstream(file, true);
+  if (!ofile)
+     {
+        std::cerr << "\nCan not produce output file: " << file << '\n' << std::endl;
+        return;
+      }
+  ofile ->precision(precision);  
+  self -> PrintStats(*ofile);
+  delete ofile;
   }
 
 SWIGINTERN int
@@ -6477,14 +6512,20 @@ SWIGINTERN PyObject *_wrap_NCMesh_LoadVertexParents(PyObject *SWIGUNUSEDPARM(sel
       }
     }
     if (stream2 == 0){
-      if (temp2->isGZ()){
-        in_gz2 = new mfem::ifgzstream(temp2->getFilename());
-        arg2 = in_gz2;
-      } else {
-        in_txt2.open(temp2->getFilename(), std::ifstream::in);
-        in_txt2.precision(temp2->getPrecision());
-        arg2 = &in_txt2;
-      }
+      /*
+            if (temp2->isGZ()){
+        	 in_gz2 = new mfem::ifgzstream(temp2->getFilename());
+               arg2 = in_gz2;
+            } else {
+        	 in_txt2.open(temp2->getFilename(), std::ifstream::in);
+               in_txt2.precision(temp2->getPrecision());
+               arg2 = &in_txt2;
+            }
+           */
+      /* this will auto-detect the input file type */
+      in_gz2 = new mfem::ifgzstream(temp2->getFilename());
+      arg2 = in_gz2;
+      
       if (temp2->isTemporary()){
         delete temp2;
       }
@@ -6506,18 +6547,6 @@ SWIGINTERN PyObject *_wrap_NCMesh_LoadVertexParents(PyObject *SWIGUNUSEDPARM(sel
     //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
-  {
-    if (stream2) {
-      ret2 = PyLong_FromSsize_t(len2);
-      if (PyErr_Occurred()) {
-        PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
-        return NULL;
-      }
-      delete stream2;    
-      Py_XDECREF(resultobj);   /* Blow away any previous result */
-      resultobj = ret2;    
-    }
-  }
   {
     if (!stream2) {
       if (temp2) {
@@ -6611,14 +6640,20 @@ SWIGINTERN PyObject *_wrap_NCMesh_LoadCoarseElements(PyObject *SWIGUNUSEDPARM(se
       }
     }
     if (stream2 == 0){
-      if (temp2->isGZ()){
-        in_gz2 = new mfem::ifgzstream(temp2->getFilename());
-        arg2 = in_gz2;
-      } else {
-        in_txt2.open(temp2->getFilename(), std::ifstream::in);
-        in_txt2.precision(temp2->getPrecision());
-        arg2 = &in_txt2;
-      }
+      /*
+            if (temp2->isGZ()){
+        	 in_gz2 = new mfem::ifgzstream(temp2->getFilename());
+               arg2 = in_gz2;
+            } else {
+        	 in_txt2.open(temp2->getFilename(), std::ifstream::in);
+               in_txt2.precision(temp2->getPrecision());
+               arg2 = &in_txt2;
+            }
+           */
+      /* this will auto-detect the input file type */
+      in_gz2 = new mfem::ifgzstream(temp2->getFilename());
+      arg2 = in_gz2;
+      
       if (temp2->isTemporary()){
         delete temp2;
       }
@@ -6640,18 +6675,6 @@ SWIGINTERN PyObject *_wrap_NCMesh_LoadCoarseElements(PyObject *SWIGUNUSEDPARM(se
     //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
-  {
-    if (stream2) {
-      ret2 = PyLong_FromSsize_t(len2);
-      if (PyErr_Occurred()) {
-        PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
-        return NULL;
-      }
-      delete stream2;    
-      Py_XDECREF(resultobj);   /* Blow away any previous result */
-      resultobj = ret2;    
-    }
-  }
   {
     if (!stream2) {
       if (temp2) {
@@ -7018,6 +7041,64 @@ fail:
 }
 
 
+SWIGINTERN PyObject *_wrap_NCMesh_PrintVertexParentsGZ(PyObject *SWIGUNUSEDPARM(self), PyObject *args, PyObject *kwargs) {
+  PyObject *resultobj = 0;
+  mfem::NCMesh *arg1 = (mfem::NCMesh *) 0 ;
+  char *arg2 = (char *) 0 ;
+  int arg3 = (int) 8 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int res2 ;
+  char *buf2 = 0 ;
+  int alloc2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  char * kwnames[] = {
+    (char *)"self",  (char *)"file",  (char *)"precision",  NULL 
+  };
+  
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OO|O:NCMesh_PrintVertexParentsGZ", kwnames, &obj0, &obj1, &obj2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_mfem__NCMesh, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "NCMesh_PrintVertexParentsGZ" "', argument " "1"" of type '" "mfem::NCMesh *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::NCMesh * >(argp1);
+  res2 = SWIG_AsCharPtrAndSize(obj1, &buf2, NULL, &alloc2);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "NCMesh_PrintVertexParentsGZ" "', argument " "2"" of type '" "char const *""'");
+  }
+  arg2 = reinterpret_cast< char * >(buf2);
+  if (obj2) {
+    {
+      if ((PyArray_PyIntAsInt(obj2) == -1) && PyErr_Occurred()) {
+        SWIG_exception_fail(SWIG_TypeError, "Input must be integer");
+      };  
+      arg3 = PyArray_PyIntAsInt(obj2);
+    }
+  }
+  {
+    try {
+      mfem_NCMesh_PrintVertexParentsGZ(arg1,(char const *)arg2,arg3); 
+    }
+    catch (Swig::DirectorException &e) {
+      SWIG_fail; 
+    }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
+  }
+  resultobj = SWIG_Py_Void();
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return resultobj;
+fail:
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return NULL;
+}
+
+
 SWIGINTERN PyObject *_wrap_NCMesh_PrintVertexParents__SWIG_2(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
   PyObject *resultobj = 0;
   mfem::NCMesh *arg1 = (mfem::NCMesh *) 0 ;
@@ -7176,6 +7257,64 @@ SWIGINTERN PyObject *_wrap_NCMesh_PrintCoarseElements__SWIG_1(PyObject *SWIGUNUS
   {
     try {
       mfem_NCMesh_PrintCoarseElements__SWIG_1(arg1,(char const *)arg2,arg3); 
+    }
+    catch (Swig::DirectorException &e) {
+      SWIG_fail; 
+    }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
+  }
+  resultobj = SWIG_Py_Void();
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return resultobj;
+fail:
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_NCMesh_PrintCoarseElementsGZ(PyObject *SWIGUNUSEDPARM(self), PyObject *args, PyObject *kwargs) {
+  PyObject *resultobj = 0;
+  mfem::NCMesh *arg1 = (mfem::NCMesh *) 0 ;
+  char *arg2 = (char *) 0 ;
+  int arg3 = (int) 8 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int res2 ;
+  char *buf2 = 0 ;
+  int alloc2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  char * kwnames[] = {
+    (char *)"self",  (char *)"file",  (char *)"precision",  NULL 
+  };
+  
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OO|O:NCMesh_PrintCoarseElementsGZ", kwnames, &obj0, &obj1, &obj2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_mfem__NCMesh, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "NCMesh_PrintCoarseElementsGZ" "', argument " "1"" of type '" "mfem::NCMesh *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::NCMesh * >(argp1);
+  res2 = SWIG_AsCharPtrAndSize(obj1, &buf2, NULL, &alloc2);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "NCMesh_PrintCoarseElementsGZ" "', argument " "2"" of type '" "char const *""'");
+  }
+  arg2 = reinterpret_cast< char * >(buf2);
+  if (obj2) {
+    {
+      if ((PyArray_PyIntAsInt(obj2) == -1) && PyErr_Occurred()) {
+        SWIG_exception_fail(SWIG_TypeError, "Input must be integer");
+      };  
+      arg3 = PyArray_PyIntAsInt(obj2);
+    }
+  }
+  {
+    try {
+      mfem_NCMesh_PrintCoarseElementsGZ(arg1,(char const *)arg2,arg3); 
     }
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
@@ -7455,6 +7594,64 @@ fail:
     "    mfem::NCMesh::PrintStats(std::ostream &) const\n"
     "    mfem::NCMesh::PrintStats(char const *,int)\n");
   return 0;
+}
+
+
+SWIGINTERN PyObject *_wrap_NCMesh_PrintStatsGZ(PyObject *SWIGUNUSEDPARM(self), PyObject *args, PyObject *kwargs) {
+  PyObject *resultobj = 0;
+  mfem::NCMesh *arg1 = (mfem::NCMesh *) 0 ;
+  char *arg2 = (char *) 0 ;
+  int arg3 = (int) 8 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int res2 ;
+  char *buf2 = 0 ;
+  int alloc2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  char * kwnames[] = {
+    (char *)"self",  (char *)"file",  (char *)"precision",  NULL 
+  };
+  
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OO|O:NCMesh_PrintStatsGZ", kwnames, &obj0, &obj1, &obj2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_mfem__NCMesh, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "NCMesh_PrintStatsGZ" "', argument " "1"" of type '" "mfem::NCMesh *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::NCMesh * >(argp1);
+  res2 = SWIG_AsCharPtrAndSize(obj1, &buf2, NULL, &alloc2);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "NCMesh_PrintStatsGZ" "', argument " "2"" of type '" "char const *""'");
+  }
+  arg2 = reinterpret_cast< char * >(buf2);
+  if (obj2) {
+    {
+      if ((PyArray_PyIntAsInt(obj2) == -1) && PyErr_Occurred()) {
+        SWIG_exception_fail(SWIG_TypeError, "Input must be integer");
+      };  
+      arg3 = PyArray_PyIntAsInt(obj2);
+    }
+  }
+  {
+    try {
+      mfem_NCMesh_PrintStatsGZ(arg1,(char const *)arg2,arg3); 
+    }
+    catch (Swig::DirectorException &e) {
+      SWIG_fail; 
+    }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
+  }
+  resultobj = SWIG_Py_Void();
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return resultobj;
+fail:
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return NULL;
 }
 
 
@@ -9993,11 +10190,13 @@ static PyMethodDef SwigMethods[] = {
 	 { "NCMesh_Trim", _wrap_NCMesh_Trim, METH_O, "NCMesh_Trim(NCMesh self)"},
 	 { "NCMesh_MemoryUsage", _wrap_NCMesh_MemoryUsage, METH_O, "NCMesh_MemoryUsage(NCMesh self) -> long"},
 	 { "NCMesh_PrintMemoryDetail", _wrap_NCMesh_PrintMemoryDetail, METH_O, "NCMesh_PrintMemoryDetail(NCMesh self) -> int"},
+	 { "NCMesh_PrintVertexParentsGZ", (PyCFunction)(void(*)(void))_wrap_NCMesh_PrintVertexParentsGZ, METH_VARARGS|METH_KEYWORDS, "NCMesh_PrintVertexParentsGZ(NCMesh self, char const * file, int precision=8)"},
 	 { "NCMesh_PrintVertexParents", _wrap_NCMesh_PrintVertexParents, METH_VARARGS, "\n"
 		"NCMesh_PrintVertexParents(NCMesh self, std::ostream & out)\n"
 		"NCMesh_PrintVertexParents(NCMesh self, char const * file, int precision=8)\n"
 		"NCMesh_PrintVertexParents(NCMesh self)\n"
 		""},
+	 { "NCMesh_PrintCoarseElementsGZ", (PyCFunction)(void(*)(void))_wrap_NCMesh_PrintCoarseElementsGZ, METH_VARARGS|METH_KEYWORDS, "NCMesh_PrintCoarseElementsGZ(NCMesh self, char const * file, int precision=8)"},
 	 { "NCMesh_PrintCoarseElements", _wrap_NCMesh_PrintCoarseElements, METH_VARARGS, "\n"
 		"NCMesh_PrintCoarseElements(NCMesh self, std::ostream & out)\n"
 		"NCMesh_PrintCoarseElements(NCMesh self, char const * file, int precision=8)\n"
@@ -10007,6 +10206,7 @@ static PyMethodDef SwigMethods[] = {
 		"NCMesh_PrintStats(NCMesh self, std::ostream & out=out)\n"
 		"NCMesh_PrintStats(NCMesh self, char const * file, int precision=8)\n"
 		""},
+	 { "NCMesh_PrintStatsGZ", (PyCFunction)(void(*)(void))_wrap_NCMesh_PrintStatsGZ, METH_VARARGS|METH_KEYWORDS, "NCMesh_PrintStatsGZ(NCMesh self, char const * file, int precision=8)"},
 	 { "NCMesh_swigregister", NCMesh_swigregister, METH_O, NULL},
 	 { "NCMesh_swiginit", NCMesh_swiginit, METH_VARARGS, NULL},
 	 { "new_RefinementArray", _wrap_new_RefinementArray, METH_VARARGS, "\n"
@@ -10161,11 +10361,13 @@ static PyMethodDef SwigMethods_proxydocs[] = {
 	 { "NCMesh_Trim", _wrap_NCMesh_Trim, METH_O, "Trim(NCMesh self)"},
 	 { "NCMesh_MemoryUsage", _wrap_NCMesh_MemoryUsage, METH_O, "MemoryUsage(NCMesh self) -> long"},
 	 { "NCMesh_PrintMemoryDetail", _wrap_NCMesh_PrintMemoryDetail, METH_O, "PrintMemoryDetail(NCMesh self) -> int"},
+	 { "NCMesh_PrintVertexParentsGZ", (PyCFunction)(void(*)(void))_wrap_NCMesh_PrintVertexParentsGZ, METH_VARARGS|METH_KEYWORDS, "PrintVertexParentsGZ(NCMesh self, char const * file, int precision=8)"},
 	 { "NCMesh_PrintVertexParents", _wrap_NCMesh_PrintVertexParents, METH_VARARGS, "\n"
 		"PrintVertexParents(NCMesh self, std::ostream & out)\n"
 		"PrintVertexParents(NCMesh self, char const * file, int precision=8)\n"
 		"PrintVertexParents(NCMesh self)\n"
 		""},
+	 { "NCMesh_PrintCoarseElementsGZ", (PyCFunction)(void(*)(void))_wrap_NCMesh_PrintCoarseElementsGZ, METH_VARARGS|METH_KEYWORDS, "PrintCoarseElementsGZ(NCMesh self, char const * file, int precision=8)"},
 	 { "NCMesh_PrintCoarseElements", _wrap_NCMesh_PrintCoarseElements, METH_VARARGS, "\n"
 		"PrintCoarseElements(NCMesh self, std::ostream & out)\n"
 		"PrintCoarseElements(NCMesh self, char const * file, int precision=8)\n"
@@ -10175,6 +10377,7 @@ static PyMethodDef SwigMethods_proxydocs[] = {
 		"PrintStats(NCMesh self, std::ostream & out=out)\n"
 		"PrintStats(NCMesh self, char const * file, int precision=8)\n"
 		""},
+	 { "NCMesh_PrintStatsGZ", (PyCFunction)(void(*)(void))_wrap_NCMesh_PrintStatsGZ, METH_VARARGS|METH_KEYWORDS, "PrintStatsGZ(NCMesh self, char const * file, int precision=8)"},
 	 { "NCMesh_swigregister", NCMesh_swigregister, METH_O, NULL},
 	 { "NCMesh_swiginit", NCMesh_swiginit, METH_VARARGS, NULL},
 	 { "new_RefinementArray", _wrap_new_RefinementArray, METH_VARARGS, "\n"

--- a/mfem/_par/operators.py
+++ b/mfem/_par/operators.py
@@ -224,6 +224,11 @@ class Operator(object):
         """
         return _operators.Operator_PrintMatlab(self, *args)
     PrintMatlab = _swig_new_instance_method(_operators.Operator_PrintMatlab)
+
+    def PrintMatlabGZ(self, file, precision=8):
+        r"""PrintMatlabGZ(Operator self, char const * file, int precision=8)"""
+        return _operators.Operator_PrintMatlabGZ(self, file, precision)
+    PrintMatlabGZ = _swig_new_instance_method(_operators.Operator_PrintMatlabGZ)
     def __disown__(self):
         self.this.disown()
         _operators.disown_Operator(self)

--- a/mfem/_par/operators_wrap.cxx
+++ b/mfem/_par/operators_wrap.cxx
@@ -3550,6 +3550,17 @@ SWIGINTERN void mfem_Operator_PrintMatlab__SWIG_1(mfem::Operator *self,char cons
   self -> PrintMatlab(ofile);
   ofile.close();
   }
+SWIGINTERN void mfem_Operator_PrintMatlabGZ(mfem::Operator *self,char const *file,int precision=8){
+  mfem::ofgzstream *ofile = new mfem::ofgzstream(file, true);
+  if (!ofile)
+     {
+        std::cerr << "\nCan not produce output file: " << file << '\n' << std::endl;
+        return;
+      }
+  ofile ->precision(precision);  
+  self -> PrintMatlab(*ofile);
+  delete ofile;
+  }
 
   #define SWIG_From_double   PyFloat_FromDouble 
 
@@ -7997,6 +8008,64 @@ fail:
     "    mfem::Operator::PrintMatlab(std::ostream &,int,int) const\n"
     "    mfem::Operator::PrintMatlab(char const *,int)\n");
   return 0;
+}
+
+
+SWIGINTERN PyObject *_wrap_Operator_PrintMatlabGZ(PyObject *SWIGUNUSEDPARM(self), PyObject *args, PyObject *kwargs) {
+  PyObject *resultobj = 0;
+  mfem::Operator *arg1 = (mfem::Operator *) 0 ;
+  char *arg2 = (char *) 0 ;
+  int arg3 = (int) 8 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int res2 ;
+  char *buf2 = 0 ;
+  int alloc2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  char * kwnames[] = {
+    (char *)"self",  (char *)"file",  (char *)"precision",  NULL 
+  };
+  
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OO|O:Operator_PrintMatlabGZ", kwnames, &obj0, &obj1, &obj2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_mfem__Operator, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "Operator_PrintMatlabGZ" "', argument " "1"" of type '" "mfem::Operator *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::Operator * >(argp1);
+  res2 = SWIG_AsCharPtrAndSize(obj1, &buf2, NULL, &alloc2);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "Operator_PrintMatlabGZ" "', argument " "2"" of type '" "char const *""'");
+  }
+  arg2 = reinterpret_cast< char * >(buf2);
+  if (obj2) {
+    {
+      if ((PyArray_PyIntAsInt(obj2) == -1) && PyErr_Occurred()) {
+        SWIG_exception_fail(SWIG_TypeError, "Input must be integer");
+      };  
+      arg3 = PyArray_PyIntAsInt(obj2);
+    }
+  }
+  {
+    try {
+      mfem_Operator_PrintMatlabGZ(arg1,(char const *)arg2,arg3); 
+    }
+    catch (Swig::DirectorException &e) {
+      SWIG_fail; 
+    }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
+  }
+  resultobj = SWIG_Py_Void();
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return resultobj;
+fail:
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return NULL;
 }
 
 
@@ -14017,6 +14086,7 @@ static PyMethodDef SwigMethods[] = {
 		"Operator_PrintMatlab(Operator self, std::ostream & out, int n=0, int m=0)\n"
 		"Operator_PrintMatlab(Operator self, char const * file, int precision=8)\n"
 		""},
+	 { "Operator_PrintMatlabGZ", (PyCFunction)(void(*)(void))_wrap_Operator_PrintMatlabGZ, METH_VARARGS|METH_KEYWORDS, "Operator_PrintMatlabGZ(Operator self, char const * file, int precision=8)"},
 	 { "disown_Operator", (PyCFunction)(void(*)(void))_wrap_disown_Operator, METH_VARARGS|METH_KEYWORDS, NULL},
 	 { "Operator_swigregister", Operator_swigregister, METH_O, NULL},
 	 { "Operator_swiginit", Operator_swiginit, METH_VARARGS, NULL},
@@ -14197,6 +14267,7 @@ static PyMethodDef SwigMethods_proxydocs[] = {
 		"PrintMatlab(Operator self, std::ostream & out, int n=0, int m=0)\n"
 		"PrintMatlab(Operator self, char const * file, int precision=8)\n"
 		""},
+	 { "Operator_PrintMatlabGZ", (PyCFunction)(void(*)(void))_wrap_Operator_PrintMatlabGZ, METH_VARARGS|METH_KEYWORDS, "PrintMatlabGZ(Operator self, char const * file, int precision=8)"},
 	 { "disown_Operator", (PyCFunction)(void(*)(void))_wrap_disown_Operator, METH_VARARGS|METH_KEYWORDS, NULL},
 	 { "Operator_swigregister", Operator_swigregister, METH_O, NULL},
 	 { "Operator_swiginit", Operator_swiginit, METH_VARARGS, NULL},

--- a/mfem/_par/pfespace.i
+++ b/mfem/_par/pfespace.i
@@ -42,40 +42,33 @@ import_array();
    $1 = PyInt_Check($input) ? 1 : 0;
 }
 
-%feature("shadow") mfem::ParFiniteElementSpace::GetBdrElementDofs %{
-def GetBdrElementDofs(self, i):
-    from  .array import intArray
-    vdofs = intArray()
-    _pfespace.ParFiniteElementSpace_GetBdrElementDofs(self, i, vdofs)
-    return vdofs.ToList()
-%}
-%feature("shadow") mfem::ParFiniteElementSpace::GetElementDofs %{
-def GetElementDofs(self, i):
-    from  .array import intArray
-    vdofs = intArray()
-    _pfespace.ParFiniteElementSpace_GetElementDofs(self, i, vdofs)
-    return vdofs.ToList()
-%}
-%feature("shadow") mfem::ParFiniteElementSpace::GetFaceDofs %{
-def GetFaceDofs(self, i):
-    from  .array import intArray
-    vdofs = intArray()
-    _pfespace.ParFiniteElementSpace_GetFaceDofs(self, i, vdofs)
-    return vdofs.ToList()
-%}
 %feature("shadow") mfem::ParFiniteElementSpace::GetSharedEdgeDofs %{
-  def GetSharedEdgeDofs(self, group, ei):
+def GetSharedEdgeDofs(self, group, ei):
     from  .array import intArray
-    dofs = intArray()      
-    _pfespace.ParFiniteElementSpace_GetSharedEdgeDofs(self, group, ei, dofs)
-    return dofs.ToList()      
+    dofs = intArray() 
+    $action(self, group, ei, dofs)
+    return dofs.ToList()
 %}
 %feature("shadow") mfem::ParFiniteElementSpace::GetSharedFaceDofs %{
-  def GetSharedFaceDofs(self, group, fi):
+def GetSharedFaceDofs(self, group, fi):
     from  .array import intArray
-    dofs = intArray()      
-    _pfespace.ParFiniteElementSpace_GetSharedFaceDofs(self, group, fi, dofs)
-    return dofs.ToList()      
+    dofs = intArray()
+    $action(self, group, fi, dofs)
+    return dofs.ToList()
+%}
+%feature("shadow") mfem::ParFiniteElementSpace::GetSharedTriangleDofs %{
+def GetSharedTriangleDofs(self, group, fi):
+    from  .array import intArray
+    dofs = intArray()
+    $action(self, group, fi, dofs)
+    return dofs.ToList()
+%}
+%feature("shadow") mfem::ParFiniteElementSpace::GetSharedQuadrilateralDofs %{
+def GetSharedQuadrilateralDofs(self, group, fi):
+    from  .array import intArray
+    dofs = intArray()
+    $action(self, group, fi, dofs)
+    return dofs.ToList()
 %}
 
 %include "fem/pfespace.hpp"

--- a/mfem/_par/pfespace.py
+++ b/mfem/_par/pfespace.py
@@ -211,22 +211,28 @@ class ParFiniteElementSpace(mfem._par.fespace.FiniteElementSpace):
     GetFaceRestriction = _swig_new_instance_method(_pfespace.ParFiniteElementSpace_GetFaceRestriction)
 
     def GetSharedEdgeDofs(self, group, ei):
-      from  .array import intArray
-      dofs = intArray()      
-      _pfespace.ParFiniteElementSpace_GetSharedEdgeDofs(self, group, ei, dofs)
-      return dofs.ToList()      
+        from  .array import intArray
+        dofs = intArray() 
+        _pfespace.ParFiniteElementSpace_GetSharedEdgeDofs(self, group, ei, dofs)
+        return dofs.ToList()
 
 
 
-    def GetSharedTriangleDofs(self, group, fi, dofs):
-        r"""GetSharedTriangleDofs(ParFiniteElementSpace self, int group, int fi, intArray dofs)"""
-        return _pfespace.ParFiniteElementSpace_GetSharedTriangleDofs(self, group, fi, dofs)
-    GetSharedTriangleDofs = _swig_new_instance_method(_pfespace.ParFiniteElementSpace_GetSharedTriangleDofs)
+    def GetSharedTriangleDofs(self, group, fi):
+        from  .array import intArray
+        dofs = intArray()
+        _pfespace.ParFiniteElementSpace_GetSharedTriangleDofs(self, group, fi, dofs)
+        return dofs.ToList()
 
-    def GetSharedQuadrilateralDofs(self, group, fi, dofs):
-        r"""GetSharedQuadrilateralDofs(ParFiniteElementSpace self, int group, int fi, intArray dofs)"""
-        return _pfespace.ParFiniteElementSpace_GetSharedQuadrilateralDofs(self, group, fi, dofs)
-    GetSharedQuadrilateralDofs = _swig_new_instance_method(_pfespace.ParFiniteElementSpace_GetSharedQuadrilateralDofs)
+
+
+    def GetSharedQuadrilateralDofs(self, group, fi):
+        from  .array import intArray
+        dofs = intArray()
+        _pfespace.ParFiniteElementSpace_GetSharedQuadrilateralDofs(self, group, fi, dofs)
+        return dofs.ToList()
+
+
 
     def Dof_TrueDof_Matrix(self):
         r"""Dof_TrueDof_Matrix(ParFiniteElementSpace self) -> HypreParMatrix"""

--- a/mfem/_par/pgridfunc.py
+++ b/mfem/_par/pgridfunc.py
@@ -418,6 +418,11 @@ class ParGridFunction(mfem._par.gridfunc.GridFunction):
         return _pgridfunc.ParGridFunction_Save(self, *args)
     Save = _swig_new_instance_method(_pgridfunc.ParGridFunction_Save)
 
+    def SaveGZ(self, file, precision=8):
+        r"""SaveGZ(ParGridFunction self, char const * file, int precision=8)"""
+        return _pgridfunc.ParGridFunction_SaveGZ(self, file, precision)
+    SaveGZ = _swig_new_instance_method(_pgridfunc.ParGridFunction_SaveGZ)
+
     def SaveAsOne(self, *args):
         r"""
         SaveAsOne(ParGridFunction self, std::ostream & out=out)
@@ -425,6 +430,11 @@ class ParGridFunction(mfem._par.gridfunc.GridFunction):
         """
         return _pgridfunc.ParGridFunction_SaveAsOne(self, *args)
     SaveAsOne = _swig_new_instance_method(_pgridfunc.ParGridFunction_SaveAsOne)
+
+    def SaveAsOneGZ(self, file, precision=8):
+        r"""SaveAsOneGZ(ParGridFunction self, char const * file, int precision=8)"""
+        return _pgridfunc.ParGridFunction_SaveAsOneGZ(self, file, precision)
+    SaveAsOneGZ = _swig_new_instance_method(_pgridfunc.ParGridFunction_SaveAsOneGZ)
 
 # Register ParGridFunction in _pgridfunc:
 _pgridfunc.ParGridFunction_swigregister(ParGridFunction)

--- a/mfem/_par/pgridfunc_wrap.cxx
+++ b/mfem/_par/pgridfunc_wrap.cxx
@@ -3752,6 +3752,17 @@ SWIGINTERN void mfem_ParGridFunction_Save__SWIG_1(mfem::ParGridFunction *self,ch
   self -> Save(ofile);
   ofile.close();
   }
+SWIGINTERN void mfem_ParGridFunction_SaveGZ(mfem::ParGridFunction *self,char const *file,int precision=8){
+  mfem::ofgzstream *ofile = new mfem::ofgzstream(file, true);
+  if (!ofile)
+     {
+        std::cerr << "\nCan not produce output file: " << file << '\n' << std::endl;
+        return;
+      }
+  ofile ->precision(precision);  
+  self -> Save(*ofile);
+  delete ofile;
+  }
 SWIGINTERN void mfem_ParGridFunction_SaveAsOne__SWIG_1(mfem::ParGridFunction *self,char const *file,int precision=8){
   std::ofstream ofile(file);
   if (!ofile)
@@ -3762,6 +3773,17 @@ SWIGINTERN void mfem_ParGridFunction_SaveAsOne__SWIG_1(mfem::ParGridFunction *se
   ofile.precision(precision);  
   self -> SaveAsOne(ofile);
   ofile.close();
+  }
+SWIGINTERN void mfem_ParGridFunction_SaveAsOneGZ(mfem::ParGridFunction *self,char const *file,int precision=8){
+  mfem::ofgzstream *ofile = new mfem::ofgzstream(file, true);
+  if (!ofile)
+     {
+        std::cerr << "\nCan not produce output file: " << file << '\n' << std::endl;
+        return;
+      }
+  ofile ->precision(precision);  
+  self -> SaveAsOne(*ofile);
+  delete ofile;
   }
 
 
@@ -4162,14 +4184,20 @@ SWIGINTERN PyObject *_wrap_new_ParGridFunction__SWIG_7(PyObject *SWIGUNUSEDPARM(
       }
     }
     if (stream2 == 0){
-      if (temp2->isGZ()){
-        in_gz2 = new mfem::ifgzstream(temp2->getFilename());
-        arg2 = in_gz2;
-      } else {
-        in_txt2.open(temp2->getFilename(), std::ifstream::in);
-        in_txt2.precision(temp2->getPrecision());
-        arg2 = &in_txt2;
-      }
+      /*
+            if (temp2->isGZ()){
+        	 in_gz2 = new mfem::ifgzstream(temp2->getFilename());
+               arg2 = in_gz2;
+            } else {
+        	 in_txt2.open(temp2->getFilename(), std::ifstream::in);
+               in_txt2.precision(temp2->getPrecision());
+               arg2 = &in_txt2;
+            }
+           */
+      /* this will auto-detect the input file type */
+      in_gz2 = new mfem::ifgzstream(temp2->getFilename());
+      arg2 = in_gz2;
+      
       if (temp2->isTemporary()){
         delete temp2;
       }
@@ -4191,18 +4219,6 @@ SWIGINTERN PyObject *_wrap_new_ParGridFunction__SWIG_7(PyObject *SWIGUNUSEDPARM(
     //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__ParGridFunction, SWIG_POINTER_NEW |  0 );
-  {
-    if (stream2) {
-      ret2 = PyLong_FromSsize_t(len2);
-      if (PyErr_Occurred()) {
-        PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
-        return NULL;
-      }
-      delete stream2;    
-      Py_XDECREF(resultobj);   /* Blow away any previous result */
-      resultobj = ret2;    
-    }
-  }
   {
     if (!stream2) {
       if (temp2) {
@@ -10683,6 +10699,64 @@ fail:
 }
 
 
+SWIGINTERN PyObject *_wrap_ParGridFunction_SaveGZ(PyObject *SWIGUNUSEDPARM(self), PyObject *args, PyObject *kwargs) {
+  PyObject *resultobj = 0;
+  mfem::ParGridFunction *arg1 = (mfem::ParGridFunction *) 0 ;
+  char *arg2 = (char *) 0 ;
+  int arg3 = (int) 8 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int res2 ;
+  char *buf2 = 0 ;
+  int alloc2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  char * kwnames[] = {
+    (char *)"self",  (char *)"file",  (char *)"precision",  NULL 
+  };
+  
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OO|O:ParGridFunction_SaveGZ", kwnames, &obj0, &obj1, &obj2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_mfem__ParGridFunction, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "ParGridFunction_SaveGZ" "', argument " "1"" of type '" "mfem::ParGridFunction *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::ParGridFunction * >(argp1);
+  res2 = SWIG_AsCharPtrAndSize(obj1, &buf2, NULL, &alloc2);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "ParGridFunction_SaveGZ" "', argument " "2"" of type '" "char const *""'");
+  }
+  arg2 = reinterpret_cast< char * >(buf2);
+  if (obj2) {
+    {
+      if ((PyArray_PyIntAsInt(obj2) == -1) && PyErr_Occurred()) {
+        SWIG_exception_fail(SWIG_TypeError, "Input must be integer");
+      };  
+      arg3 = PyArray_PyIntAsInt(obj2);
+    }
+  }
+  {
+    try {
+      mfem_ParGridFunction_SaveGZ(arg1,(char const *)arg2,arg3); 
+    }
+    catch (Swig::DirectorException &e) {
+      SWIG_fail; 
+    }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
+  }
+  resultobj = SWIG_Py_Void();
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return resultobj;
+fail:
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return NULL;
+}
+
+
 SWIGINTERN PyObject *_wrap_ParGridFunction_SaveAsOne__SWIG_1(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
   PyObject *resultobj = 0;
   mfem::ParGridFunction *arg1 = (mfem::ParGridFunction *) 0 ;
@@ -10818,6 +10892,64 @@ fail:
     "    mfem::ParGridFunction::SaveAsOne(std::ostream &)\n"
     "    mfem::ParGridFunction::SaveAsOne(char const *,int)\n");
   return 0;
+}
+
+
+SWIGINTERN PyObject *_wrap_ParGridFunction_SaveAsOneGZ(PyObject *SWIGUNUSEDPARM(self), PyObject *args, PyObject *kwargs) {
+  PyObject *resultobj = 0;
+  mfem::ParGridFunction *arg1 = (mfem::ParGridFunction *) 0 ;
+  char *arg2 = (char *) 0 ;
+  int arg3 = (int) 8 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int res2 ;
+  char *buf2 = 0 ;
+  int alloc2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  char * kwnames[] = {
+    (char *)"self",  (char *)"file",  (char *)"precision",  NULL 
+  };
+  
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OO|O:ParGridFunction_SaveAsOneGZ", kwnames, &obj0, &obj1, &obj2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_mfem__ParGridFunction, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "ParGridFunction_SaveAsOneGZ" "', argument " "1"" of type '" "mfem::ParGridFunction *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::ParGridFunction * >(argp1);
+  res2 = SWIG_AsCharPtrAndSize(obj1, &buf2, NULL, &alloc2);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "ParGridFunction_SaveAsOneGZ" "', argument " "2"" of type '" "char const *""'");
+  }
+  arg2 = reinterpret_cast< char * >(buf2);
+  if (obj2) {
+    {
+      if ((PyArray_PyIntAsInt(obj2) == -1) && PyErr_Occurred()) {
+        SWIG_exception_fail(SWIG_TypeError, "Input must be integer");
+      };  
+      arg3 = PyArray_PyIntAsInt(obj2);
+    }
+  }
+  {
+    try {
+      mfem_ParGridFunction_SaveAsOneGZ(arg1,(char const *)arg2,arg3); 
+    }
+    catch (Swig::DirectorException &e) {
+      SWIG_fail; 
+    }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
+  }
+  resultobj = SWIG_Py_Void();
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return resultobj;
+fail:
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return NULL;
 }
 
 
@@ -11088,10 +11220,12 @@ static PyMethodDef SwigMethods[] = {
 		"ParGridFunction_Save(ParGridFunction self, std::ostream & out)\n"
 		"ParGridFunction_Save(ParGridFunction self, char const * file, int precision=8)\n"
 		""},
+	 { "ParGridFunction_SaveGZ", (PyCFunction)(void(*)(void))_wrap_ParGridFunction_SaveGZ, METH_VARARGS|METH_KEYWORDS, "ParGridFunction_SaveGZ(ParGridFunction self, char const * file, int precision=8)"},
 	 { "ParGridFunction_SaveAsOne", _wrap_ParGridFunction_SaveAsOne, METH_VARARGS, "\n"
 		"ParGridFunction_SaveAsOne(ParGridFunction self, std::ostream & out=out)\n"
 		"ParGridFunction_SaveAsOne(ParGridFunction self, char const * file, int precision=8)\n"
 		""},
+	 { "ParGridFunction_SaveAsOneGZ", (PyCFunction)(void(*)(void))_wrap_ParGridFunction_SaveAsOneGZ, METH_VARARGS|METH_KEYWORDS, "ParGridFunction_SaveAsOneGZ(ParGridFunction self, char const * file, int precision=8)"},
 	 { "ParGridFunction_swigregister", ParGridFunction_swigregister, METH_O, NULL},
 	 { "ParGridFunction_swiginit", ParGridFunction_swiginit, METH_VARARGS, NULL},
 	 { "L2ZZErrorEstimator", (PyCFunction)(void(*)(void))_wrap_L2ZZErrorEstimator, METH_VARARGS|METH_KEYWORDS, "L2ZZErrorEstimator(BilinearFormIntegrator flux_integrator, ParGridFunction x, ParFiniteElementSpace smooth_flux_fes, ParFiniteElementSpace flux_fes, Vector errors, int norm_p=2, double solver_tol=1e-12, int solver_max_it=200) -> double"},
@@ -11235,10 +11369,12 @@ static PyMethodDef SwigMethods_proxydocs[] = {
 		"Save(ParGridFunction self, std::ostream & out)\n"
 		"Save(ParGridFunction self, char const * file, int precision=8)\n"
 		""},
+	 { "ParGridFunction_SaveGZ", (PyCFunction)(void(*)(void))_wrap_ParGridFunction_SaveGZ, METH_VARARGS|METH_KEYWORDS, "SaveGZ(ParGridFunction self, char const * file, int precision=8)"},
 	 { "ParGridFunction_SaveAsOne", _wrap_ParGridFunction_SaveAsOne, METH_VARARGS, "\n"
 		"SaveAsOne(ParGridFunction self, std::ostream & out=out)\n"
 		"SaveAsOne(ParGridFunction self, char const * file, int precision=8)\n"
 		""},
+	 { "ParGridFunction_SaveAsOneGZ", (PyCFunction)(void(*)(void))_wrap_ParGridFunction_SaveAsOneGZ, METH_VARARGS|METH_KEYWORDS, "SaveAsOneGZ(ParGridFunction self, char const * file, int precision=8)"},
 	 { "ParGridFunction_swigregister", ParGridFunction_swigregister, METH_O, NULL},
 	 { "ParGridFunction_swiginit", ParGridFunction_swiginit, METH_VARARGS, NULL},
 	 { "L2ZZErrorEstimator", (PyCFunction)(void(*)(void))_wrap_L2ZZErrorEstimator, METH_VARARGS|METH_KEYWORDS, "L2ZZErrorEstimator(BilinearFormIntegrator flux_integrator, ParGridFunction x, ParFiniteElementSpace smooth_flux_fes, ParFiniteElementSpace flux_fes, Vector errors, int norm_p=2, double solver_tol=1e-12, int solver_max_it=200) -> double"},

--- a/mfem/_par/pmesh.i
+++ b/mfem/_par/pmesh.i
@@ -55,10 +55,10 @@ def GroupFace(self, group, i, *args):
         from mfem.par import intp    
         face = intp()
         o = intp()
-        _pmesh.Mesh_ParGroupFace(self, group, i, face, o)      
+        $action(self, group, i, face, o)      
         return face.value(), o.value()
     else:
-        return _pmesh.ParMesh_GroupFace(self, group, i, *args)            
+        return $action(self, group, i, *args)            
 %}
 	  
 %feature("shadow") mfem::ParMesh::GroupEdge %{
@@ -67,10 +67,10 @@ def GroupEdge(self, group, i, *args):
         from mfem.par import intp  
         edge = intp()
         o = intp()  
-        _pmesh.ParMesh_GroupEdge(self, group, i, edge, o)
+        $action(self, group, i, edge, o)
         return edge.value(), o.value()
     else:
-        return _pmesh.ParMesh_GroupEdge(self, group, i, *args)      
+        return $action(self, group, i, *args)      
 %}
 
 

--- a/mfem/_par/pmesh.py
+++ b/mfem/_par/pmesh.py
@@ -312,7 +312,7 @@ class ParMesh(mfem._par.mesh.Mesh):
         from  .vector import Vector
         min = Vector()
         max = Vector()      
-        _mesh.Mesh_GetBoundingBox(self, min, max, ref)      
+        _pmesh.ParMesh_GetBoundingBox(self, min, max, ref)      
         return min.GetDataArray().copy(), max.GetDataArray().copy()
 
 
@@ -337,7 +337,7 @@ class ParMesh(mfem._par.mesh.Mesh):
         M.Assign(pp)
         elem_ids = mfem.intArray()
         int_points = mfem.IntegrationPointArray()
-        count = _mesh.Mesh_FindPoints(self, M, elem_ids, int_points, warn, inv_trans)      
+        count = _pmesh.ParMesh_FindPoints(self, M, elem_ids, int_points, warn, inv_trans)      
         elem_ids = elem_ids.ToList()
         return count, elem_ids, int_points
 

--- a/mfem/_par/pmesh.py
+++ b/mfem/_par/pmesh.py
@@ -362,6 +362,11 @@ class ParMesh(mfem._par.mesh.Mesh):
         return _pmesh.ParMesh_Print(self, *args)
     Print = _swig_new_instance_method(_pmesh.ParMesh_Print)
 
+    def PrintGZ(self, file, precision=8):
+        r"""PrintGZ(ParMesh self, char const * file, int precision=8)"""
+        return _pmesh.ParMesh_PrintGZ(self, file, precision)
+    PrintGZ = _swig_new_instance_method(_pmesh.ParMesh_PrintGZ)
+
     def PrintXG(self, *args):
         r"""
         PrintXG(ParMesh self, std::ostream & out=out)
@@ -369,6 +374,11 @@ class ParMesh(mfem._par.mesh.Mesh):
         """
         return _pmesh.ParMesh_PrintXG(self, *args)
     PrintXG = _swig_new_instance_method(_pmesh.ParMesh_PrintXG)
+
+    def PrintXGGZ(self, file, precision=8):
+        r"""PrintXGGZ(ParMesh self, char const * file, int precision=8)"""
+        return _pmesh.ParMesh_PrintXGGZ(self, file, precision)
+    PrintXGGZ = _swig_new_instance_method(_pmesh.ParMesh_PrintXGGZ)
 
     def PrintAsOne(self, *args):
         r"""
@@ -378,6 +388,11 @@ class ParMesh(mfem._par.mesh.Mesh):
         return _pmesh.ParMesh_PrintAsOne(self, *args)
     PrintAsOne = _swig_new_instance_method(_pmesh.ParMesh_PrintAsOne)
 
+    def PrintAsOneGZ(self, file, precision=8):
+        r"""PrintAsOneGZ(ParMesh self, char const * file, int precision=8)"""
+        return _pmesh.ParMesh_PrintAsOneGZ(self, file, precision)
+    PrintAsOneGZ = _swig_new_instance_method(_pmesh.ParMesh_PrintAsOneGZ)
+
     def PrintAsOneXG(self, *args):
         r"""
         PrintAsOneXG(ParMesh self, std::ostream & out=out)
@@ -386,6 +401,11 @@ class ParMesh(mfem._par.mesh.Mesh):
         return _pmesh.ParMesh_PrintAsOneXG(self, *args)
     PrintAsOneXG = _swig_new_instance_method(_pmesh.ParMesh_PrintAsOneXG)
 
+    def PrintAsOneXGGZ(self, file, precision=8):
+        r"""PrintAsOneXGGZ(ParMesh self, char const * file, int precision=8)"""
+        return _pmesh.ParMesh_PrintAsOneXGGZ(self, file, precision)
+    PrintAsOneXGGZ = _swig_new_instance_method(_pmesh.ParMesh_PrintAsOneXGGZ)
+
     def PrintInfo(self, *args):
         r"""
         PrintInfo(ParMesh self, std::ostream & out=out)
@@ -393,6 +413,16 @@ class ParMesh(mfem._par.mesh.Mesh):
         """
         return _pmesh.ParMesh_PrintInfo(self, *args)
     PrintInfo = _swig_new_instance_method(_pmesh.ParMesh_PrintInfo)
+
+    def PrintInfoGZ(self, file, precision=8):
+        r"""PrintInfoGZ(ParMesh self, char const * file, int precision=8)"""
+        return _pmesh.ParMesh_PrintInfoGZ(self, file, precision)
+    PrintInfoGZ = _swig_new_instance_method(_pmesh.ParMesh_PrintInfoGZ)
+
+    def ParPrintGZ(self, file, precision=8):
+        r"""ParPrintGZ(ParMesh self, char const * file, int precision=8)"""
+        return _pmesh.ParMesh_ParPrintGZ(self, file, precision)
+    ParPrintGZ = _swig_new_instance_method(_pmesh.ParMesh_ParPrintGZ)
 
     def ParPrint(self, *args):
         r"""

--- a/mfem/_par/pmesh_wrap.cxx
+++ b/mfem/_par/pmesh_wrap.cxx
@@ -3673,6 +3673,17 @@ SWIGINTERN void mfem_ParMesh_Print__SWIG_1(mfem::ParMesh *self,char const *file,
   self -> Print(ofile);
   ofile.close();
   }
+SWIGINTERN void mfem_ParMesh_PrintGZ(mfem::ParMesh *self,char const *file,int precision=8){
+  mfem::ofgzstream *ofile = new mfem::ofgzstream(file, true);
+  if (!ofile)
+     {
+        std::cerr << "\nCan not produce output file: " << file << '\n' << std::endl;
+        return;
+      }
+  ofile ->precision(precision);  
+  self -> Print(*ofile);
+  delete ofile;
+  }
 SWIGINTERN void mfem_ParMesh_PrintXG__SWIG_1(mfem::ParMesh *self,char const *file,int precision=8){
   std::ofstream ofile(file);
   if (!ofile)
@@ -3683,6 +3694,17 @@ SWIGINTERN void mfem_ParMesh_PrintXG__SWIG_1(mfem::ParMesh *self,char const *fil
   ofile.precision(precision);  
   self -> PrintXG(ofile);
   ofile.close();
+  }
+SWIGINTERN void mfem_ParMesh_PrintXGGZ(mfem::ParMesh *self,char const *file,int precision=8){
+  mfem::ofgzstream *ofile = new mfem::ofgzstream(file, true);
+  if (!ofile)
+     {
+        std::cerr << "\nCan not produce output file: " << file << '\n' << std::endl;
+        return;
+      }
+  ofile ->precision(precision);  
+  self -> PrintXG(*ofile);
+  delete ofile;
   }
 SWIGINTERN void mfem_ParMesh_PrintAsOne__SWIG_1(mfem::ParMesh *self,char const *file,int precision=8){
   std::ofstream ofile(file);
@@ -3695,6 +3717,17 @@ SWIGINTERN void mfem_ParMesh_PrintAsOne__SWIG_1(mfem::ParMesh *self,char const *
   self -> PrintAsOne(ofile);
   ofile.close();
   }
+SWIGINTERN void mfem_ParMesh_PrintAsOneGZ(mfem::ParMesh *self,char const *file,int precision=8){
+  mfem::ofgzstream *ofile = new mfem::ofgzstream(file, true);
+  if (!ofile)
+     {
+        std::cerr << "\nCan not produce output file: " << file << '\n' << std::endl;
+        return;
+      }
+  ofile ->precision(precision);  
+  self -> PrintAsOne(*ofile);
+  delete ofile;
+  }
 SWIGINTERN void mfem_ParMesh_PrintAsOneXG__SWIG_1(mfem::ParMesh *self,char const *file,int precision=8){
   std::ofstream ofile(file);
   if (!ofile)
@@ -3705,6 +3738,17 @@ SWIGINTERN void mfem_ParMesh_PrintAsOneXG__SWIG_1(mfem::ParMesh *self,char const
   ofile.precision(precision);  
   self -> PrintAsOneXG(ofile);
   ofile.close();
+  }
+SWIGINTERN void mfem_ParMesh_PrintAsOneXGGZ(mfem::ParMesh *self,char const *file,int precision=8){
+  mfem::ofgzstream *ofile = new mfem::ofgzstream(file, true);
+  if (!ofile)
+     {
+        std::cerr << "\nCan not produce output file: " << file << '\n' << std::endl;
+        return;
+      }
+  ofile ->precision(precision);  
+  self -> PrintAsOneXG(*ofile);
+  delete ofile;
   }
 SWIGINTERN void mfem_ParMesh_PrintInfo__SWIG_1(mfem::ParMesh *self,char const *file,int precision=8){
   std::ofstream ofile(file);
@@ -3717,6 +3761,17 @@ SWIGINTERN void mfem_ParMesh_PrintInfo__SWIG_1(mfem::ParMesh *self,char const *f
   self -> PrintInfo(ofile);
   ofile.close();
   }
+SWIGINTERN void mfem_ParMesh_PrintInfoGZ(mfem::ParMesh *self,char const *file,int precision=8){
+  mfem::ofgzstream *ofile = new mfem::ofgzstream(file, true);
+  if (!ofile)
+     {
+        std::cerr << "\nCan not produce output file: " << file << '\n' << std::endl;
+        return;
+      }
+  ofile ->precision(precision);  
+  self -> PrintInfo(*ofile);
+  delete ofile;
+  }
 SWIGINTERN void mfem_ParMesh_ParPrint__SWIG_1(mfem::ParMesh *self,char const *file,int precision=8){
   std::ofstream ofile(file);
   if (!ofile)
@@ -3727,6 +3782,18 @@ SWIGINTERN void mfem_ParMesh_ParPrint__SWIG_1(mfem::ParMesh *self,char const *fi
   ofile.precision(precision);    
   self -> ParPrint(ofile);
   ofile.close();
+  }
+SWIGINTERN void mfem_ParMesh_ParPrintGZ(mfem::ParMesh *self,char const *file,int precision=8){
+  mfem::ofgzstream *ofile = new mfem::ofgzstream(file, true);
+  
+  if (!ofile)
+     {
+        std::cerr << "\nCan not produce output file: " << file << '\n' << std::endl;
+        return;
+      }
+  ofile -> precision(precision);  
+  self -> ParPrint(*ofile);
+  delete ofile;
   }
 SWIGINTERN void mfem_ParMesh_ParPrint__SWIG_2(mfem::ParMesh *self){
   self -> ParPrint(std::cout);
@@ -3921,14 +3988,20 @@ SWIGINTERN PyObject *_wrap_new_ParMesh__SWIG_4(PyObject *SWIGUNUSEDPARM(self), P
       }
     }
     if (stream2 == 0){
-      if (temp2->isGZ()){
-        in_gz2 = new mfem::ifgzstream(temp2->getFilename());
-        arg2 = in_gz2;
-      } else {
-        in_txt2.open(temp2->getFilename(), std::ifstream::in);
-        in_txt2.precision(temp2->getPrecision());
-        arg2 = &in_txt2;
-      }
+      /*
+            if (temp2->isGZ()){
+        	 in_gz2 = new mfem::ifgzstream(temp2->getFilename());
+               arg2 = in_gz2;
+            } else {
+        	 in_txt2.open(temp2->getFilename(), std::ifstream::in);
+               in_txt2.precision(temp2->getPrecision());
+               arg2 = &in_txt2;
+            }
+           */
+      /* this will auto-detect the input file type */
+      in_gz2 = new mfem::ifgzstream(temp2->getFilename());
+      arg2 = in_gz2;
+      
       if (temp2->isTemporary()){
         delete temp2;
       }
@@ -3957,18 +4030,6 @@ SWIGINTERN PyObject *_wrap_new_ParMesh__SWIG_4(PyObject *SWIGUNUSEDPARM(self), P
     //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__ParMesh, SWIG_POINTER_NEW |  0 );
-  {
-    if (stream2) {
-      ret2 = PyLong_FromSsize_t(len2);
-      if (PyErr_Occurred()) {
-        PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
-        return NULL;
-      }
-      delete stream2;    
-      Py_XDECREF(resultobj);   /* Blow away any previous result */
-      resultobj = ret2;    
-    }
-  }
   {
     if (!stream2) {
       if (temp2) {
@@ -7574,6 +7635,64 @@ fail:
 }
 
 
+SWIGINTERN PyObject *_wrap_ParMesh_PrintGZ(PyObject *SWIGUNUSEDPARM(self), PyObject *args, PyObject *kwargs) {
+  PyObject *resultobj = 0;
+  mfem::ParMesh *arg1 = (mfem::ParMesh *) 0 ;
+  char *arg2 = (char *) 0 ;
+  int arg3 = (int) 8 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int res2 ;
+  char *buf2 = 0 ;
+  int alloc2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  char * kwnames[] = {
+    (char *)"self",  (char *)"file",  (char *)"precision",  NULL 
+  };
+  
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OO|O:ParMesh_PrintGZ", kwnames, &obj0, &obj1, &obj2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_mfem__ParMesh, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "ParMesh_PrintGZ" "', argument " "1"" of type '" "mfem::ParMesh *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::ParMesh * >(argp1);
+  res2 = SWIG_AsCharPtrAndSize(obj1, &buf2, NULL, &alloc2);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "ParMesh_PrintGZ" "', argument " "2"" of type '" "char const *""'");
+  }
+  arg2 = reinterpret_cast< char * >(buf2);
+  if (obj2) {
+    {
+      if ((PyArray_PyIntAsInt(obj2) == -1) && PyErr_Occurred()) {
+        SWIG_exception_fail(SWIG_TypeError, "Input must be integer");
+      };  
+      arg3 = PyArray_PyIntAsInt(obj2);
+    }
+  }
+  {
+    try {
+      mfem_ParMesh_PrintGZ(arg1,(char const *)arg2,arg3); 
+    }
+    catch (Swig::DirectorException &e) {
+      SWIG_fail; 
+    }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
+  }
+  resultobj = SWIG_Py_Void();
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return resultobj;
+fail:
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return NULL;
+}
+
+
 SWIGINTERN PyObject *_wrap_ParMesh_PrintXG__SWIG_1(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
   PyObject *resultobj = 0;
   mfem::ParMesh *arg1 = (mfem::ParMesh *) 0 ;
@@ -7709,6 +7828,64 @@ fail:
     "    mfem::ParMesh::PrintXG(std::ostream &) const\n"
     "    mfem::ParMesh::PrintXG(char const *,int)\n");
   return 0;
+}
+
+
+SWIGINTERN PyObject *_wrap_ParMesh_PrintXGGZ(PyObject *SWIGUNUSEDPARM(self), PyObject *args, PyObject *kwargs) {
+  PyObject *resultobj = 0;
+  mfem::ParMesh *arg1 = (mfem::ParMesh *) 0 ;
+  char *arg2 = (char *) 0 ;
+  int arg3 = (int) 8 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int res2 ;
+  char *buf2 = 0 ;
+  int alloc2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  char * kwnames[] = {
+    (char *)"self",  (char *)"file",  (char *)"precision",  NULL 
+  };
+  
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OO|O:ParMesh_PrintXGGZ", kwnames, &obj0, &obj1, &obj2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_mfem__ParMesh, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "ParMesh_PrintXGGZ" "', argument " "1"" of type '" "mfem::ParMesh *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::ParMesh * >(argp1);
+  res2 = SWIG_AsCharPtrAndSize(obj1, &buf2, NULL, &alloc2);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "ParMesh_PrintXGGZ" "', argument " "2"" of type '" "char const *""'");
+  }
+  arg2 = reinterpret_cast< char * >(buf2);
+  if (obj2) {
+    {
+      if ((PyArray_PyIntAsInt(obj2) == -1) && PyErr_Occurred()) {
+        SWIG_exception_fail(SWIG_TypeError, "Input must be integer");
+      };  
+      arg3 = PyArray_PyIntAsInt(obj2);
+    }
+  }
+  {
+    try {
+      mfem_ParMesh_PrintXGGZ(arg1,(char const *)arg2,arg3); 
+    }
+    catch (Swig::DirectorException &e) {
+      SWIG_fail; 
+    }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
+  }
+  resultobj = SWIG_Py_Void();
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return resultobj;
+fail:
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return NULL;
 }
 
 
@@ -7850,6 +8027,64 @@ fail:
 }
 
 
+SWIGINTERN PyObject *_wrap_ParMesh_PrintAsOneGZ(PyObject *SWIGUNUSEDPARM(self), PyObject *args, PyObject *kwargs) {
+  PyObject *resultobj = 0;
+  mfem::ParMesh *arg1 = (mfem::ParMesh *) 0 ;
+  char *arg2 = (char *) 0 ;
+  int arg3 = (int) 8 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int res2 ;
+  char *buf2 = 0 ;
+  int alloc2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  char * kwnames[] = {
+    (char *)"self",  (char *)"file",  (char *)"precision",  NULL 
+  };
+  
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OO|O:ParMesh_PrintAsOneGZ", kwnames, &obj0, &obj1, &obj2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_mfem__ParMesh, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "ParMesh_PrintAsOneGZ" "', argument " "1"" of type '" "mfem::ParMesh *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::ParMesh * >(argp1);
+  res2 = SWIG_AsCharPtrAndSize(obj1, &buf2, NULL, &alloc2);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "ParMesh_PrintAsOneGZ" "', argument " "2"" of type '" "char const *""'");
+  }
+  arg2 = reinterpret_cast< char * >(buf2);
+  if (obj2) {
+    {
+      if ((PyArray_PyIntAsInt(obj2) == -1) && PyErr_Occurred()) {
+        SWIG_exception_fail(SWIG_TypeError, "Input must be integer");
+      };  
+      arg3 = PyArray_PyIntAsInt(obj2);
+    }
+  }
+  {
+    try {
+      mfem_ParMesh_PrintAsOneGZ(arg1,(char const *)arg2,arg3); 
+    }
+    catch (Swig::DirectorException &e) {
+      SWIG_fail; 
+    }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
+  }
+  resultobj = SWIG_Py_Void();
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return resultobj;
+fail:
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return NULL;
+}
+
+
 SWIGINTERN PyObject *_wrap_ParMesh_PrintAsOneXG__SWIG_1(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
   PyObject *resultobj = 0;
   mfem::ParMesh *arg1 = (mfem::ParMesh *) 0 ;
@@ -7985,6 +8220,64 @@ fail:
     "    mfem::ParMesh::PrintAsOneXG(std::ostream &)\n"
     "    mfem::ParMesh::PrintAsOneXG(char const *,int)\n");
   return 0;
+}
+
+
+SWIGINTERN PyObject *_wrap_ParMesh_PrintAsOneXGGZ(PyObject *SWIGUNUSEDPARM(self), PyObject *args, PyObject *kwargs) {
+  PyObject *resultobj = 0;
+  mfem::ParMesh *arg1 = (mfem::ParMesh *) 0 ;
+  char *arg2 = (char *) 0 ;
+  int arg3 = (int) 8 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int res2 ;
+  char *buf2 = 0 ;
+  int alloc2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  char * kwnames[] = {
+    (char *)"self",  (char *)"file",  (char *)"precision",  NULL 
+  };
+  
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OO|O:ParMesh_PrintAsOneXGGZ", kwnames, &obj0, &obj1, &obj2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_mfem__ParMesh, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "ParMesh_PrintAsOneXGGZ" "', argument " "1"" of type '" "mfem::ParMesh *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::ParMesh * >(argp1);
+  res2 = SWIG_AsCharPtrAndSize(obj1, &buf2, NULL, &alloc2);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "ParMesh_PrintAsOneXGGZ" "', argument " "2"" of type '" "char const *""'");
+  }
+  arg2 = reinterpret_cast< char * >(buf2);
+  if (obj2) {
+    {
+      if ((PyArray_PyIntAsInt(obj2) == -1) && PyErr_Occurred()) {
+        SWIG_exception_fail(SWIG_TypeError, "Input must be integer");
+      };  
+      arg3 = PyArray_PyIntAsInt(obj2);
+    }
+  }
+  {
+    try {
+      mfem_ParMesh_PrintAsOneXGGZ(arg1,(char const *)arg2,arg3); 
+    }
+    catch (Swig::DirectorException &e) {
+      SWIG_fail; 
+    }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
+  }
+  resultobj = SWIG_Py_Void();
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return resultobj;
+fail:
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return NULL;
 }
 
 
@@ -8126,6 +8419,64 @@ fail:
 }
 
 
+SWIGINTERN PyObject *_wrap_ParMesh_PrintInfoGZ(PyObject *SWIGUNUSEDPARM(self), PyObject *args, PyObject *kwargs) {
+  PyObject *resultobj = 0;
+  mfem::ParMesh *arg1 = (mfem::ParMesh *) 0 ;
+  char *arg2 = (char *) 0 ;
+  int arg3 = (int) 8 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int res2 ;
+  char *buf2 = 0 ;
+  int alloc2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  char * kwnames[] = {
+    (char *)"self",  (char *)"file",  (char *)"precision",  NULL 
+  };
+  
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OO|O:ParMesh_PrintInfoGZ", kwnames, &obj0, &obj1, &obj2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_mfem__ParMesh, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "ParMesh_PrintInfoGZ" "', argument " "1"" of type '" "mfem::ParMesh *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::ParMesh * >(argp1);
+  res2 = SWIG_AsCharPtrAndSize(obj1, &buf2, NULL, &alloc2);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "ParMesh_PrintInfoGZ" "', argument " "2"" of type '" "char const *""'");
+  }
+  arg2 = reinterpret_cast< char * >(buf2);
+  if (obj2) {
+    {
+      if ((PyArray_PyIntAsInt(obj2) == -1) && PyErr_Occurred()) {
+        SWIG_exception_fail(SWIG_TypeError, "Input must be integer");
+      };  
+      arg3 = PyArray_PyIntAsInt(obj2);
+    }
+  }
+  {
+    try {
+      mfem_ParMesh_PrintInfoGZ(arg1,(char const *)arg2,arg3); 
+    }
+    catch (Swig::DirectorException &e) {
+      SWIG_fail; 
+    }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
+  }
+  resultobj = SWIG_Py_Void();
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return resultobj;
+fail:
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return NULL;
+}
+
+
 SWIGINTERN PyObject *_wrap_ParMesh_ParPrint__SWIG_1(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
   PyObject *resultobj = 0;
   mfem::ParMesh *arg1 = (mfem::ParMesh *) 0 ;
@@ -8159,6 +8510,64 @@ SWIGINTERN PyObject *_wrap_ParMesh_ParPrint__SWIG_1(PyObject *SWIGUNUSEDPARM(sel
   {
     try {
       mfem_ParMesh_ParPrint__SWIG_1(arg1,(char const *)arg2,arg3); 
+    }
+    catch (Swig::DirectorException &e) {
+      SWIG_fail; 
+    }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
+  }
+  resultobj = SWIG_Py_Void();
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return resultobj;
+fail:
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_ParMesh_ParPrintGZ(PyObject *SWIGUNUSEDPARM(self), PyObject *args, PyObject *kwargs) {
+  PyObject *resultobj = 0;
+  mfem::ParMesh *arg1 = (mfem::ParMesh *) 0 ;
+  char *arg2 = (char *) 0 ;
+  int arg3 = (int) 8 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int res2 ;
+  char *buf2 = 0 ;
+  int alloc2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  char * kwnames[] = {
+    (char *)"self",  (char *)"file",  (char *)"precision",  NULL 
+  };
+  
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OO|O:ParMesh_ParPrintGZ", kwnames, &obj0, &obj1, &obj2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_mfem__ParMesh, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "ParMesh_ParPrintGZ" "', argument " "1"" of type '" "mfem::ParMesh *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::ParMesh * >(argp1);
+  res2 = SWIG_AsCharPtrAndSize(obj1, &buf2, NULL, &alloc2);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "ParMesh_ParPrintGZ" "', argument " "2"" of type '" "char const *""'");
+  }
+  arg2 = reinterpret_cast< char * >(buf2);
+  if (obj2) {
+    {
+      if ((PyArray_PyIntAsInt(obj2) == -1) && PyErr_Occurred()) {
+        SWIG_exception_fail(SWIG_TypeError, "Input must be integer");
+      };  
+      arg3 = PyArray_PyIntAsInt(obj2);
+    }
+  }
+  {
+    try {
+      mfem_ParMesh_ParPrintGZ(arg1,(char const *)arg2,arg3); 
     }
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
@@ -8385,22 +8794,28 @@ static PyMethodDef SwigMethods[] = {
 		"ParMesh_Print(ParMesh self, std::ostream & out=out)\n"
 		"ParMesh_Print(ParMesh self, char const * file, int precision=8)\n"
 		""},
+	 { "ParMesh_PrintGZ", (PyCFunction)(void(*)(void))_wrap_ParMesh_PrintGZ, METH_VARARGS|METH_KEYWORDS, "ParMesh_PrintGZ(ParMesh self, char const * file, int precision=8)"},
 	 { "ParMesh_PrintXG", _wrap_ParMesh_PrintXG, METH_VARARGS, "\n"
 		"ParMesh_PrintXG(ParMesh self, std::ostream & out=out)\n"
 		"ParMesh_PrintXG(ParMesh self, char const * file, int precision=8)\n"
 		""},
+	 { "ParMesh_PrintXGGZ", (PyCFunction)(void(*)(void))_wrap_ParMesh_PrintXGGZ, METH_VARARGS|METH_KEYWORDS, "ParMesh_PrintXGGZ(ParMesh self, char const * file, int precision=8)"},
 	 { "ParMesh_PrintAsOne", _wrap_ParMesh_PrintAsOne, METH_VARARGS, "\n"
 		"ParMesh_PrintAsOne(ParMesh self, std::ostream & out=out)\n"
 		"ParMesh_PrintAsOne(ParMesh self, char const * file, int precision=8)\n"
 		""},
+	 { "ParMesh_PrintAsOneGZ", (PyCFunction)(void(*)(void))_wrap_ParMesh_PrintAsOneGZ, METH_VARARGS|METH_KEYWORDS, "ParMesh_PrintAsOneGZ(ParMesh self, char const * file, int precision=8)"},
 	 { "ParMesh_PrintAsOneXG", _wrap_ParMesh_PrintAsOneXG, METH_VARARGS, "\n"
 		"ParMesh_PrintAsOneXG(ParMesh self, std::ostream & out=out)\n"
 		"ParMesh_PrintAsOneXG(ParMesh self, char const * file, int precision=8)\n"
 		""},
+	 { "ParMesh_PrintAsOneXGGZ", (PyCFunction)(void(*)(void))_wrap_ParMesh_PrintAsOneXGGZ, METH_VARARGS|METH_KEYWORDS, "ParMesh_PrintAsOneXGGZ(ParMesh self, char const * file, int precision=8)"},
 	 { "ParMesh_PrintInfo", _wrap_ParMesh_PrintInfo, METH_VARARGS, "\n"
 		"ParMesh_PrintInfo(ParMesh self, std::ostream & out=out)\n"
 		"ParMesh_PrintInfo(ParMesh self, char const * file, int precision=8)\n"
 		""},
+	 { "ParMesh_PrintInfoGZ", (PyCFunction)(void(*)(void))_wrap_ParMesh_PrintInfoGZ, METH_VARARGS|METH_KEYWORDS, "ParMesh_PrintInfoGZ(ParMesh self, char const * file, int precision=8)"},
+	 { "ParMesh_ParPrintGZ", (PyCFunction)(void(*)(void))_wrap_ParMesh_ParPrintGZ, METH_VARARGS|METH_KEYWORDS, "ParMesh_ParPrintGZ(ParMesh self, char const * file, int precision=8)"},
 	 { "ParMesh_ParPrint", _wrap_ParMesh_ParPrint, METH_VARARGS, "\n"
 		"ParMesh_ParPrint(ParMesh self, std::ostream & out)\n"
 		"ParMesh_ParPrint(ParMesh self, char const * file, int precision=8)\n"
@@ -8482,22 +8897,28 @@ static PyMethodDef SwigMethods_proxydocs[] = {
 		"Print(ParMesh self, std::ostream & out=out)\n"
 		"Print(ParMesh self, char const * file, int precision=8)\n"
 		""},
+	 { "ParMesh_PrintGZ", (PyCFunction)(void(*)(void))_wrap_ParMesh_PrintGZ, METH_VARARGS|METH_KEYWORDS, "PrintGZ(ParMesh self, char const * file, int precision=8)"},
 	 { "ParMesh_PrintXG", _wrap_ParMesh_PrintXG, METH_VARARGS, "\n"
 		"PrintXG(ParMesh self, std::ostream & out=out)\n"
 		"PrintXG(ParMesh self, char const * file, int precision=8)\n"
 		""},
+	 { "ParMesh_PrintXGGZ", (PyCFunction)(void(*)(void))_wrap_ParMesh_PrintXGGZ, METH_VARARGS|METH_KEYWORDS, "PrintXGGZ(ParMesh self, char const * file, int precision=8)"},
 	 { "ParMesh_PrintAsOne", _wrap_ParMesh_PrintAsOne, METH_VARARGS, "\n"
 		"PrintAsOne(ParMesh self, std::ostream & out=out)\n"
 		"PrintAsOne(ParMesh self, char const * file, int precision=8)\n"
 		""},
+	 { "ParMesh_PrintAsOneGZ", (PyCFunction)(void(*)(void))_wrap_ParMesh_PrintAsOneGZ, METH_VARARGS|METH_KEYWORDS, "PrintAsOneGZ(ParMesh self, char const * file, int precision=8)"},
 	 { "ParMesh_PrintAsOneXG", _wrap_ParMesh_PrintAsOneXG, METH_VARARGS, "\n"
 		"PrintAsOneXG(ParMesh self, std::ostream & out=out)\n"
 		"PrintAsOneXG(ParMesh self, char const * file, int precision=8)\n"
 		""},
+	 { "ParMesh_PrintAsOneXGGZ", (PyCFunction)(void(*)(void))_wrap_ParMesh_PrintAsOneXGGZ, METH_VARARGS|METH_KEYWORDS, "PrintAsOneXGGZ(ParMesh self, char const * file, int precision=8)"},
 	 { "ParMesh_PrintInfo", _wrap_ParMesh_PrintInfo, METH_VARARGS, "\n"
 		"PrintInfo(ParMesh self, std::ostream & out=out)\n"
 		"PrintInfo(ParMesh self, char const * file, int precision=8)\n"
 		""},
+	 { "ParMesh_PrintInfoGZ", (PyCFunction)(void(*)(void))_wrap_ParMesh_PrintInfoGZ, METH_VARARGS|METH_KEYWORDS, "PrintInfoGZ(ParMesh self, char const * file, int precision=8)"},
+	 { "ParMesh_ParPrintGZ", (PyCFunction)(void(*)(void))_wrap_ParMesh_ParPrintGZ, METH_VARARGS|METH_KEYWORDS, "ParPrintGZ(ParMesh self, char const * file, int precision=8)"},
 	 { "ParMesh_ParPrint", _wrap_ParMesh_ParPrint, METH_VARARGS, "\n"
 		"ParPrint(ParMesh self, std::ostream & out)\n"
 		"ParPrint(ParMesh self, char const * file, int precision=8)\n"

--- a/mfem/_par/pumi_wrap.cxx
+++ b/mfem/_par/pumi_wrap.cxx
@@ -3653,14 +3653,20 @@ SWIGINTERN PyObject *_wrap_PumiMesh_Load__SWIG_0_0(PyObject *SWIGUNUSEDPARM(self
       }
     }
     if (stream2 == 0){
-      if (temp2->isGZ()){
-        in_gz2 = new mfem::ifgzstream(temp2->getFilename());
-        arg2 = in_gz2;
-      } else {
-        in_txt2.open(temp2->getFilename(), std::ifstream::in);
-        in_txt2.precision(temp2->getPrecision());
-        arg2 = &in_txt2;
-      }
+      /*
+            if (temp2->isGZ()){
+        	 in_gz2 = new mfem::ifgzstream(temp2->getFilename());
+               arg2 = in_gz2;
+            } else {
+        	 in_txt2.open(temp2->getFilename(), std::ifstream::in);
+               in_txt2.precision(temp2->getPrecision());
+               arg2 = &in_txt2;
+            }
+           */
+      /* this will auto-detect the input file type */
+      in_gz2 = new mfem::ifgzstream(temp2->getFilename());
+      arg2 = in_gz2;
+      
       if (temp2->isTemporary()){
         delete temp2;
       }
@@ -3705,18 +3711,6 @@ SWIGINTERN PyObject *_wrap_PumiMesh_Load__SWIG_0_0(PyObject *SWIGUNUSEDPARM(self
     //    catch (std::exception &e) { SWIG_fail; }    
   }
   resultobj = SWIG_Py_Void();
-  {
-    if (stream2) {
-      ret2 = PyLong_FromSsize_t(len2);
-      if (PyErr_Occurred()) {
-        PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
-        return NULL;
-      }
-      delete stream2;    
-      Py_XDECREF(resultobj);   /* Blow away any previous result */
-      resultobj = ret2;    
-    }
-  }
   {
     if (!stream2) {
       if (temp2) {

--- a/mfem/_par/sparsemat.py
+++ b/mfem/_par/sparsemat.py
@@ -806,6 +806,11 @@ class SparseMatrix(mfem._par.matrix.AbstractSparseMatrix):
         return _sparsemat.SparseMatrix_Print(self, *args)
     Print = _swig_new_instance_method(_sparsemat.SparseMatrix_Print)
 
+    def PrintGZ(self, file, precision=8):
+        r"""PrintGZ(SparseMatrix self, char const * file, int precision=8)"""
+        return _sparsemat.SparseMatrix_PrintGZ(self, file, precision)
+    PrintGZ = _swig_new_instance_method(_sparsemat.SparseMatrix_PrintGZ)
+
     def PrintMatlab(self, *args):
         r"""
         PrintMatlab(SparseMatrix self, std::ostream & out=mfem::out)
@@ -814,6 +819,11 @@ class SparseMatrix(mfem._par.matrix.AbstractSparseMatrix):
         return _sparsemat.SparseMatrix_PrintMatlab(self, *args)
     PrintMatlab = _swig_new_instance_method(_sparsemat.SparseMatrix_PrintMatlab)
 
+    def PrintMatlabGZ(self, file, precision=8):
+        r"""PrintMatlabGZ(SparseMatrix self, char const * file, int precision=8)"""
+        return _sparsemat.SparseMatrix_PrintMatlabGZ(self, file, precision)
+    PrintMatlabGZ = _swig_new_instance_method(_sparsemat.SparseMatrix_PrintMatlabGZ)
+
     def PrintMM(self, *args):
         r"""
         PrintMM(SparseMatrix self, std::ostream & out=mfem::out)
@@ -821,6 +831,16 @@ class SparseMatrix(mfem._par.matrix.AbstractSparseMatrix):
         """
         return _sparsemat.SparseMatrix_PrintMM(self, *args)
     PrintMM = _swig_new_instance_method(_sparsemat.SparseMatrix_PrintMM)
+
+    def PrintMMGZ(self, file, precision=8):
+        r"""PrintMMGZ(SparseMatrix self, char const * file, int precision=8)"""
+        return _sparsemat.SparseMatrix_PrintMMGZ(self, file, precision)
+    PrintMMGZ = _swig_new_instance_method(_sparsemat.SparseMatrix_PrintMMGZ)
+
+    def PrintCSRGZ(self, file, precision=8):
+        r"""PrintCSRGZ(SparseMatrix self, char const * file, int precision=8)"""
+        return _sparsemat.SparseMatrix_PrintCSRGZ(self, file, precision)
+    PrintCSRGZ = _swig_new_instance_method(_sparsemat.SparseMatrix_PrintCSRGZ)
 
     def PrintCSR(self, *args):
         r"""
@@ -831,6 +851,11 @@ class SparseMatrix(mfem._par.matrix.AbstractSparseMatrix):
         return _sparsemat.SparseMatrix_PrintCSR(self, *args)
     PrintCSR = _swig_new_instance_method(_sparsemat.SparseMatrix_PrintCSR)
 
+    def PrintCSR2GZ(self, file, precision=8):
+        r"""PrintCSR2GZ(SparseMatrix self, char const * file, int precision=8)"""
+        return _sparsemat.SparseMatrix_PrintCSR2GZ(self, file, precision)
+    PrintCSR2GZ = _swig_new_instance_method(_sparsemat.SparseMatrix_PrintCSR2GZ)
+
     def PrintCSR2(self, *args):
         r"""
         PrintCSR2(SparseMatrix self, std::ostream & out)
@@ -839,6 +864,11 @@ class SparseMatrix(mfem._par.matrix.AbstractSparseMatrix):
         """
         return _sparsemat.SparseMatrix_PrintCSR2(self, *args)
     PrintCSR2 = _swig_new_instance_method(_sparsemat.SparseMatrix_PrintCSR2)
+
+    def PrintInfoGZ(self, file, precision=8):
+        r"""PrintInfoGZ(SparseMatrix self, char const * file, int precision=8)"""
+        return _sparsemat.SparseMatrix_PrintInfoGZ(self, file, precision)
+    PrintInfoGZ = _swig_new_instance_method(_sparsemat.SparseMatrix_PrintInfoGZ)
 
     def PrintInfo(self, *args):
         r"""

--- a/mfem/_par/sparsemat_wrap.cxx
+++ b/mfem/_par/sparsemat_wrap.cxx
@@ -3613,6 +3613,17 @@ SWIGINTERN void mfem_SparseMatrix_Print__SWIG_1(mfem::SparseMatrix *self,char co
   self -> Print(ofile);
   ofile.close();
   }
+SWIGINTERN void mfem_SparseMatrix_PrintGZ(mfem::SparseMatrix *self,char const *file,int precision=8){
+  mfem::ofgzstream *ofile = new mfem::ofgzstream(file, true);
+  if (!ofile)
+     {
+        std::cerr << "\nCan not produce output file: " << file << '\n' << std::endl;
+        return;
+      }
+  ofile ->precision(precision);  
+  self -> Print(*ofile);
+  delete ofile;
+  }
 SWIGINTERN void mfem_SparseMatrix_PrintMatlab__SWIG_1(mfem::SparseMatrix *self,char const *file,int precision=8){
   std::ofstream ofile(file);
   if (!ofile)
@@ -3623,6 +3634,17 @@ SWIGINTERN void mfem_SparseMatrix_PrintMatlab__SWIG_1(mfem::SparseMatrix *self,c
   ofile.precision(precision);  
   self -> PrintMatlab(ofile);
   ofile.close();
+  }
+SWIGINTERN void mfem_SparseMatrix_PrintMatlabGZ(mfem::SparseMatrix *self,char const *file,int precision=8){
+  mfem::ofgzstream *ofile = new mfem::ofgzstream(file, true);
+  if (!ofile)
+     {
+        std::cerr << "\nCan not produce output file: " << file << '\n' << std::endl;
+        return;
+      }
+  ofile ->precision(precision);  
+  self -> PrintMatlab(*ofile);
+  delete ofile;
   }
 SWIGINTERN void mfem_SparseMatrix_PrintMM__SWIG_1(mfem::SparseMatrix *self,char const *file,int precision=8){
   std::ofstream ofile(file);
@@ -3635,6 +3657,17 @@ SWIGINTERN void mfem_SparseMatrix_PrintMM__SWIG_1(mfem::SparseMatrix *self,char 
   self -> PrintMM(ofile);
   ofile.close();
   }
+SWIGINTERN void mfem_SparseMatrix_PrintMMGZ(mfem::SparseMatrix *self,char const *file,int precision=8){
+  mfem::ofgzstream *ofile = new mfem::ofgzstream(file, true);
+  if (!ofile)
+     {
+        std::cerr << "\nCan not produce output file: " << file << '\n' << std::endl;
+        return;
+      }
+  ofile ->precision(precision);  
+  self -> PrintMM(*ofile);
+  delete ofile;
+  }
 SWIGINTERN void mfem_SparseMatrix_PrintCSR__SWIG_1(mfem::SparseMatrix *self,char const *file,int precision=8){
   std::ofstream ofile(file);
   if (!ofile)
@@ -3645,6 +3678,18 @@ SWIGINTERN void mfem_SparseMatrix_PrintCSR__SWIG_1(mfem::SparseMatrix *self,char
   ofile.precision(precision);    
   self -> PrintCSR(ofile);
   ofile.close();
+  }
+SWIGINTERN void mfem_SparseMatrix_PrintCSRGZ(mfem::SparseMatrix *self,char const *file,int precision=8){
+  mfem::ofgzstream *ofile = new mfem::ofgzstream(file, true);
+  
+  if (!ofile)
+     {
+        std::cerr << "\nCan not produce output file: " << file << '\n' << std::endl;
+        return;
+      }
+  ofile -> precision(precision);  
+  self -> PrintCSR(*ofile);
+  delete ofile;
   }
 SWIGINTERN void mfem_SparseMatrix_PrintCSR__SWIG_2(mfem::SparseMatrix *self){
   self -> PrintCSR(std::cout);
@@ -3660,6 +3705,18 @@ SWIGINTERN void mfem_SparseMatrix_PrintCSR2__SWIG_1(mfem::SparseMatrix *self,cha
   self -> PrintCSR2(ofile);
   ofile.close();
   }
+SWIGINTERN void mfem_SparseMatrix_PrintCSR2GZ(mfem::SparseMatrix *self,char const *file,int precision=8){
+  mfem::ofgzstream *ofile = new mfem::ofgzstream(file, true);
+  
+  if (!ofile)
+     {
+        std::cerr << "\nCan not produce output file: " << file << '\n' << std::endl;
+        return;
+      }
+  ofile -> precision(precision);  
+  self -> PrintCSR2(*ofile);
+  delete ofile;
+  }
 SWIGINTERN void mfem_SparseMatrix_PrintCSR2__SWIG_2(mfem::SparseMatrix *self){
   self -> PrintCSR2(std::cout);
   }
@@ -3673,6 +3730,18 @@ SWIGINTERN void mfem_SparseMatrix_PrintInfo__SWIG_1(mfem::SparseMatrix *self,cha
   ofile.precision(precision);    
   self -> PrintInfo(ofile);
   ofile.close();
+  }
+SWIGINTERN void mfem_SparseMatrix_PrintInfoGZ(mfem::SparseMatrix *self,char const *file,int precision=8){
+  mfem::ofgzstream *ofile = new mfem::ofgzstream(file, true);
+  
+  if (!ofile)
+     {
+        std::cerr << "\nCan not produce output file: " << file << '\n' << std::endl;
+        return;
+      }
+  ofile -> precision(precision);  
+  self -> PrintInfo(*ofile);
+  delete ofile;
   }
 SWIGINTERN void mfem_SparseMatrix_PrintInfo__SWIG_2(mfem::SparseMatrix *self){
   self -> PrintInfo(std::cout);
@@ -13181,6 +13250,64 @@ fail:
 }
 
 
+SWIGINTERN PyObject *_wrap_SparseMatrix_PrintGZ(PyObject *SWIGUNUSEDPARM(self), PyObject *args, PyObject *kwargs) {
+  PyObject *resultobj = 0;
+  mfem::SparseMatrix *arg1 = (mfem::SparseMatrix *) 0 ;
+  char *arg2 = (char *) 0 ;
+  int arg3 = (int) 8 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int res2 ;
+  char *buf2 = 0 ;
+  int alloc2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  char * kwnames[] = {
+    (char *)"self",  (char *)"file",  (char *)"precision",  NULL 
+  };
+  
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OO|O:SparseMatrix_PrintGZ", kwnames, &obj0, &obj1, &obj2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_mfem__SparseMatrix, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "SparseMatrix_PrintGZ" "', argument " "1"" of type '" "mfem::SparseMatrix *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::SparseMatrix * >(argp1);
+  res2 = SWIG_AsCharPtrAndSize(obj1, &buf2, NULL, &alloc2);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "SparseMatrix_PrintGZ" "', argument " "2"" of type '" "char const *""'");
+  }
+  arg2 = reinterpret_cast< char * >(buf2);
+  if (obj2) {
+    {
+      if ((PyArray_PyIntAsInt(obj2) == -1) && PyErr_Occurred()) {
+        SWIG_exception_fail(SWIG_TypeError, "Input must be integer");
+      };  
+      arg3 = PyArray_PyIntAsInt(obj2);
+    }
+  }
+  {
+    try {
+      mfem_SparseMatrix_PrintGZ(arg1,(char const *)arg2,arg3); 
+    }
+    catch (Swig::DirectorException &e) {
+      SWIG_fail; 
+    }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
+  }
+  resultobj = SWIG_Py_Void();
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return resultobj;
+fail:
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return NULL;
+}
+
+
 SWIGINTERN PyObject *_wrap_SparseMatrix_PrintMatlab__SWIG_1(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
   PyObject *resultobj = 0;
   mfem::SparseMatrix *arg1 = (mfem::SparseMatrix *) 0 ;
@@ -13316,6 +13443,64 @@ fail:
     "    mfem::SparseMatrix::PrintMatlab(std::ostream &) const\n"
     "    mfem::SparseMatrix::PrintMatlab(char const *,int)\n");
   return 0;
+}
+
+
+SWIGINTERN PyObject *_wrap_SparseMatrix_PrintMatlabGZ(PyObject *SWIGUNUSEDPARM(self), PyObject *args, PyObject *kwargs) {
+  PyObject *resultobj = 0;
+  mfem::SparseMatrix *arg1 = (mfem::SparseMatrix *) 0 ;
+  char *arg2 = (char *) 0 ;
+  int arg3 = (int) 8 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int res2 ;
+  char *buf2 = 0 ;
+  int alloc2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  char * kwnames[] = {
+    (char *)"self",  (char *)"file",  (char *)"precision",  NULL 
+  };
+  
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OO|O:SparseMatrix_PrintMatlabGZ", kwnames, &obj0, &obj1, &obj2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_mfem__SparseMatrix, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "SparseMatrix_PrintMatlabGZ" "', argument " "1"" of type '" "mfem::SparseMatrix *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::SparseMatrix * >(argp1);
+  res2 = SWIG_AsCharPtrAndSize(obj1, &buf2, NULL, &alloc2);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "SparseMatrix_PrintMatlabGZ" "', argument " "2"" of type '" "char const *""'");
+  }
+  arg2 = reinterpret_cast< char * >(buf2);
+  if (obj2) {
+    {
+      if ((PyArray_PyIntAsInt(obj2) == -1) && PyErr_Occurred()) {
+        SWIG_exception_fail(SWIG_TypeError, "Input must be integer");
+      };  
+      arg3 = PyArray_PyIntAsInt(obj2);
+    }
+  }
+  {
+    try {
+      mfem_SparseMatrix_PrintMatlabGZ(arg1,(char const *)arg2,arg3); 
+    }
+    catch (Swig::DirectorException &e) {
+      SWIG_fail; 
+    }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
+  }
+  resultobj = SWIG_Py_Void();
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return resultobj;
+fail:
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return NULL;
 }
 
 
@@ -13457,6 +13642,64 @@ fail:
 }
 
 
+SWIGINTERN PyObject *_wrap_SparseMatrix_PrintMMGZ(PyObject *SWIGUNUSEDPARM(self), PyObject *args, PyObject *kwargs) {
+  PyObject *resultobj = 0;
+  mfem::SparseMatrix *arg1 = (mfem::SparseMatrix *) 0 ;
+  char *arg2 = (char *) 0 ;
+  int arg3 = (int) 8 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int res2 ;
+  char *buf2 = 0 ;
+  int alloc2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  char * kwnames[] = {
+    (char *)"self",  (char *)"file",  (char *)"precision",  NULL 
+  };
+  
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OO|O:SparseMatrix_PrintMMGZ", kwnames, &obj0, &obj1, &obj2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_mfem__SparseMatrix, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "SparseMatrix_PrintMMGZ" "', argument " "1"" of type '" "mfem::SparseMatrix *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::SparseMatrix * >(argp1);
+  res2 = SWIG_AsCharPtrAndSize(obj1, &buf2, NULL, &alloc2);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "SparseMatrix_PrintMMGZ" "', argument " "2"" of type '" "char const *""'");
+  }
+  arg2 = reinterpret_cast< char * >(buf2);
+  if (obj2) {
+    {
+      if ((PyArray_PyIntAsInt(obj2) == -1) && PyErr_Occurred()) {
+        SWIG_exception_fail(SWIG_TypeError, "Input must be integer");
+      };  
+      arg3 = PyArray_PyIntAsInt(obj2);
+    }
+  }
+  {
+    try {
+      mfem_SparseMatrix_PrintMMGZ(arg1,(char const *)arg2,arg3); 
+    }
+    catch (Swig::DirectorException &e) {
+      SWIG_fail; 
+    }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
+  }
+  resultobj = SWIG_Py_Void();
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return resultobj;
+fail:
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return NULL;
+}
+
+
 SWIGINTERN PyObject *_wrap_SparseMatrix_PrintCSR__SWIG_1(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
   PyObject *resultobj = 0;
   mfem::SparseMatrix *arg1 = (mfem::SparseMatrix *) 0 ;
@@ -13490,6 +13733,64 @@ SWIGINTERN PyObject *_wrap_SparseMatrix_PrintCSR__SWIG_1(PyObject *SWIGUNUSEDPAR
   {
     try {
       mfem_SparseMatrix_PrintCSR__SWIG_1(arg1,(char const *)arg2,arg3); 
+    }
+    catch (Swig::DirectorException &e) {
+      SWIG_fail; 
+    }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
+  }
+  resultobj = SWIG_Py_Void();
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return resultobj;
+fail:
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_SparseMatrix_PrintCSRGZ(PyObject *SWIGUNUSEDPARM(self), PyObject *args, PyObject *kwargs) {
+  PyObject *resultobj = 0;
+  mfem::SparseMatrix *arg1 = (mfem::SparseMatrix *) 0 ;
+  char *arg2 = (char *) 0 ;
+  int arg3 = (int) 8 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int res2 ;
+  char *buf2 = 0 ;
+  int alloc2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  char * kwnames[] = {
+    (char *)"self",  (char *)"file",  (char *)"precision",  NULL 
+  };
+  
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OO|O:SparseMatrix_PrintCSRGZ", kwnames, &obj0, &obj1, &obj2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_mfem__SparseMatrix, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "SparseMatrix_PrintCSRGZ" "', argument " "1"" of type '" "mfem::SparseMatrix *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::SparseMatrix * >(argp1);
+  res2 = SWIG_AsCharPtrAndSize(obj1, &buf2, NULL, &alloc2);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "SparseMatrix_PrintCSRGZ" "', argument " "2"" of type '" "char const *""'");
+  }
+  arg2 = reinterpret_cast< char * >(buf2);
+  if (obj2) {
+    {
+      if ((PyArray_PyIntAsInt(obj2) == -1) && PyErr_Occurred()) {
+        SWIG_exception_fail(SWIG_TypeError, "Input must be integer");
+      };  
+      arg3 = PyArray_PyIntAsInt(obj2);
+    }
+  }
+  {
+    try {
+      mfem_SparseMatrix_PrintCSRGZ(arg1,(char const *)arg2,arg3); 
     }
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
@@ -13686,6 +13987,64 @@ fail:
 }
 
 
+SWIGINTERN PyObject *_wrap_SparseMatrix_PrintCSR2GZ(PyObject *SWIGUNUSEDPARM(self), PyObject *args, PyObject *kwargs) {
+  PyObject *resultobj = 0;
+  mfem::SparseMatrix *arg1 = (mfem::SparseMatrix *) 0 ;
+  char *arg2 = (char *) 0 ;
+  int arg3 = (int) 8 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int res2 ;
+  char *buf2 = 0 ;
+  int alloc2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  char * kwnames[] = {
+    (char *)"self",  (char *)"file",  (char *)"precision",  NULL 
+  };
+  
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OO|O:SparseMatrix_PrintCSR2GZ", kwnames, &obj0, &obj1, &obj2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_mfem__SparseMatrix, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "SparseMatrix_PrintCSR2GZ" "', argument " "1"" of type '" "mfem::SparseMatrix *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::SparseMatrix * >(argp1);
+  res2 = SWIG_AsCharPtrAndSize(obj1, &buf2, NULL, &alloc2);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "SparseMatrix_PrintCSR2GZ" "', argument " "2"" of type '" "char const *""'");
+  }
+  arg2 = reinterpret_cast< char * >(buf2);
+  if (obj2) {
+    {
+      if ((PyArray_PyIntAsInt(obj2) == -1) && PyErr_Occurred()) {
+        SWIG_exception_fail(SWIG_TypeError, "Input must be integer");
+      };  
+      arg3 = PyArray_PyIntAsInt(obj2);
+    }
+  }
+  {
+    try {
+      mfem_SparseMatrix_PrintCSR2GZ(arg1,(char const *)arg2,arg3); 
+    }
+    catch (Swig::DirectorException &e) {
+      SWIG_fail; 
+    }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
+  }
+  resultobj = SWIG_Py_Void();
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return resultobj;
+fail:
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return NULL;
+}
+
+
 SWIGINTERN PyObject *_wrap_SparseMatrix_PrintCSR2__SWIG_2(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
   PyObject *resultobj = 0;
   mfem::SparseMatrix *arg1 = (mfem::SparseMatrix *) 0 ;
@@ -13844,6 +14203,64 @@ SWIGINTERN PyObject *_wrap_SparseMatrix_PrintInfo__SWIG_1(PyObject *SWIGUNUSEDPA
   {
     try {
       mfem_SparseMatrix_PrintInfo__SWIG_1(arg1,(char const *)arg2,arg3); 
+    }
+    catch (Swig::DirectorException &e) {
+      SWIG_fail; 
+    }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
+  }
+  resultobj = SWIG_Py_Void();
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return resultobj;
+fail:
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_SparseMatrix_PrintInfoGZ(PyObject *SWIGUNUSEDPARM(self), PyObject *args, PyObject *kwargs) {
+  PyObject *resultobj = 0;
+  mfem::SparseMatrix *arg1 = (mfem::SparseMatrix *) 0 ;
+  char *arg2 = (char *) 0 ;
+  int arg3 = (int) 8 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int res2 ;
+  char *buf2 = 0 ;
+  int alloc2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  char * kwnames[] = {
+    (char *)"self",  (char *)"file",  (char *)"precision",  NULL 
+  };
+  
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OO|O:SparseMatrix_PrintInfoGZ", kwnames, &obj0, &obj1, &obj2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_mfem__SparseMatrix, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "SparseMatrix_PrintInfoGZ" "', argument " "1"" of type '" "mfem::SparseMatrix *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::SparseMatrix * >(argp1);
+  res2 = SWIG_AsCharPtrAndSize(obj1, &buf2, NULL, &alloc2);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "SparseMatrix_PrintInfoGZ" "', argument " "2"" of type '" "char const *""'");
+  }
+  arg2 = reinterpret_cast< char * >(buf2);
+  if (obj2) {
+    {
+      if ((PyArray_PyIntAsInt(obj2) == -1) && PyErr_Occurred()) {
+        SWIG_exception_fail(SWIG_TypeError, "Input must be integer");
+      };  
+      arg3 = PyArray_PyIntAsInt(obj2);
+    }
+  }
+  {
+    try {
+      mfem_SparseMatrix_PrintInfoGZ(arg1,(char const *)arg2,arg3); 
     }
     catch (Swig::DirectorException &e) {
       SWIG_fail; 
@@ -14865,24 +15282,30 @@ static PyMethodDef SwigMethods[] = {
 		"SparseMatrix_Print(SparseMatrix self, std::ostream & out=mfem::out, int width_=4)\n"
 		"SparseMatrix_Print(SparseMatrix self, char const * file, int precision=8)\n"
 		""},
+	 { "SparseMatrix_PrintGZ", (PyCFunction)(void(*)(void))_wrap_SparseMatrix_PrintGZ, METH_VARARGS|METH_KEYWORDS, "SparseMatrix_PrintGZ(SparseMatrix self, char const * file, int precision=8)"},
 	 { "SparseMatrix_PrintMatlab", _wrap_SparseMatrix_PrintMatlab, METH_VARARGS, "\n"
 		"SparseMatrix_PrintMatlab(SparseMatrix self, std::ostream & out=mfem::out)\n"
 		"SparseMatrix_PrintMatlab(SparseMatrix self, char const * file, int precision=8)\n"
 		""},
+	 { "SparseMatrix_PrintMatlabGZ", (PyCFunction)(void(*)(void))_wrap_SparseMatrix_PrintMatlabGZ, METH_VARARGS|METH_KEYWORDS, "SparseMatrix_PrintMatlabGZ(SparseMatrix self, char const * file, int precision=8)"},
 	 { "SparseMatrix_PrintMM", _wrap_SparseMatrix_PrintMM, METH_VARARGS, "\n"
 		"SparseMatrix_PrintMM(SparseMatrix self, std::ostream & out=mfem::out)\n"
 		"SparseMatrix_PrintMM(SparseMatrix self, char const * file, int precision=8)\n"
 		""},
+	 { "SparseMatrix_PrintMMGZ", (PyCFunction)(void(*)(void))_wrap_SparseMatrix_PrintMMGZ, METH_VARARGS|METH_KEYWORDS, "SparseMatrix_PrintMMGZ(SparseMatrix self, char const * file, int precision=8)"},
+	 { "SparseMatrix_PrintCSRGZ", (PyCFunction)(void(*)(void))_wrap_SparseMatrix_PrintCSRGZ, METH_VARARGS|METH_KEYWORDS, "SparseMatrix_PrintCSRGZ(SparseMatrix self, char const * file, int precision=8)"},
 	 { "SparseMatrix_PrintCSR", _wrap_SparseMatrix_PrintCSR, METH_VARARGS, "\n"
 		"SparseMatrix_PrintCSR(SparseMatrix self, std::ostream & out)\n"
 		"SparseMatrix_PrintCSR(SparseMatrix self, char const * file, int precision=8)\n"
 		"SparseMatrix_PrintCSR(SparseMatrix self)\n"
 		""},
+	 { "SparseMatrix_PrintCSR2GZ", (PyCFunction)(void(*)(void))_wrap_SparseMatrix_PrintCSR2GZ, METH_VARARGS|METH_KEYWORDS, "SparseMatrix_PrintCSR2GZ(SparseMatrix self, char const * file, int precision=8)"},
 	 { "SparseMatrix_PrintCSR2", _wrap_SparseMatrix_PrintCSR2, METH_VARARGS, "\n"
 		"SparseMatrix_PrintCSR2(SparseMatrix self, std::ostream & out)\n"
 		"SparseMatrix_PrintCSR2(SparseMatrix self, char const * file, int precision=8)\n"
 		"SparseMatrix_PrintCSR2(SparseMatrix self)\n"
 		""},
+	 { "SparseMatrix_PrintInfoGZ", (PyCFunction)(void(*)(void))_wrap_SparseMatrix_PrintInfoGZ, METH_VARARGS|METH_KEYWORDS, "SparseMatrix_PrintInfoGZ(SparseMatrix self, char const * file, int precision=8)"},
 	 { "SparseMatrix_PrintInfo", _wrap_SparseMatrix_PrintInfo, METH_VARARGS, "\n"
 		"SparseMatrix_PrintInfo(SparseMatrix self, std::ostream & out)\n"
 		"SparseMatrix_PrintInfo(SparseMatrix self, char const * file, int precision=8)\n"
@@ -15109,24 +15532,30 @@ static PyMethodDef SwigMethods_proxydocs[] = {
 		"Print(SparseMatrix self, std::ostream & out=mfem::out, int width_=4)\n"
 		"Print(SparseMatrix self, char const * file, int precision=8)\n"
 		""},
+	 { "SparseMatrix_PrintGZ", (PyCFunction)(void(*)(void))_wrap_SparseMatrix_PrintGZ, METH_VARARGS|METH_KEYWORDS, "PrintGZ(SparseMatrix self, char const * file, int precision=8)"},
 	 { "SparseMatrix_PrintMatlab", _wrap_SparseMatrix_PrintMatlab, METH_VARARGS, "\n"
 		"PrintMatlab(SparseMatrix self, std::ostream & out=mfem::out)\n"
 		"PrintMatlab(SparseMatrix self, char const * file, int precision=8)\n"
 		""},
+	 { "SparseMatrix_PrintMatlabGZ", (PyCFunction)(void(*)(void))_wrap_SparseMatrix_PrintMatlabGZ, METH_VARARGS|METH_KEYWORDS, "PrintMatlabGZ(SparseMatrix self, char const * file, int precision=8)"},
 	 { "SparseMatrix_PrintMM", _wrap_SparseMatrix_PrintMM, METH_VARARGS, "\n"
 		"PrintMM(SparseMatrix self, std::ostream & out=mfem::out)\n"
 		"PrintMM(SparseMatrix self, char const * file, int precision=8)\n"
 		""},
+	 { "SparseMatrix_PrintMMGZ", (PyCFunction)(void(*)(void))_wrap_SparseMatrix_PrintMMGZ, METH_VARARGS|METH_KEYWORDS, "PrintMMGZ(SparseMatrix self, char const * file, int precision=8)"},
+	 { "SparseMatrix_PrintCSRGZ", (PyCFunction)(void(*)(void))_wrap_SparseMatrix_PrintCSRGZ, METH_VARARGS|METH_KEYWORDS, "PrintCSRGZ(SparseMatrix self, char const * file, int precision=8)"},
 	 { "SparseMatrix_PrintCSR", _wrap_SparseMatrix_PrintCSR, METH_VARARGS, "\n"
 		"PrintCSR(SparseMatrix self, std::ostream & out)\n"
 		"PrintCSR(SparseMatrix self, char const * file, int precision=8)\n"
 		"PrintCSR(SparseMatrix self)\n"
 		""},
+	 { "SparseMatrix_PrintCSR2GZ", (PyCFunction)(void(*)(void))_wrap_SparseMatrix_PrintCSR2GZ, METH_VARARGS|METH_KEYWORDS, "PrintCSR2GZ(SparseMatrix self, char const * file, int precision=8)"},
 	 { "SparseMatrix_PrintCSR2", _wrap_SparseMatrix_PrintCSR2, METH_VARARGS, "\n"
 		"PrintCSR2(SparseMatrix self, std::ostream & out)\n"
 		"PrintCSR2(SparseMatrix self, char const * file, int precision=8)\n"
 		"PrintCSR2(SparseMatrix self)\n"
 		""},
+	 { "SparseMatrix_PrintInfoGZ", (PyCFunction)(void(*)(void))_wrap_SparseMatrix_PrintInfoGZ, METH_VARARGS|METH_KEYWORDS, "PrintInfoGZ(SparseMatrix self, char const * file, int precision=8)"},
 	 { "SparseMatrix_PrintInfo", _wrap_SparseMatrix_PrintInfo, METH_VARARGS, "\n"
 		"PrintInfo(SparseMatrix self, std::ostream & out)\n"
 		"PrintInfo(SparseMatrix self, char const * file, int precision=8)\n"

--- a/mfem/_par/stable3d.py
+++ b/mfem/_par/stable3d.py
@@ -143,6 +143,11 @@ class STable3D(object):
         return _stable3d.STable3D_Print(self, *args)
     Print = _swig_new_instance_method(_stable3d.STable3D_Print)
 
+    def PrintGZ(self, file, precision=8):
+        r"""PrintGZ(STable3D self, char const * file, int precision=8)"""
+        return _stable3d.STable3D_PrintGZ(self, file, precision)
+    PrintGZ = _swig_new_instance_method(_stable3d.STable3D_PrintGZ)
+
 # Register STable3D in _stable3d:
 _stable3d.STable3D_swigregister(STable3D)
 

--- a/mfem/_par/stable3d_wrap.cxx
+++ b/mfem/_par/stable3d_wrap.cxx
@@ -3358,6 +3358,17 @@ SWIGINTERN void mfem_STable3D_Print__SWIG_1(mfem::STable3D *self,char const *fil
   self -> Print(ofile);
   ofile.close();
   }
+SWIGINTERN void mfem_STable3D_PrintGZ(mfem::STable3D *self,char const *file,int precision=8){
+  mfem::ofgzstream *ofile = new mfem::ofgzstream(file, true);
+  if (!ofile)
+     {
+        std::cerr << "\nCan not produce output file: " << file << '\n' << std::endl;
+        return;
+      }
+  ofile ->precision(precision);  
+  self -> Print(*ofile);
+  delete ofile;
+  }
 
 
 /* ---------------------------------------------------
@@ -4435,6 +4446,64 @@ fail:
 }
 
 
+SWIGINTERN PyObject *_wrap_STable3D_PrintGZ(PyObject *SWIGUNUSEDPARM(self), PyObject *args, PyObject *kwargs) {
+  PyObject *resultobj = 0;
+  mfem::STable3D *arg1 = (mfem::STable3D *) 0 ;
+  char *arg2 = (char *) 0 ;
+  int arg3 = (int) 8 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int res2 ;
+  char *buf2 = 0 ;
+  int alloc2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  char * kwnames[] = {
+    (char *)"self",  (char *)"file",  (char *)"precision",  NULL 
+  };
+  
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OO|O:STable3D_PrintGZ", kwnames, &obj0, &obj1, &obj2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_mfem__STable3D, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "STable3D_PrintGZ" "', argument " "1"" of type '" "mfem::STable3D *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::STable3D * >(argp1);
+  res2 = SWIG_AsCharPtrAndSize(obj1, &buf2, NULL, &alloc2);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "STable3D_PrintGZ" "', argument " "2"" of type '" "char const *""'");
+  }
+  arg2 = reinterpret_cast< char * >(buf2);
+  if (obj2) {
+    {
+      if ((PyArray_PyIntAsInt(obj2) == -1) && PyErr_Occurred()) {
+        SWIG_exception_fail(SWIG_TypeError, "Input must be integer");
+      };  
+      arg3 = PyArray_PyIntAsInt(obj2);
+    }
+  }
+  {
+    try {
+      mfem_STable3D_PrintGZ(arg1,(char const *)arg2,arg3); 
+    }
+    catch (Swig::DirectorException &e) {
+      SWIG_fail; 
+    }    
+    //catch (...){
+    //  SWIG_fail;
+    //}
+    //    catch (Swig::DirectorMethodException &e) { SWIG_fail; }
+    //    catch (std::exception &e) { SWIG_fail; }    
+  }
+  resultobj = SWIG_Py_Void();
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return resultobj;
+fail:
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return NULL;
+}
+
+
 SWIGINTERN PyObject *STable3D_swigregister(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *obj;
   if (!SWIG_Python_UnpackTuple(args, "swigregister", 1, 1, &obj)) return NULL;
@@ -4475,6 +4544,7 @@ static PyMethodDef SwigMethods[] = {
 		"STable3D_Print(STable3D self, std::ostream & out=out)\n"
 		"STable3D_Print(STable3D self, char const * file, int precision=8)\n"
 		""},
+	 { "STable3D_PrintGZ", (PyCFunction)(void(*)(void))_wrap_STable3D_PrintGZ, METH_VARARGS|METH_KEYWORDS, "STable3D_PrintGZ(STable3D self, char const * file, int precision=8)"},
 	 { "STable3D_swigregister", STable3D_swigregister, METH_O, NULL},
 	 { "STable3D_swiginit", STable3D_swiginit, METH_VARARGS, NULL},
 	 { NULL, NULL, 0, NULL }
@@ -4509,6 +4579,7 @@ static PyMethodDef SwigMethods_proxydocs[] = {
 		"Print(STable3D self, std::ostream & out=out)\n"
 		"Print(STable3D self, char const * file, int precision=8)\n"
 		""},
+	 { "STable3D_PrintGZ", (PyCFunction)(void(*)(void))_wrap_STable3D_PrintGZ, METH_VARARGS|METH_KEYWORDS, "PrintGZ(STable3D self, char const * file, int precision=8)"},
 	 { "STable3D_swigregister", STable3D_swigregister, METH_O, NULL},
 	 { "STable3D_swiginit", STable3D_swiginit, METH_VARARGS, NULL},
 	 { NULL, NULL, 0, NULL }

--- a/mfem/_par/table.py
+++ b/mfem/_par/table.py
@@ -291,6 +291,11 @@ class Table(object):
         return _table.Table_Print(self, *args)
     Print = _swig_new_instance_method(_table.Table_Print)
 
+    def PrintGZ(self, file, precision=8):
+        r"""PrintGZ(Table self, char const * file, int precision=8)"""
+        return _table.Table_PrintGZ(self, file, precision)
+    PrintGZ = _swig_new_instance_method(_table.Table_PrintGZ)
+
     def PrintMatlab(self, *args):
         r"""
         PrintMatlab(Table self, std::ostream & out)
@@ -298,6 +303,16 @@ class Table(object):
         """
         return _table.Table_PrintMatlab(self, *args)
     PrintMatlab = _swig_new_instance_method(_table.Table_PrintMatlab)
+
+    def PrintMatlabGZ(self, file, precision=8):
+        r"""PrintMatlabGZ(Table self, char const * file, int precision=8)"""
+        return _table.Table_PrintMatlabGZ(self, file, precision)
+    PrintMatlabGZ = _swig_new_instance_method(_table.Table_PrintMatlabGZ)
+
+    def SaveGZ(self, file, precision=8):
+        r"""SaveGZ(Table self, char const * file, int precision=8)"""
+        return _table.Table_SaveGZ(self, file, precision)
+    SaveGZ = _swig_new_instance_method(_table.Table_SaveGZ)
 
     def Save(self, *args):
         r"""

--- a/mfem/_par/table_wrap.cxx
+++ b/mfem/_par/table_wrap.cxx
@@ -2979,6 +2979,17 @@ SWIGINTERN void mfem_Table_Print__SWIG_1(mfem::Table *self,char const *file,int 
   self -> Print(ofile);
   ofile.close();
   }
+SWIGINTERN void mfem_Table_PrintGZ(mfem::Table *self,char const *file,int precision=8){
+  mfem::ofgzstream *ofile = new mfem::ofgzstream(file, true);
+  if (!ofile)
+     {
+        std::cerr << "\nCan not produce output file: " << file << '\n' << std::endl;
+        return;
+      }
+  ofile ->precision(precision);  
+  self -> Print(*ofile);
+  delete ofile;
+  }
 SWIGINTERN void mfem_Table_PrintMatlab__SWIG_1(mfem::Table *self,char const *file,int precision=8){
   std::ofstream ofile(file);
   if (!ofile)
@@ -2990,6 +3001,17 @@ SWIGINTERN void mfem_Table_PrintMatlab__SWIG_1(mfem::Table *self,char const *fil
   self -> PrintMatlab(ofile);
   ofile.close();
   }
+SWIGINTERN void mfem_Table_PrintMatlabGZ(mfem::Table *self,char const *file,int precision=8){
+  mfem::ofgzstream *ofile = new mfem::ofgzstream(file, true);
+  if (!ofile)
+     {
+        std::cerr << "\nCan not produce output file: " << file << '\n' << std::endl;
+        return;
+      }
+  ofile ->precision(precision);  
+  self -> PrintMatlab(*ofile);
+  delete ofile;
+  }
 SWIGINTERN void mfem_Table_Save__SWIG_1(mfem::Table *self,char const *file,int precision=8){
   std::ofstream ofile(file);
   if (!ofile)
@@ -3000,6 +3022,18 @@ SWIGINTERN void mfem_Table_Save__SWIG_1(mfem::Table *self,char const *file,int p
   ofile.precision(precision);    
   self -> Save(ofile);
   ofile.close();
+  }
+SWIGINTERN void mfem_Table_SaveGZ(mfem::Table *self,char const *file,int precision=8){
+  mfem::ofgzstream *ofile = new mfem::ofgzstream(file, true);
+  
+  if (!ofile)
+     {
+        std::cerr << "\nCan not produce output file: " << file << '\n' << std::endl;
+        return;
+      }
+  ofile -> precision(precision);  
+  self -> Save(*ofile);
+  delete ofile;
   }
 SWIGINTERN void mfem_Table_Save__SWIG_2(mfem::Table *self){
   self -> Save(std::cout);
@@ -5779,14 +5813,20 @@ SWIGINTERN PyObject *_wrap_Table_Load(PyObject *SWIGUNUSEDPARM(self), PyObject *
       }
     }
     if (stream2 == 0){
-      if (temp2->isGZ()){
-        in_gz2 = new mfem::ifgzstream(temp2->getFilename());
-        arg2 = in_gz2;
-      } else {
-        in_txt2.open(temp2->getFilename(), std::ifstream::in);
-        in_txt2.precision(temp2->getPrecision());
-        arg2 = &in_txt2;
-      }
+      /*
+            if (temp2->isGZ()){
+        	 in_gz2 = new mfem::ifgzstream(temp2->getFilename());
+               arg2 = in_gz2;
+            } else {
+        	 in_txt2.open(temp2->getFilename(), std::ifstream::in);
+               in_txt2.precision(temp2->getPrecision());
+               arg2 = &in_txt2;
+            }
+           */
+      /* this will auto-detect the input file type */
+      in_gz2 = new mfem::ifgzstream(temp2->getFilename());
+      arg2 = in_gz2;
+      
       if (temp2->isTemporary()){
         delete temp2;
       }
@@ -5811,18 +5851,6 @@ SWIGINTERN PyObject *_wrap_Table_Load(PyObject *SWIGUNUSEDPARM(self), PyObject *
     }	 
   }
   resultobj = SWIG_Py_Void();
-  {
-    if (stream2) {
-      ret2 = PyLong_FromSsize_t(len2);
-      if (PyErr_Occurred()) {
-        PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
-        return NULL;
-      }
-      delete stream2;    
-      Py_XDECREF(resultobj);   /* Blow away any previous result */
-      resultobj = ret2;    
-    }
-  }
   {
     if (!stream2) {
       if (temp2) {
@@ -6265,6 +6293,67 @@ fail:
 }
 
 
+SWIGINTERN PyObject *_wrap_Table_PrintGZ(PyObject *SWIGUNUSEDPARM(self), PyObject *args, PyObject *kwargs) {
+  PyObject *resultobj = 0;
+  mfem::Table *arg1 = (mfem::Table *) 0 ;
+  char *arg2 = (char *) 0 ;
+  int arg3 = (int) 8 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int res2 ;
+  char *buf2 = 0 ;
+  int alloc2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  char * kwnames[] = {
+    (char *)"self",  (char *)"file",  (char *)"precision",  NULL 
+  };
+  
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OO|O:Table_PrintGZ", kwnames, &obj0, &obj1, &obj2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_mfem__Table, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "Table_PrintGZ" "', argument " "1"" of type '" "mfem::Table *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::Table * >(argp1);
+  res2 = SWIG_AsCharPtrAndSize(obj1, &buf2, NULL, &alloc2);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "Table_PrintGZ" "', argument " "2"" of type '" "char const *""'");
+  }
+  arg2 = reinterpret_cast< char * >(buf2);
+  if (obj2) {
+    {
+      if ((PyArray_PyIntAsInt(obj2) == -1) && PyErr_Occurred()) {
+        SWIG_exception_fail(SWIG_TypeError, "Input must be integer");
+      };  
+      arg3 = PyArray_PyIntAsInt(obj2);
+    }
+  }
+  {
+    try {
+      mfem_Table_PrintGZ(arg1,(char const *)arg2,arg3);
+    }
+#ifdef  MFEM_USE_EXCEPTIONS
+    catch (mfem::ErrorException &_e) {
+      std::string s("PyMFEM error (mfem::ErrorException): "), s2(_e.what());
+      s = s + s2;    
+      SWIG_exception(SWIG_RuntimeError, s.c_str());
+    }
+#endif
+    
+    catch (...) {
+      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+    }	 
+  }
+  resultobj = SWIG_Py_Void();
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return resultobj;
+fail:
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return NULL;
+}
+
+
 SWIGINTERN PyObject *_wrap_Table_PrintMatlab__SWIG_1(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
   PyObject *resultobj = 0;
   mfem::Table *arg1 = (mfem::Table *) 0 ;
@@ -6403,6 +6492,67 @@ fail:
 }
 
 
+SWIGINTERN PyObject *_wrap_Table_PrintMatlabGZ(PyObject *SWIGUNUSEDPARM(self), PyObject *args, PyObject *kwargs) {
+  PyObject *resultobj = 0;
+  mfem::Table *arg1 = (mfem::Table *) 0 ;
+  char *arg2 = (char *) 0 ;
+  int arg3 = (int) 8 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int res2 ;
+  char *buf2 = 0 ;
+  int alloc2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  char * kwnames[] = {
+    (char *)"self",  (char *)"file",  (char *)"precision",  NULL 
+  };
+  
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OO|O:Table_PrintMatlabGZ", kwnames, &obj0, &obj1, &obj2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_mfem__Table, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "Table_PrintMatlabGZ" "', argument " "1"" of type '" "mfem::Table *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::Table * >(argp1);
+  res2 = SWIG_AsCharPtrAndSize(obj1, &buf2, NULL, &alloc2);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "Table_PrintMatlabGZ" "', argument " "2"" of type '" "char const *""'");
+  }
+  arg2 = reinterpret_cast< char * >(buf2);
+  if (obj2) {
+    {
+      if ((PyArray_PyIntAsInt(obj2) == -1) && PyErr_Occurred()) {
+        SWIG_exception_fail(SWIG_TypeError, "Input must be integer");
+      };  
+      arg3 = PyArray_PyIntAsInt(obj2);
+    }
+  }
+  {
+    try {
+      mfem_Table_PrintMatlabGZ(arg1,(char const *)arg2,arg3);
+    }
+#ifdef  MFEM_USE_EXCEPTIONS
+    catch (mfem::ErrorException &_e) {
+      std::string s("PyMFEM error (mfem::ErrorException): "), s2(_e.what());
+      s = s + s2;    
+      SWIG_exception(SWIG_RuntimeError, s.c_str());
+    }
+#endif
+    
+    catch (...) {
+      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+    }	 
+  }
+  resultobj = SWIG_Py_Void();
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return resultobj;
+fail:
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return NULL;
+}
+
+
 SWIGINTERN PyObject *_wrap_Table_Save__SWIG_1(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
   PyObject *resultobj = 0;
   mfem::Table *arg1 = (mfem::Table *) 0 ;
@@ -6436,6 +6586,67 @@ SWIGINTERN PyObject *_wrap_Table_Save__SWIG_1(PyObject *SWIGUNUSEDPARM(self), Py
   {
     try {
       mfem_Table_Save__SWIG_1(arg1,(char const *)arg2,arg3);
+    }
+#ifdef  MFEM_USE_EXCEPTIONS
+    catch (mfem::ErrorException &_e) {
+      std::string s("PyMFEM error (mfem::ErrorException): "), s2(_e.what());
+      s = s + s2;    
+      SWIG_exception(SWIG_RuntimeError, s.c_str());
+    }
+#endif
+    
+    catch (...) {
+      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+    }	 
+  }
+  resultobj = SWIG_Py_Void();
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return resultobj;
+fail:
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_Table_SaveGZ(PyObject *SWIGUNUSEDPARM(self), PyObject *args, PyObject *kwargs) {
+  PyObject *resultobj = 0;
+  mfem::Table *arg1 = (mfem::Table *) 0 ;
+  char *arg2 = (char *) 0 ;
+  int arg3 = (int) 8 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int res2 ;
+  char *buf2 = 0 ;
+  int alloc2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  char * kwnames[] = {
+    (char *)"self",  (char *)"file",  (char *)"precision",  NULL 
+  };
+  
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OO|O:Table_SaveGZ", kwnames, &obj0, &obj1, &obj2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_mfem__Table, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "Table_SaveGZ" "', argument " "1"" of type '" "mfem::Table *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::Table * >(argp1);
+  res2 = SWIG_AsCharPtrAndSize(obj1, &buf2, NULL, &alloc2);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "Table_SaveGZ" "', argument " "2"" of type '" "char const *""'");
+  }
+  arg2 = reinterpret_cast< char * >(buf2);
+  if (obj2) {
+    {
+      if ((PyArray_PyIntAsInt(obj2) == -1) && PyErr_Occurred()) {
+        SWIG_exception_fail(SWIG_TypeError, "Input must be integer");
+      };  
+      arg3 = PyArray_PyIntAsInt(obj2);
+    }
+  }
+  {
+    try {
+      mfem_Table_SaveGZ(arg1,(char const *)arg2,arg3);
     }
 #ifdef  MFEM_USE_EXCEPTIONS
     catch (mfem::ErrorException &_e) {
@@ -7156,10 +7367,13 @@ static PyMethodDef SwigMethods[] = {
 		"Table_Print(Table self, std::ostream & out=mfem::out, int width=4)\n"
 		"Table_Print(Table self, char const * file, int precision=8)\n"
 		""},
+	 { "Table_PrintGZ", (PyCFunction)(void(*)(void))_wrap_Table_PrintGZ, METH_VARARGS|METH_KEYWORDS, "Table_PrintGZ(Table self, char const * file, int precision=8)"},
 	 { "Table_PrintMatlab", _wrap_Table_PrintMatlab, METH_VARARGS, "\n"
 		"Table_PrintMatlab(Table self, std::ostream & out)\n"
 		"Table_PrintMatlab(Table self, char const * file, int precision=8)\n"
 		""},
+	 { "Table_PrintMatlabGZ", (PyCFunction)(void(*)(void))_wrap_Table_PrintMatlabGZ, METH_VARARGS|METH_KEYWORDS, "Table_PrintMatlabGZ(Table self, char const * file, int precision=8)"},
+	 { "Table_SaveGZ", (PyCFunction)(void(*)(void))_wrap_Table_SaveGZ, METH_VARARGS|METH_KEYWORDS, "Table_SaveGZ(Table self, char const * file, int precision=8)"},
 	 { "Table_Save", _wrap_Table_Save, METH_VARARGS, "\n"
 		"Table_Save(Table self, std::ostream & out)\n"
 		"Table_Save(Table self, char const * file, int precision=8)\n"
@@ -7259,10 +7473,13 @@ static PyMethodDef SwigMethods_proxydocs[] = {
 		"Print(Table self, std::ostream & out=mfem::out, int width=4)\n"
 		"Print(Table self, char const * file, int precision=8)\n"
 		""},
+	 { "Table_PrintGZ", (PyCFunction)(void(*)(void))_wrap_Table_PrintGZ, METH_VARARGS|METH_KEYWORDS, "PrintGZ(Table self, char const * file, int precision=8)"},
 	 { "Table_PrintMatlab", _wrap_Table_PrintMatlab, METH_VARARGS, "\n"
 		"PrintMatlab(Table self, std::ostream & out)\n"
 		"PrintMatlab(Table self, char const * file, int precision=8)\n"
 		""},
+	 { "Table_PrintMatlabGZ", (PyCFunction)(void(*)(void))_wrap_Table_PrintMatlabGZ, METH_VARARGS|METH_KEYWORDS, "PrintMatlabGZ(Table self, char const * file, int precision=8)"},
+	 { "Table_SaveGZ", (PyCFunction)(void(*)(void))_wrap_Table_SaveGZ, METH_VARARGS|METH_KEYWORDS, "SaveGZ(Table self, char const * file, int precision=8)"},
 	 { "Table_Save", _wrap_Table_Save, METH_VARARGS, "\n"
 		"Save(Table self, std::ostream & out)\n"
 		"Save(Table self, char const * file, int precision=8)\n"

--- a/mfem/_par/vector.py
+++ b/mfem/_par/vector.py
@@ -514,6 +514,16 @@ class Vector(object):
         return _vector.Vector_Print(self, *args)
     Print = _swig_new_instance_method(_vector.Vector_Print)
 
+    def PrintGZ(self, file, precision=8):
+        r"""PrintGZ(Vector self, char const * file, int precision=8)"""
+        return _vector.Vector_PrintGZ(self, file, precision)
+    PrintGZ = _swig_new_instance_method(_vector.Vector_PrintGZ)
+
+    def Print_HYPREGZ(self, file, precision=8):
+        r"""Print_HYPREGZ(Vector self, char const * file, int precision=8)"""
+        return _vector.Vector_Print_HYPREGZ(self, file, precision)
+    Print_HYPREGZ = _swig_new_instance_method(_vector.Vector_Print_HYPREGZ)
+
     def Print_HYPRE(self, *args):
         r"""
         Print_HYPRE(Vector self, std::ostream & out)

--- a/mfem/_par/vector_wrap.cxx
+++ b/mfem/_par/vector_wrap.cxx
@@ -3290,6 +3290,17 @@ SWIGINTERN void mfem_Vector_Print__SWIG_1(mfem::Vector *self,char const *file,in
   self -> Print(ofile);
   ofile.close();
   }
+SWIGINTERN void mfem_Vector_PrintGZ(mfem::Vector *self,char const *file,int precision=8){
+  mfem::ofgzstream *ofile = new mfem::ofgzstream(file, true);
+  if (!ofile)
+     {
+        std::cerr << "\nCan not produce output file: " << file << '\n' << std::endl;
+        return;
+      }
+  ofile ->precision(precision);  
+  self -> Print(*ofile);
+  delete ofile;
+  }
 SWIGINTERN void mfem_Vector_Print_HYPRE__SWIG_1(mfem::Vector *self,char const *file,int precision=8){
   std::ofstream ofile(file);
   if (!ofile)
@@ -3300,6 +3311,18 @@ SWIGINTERN void mfem_Vector_Print_HYPRE__SWIG_1(mfem::Vector *self,char const *f
   ofile.precision(precision);    
   self -> Print_HYPRE(ofile);
   ofile.close();
+  }
+SWIGINTERN void mfem_Vector_Print_HYPREGZ(mfem::Vector *self,char const *file,int precision=8){
+  mfem::ofgzstream *ofile = new mfem::ofgzstream(file, true);
+  
+  if (!ofile)
+     {
+        std::cerr << "\nCan not produce output file: " << file << '\n' << std::endl;
+        return;
+      }
+  ofile -> precision(precision);  
+  self -> Print_HYPRE(*ofile);
+  delete ofile;
   }
 SWIGINTERN void mfem_Vector_Print_HYPRE__SWIG_2(mfem::Vector *self){
   self -> Print_HYPRE(std::cout);
@@ -4406,14 +4429,20 @@ SWIGINTERN PyObject *_wrap_Vector_Load__SWIG_1(PyObject *SWIGUNUSEDPARM(self), P
       }
     }
     if (stream2 == 0){
-      if (temp2->isGZ()){
-        in_gz2 = new mfem::ifgzstream(temp2->getFilename());
-        arg2 = in_gz2;
-      } else {
-        in_txt2.open(temp2->getFilename(), std::ifstream::in);
-        in_txt2.precision(temp2->getPrecision());
-        arg2 = &in_txt2;
-      }
+      /*
+            if (temp2->isGZ()){
+        	 in_gz2 = new mfem::ifgzstream(temp2->getFilename());
+               arg2 = in_gz2;
+            } else {
+        	 in_txt2.open(temp2->getFilename(), std::ifstream::in);
+               in_txt2.precision(temp2->getPrecision());
+               arg2 = &in_txt2;
+            }
+           */
+      /* this will auto-detect the input file type */
+      in_gz2 = new mfem::ifgzstream(temp2->getFilename());
+      arg2 = in_gz2;
+      
       if (temp2->isTemporary()){
         delete temp2;
       }
@@ -4444,18 +4473,6 @@ SWIGINTERN PyObject *_wrap_Vector_Load__SWIG_1(PyObject *SWIGUNUSEDPARM(self), P
     }	 
   }
   resultobj = SWIG_Py_Void();
-  {
-    if (stream2) {
-      ret2 = PyLong_FromSsize_t(len2);
-      if (PyErr_Occurred()) {
-        PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
-        return NULL;
-      }
-      delete stream2;    
-      Py_XDECREF(resultobj);   /* Blow away any previous result */
-      resultobj = ret2;    
-    }
-  }
   {
     if (!stream2) {
       if (temp2) {
@@ -4544,14 +4561,20 @@ SWIGINTERN PyObject *_wrap_Vector_Load__SWIG_2(PyObject *SWIGUNUSEDPARM(self), P
       }
     }
     if (stream2 == 0){
-      if (temp2->isGZ()){
-        in_gz2 = new mfem::ifgzstream(temp2->getFilename());
-        arg2 = in_gz2;
-      } else {
-        in_txt2.open(temp2->getFilename(), std::ifstream::in);
-        in_txt2.precision(temp2->getPrecision());
-        arg2 = &in_txt2;
-      }
+      /*
+            if (temp2->isGZ()){
+        	 in_gz2 = new mfem::ifgzstream(temp2->getFilename());
+               arg2 = in_gz2;
+            } else {
+        	 in_txt2.open(temp2->getFilename(), std::ifstream::in);
+               in_txt2.precision(temp2->getPrecision());
+               arg2 = &in_txt2;
+            }
+           */
+      /* this will auto-detect the input file type */
+      in_gz2 = new mfem::ifgzstream(temp2->getFilename());
+      arg2 = in_gz2;
+      
       if (temp2->isTemporary()){
         delete temp2;
       }
@@ -4576,18 +4599,6 @@ SWIGINTERN PyObject *_wrap_Vector_Load__SWIG_2(PyObject *SWIGUNUSEDPARM(self), P
     }	 
   }
   resultobj = SWIG_Py_Void();
-  {
-    if (stream2) {
-      ret2 = PyLong_FromSsize_t(len2);
-      if (PyErr_Occurred()) {
-        PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
-        return NULL;
-      }
-      delete stream2;    
-      Py_XDECREF(resultobj);   /* Blow away any previous result */
-      resultobj = ret2;    
-    }
-  }
   {
     if (!stream2) {
       if (temp2) {
@@ -9493,6 +9504,67 @@ fail:
 }
 
 
+SWIGINTERN PyObject *_wrap_Vector_PrintGZ(PyObject *SWIGUNUSEDPARM(self), PyObject *args, PyObject *kwargs) {
+  PyObject *resultobj = 0;
+  mfem::Vector *arg1 = (mfem::Vector *) 0 ;
+  char *arg2 = (char *) 0 ;
+  int arg3 = (int) 8 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int res2 ;
+  char *buf2 = 0 ;
+  int alloc2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  char * kwnames[] = {
+    (char *)"self",  (char *)"file",  (char *)"precision",  NULL 
+  };
+  
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OO|O:Vector_PrintGZ", kwnames, &obj0, &obj1, &obj2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_mfem__Vector, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "Vector_PrintGZ" "', argument " "1"" of type '" "mfem::Vector *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::Vector * >(argp1);
+  res2 = SWIG_AsCharPtrAndSize(obj1, &buf2, NULL, &alloc2);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "Vector_PrintGZ" "', argument " "2"" of type '" "char const *""'");
+  }
+  arg2 = reinterpret_cast< char * >(buf2);
+  if (obj2) {
+    {
+      if ((PyArray_PyIntAsInt(obj2) == -1) && PyErr_Occurred()) {
+        SWIG_exception_fail(SWIG_TypeError, "Input must be integer");
+      };  
+      arg3 = PyArray_PyIntAsInt(obj2);
+    }
+  }
+  {
+    try {
+      mfem_Vector_PrintGZ(arg1,(char const *)arg2,arg3);
+    }
+#ifdef  MFEM_USE_EXCEPTIONS
+    catch (mfem::ErrorException &_e) {
+      std::string s("PyMFEM error (mfem::ErrorException): "), s2(_e.what());
+      s = s + s2;    
+      SWIG_exception(SWIG_RuntimeError, s.c_str());
+    }
+#endif
+    
+    catch (...) {
+      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+    }	 
+  }
+  resultobj = SWIG_Py_Void();
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return resultobj;
+fail:
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return NULL;
+}
+
+
 SWIGINTERN PyObject *_wrap_Vector_Print_HYPRE__SWIG_1(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
   PyObject *resultobj = 0;
   mfem::Vector *arg1 = (mfem::Vector *) 0 ;
@@ -9526,6 +9598,67 @@ SWIGINTERN PyObject *_wrap_Vector_Print_HYPRE__SWIG_1(PyObject *SWIGUNUSEDPARM(s
   {
     try {
       mfem_Vector_Print_HYPRE__SWIG_1(arg1,(char const *)arg2,arg3);
+    }
+#ifdef  MFEM_USE_EXCEPTIONS
+    catch (mfem::ErrorException &_e) {
+      std::string s("PyMFEM error (mfem::ErrorException): "), s2(_e.what());
+      s = s + s2;    
+      SWIG_exception(SWIG_RuntimeError, s.c_str());
+    }
+#endif
+    
+    catch (...) {
+      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+    }	 
+  }
+  resultobj = SWIG_Py_Void();
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return resultobj;
+fail:
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_Vector_Print_HYPREGZ(PyObject *SWIGUNUSEDPARM(self), PyObject *args, PyObject *kwargs) {
+  PyObject *resultobj = 0;
+  mfem::Vector *arg1 = (mfem::Vector *) 0 ;
+  char *arg2 = (char *) 0 ;
+  int arg3 = (int) 8 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int res2 ;
+  char *buf2 = 0 ;
+  int alloc2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  char * kwnames[] = {
+    (char *)"self",  (char *)"file",  (char *)"precision",  NULL 
+  };
+  
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OO|O:Vector_Print_HYPREGZ", kwnames, &obj0, &obj1, &obj2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_mfem__Vector, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "Vector_Print_HYPREGZ" "', argument " "1"" of type '" "mfem::Vector *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::Vector * >(argp1);
+  res2 = SWIG_AsCharPtrAndSize(obj1, &buf2, NULL, &alloc2);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "Vector_Print_HYPREGZ" "', argument " "2"" of type '" "char const *""'");
+  }
+  arg2 = reinterpret_cast< char * >(buf2);
+  if (obj2) {
+    {
+      if ((PyArray_PyIntAsInt(obj2) == -1) && PyErr_Occurred()) {
+        SWIG_exception_fail(SWIG_TypeError, "Input must be integer");
+      };  
+      arg3 = PyArray_PyIntAsInt(obj2);
+    }
+  }
+  {
+    try {
+      mfem_Vector_Print_HYPREGZ(arg1,(char const *)arg2,arg3);
     }
 #ifdef  MFEM_USE_EXCEPTIONS
     catch (mfem::ErrorException &_e) {
@@ -9977,6 +10110,8 @@ static PyMethodDef SwigMethods[] = {
 		"Vector_Print(Vector self, std::ostream & out=mfem::out, int width=8)\n"
 		"Vector_Print(Vector self, char const * file, int precision=8)\n"
 		""},
+	 { "Vector_PrintGZ", (PyCFunction)(void(*)(void))_wrap_Vector_PrintGZ, METH_VARARGS|METH_KEYWORDS, "Vector_PrintGZ(Vector self, char const * file, int precision=8)"},
+	 { "Vector_Print_HYPREGZ", (PyCFunction)(void(*)(void))_wrap_Vector_Print_HYPREGZ, METH_VARARGS|METH_KEYWORDS, "Vector_Print_HYPREGZ(Vector self, char const * file, int precision=8)"},
 	 { "Vector_Print_HYPRE", _wrap_Vector_Print_HYPRE, METH_VARARGS, "\n"
 		"Vector_Print_HYPRE(Vector self, std::ostream & out)\n"
 		"Vector_Print_HYPRE(Vector self, char const * file, int precision=8)\n"
@@ -10124,6 +10259,8 @@ static PyMethodDef SwigMethods_proxydocs[] = {
 		"Print(Vector self, std::ostream & out=mfem::out, int width=8)\n"
 		"Print(Vector self, char const * file, int precision=8)\n"
 		""},
+	 { "Vector_PrintGZ", (PyCFunction)(void(*)(void))_wrap_Vector_PrintGZ, METH_VARARGS|METH_KEYWORDS, "PrintGZ(Vector self, char const * file, int precision=8)"},
+	 { "Vector_Print_HYPREGZ", (PyCFunction)(void(*)(void))_wrap_Vector_Print_HYPREGZ, METH_VARARGS|METH_KEYWORDS, "Print_HYPREGZ(Vector self, char const * file, int precision=8)"},
 	 { "Vector_Print_HYPRE", _wrap_Vector_Print_HYPRE, METH_VARARGS, "\n"
 		"Print_HYPRE(Vector self, std::ostream & out)\n"
 		"Print_HYPRE(Vector self, char const * file, int precision=8)\n"

--- a/mfem/_ser/array.py
+++ b/mfem/_ser/array.py
@@ -348,6 +348,16 @@ class intArray(object):
         return _array.intArray_Print(self, *args)
     Print = _swig_new_instance_method(_array.intArray_Print)
 
+    def PrintGZ(self, file, precision=8):
+        r"""PrintGZ(intArray self, char const * file, int precision=8)"""
+        return _array.intArray_PrintGZ(self, file, precision)
+    PrintGZ = _swig_new_instance_method(_array.intArray_PrintGZ)
+
+    def SaveGZ(self, file, precision=8):
+        r"""SaveGZ(intArray self, char const * file, int precision=8)"""
+        return _array.intArray_SaveGZ(self, file, precision)
+    SaveGZ = _swig_new_instance_method(_array.intArray_SaveGZ)
+
     def Save(self, *args):
         r"""
         Save(intArray self, std::ostream & out, int fmt=0)
@@ -642,6 +652,16 @@ class doubleArray(object):
         """
         return _array.doubleArray_Print(self, *args)
     Print = _swig_new_instance_method(_array.doubleArray_Print)
+
+    def PrintGZ(self, file, precision=8):
+        r"""PrintGZ(doubleArray self, char const * file, int precision=8)"""
+        return _array.doubleArray_PrintGZ(self, file, precision)
+    PrintGZ = _swig_new_instance_method(_array.doubleArray_PrintGZ)
+
+    def SaveGZ(self, file, precision=8):
+        r"""SaveGZ(doubleArray self, char const * file, int precision=8)"""
+        return _array.doubleArray_SaveGZ(self, file, precision)
+    SaveGZ = _swig_new_instance_method(_array.doubleArray_SaveGZ)
 
     def Save(self, *args):
         r"""

--- a/mfem/_ser/array_wrap.cxx
+++ b/mfem/_ser/array_wrap.cxx
@@ -3148,6 +3148,17 @@ SWIGINTERN void mfem_Array_Sl_int_Sg__Print__SWIG_1(mfem::Array< int > *self,cha
   self -> Print(ofile);
   ofile.close();
   }
+SWIGINTERN void mfem_Array_Sl_int_Sg__PrintGZ(mfem::Array< int > *self,char const *file,int precision=8){
+  mfem::ofgzstream *ofile = new mfem::ofgzstream(file, true);
+  if (!ofile)
+     {
+        std::cerr << "\nCan not produce output file: " << file << '\n' << std::endl;
+        return;
+      }
+  ofile ->precision(precision);  
+  self -> Print(*ofile);
+  delete ofile;
+  }
 SWIGINTERN void mfem_Array_Sl_int_Sg__Save__SWIG_1(mfem::Array< int > *self,char const *file,int precision=8){
   std::ofstream ofile(file);
   if (!ofile)
@@ -3158,6 +3169,18 @@ SWIGINTERN void mfem_Array_Sl_int_Sg__Save__SWIG_1(mfem::Array< int > *self,char
   ofile.precision(precision);    
   self -> Save(ofile);
   ofile.close();
+  }
+SWIGINTERN void mfem_Array_Sl_int_Sg__SaveGZ(mfem::Array< int > *self,char const *file,int precision=8){
+  mfem::ofgzstream *ofile = new mfem::ofgzstream(file, true);
+  
+  if (!ofile)
+     {
+        std::cerr << "\nCan not produce output file: " << file << '\n' << std::endl;
+        return;
+      }
+  ofile -> precision(precision);  
+  self -> Save(*ofile);
+  delete ofile;
   }
 SWIGINTERN void mfem_Array_Sl_int_Sg__Save__SWIG_2(mfem::Array< int > *self){
   self -> Save(std::cout);
@@ -3186,6 +3209,17 @@ SWIGINTERN void mfem_Array_Sl_double_Sg__Print__SWIG_1(mfem::Array< double > *se
   self -> Print(ofile);
   ofile.close();
   }
+SWIGINTERN void mfem_Array_Sl_double_Sg__PrintGZ(mfem::Array< double > *self,char const *file,int precision=8){
+  mfem::ofgzstream *ofile = new mfem::ofgzstream(file, true);
+  if (!ofile)
+     {
+        std::cerr << "\nCan not produce output file: " << file << '\n' << std::endl;
+        return;
+      }
+  ofile ->precision(precision);  
+  self -> Print(*ofile);
+  delete ofile;
+  }
 SWIGINTERN void mfem_Array_Sl_double_Sg__Save__SWIG_1(mfem::Array< double > *self,char const *file,int precision=8){
   std::ofstream ofile(file);
   if (!ofile)
@@ -3196,6 +3230,18 @@ SWIGINTERN void mfem_Array_Sl_double_Sg__Save__SWIG_1(mfem::Array< double > *sel
   ofile.precision(precision);    
   self -> Save(ofile);
   ofile.close();
+  }
+SWIGINTERN void mfem_Array_Sl_double_Sg__SaveGZ(mfem::Array< double > *self,char const *file,int precision=8){
+  mfem::ofgzstream *ofile = new mfem::ofgzstream(file, true);
+  
+  if (!ofile)
+     {
+        std::cerr << "\nCan not produce output file: " << file << '\n' << std::endl;
+        return;
+      }
+  ofile -> precision(precision);  
+  self -> Save(*ofile);
+  delete ofile;
   }
 SWIGINTERN void mfem_Array_Sl_double_Sg__Save__SWIG_2(mfem::Array< double > *self){
   self -> Save(std::cout);
@@ -5531,14 +5577,20 @@ SWIGINTERN PyObject *_wrap_intArray_Load__SWIG_0(PyObject *SWIGUNUSEDPARM(self),
       }
     }
     if (stream2 == 0){
-      if (temp2->isGZ()){
-        in_gz2 = new mfem::ifgzstream(temp2->getFilename());
-        arg2 = in_gz2;
-      } else {
-        in_txt2.open(temp2->getFilename(), std::ifstream::in);
-        in_txt2.precision(temp2->getPrecision());
-        arg2 = &in_txt2;
-      }
+      /*
+            if (temp2->isGZ()){
+        	 in_gz2 = new mfem::ifgzstream(temp2->getFilename());
+               arg2 = in_gz2;
+            } else {
+        	 in_txt2.open(temp2->getFilename(), std::ifstream::in);
+               in_txt2.precision(temp2->getPrecision());
+               arg2 = &in_txt2;
+            }
+           */
+      /* this will auto-detect the input file type */
+      in_gz2 = new mfem::ifgzstream(temp2->getFilename());
+      arg2 = in_gz2;
+      
       if (temp2->isTemporary()){
         delete temp2;
       }
@@ -5570,18 +5622,6 @@ SWIGINTERN PyObject *_wrap_intArray_Load__SWIG_0(PyObject *SWIGUNUSEDPARM(self),
     }	 
   }
   resultobj = SWIG_Py_Void();
-  {
-    if (stream2) {
-      ret2 = PyLong_FromSsize_t(len2);
-      if (PyErr_Occurred()) {
-        PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
-        return NULL;
-      }
-      delete stream2;    
-      Py_XDECREF(resultobj);   /* Blow away any previous result */
-      resultobj = ret2;    
-    }
-  }
   {
     if (!stream2) {
       if (temp2) {
@@ -5678,14 +5718,20 @@ SWIGINTERN PyObject *_wrap_intArray_Load__SWIG_1(PyObject *SWIGUNUSEDPARM(self),
       }
     }
     if (stream3 == 0){
-      if (temp3->isGZ()){
-        in_gz3 = new mfem::ifgzstream(temp3->getFilename());
-        arg3 = in_gz3;
-      } else {
-        in_txt3.open(temp3->getFilename(), std::ifstream::in);
-        in_txt3.precision(temp3->getPrecision());
-        arg3 = &in_txt3;
-      }
+      /*
+            if (temp3->isGZ()){
+        	 in_gz3 = new mfem::ifgzstream(temp3->getFilename());
+               arg3 = in_gz3;
+            } else {
+        	 in_txt3.open(temp3->getFilename(), std::ifstream::in);
+               in_txt3.precision(temp3->getPrecision());
+               arg3 = &in_txt3;
+            }
+           */
+      /* this will auto-detect the input file type */
+      in_gz3 = new mfem::ifgzstream(temp3->getFilename());
+      arg3 = in_gz3;
+      
       if (temp3->isTemporary()){
         delete temp3;
       }
@@ -5710,18 +5756,6 @@ SWIGINTERN PyObject *_wrap_intArray_Load__SWIG_1(PyObject *SWIGUNUSEDPARM(self),
     }	 
   }
   resultobj = SWIG_Py_Void();
-  {
-    if (stream3) {
-      ret3 = PyLong_FromSsize_t(len3);
-      if (PyErr_Occurred()) {
-        PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
-        return NULL;
-      }
-      delete stream3;    
-      Py_XDECREF(resultobj);   /* Blow away any previous result */
-      resultobj = ret3;    
-    }
-  }
   {
     if (!stream3) {
       if (temp3) {
@@ -7068,6 +7102,68 @@ fail:
 }
 
 
+SWIGINTERN PyObject *_wrap_intArray_PrintGZ(PyObject *SWIGUNUSEDPARM(self), PyObject *args, PyObject *kwargs) {
+  PyObject *resultobj = 0;
+  mfem::Array< int > *arg1 = (mfem::Array< int > *) 0 ;
+  char *arg2 = (char *) 0 ;
+  int arg3 = (int) 8 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int res2 ;
+  char *buf2 = 0 ;
+  int alloc2 = 0 ;
+  int val3 ;
+  int ecode3 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  char * kwnames[] = {
+    (char *)"self",  (char *)"file",  (char *)"precision",  NULL 
+  };
+  
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OO|O:intArray_PrintGZ", kwnames, &obj0, &obj1, &obj2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_mfem__ArrayT_int_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "intArray_PrintGZ" "', argument " "1"" of type '" "mfem::Array< int > *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::Array< int > * >(argp1);
+  res2 = SWIG_AsCharPtrAndSize(obj1, &buf2, NULL, &alloc2);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "intArray_PrintGZ" "', argument " "2"" of type '" "char const *""'");
+  }
+  arg2 = reinterpret_cast< char * >(buf2);
+  if (obj2) {
+    ecode3 = SWIG_AsVal_int(obj2, &val3);
+    if (!SWIG_IsOK(ecode3)) {
+      SWIG_exception_fail(SWIG_ArgError(ecode3), "in method '" "intArray_PrintGZ" "', argument " "3"" of type '" "int""'");
+    } 
+    arg3 = static_cast< int >(val3);
+  }
+  {
+    try {
+      mfem_Array_Sl_int_Sg__PrintGZ(arg1,(char const *)arg2,arg3);
+    }
+#ifdef  MFEM_USE_EXCEPTIONS
+    catch (mfem::ErrorException &_e) {
+      std::string s("PyMFEM error (mfem::ErrorException): "), s2(_e.what());
+      s = s + s2;    
+      SWIG_exception(SWIG_RuntimeError, s.c_str());
+    }
+#endif
+    
+    catch (...) {
+      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+    }	 
+  }
+  resultobj = SWIG_Py_Void();
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return resultobj;
+fail:
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return NULL;
+}
+
+
 SWIGINTERN PyObject *_wrap_intArray_Save__SWIG_1(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
   PyObject *resultobj = 0;
   mfem::Array< int > *arg1 = (mfem::Array< int > *) 0 ;
@@ -7102,6 +7198,68 @@ SWIGINTERN PyObject *_wrap_intArray_Save__SWIG_1(PyObject *SWIGUNUSEDPARM(self),
   {
     try {
       mfem_Array_Sl_int_Sg__Save__SWIG_1(arg1,(char const *)arg2,arg3);
+    }
+#ifdef  MFEM_USE_EXCEPTIONS
+    catch (mfem::ErrorException &_e) {
+      std::string s("PyMFEM error (mfem::ErrorException): "), s2(_e.what());
+      s = s + s2;    
+      SWIG_exception(SWIG_RuntimeError, s.c_str());
+    }
+#endif
+    
+    catch (...) {
+      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+    }	 
+  }
+  resultobj = SWIG_Py_Void();
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return resultobj;
+fail:
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_intArray_SaveGZ(PyObject *SWIGUNUSEDPARM(self), PyObject *args, PyObject *kwargs) {
+  PyObject *resultobj = 0;
+  mfem::Array< int > *arg1 = (mfem::Array< int > *) 0 ;
+  char *arg2 = (char *) 0 ;
+  int arg3 = (int) 8 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int res2 ;
+  char *buf2 = 0 ;
+  int alloc2 = 0 ;
+  int val3 ;
+  int ecode3 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  char * kwnames[] = {
+    (char *)"self",  (char *)"file",  (char *)"precision",  NULL 
+  };
+  
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OO|O:intArray_SaveGZ", kwnames, &obj0, &obj1, &obj2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_mfem__ArrayT_int_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "intArray_SaveGZ" "', argument " "1"" of type '" "mfem::Array< int > *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::Array< int > * >(argp1);
+  res2 = SWIG_AsCharPtrAndSize(obj1, &buf2, NULL, &alloc2);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "intArray_SaveGZ" "', argument " "2"" of type '" "char const *""'");
+  }
+  arg2 = reinterpret_cast< char * >(buf2);
+  if (obj2) {
+    ecode3 = SWIG_AsVal_int(obj2, &val3);
+    if (!SWIG_IsOK(ecode3)) {
+      SWIG_exception_fail(SWIG_ArgError(ecode3), "in method '" "intArray_SaveGZ" "', argument " "3"" of type '" "int""'");
+    } 
+    arg3 = static_cast< int >(val3);
+  }
+  {
+    try {
+      mfem_Array_Sl_int_Sg__SaveGZ(arg1,(char const *)arg2,arg3);
     }
 #ifdef  MFEM_USE_EXCEPTIONS
     catch (mfem::ErrorException &_e) {
@@ -9596,14 +9754,20 @@ SWIGINTERN PyObject *_wrap_doubleArray_Load__SWIG_0(PyObject *SWIGUNUSEDPARM(sel
       }
     }
     if (stream2 == 0){
-      if (temp2->isGZ()){
-        in_gz2 = new mfem::ifgzstream(temp2->getFilename());
-        arg2 = in_gz2;
-      } else {
-        in_txt2.open(temp2->getFilename(), std::ifstream::in);
-        in_txt2.precision(temp2->getPrecision());
-        arg2 = &in_txt2;
-      }
+      /*
+            if (temp2->isGZ()){
+        	 in_gz2 = new mfem::ifgzstream(temp2->getFilename());
+               arg2 = in_gz2;
+            } else {
+        	 in_txt2.open(temp2->getFilename(), std::ifstream::in);
+               in_txt2.precision(temp2->getPrecision());
+               arg2 = &in_txt2;
+            }
+           */
+      /* this will auto-detect the input file type */
+      in_gz2 = new mfem::ifgzstream(temp2->getFilename());
+      arg2 = in_gz2;
+      
       if (temp2->isTemporary()){
         delete temp2;
       }
@@ -9635,18 +9799,6 @@ SWIGINTERN PyObject *_wrap_doubleArray_Load__SWIG_0(PyObject *SWIGUNUSEDPARM(sel
     }	 
   }
   resultobj = SWIG_Py_Void();
-  {
-    if (stream2) {
-      ret2 = PyLong_FromSsize_t(len2);
-      if (PyErr_Occurred()) {
-        PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
-        return NULL;
-      }
-      delete stream2;    
-      Py_XDECREF(resultobj);   /* Blow away any previous result */
-      resultobj = ret2;    
-    }
-  }
   {
     if (!stream2) {
       if (temp2) {
@@ -9743,14 +9895,20 @@ SWIGINTERN PyObject *_wrap_doubleArray_Load__SWIG_1(PyObject *SWIGUNUSEDPARM(sel
       }
     }
     if (stream3 == 0){
-      if (temp3->isGZ()){
-        in_gz3 = new mfem::ifgzstream(temp3->getFilename());
-        arg3 = in_gz3;
-      } else {
-        in_txt3.open(temp3->getFilename(), std::ifstream::in);
-        in_txt3.precision(temp3->getPrecision());
-        arg3 = &in_txt3;
-      }
+      /*
+            if (temp3->isGZ()){
+        	 in_gz3 = new mfem::ifgzstream(temp3->getFilename());
+               arg3 = in_gz3;
+            } else {
+        	 in_txt3.open(temp3->getFilename(), std::ifstream::in);
+               in_txt3.precision(temp3->getPrecision());
+               arg3 = &in_txt3;
+            }
+           */
+      /* this will auto-detect the input file type */
+      in_gz3 = new mfem::ifgzstream(temp3->getFilename());
+      arg3 = in_gz3;
+      
       if (temp3->isTemporary()){
         delete temp3;
       }
@@ -9775,18 +9933,6 @@ SWIGINTERN PyObject *_wrap_doubleArray_Load__SWIG_1(PyObject *SWIGUNUSEDPARM(sel
     }	 
   }
   resultobj = SWIG_Py_Void();
-  {
-    if (stream3) {
-      ret3 = PyLong_FromSsize_t(len3);
-      if (PyErr_Occurred()) {
-        PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
-        return NULL;
-      }
-      delete stream3;    
-      Py_XDECREF(resultobj);   /* Blow away any previous result */
-      resultobj = ret3;    
-    }
-  }
   {
     if (!stream3) {
       if (temp3) {
@@ -11133,6 +11279,68 @@ fail:
 }
 
 
+SWIGINTERN PyObject *_wrap_doubleArray_PrintGZ(PyObject *SWIGUNUSEDPARM(self), PyObject *args, PyObject *kwargs) {
+  PyObject *resultobj = 0;
+  mfem::Array< double > *arg1 = (mfem::Array< double > *) 0 ;
+  char *arg2 = (char *) 0 ;
+  int arg3 = (int) 8 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int res2 ;
+  char *buf2 = 0 ;
+  int alloc2 = 0 ;
+  int val3 ;
+  int ecode3 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  char * kwnames[] = {
+    (char *)"self",  (char *)"file",  (char *)"precision",  NULL 
+  };
+  
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OO|O:doubleArray_PrintGZ", kwnames, &obj0, &obj1, &obj2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_mfem__ArrayT_double_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "doubleArray_PrintGZ" "', argument " "1"" of type '" "mfem::Array< double > *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::Array< double > * >(argp1);
+  res2 = SWIG_AsCharPtrAndSize(obj1, &buf2, NULL, &alloc2);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "doubleArray_PrintGZ" "', argument " "2"" of type '" "char const *""'");
+  }
+  arg2 = reinterpret_cast< char * >(buf2);
+  if (obj2) {
+    ecode3 = SWIG_AsVal_int(obj2, &val3);
+    if (!SWIG_IsOK(ecode3)) {
+      SWIG_exception_fail(SWIG_ArgError(ecode3), "in method '" "doubleArray_PrintGZ" "', argument " "3"" of type '" "int""'");
+    } 
+    arg3 = static_cast< int >(val3);
+  }
+  {
+    try {
+      mfem_Array_Sl_double_Sg__PrintGZ(arg1,(char const *)arg2,arg3);
+    }
+#ifdef  MFEM_USE_EXCEPTIONS
+    catch (mfem::ErrorException &_e) {
+      std::string s("PyMFEM error (mfem::ErrorException): "), s2(_e.what());
+      s = s + s2;    
+      SWIG_exception(SWIG_RuntimeError, s.c_str());
+    }
+#endif
+    
+    catch (...) {
+      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+    }	 
+  }
+  resultobj = SWIG_Py_Void();
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return resultobj;
+fail:
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return NULL;
+}
+
+
 SWIGINTERN PyObject *_wrap_doubleArray_Save__SWIG_1(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
   PyObject *resultobj = 0;
   mfem::Array< double > *arg1 = (mfem::Array< double > *) 0 ;
@@ -11167,6 +11375,68 @@ SWIGINTERN PyObject *_wrap_doubleArray_Save__SWIG_1(PyObject *SWIGUNUSEDPARM(sel
   {
     try {
       mfem_Array_Sl_double_Sg__Save__SWIG_1(arg1,(char const *)arg2,arg3);
+    }
+#ifdef  MFEM_USE_EXCEPTIONS
+    catch (mfem::ErrorException &_e) {
+      std::string s("PyMFEM error (mfem::ErrorException): "), s2(_e.what());
+      s = s + s2;    
+      SWIG_exception(SWIG_RuntimeError, s.c_str());
+    }
+#endif
+    
+    catch (...) {
+      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+    }	 
+  }
+  resultobj = SWIG_Py_Void();
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return resultobj;
+fail:
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_doubleArray_SaveGZ(PyObject *SWIGUNUSEDPARM(self), PyObject *args, PyObject *kwargs) {
+  PyObject *resultobj = 0;
+  mfem::Array< double > *arg1 = (mfem::Array< double > *) 0 ;
+  char *arg2 = (char *) 0 ;
+  int arg3 = (int) 8 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int res2 ;
+  char *buf2 = 0 ;
+  int alloc2 = 0 ;
+  int val3 ;
+  int ecode3 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  char * kwnames[] = {
+    (char *)"self",  (char *)"file",  (char *)"precision",  NULL 
+  };
+  
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OO|O:doubleArray_SaveGZ", kwnames, &obj0, &obj1, &obj2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_mfem__ArrayT_double_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "doubleArray_SaveGZ" "', argument " "1"" of type '" "mfem::Array< double > *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::Array< double > * >(argp1);
+  res2 = SWIG_AsCharPtrAndSize(obj1, &buf2, NULL, &alloc2);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "doubleArray_SaveGZ" "', argument " "2"" of type '" "char const *""'");
+  }
+  arg2 = reinterpret_cast< char * >(buf2);
+  if (obj2) {
+    ecode3 = SWIG_AsVal_int(obj2, &val3);
+    if (!SWIG_IsOK(ecode3)) {
+      SWIG_exception_fail(SWIG_ArgError(ecode3), "in method '" "doubleArray_SaveGZ" "', argument " "3"" of type '" "int""'");
+    } 
+    arg3 = static_cast< int >(val3);
+  }
+  {
+    try {
+      mfem_Array_Sl_double_Sg__SaveGZ(arg1,(char const *)arg2,arg3);
     }
 #ifdef  MFEM_USE_EXCEPTIONS
     catch (mfem::ErrorException &_e) {
@@ -11840,6 +12110,8 @@ static PyMethodDef SwigMethods[] = {
 		"intArray_Print(intArray self, std::ostream & out=mfem::out, int width=4)\n"
 		"intArray_Print(intArray self, char const * file, int precision=8)\n"
 		""},
+	 { "intArray_PrintGZ", (PyCFunction)(void(*)(void))_wrap_intArray_PrintGZ, METH_VARARGS|METH_KEYWORDS, "intArray_PrintGZ(intArray self, char const * file, int precision=8)"},
+	 { "intArray_SaveGZ", (PyCFunction)(void(*)(void))_wrap_intArray_SaveGZ, METH_VARARGS|METH_KEYWORDS, "intArray_SaveGZ(intArray self, char const * file, int precision=8)"},
 	 { "intArray_Save", _wrap_intArray_Save, METH_VARARGS, "\n"
 		"intArray_Save(intArray self, std::ostream & out, int fmt=0)\n"
 		"intArray_Save(intArray self, char const * file, int precision=8)\n"
@@ -11935,6 +12207,8 @@ static PyMethodDef SwigMethods[] = {
 		"doubleArray_Print(doubleArray self, std::ostream & out=mfem::out, int width=4)\n"
 		"doubleArray_Print(doubleArray self, char const * file, int precision=8)\n"
 		""},
+	 { "doubleArray_PrintGZ", (PyCFunction)(void(*)(void))_wrap_doubleArray_PrintGZ, METH_VARARGS|METH_KEYWORDS, "doubleArray_PrintGZ(doubleArray self, char const * file, int precision=8)"},
+	 { "doubleArray_SaveGZ", (PyCFunction)(void(*)(void))_wrap_doubleArray_SaveGZ, METH_VARARGS|METH_KEYWORDS, "doubleArray_SaveGZ(doubleArray self, char const * file, int precision=8)"},
 	 { "doubleArray_Save", _wrap_doubleArray_Save, METH_VARARGS, "\n"
 		"doubleArray_Save(doubleArray self, std::ostream & out, int fmt=0)\n"
 		"doubleArray_Save(doubleArray self, char const * file, int precision=8)\n"
@@ -12046,6 +12320,8 @@ static PyMethodDef SwigMethods_proxydocs[] = {
 		"Print(intArray self, std::ostream & out=mfem::out, int width=4)\n"
 		"Print(intArray self, char const * file, int precision=8)\n"
 		""},
+	 { "intArray_PrintGZ", (PyCFunction)(void(*)(void))_wrap_intArray_PrintGZ, METH_VARARGS|METH_KEYWORDS, "PrintGZ(intArray self, char const * file, int precision=8)"},
+	 { "intArray_SaveGZ", (PyCFunction)(void(*)(void))_wrap_intArray_SaveGZ, METH_VARARGS|METH_KEYWORDS, "SaveGZ(intArray self, char const * file, int precision=8)"},
 	 { "intArray_Save", _wrap_intArray_Save, METH_VARARGS, "\n"
 		"Save(intArray self, std::ostream & out, int fmt=0)\n"
 		"Save(intArray self, char const * file, int precision=8)\n"
@@ -12141,6 +12417,8 @@ static PyMethodDef SwigMethods_proxydocs[] = {
 		"Print(doubleArray self, std::ostream & out=mfem::out, int width=4)\n"
 		"Print(doubleArray self, char const * file, int precision=8)\n"
 		""},
+	 { "doubleArray_PrintGZ", (PyCFunction)(void(*)(void))_wrap_doubleArray_PrintGZ, METH_VARARGS|METH_KEYWORDS, "PrintGZ(doubleArray self, char const * file, int precision=8)"},
+	 { "doubleArray_SaveGZ", (PyCFunction)(void(*)(void))_wrap_doubleArray_SaveGZ, METH_VARARGS|METH_KEYWORDS, "SaveGZ(doubleArray self, char const * file, int precision=8)"},
 	 { "doubleArray_Save", _wrap_doubleArray_Save, METH_VARARGS, "\n"
 		"Save(doubleArray self, std::ostream & out, int fmt=0)\n"
 		"Save(doubleArray self, char const * file, int precision=8)\n"

--- a/mfem/_ser/blockmatrix.py
+++ b/mfem/_ser/blockmatrix.py
@@ -233,6 +233,11 @@ class BlockMatrix(mfem._ser.matrix.AbstractSparseMatrix):
         return _blockmatrix.BlockMatrix_PrintMatlab(self, *args)
     PrintMatlab = _swig_new_instance_method(_blockmatrix.BlockMatrix_PrintMatlab)
 
+    def PrintMatlabGZ(self, file, precision=8):
+        r"""PrintMatlabGZ(BlockMatrix self, char const * file, int precision=8)"""
+        return _blockmatrix.BlockMatrix_PrintMatlabGZ(self, file, precision)
+    PrintMatlabGZ = _swig_new_instance_method(_blockmatrix.BlockMatrix_PrintMatlabGZ)
+
 # Register BlockMatrix in _blockmatrix:
 _blockmatrix.BlockMatrix_swigregister(BlockMatrix)
 

--- a/mfem/_ser/blockmatrix_wrap.cxx
+++ b/mfem/_ser/blockmatrix_wrap.cxx
@@ -3548,6 +3548,17 @@ SWIGINTERN void mfem_BlockMatrix_PrintMatlab__SWIG_1(mfem::BlockMatrix *self,cha
   self -> PrintMatlab(ofile);
   ofile.close();
   }
+SWIGINTERN void mfem_BlockMatrix_PrintMatlabGZ(mfem::BlockMatrix *self,char const *file,int precision=8){
+  mfem::ofgzstream *ofile = new mfem::ofgzstream(file, true);
+  if (!ofile)
+     {
+        std::cerr << "\nCan not produce output file: " << file << '\n' << std::endl;
+        return;
+      }
+  ofile ->precision(precision);  
+  self -> PrintMatlab(*ofile);
+  delete ofile;
+  }
 
 
 /* ---------------------------------------------------
@@ -5818,6 +5829,70 @@ fail:
 }
 
 
+SWIGINTERN PyObject *_wrap_BlockMatrix_PrintMatlabGZ(PyObject *SWIGUNUSEDPARM(self), PyObject *args, PyObject *kwargs) {
+  PyObject *resultobj = 0;
+  mfem::BlockMatrix *arg1 = (mfem::BlockMatrix *) 0 ;
+  char *arg2 = (char *) 0 ;
+  int arg3 = (int) 8 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int res2 ;
+  char *buf2 = 0 ;
+  int alloc2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  char * kwnames[] = {
+    (char *)"self",  (char *)"file",  (char *)"precision",  NULL 
+  };
+  
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OO|O:BlockMatrix_PrintMatlabGZ", kwnames, &obj0, &obj1, &obj2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_mfem__BlockMatrix, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "BlockMatrix_PrintMatlabGZ" "', argument " "1"" of type '" "mfem::BlockMatrix *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::BlockMatrix * >(argp1);
+  res2 = SWIG_AsCharPtrAndSize(obj1, &buf2, NULL, &alloc2);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "BlockMatrix_PrintMatlabGZ" "', argument " "2"" of type '" "char const *""'");
+  }
+  arg2 = reinterpret_cast< char * >(buf2);
+  if (obj2) {
+    {
+      if ((PyArray_PyIntAsInt(obj2) == -1) && PyErr_Occurred()) {
+        SWIG_exception_fail(SWIG_TypeError, "Input must be integer");
+      };  
+      arg3 = PyArray_PyIntAsInt(obj2);
+    }
+  }
+  {
+    try {
+      mfem_BlockMatrix_PrintMatlabGZ(arg1,(char const *)arg2,arg3);
+    }
+#ifdef  MFEM_USE_EXCEPTIONS
+    catch (mfem::ErrorException &_e) {
+      std::string s("PyMFEM error (mfem::ErrorException): "), s2(_e.what());
+      s = s + s2;    
+      SWIG_exception(SWIG_RuntimeError, s.c_str());
+    }
+#endif
+    
+    catch (Swig::DirectorException &e){
+      SWIG_fail;
+    }    
+    catch (...) {
+      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+    }	 
+  }
+  resultobj = SWIG_Py_Void();
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return resultobj;
+fail:
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return NULL;
+}
+
+
 SWIGINTERN PyObject *BlockMatrix_swigregister(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *obj;
   if (!SWIG_Python_UnpackTuple(args, "swigregister", 1, 1, &obj)) return NULL;
@@ -5881,6 +5956,7 @@ static PyMethodDef SwigMethods[] = {
 		"BlockMatrix_PrintMatlab(BlockMatrix self, std::ostream & os=mfem::out)\n"
 		"BlockMatrix_PrintMatlab(BlockMatrix self, char const * file, int precision=8)\n"
 		""},
+	 { "BlockMatrix_PrintMatlabGZ", (PyCFunction)(void(*)(void))_wrap_BlockMatrix_PrintMatlabGZ, METH_VARARGS|METH_KEYWORDS, "BlockMatrix_PrintMatlabGZ(BlockMatrix self, char const * file, int precision=8)"},
 	 { "BlockMatrix_swigregister", BlockMatrix_swigregister, METH_O, NULL},
 	 { "BlockMatrix_swiginit", BlockMatrix_swiginit, METH_VARARGS, NULL},
 	 { NULL, NULL, 0, NULL }
@@ -5938,6 +6014,7 @@ static PyMethodDef SwigMethods_proxydocs[] = {
 		"PrintMatlab(BlockMatrix self, std::ostream & os=mfem::out)\n"
 		"PrintMatlab(BlockMatrix self, char const * file, int precision=8)\n"
 		""},
+	 { "BlockMatrix_PrintMatlabGZ", (PyCFunction)(void(*)(void))_wrap_BlockMatrix_PrintMatlabGZ, METH_VARARGS|METH_KEYWORDS, "PrintMatlabGZ(BlockMatrix self, char const * file, int precision=8)"},
 	 { "BlockMatrix_swigregister", BlockMatrix_swigregister, METH_O, NULL},
 	 { "BlockMatrix_swiginit", BlockMatrix_swiginit, METH_VARARGS, NULL},
 	 { NULL, NULL, 0, NULL }

--- a/mfem/_ser/densemat.py
+++ b/mfem/_ser/densemat.py
@@ -621,6 +621,11 @@ class DenseMatrix(mfem._ser.matrix.Matrix):
         return _densemat.DenseMatrix_Print(self, *args)
     Print = _swig_new_instance_method(_densemat.DenseMatrix_Print)
 
+    def PrintGZ(self, file, precision=8):
+        r"""PrintGZ(DenseMatrix self, char const * file, int precision=8)"""
+        return _densemat.DenseMatrix_PrintGZ(self, file, precision)
+    PrintGZ = _swig_new_instance_method(_densemat.DenseMatrix_PrintGZ)
+
     def PrintT(self, *args):
         r"""
         PrintT(DenseMatrix self, std::ostream & out=mfem::out, int width_=4)
@@ -629,6 +634,11 @@ class DenseMatrix(mfem._ser.matrix.Matrix):
         return _densemat.DenseMatrix_PrintT(self, *args)
     PrintT = _swig_new_instance_method(_densemat.DenseMatrix_PrintT)
 
+    def PrintTGZ(self, file, precision=8):
+        r"""PrintTGZ(DenseMatrix self, char const * file, int precision=8)"""
+        return _densemat.DenseMatrix_PrintTGZ(self, file, precision)
+    PrintTGZ = _swig_new_instance_method(_densemat.DenseMatrix_PrintTGZ)
+
     def PrintMatlab(self, *args):
         r"""
         PrintMatlab(DenseMatrix self, std::ostream & out=mfem::out)
@@ -636,6 +646,11 @@ class DenseMatrix(mfem._ser.matrix.Matrix):
         """
         return _densemat.DenseMatrix_PrintMatlab(self, *args)
     PrintMatlab = _swig_new_instance_method(_densemat.DenseMatrix_PrintMatlab)
+
+    def PrintMatlabGZ(self, file, precision=8):
+        r"""PrintMatlabGZ(DenseMatrix self, char const * file, int precision=8)"""
+        return _densemat.DenseMatrix_PrintMatlabGZ(self, file, precision)
+    PrintMatlabGZ = _swig_new_instance_method(_densemat.DenseMatrix_PrintMatlabGZ)
 
 # Register DenseMatrix in _densemat:
 _densemat.DenseMatrix_swigregister(DenseMatrix)

--- a/mfem/_ser/densemat_wrap.cxx
+++ b/mfem/_ser/densemat_wrap.cxx
@@ -3637,6 +3637,17 @@ SWIGINTERN void mfem_DenseMatrix_Print__SWIG_1(mfem::DenseMatrix *self,char cons
   self -> Print(ofile);
   ofile.close();
   }
+SWIGINTERN void mfem_DenseMatrix_PrintGZ(mfem::DenseMatrix *self,char const *file,int precision=8){
+  mfem::ofgzstream *ofile = new mfem::ofgzstream(file, true);
+  if (!ofile)
+     {
+        std::cerr << "\nCan not produce output file: " << file << '\n' << std::endl;
+        return;
+      }
+  ofile ->precision(precision);  
+  self -> Print(*ofile);
+  delete ofile;
+  }
 SWIGINTERN void mfem_DenseMatrix_PrintT__SWIG_1(mfem::DenseMatrix *self,char const *file,int precision=8){
   std::ofstream ofile(file);
   if (!ofile)
@@ -3648,6 +3659,17 @@ SWIGINTERN void mfem_DenseMatrix_PrintT__SWIG_1(mfem::DenseMatrix *self,char con
   self -> PrintT(ofile);
   ofile.close();
   }
+SWIGINTERN void mfem_DenseMatrix_PrintTGZ(mfem::DenseMatrix *self,char const *file,int precision=8){
+  mfem::ofgzstream *ofile = new mfem::ofgzstream(file, true);
+  if (!ofile)
+     {
+        std::cerr << "\nCan not produce output file: " << file << '\n' << std::endl;
+        return;
+      }
+  ofile ->precision(precision);  
+  self -> PrintT(*ofile);
+  delete ofile;
+  }
 SWIGINTERN void mfem_DenseMatrix_PrintMatlab__SWIG_1(mfem::DenseMatrix *self,char const *file,int precision=8){
   std::ofstream ofile(file);
   if (!ofile)
@@ -3658,6 +3680,17 @@ SWIGINTERN void mfem_DenseMatrix_PrintMatlab__SWIG_1(mfem::DenseMatrix *self,cha
   ofile.precision(precision);  
   self -> PrintMatlab(ofile);
   ofile.close();
+  }
+SWIGINTERN void mfem_DenseMatrix_PrintMatlabGZ(mfem::DenseMatrix *self,char const *file,int precision=8){
+  mfem::ofgzstream *ofile = new mfem::ofgzstream(file, true);
+  if (!ofile)
+     {
+        std::cerr << "\nCan not produce output file: " << file << '\n' << std::endl;
+        return;
+      }
+  ofile ->precision(precision);  
+  self -> PrintMatlab(*ofile);
+  delete ofile;
   }
 SWIGINTERN void mfem_DenseTensor_Assign(mfem::DenseTensor *self,double const c){
     (* self) = c;
@@ -12239,6 +12272,70 @@ fail:
 }
 
 
+SWIGINTERN PyObject *_wrap_DenseMatrix_PrintGZ(PyObject *SWIGUNUSEDPARM(self), PyObject *args, PyObject *kwargs) {
+  PyObject *resultobj = 0;
+  mfem::DenseMatrix *arg1 = (mfem::DenseMatrix *) 0 ;
+  char *arg2 = (char *) 0 ;
+  int arg3 = (int) 8 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int res2 ;
+  char *buf2 = 0 ;
+  int alloc2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  char * kwnames[] = {
+    (char *)"self",  (char *)"file",  (char *)"precision",  NULL 
+  };
+  
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OO|O:DenseMatrix_PrintGZ", kwnames, &obj0, &obj1, &obj2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_mfem__DenseMatrix, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "DenseMatrix_PrintGZ" "', argument " "1"" of type '" "mfem::DenseMatrix *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::DenseMatrix * >(argp1);
+  res2 = SWIG_AsCharPtrAndSize(obj1, &buf2, NULL, &alloc2);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "DenseMatrix_PrintGZ" "', argument " "2"" of type '" "char const *""'");
+  }
+  arg2 = reinterpret_cast< char * >(buf2);
+  if (obj2) {
+    {
+      if ((PyArray_PyIntAsInt(obj2) == -1) && PyErr_Occurred()) {
+        SWIG_exception_fail(SWIG_TypeError, "Input must be integer");
+      };  
+      arg3 = PyArray_PyIntAsInt(obj2);
+    }
+  }
+  {
+    try {
+      mfem_DenseMatrix_PrintGZ(arg1,(char const *)arg2,arg3);
+    }
+#ifdef  MFEM_USE_EXCEPTIONS
+    catch (mfem::ErrorException &_e) {
+      std::string s("PyMFEM error (mfem::ErrorException): "), s2(_e.what());
+      s = s + s2;    
+      SWIG_exception(SWIG_RuntimeError, s.c_str());
+    }
+#endif
+    
+    catch (Swig::DirectorException &e){
+      SWIG_fail;
+    }    
+    catch (...) {
+      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+    }	 
+  }
+  resultobj = SWIG_Py_Void();
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return resultobj;
+fail:
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return NULL;
+}
+
+
 SWIGINTERN PyObject *_wrap_DenseMatrix_PrintT__SWIG_1(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
   PyObject *resultobj = 0;
   mfem::DenseMatrix *arg1 = (mfem::DenseMatrix *) 0 ;
@@ -12396,6 +12493,70 @@ fail:
 }
 
 
+SWIGINTERN PyObject *_wrap_DenseMatrix_PrintTGZ(PyObject *SWIGUNUSEDPARM(self), PyObject *args, PyObject *kwargs) {
+  PyObject *resultobj = 0;
+  mfem::DenseMatrix *arg1 = (mfem::DenseMatrix *) 0 ;
+  char *arg2 = (char *) 0 ;
+  int arg3 = (int) 8 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int res2 ;
+  char *buf2 = 0 ;
+  int alloc2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  char * kwnames[] = {
+    (char *)"self",  (char *)"file",  (char *)"precision",  NULL 
+  };
+  
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OO|O:DenseMatrix_PrintTGZ", kwnames, &obj0, &obj1, &obj2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_mfem__DenseMatrix, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "DenseMatrix_PrintTGZ" "', argument " "1"" of type '" "mfem::DenseMatrix *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::DenseMatrix * >(argp1);
+  res2 = SWIG_AsCharPtrAndSize(obj1, &buf2, NULL, &alloc2);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "DenseMatrix_PrintTGZ" "', argument " "2"" of type '" "char const *""'");
+  }
+  arg2 = reinterpret_cast< char * >(buf2);
+  if (obj2) {
+    {
+      if ((PyArray_PyIntAsInt(obj2) == -1) && PyErr_Occurred()) {
+        SWIG_exception_fail(SWIG_TypeError, "Input must be integer");
+      };  
+      arg3 = PyArray_PyIntAsInt(obj2);
+    }
+  }
+  {
+    try {
+      mfem_DenseMatrix_PrintTGZ(arg1,(char const *)arg2,arg3);
+    }
+#ifdef  MFEM_USE_EXCEPTIONS
+    catch (mfem::ErrorException &_e) {
+      std::string s("PyMFEM error (mfem::ErrorException): "), s2(_e.what());
+      s = s + s2;    
+      SWIG_exception(SWIG_RuntimeError, s.c_str());
+    }
+#endif
+    
+    catch (Swig::DirectorException &e){
+      SWIG_fail;
+    }    
+    catch (...) {
+      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+    }	 
+  }
+  resultobj = SWIG_Py_Void();
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return resultobj;
+fail:
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return NULL;
+}
+
+
 SWIGINTERN PyObject *_wrap_DenseMatrix_PrintMatlab__SWIG_1(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
   PyObject *resultobj = 0;
   mfem::DenseMatrix *arg1 = (mfem::DenseMatrix *) 0 ;
@@ -12537,6 +12698,70 @@ fail:
     "    mfem::DenseMatrix::PrintMatlab(std::ostream &) const\n"
     "    mfem::DenseMatrix::PrintMatlab(char const *,int)\n");
   return 0;
+}
+
+
+SWIGINTERN PyObject *_wrap_DenseMatrix_PrintMatlabGZ(PyObject *SWIGUNUSEDPARM(self), PyObject *args, PyObject *kwargs) {
+  PyObject *resultobj = 0;
+  mfem::DenseMatrix *arg1 = (mfem::DenseMatrix *) 0 ;
+  char *arg2 = (char *) 0 ;
+  int arg3 = (int) 8 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int res2 ;
+  char *buf2 = 0 ;
+  int alloc2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  char * kwnames[] = {
+    (char *)"self",  (char *)"file",  (char *)"precision",  NULL 
+  };
+  
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OO|O:DenseMatrix_PrintMatlabGZ", kwnames, &obj0, &obj1, &obj2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_mfem__DenseMatrix, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "DenseMatrix_PrintMatlabGZ" "', argument " "1"" of type '" "mfem::DenseMatrix *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::DenseMatrix * >(argp1);
+  res2 = SWIG_AsCharPtrAndSize(obj1, &buf2, NULL, &alloc2);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "DenseMatrix_PrintMatlabGZ" "', argument " "2"" of type '" "char const *""'");
+  }
+  arg2 = reinterpret_cast< char * >(buf2);
+  if (obj2) {
+    {
+      if ((PyArray_PyIntAsInt(obj2) == -1) && PyErr_Occurred()) {
+        SWIG_exception_fail(SWIG_TypeError, "Input must be integer");
+      };  
+      arg3 = PyArray_PyIntAsInt(obj2);
+    }
+  }
+  {
+    try {
+      mfem_DenseMatrix_PrintMatlabGZ(arg1,(char const *)arg2,arg3);
+    }
+#ifdef  MFEM_USE_EXCEPTIONS
+    catch (mfem::ErrorException &_e) {
+      std::string s("PyMFEM error (mfem::ErrorException): "), s2(_e.what());
+      s = s + s2;    
+      SWIG_exception(SWIG_RuntimeError, s.c_str());
+    }
+#endif
+    
+    catch (Swig::DirectorException &e){
+      SWIG_fail;
+    }    
+    catch (...) {
+      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+    }	 
+  }
+  resultobj = SWIG_Py_Void();
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return resultobj;
+fail:
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return NULL;
 }
 
 
@@ -19220,14 +19445,17 @@ static PyMethodDef SwigMethods[] = {
 		"DenseMatrix_Print(DenseMatrix self, std::ostream & out=mfem::out, int width_=4)\n"
 		"DenseMatrix_Print(DenseMatrix self, char const * file, int precision=8)\n"
 		""},
+	 { "DenseMatrix_PrintGZ", (PyCFunction)(void(*)(void))_wrap_DenseMatrix_PrintGZ, METH_VARARGS|METH_KEYWORDS, "DenseMatrix_PrintGZ(DenseMatrix self, char const * file, int precision=8)"},
 	 { "DenseMatrix_PrintT", _wrap_DenseMatrix_PrintT, METH_VARARGS, "\n"
 		"DenseMatrix_PrintT(DenseMatrix self, std::ostream & out=mfem::out, int width_=4)\n"
 		"DenseMatrix_PrintT(DenseMatrix self, char const * file, int precision=8)\n"
 		""},
+	 { "DenseMatrix_PrintTGZ", (PyCFunction)(void(*)(void))_wrap_DenseMatrix_PrintTGZ, METH_VARARGS|METH_KEYWORDS, "DenseMatrix_PrintTGZ(DenseMatrix self, char const * file, int precision=8)"},
 	 { "DenseMatrix_PrintMatlab", _wrap_DenseMatrix_PrintMatlab, METH_VARARGS, "\n"
 		"DenseMatrix_PrintMatlab(DenseMatrix self, std::ostream & out=mfem::out)\n"
 		"DenseMatrix_PrintMatlab(DenseMatrix self, char const * file, int precision=8)\n"
 		""},
+	 { "DenseMatrix_PrintMatlabGZ", (PyCFunction)(void(*)(void))_wrap_DenseMatrix_PrintMatlabGZ, METH_VARARGS|METH_KEYWORDS, "DenseMatrix_PrintMatlabGZ(DenseMatrix self, char const * file, int precision=8)"},
 	 { "DenseMatrix_swigregister", DenseMatrix_swigregister, METH_O, NULL},
 	 { "DenseMatrix_swiginit", DenseMatrix_swiginit, METH_VARARGS, NULL},
 	 { "LinearSolve", (PyCFunction)(void(*)(void))_wrap_LinearSolve, METH_VARARGS|METH_KEYWORDS, "LinearSolve(DenseMatrix A, double * X, double TOL=1.e-9) -> bool"},
@@ -19542,14 +19770,17 @@ static PyMethodDef SwigMethods_proxydocs[] = {
 		"Print(DenseMatrix self, std::ostream & out=mfem::out, int width_=4)\n"
 		"Print(DenseMatrix self, char const * file, int precision=8)\n"
 		""},
+	 { "DenseMatrix_PrintGZ", (PyCFunction)(void(*)(void))_wrap_DenseMatrix_PrintGZ, METH_VARARGS|METH_KEYWORDS, "PrintGZ(DenseMatrix self, char const * file, int precision=8)"},
 	 { "DenseMatrix_PrintT", _wrap_DenseMatrix_PrintT, METH_VARARGS, "\n"
 		"PrintT(DenseMatrix self, std::ostream & out=mfem::out, int width_=4)\n"
 		"PrintT(DenseMatrix self, char const * file, int precision=8)\n"
 		""},
+	 { "DenseMatrix_PrintTGZ", (PyCFunction)(void(*)(void))_wrap_DenseMatrix_PrintTGZ, METH_VARARGS|METH_KEYWORDS, "PrintTGZ(DenseMatrix self, char const * file, int precision=8)"},
 	 { "DenseMatrix_PrintMatlab", _wrap_DenseMatrix_PrintMatlab, METH_VARARGS, "\n"
 		"PrintMatlab(DenseMatrix self, std::ostream & out=mfem::out)\n"
 		"PrintMatlab(DenseMatrix self, char const * file, int precision=8)\n"
 		""},
+	 { "DenseMatrix_PrintMatlabGZ", (PyCFunction)(void(*)(void))_wrap_DenseMatrix_PrintMatlabGZ, METH_VARARGS|METH_KEYWORDS, "PrintMatlabGZ(DenseMatrix self, char const * file, int precision=8)"},
 	 { "DenseMatrix_swigregister", DenseMatrix_swigregister, METH_O, NULL},
 	 { "DenseMatrix_swiginit", DenseMatrix_swiginit, METH_VARARGS, NULL},
 	 { "LinearSolve", (PyCFunction)(void(*)(void))_wrap_LinearSolve, METH_VARARGS|METH_KEYWORDS, "LinearSolve(DenseMatrix A, double * X, double TOL=1.e-9) -> bool"},

--- a/mfem/_ser/fespace.i
+++ b/mfem/_ser/fespace.i
@@ -60,49 +60,49 @@ ISTREAM_TYPEMAP(std::istream&)
 def GetBdrElementVDofs(self, i):
     from  .array import intArray
     vdofs = intArray()
-    _fespace.FiniteElementSpace_GetBdrElementVDofs(self, i, vdofs)
+    $action(self, i, vdofs)
     return vdofs.ToList()
 %}
 %feature("shadow") mfem::FiniteElementSpace::GetElementVDofs %{
 def GetElementVDofs(self, i):
     from  .array import intArray
     vdofs = intArray()
-    _fespace.FiniteElementSpace_GetElementVDofs(self, i, vdofs)
+    $action(self, i, vdofs)
     return vdofs.ToList()
 %}
 %feature("shadow") mfem::FiniteElementSpace::GetFaceVDofs %{
 def GetFaceVDofs(self, i):
     from  .array import intArray
     vdofs = intArray()
-    _fespace.FiniteElementSpace_GetFaceVDofs(self, i, vdofs)
+    $action(self, i, vdofs)
     return vdofs.ToList()
 %}
 %feature("shadow") mfem::FiniteElementSpace::GetEdgeVDofs %{
 def GetEdgeVDofs(self, i):
     from  .array import intArray
     vdofs = intArray()
-    _fespace.FiniteElementSpace_GetEdgeVDofs(self, i, vdofs)
+    $action(self, i, vdofs)
     return vdofs.ToList()
 %}
 %feature("shadow") mfem::FiniteElementSpace::GetVertexVDofs %{
 def GetVertexVDofs(self, i):
     from  .array import intArray
     vdofs = intArray()
-    _fespace.FiniteElementSpace_GetVertexVDofs(self, i, vdofs)
+    $action(self, i, vdofs)
     return vdofs.ToList()
 %}
 %feature("shadow") mfem::FiniteElementSpace::GetElementInteriorVDofs %{
 def GetElementInteriorVDofs(self, i):
     from  .array import intArray
     vdofs = intArray()
-    _fespace.FiniteElementSpace_GetElementInteriorVDofs(self, i, vdofs)
+    $action(self, i, vdofs)
     return vdofs.ToList()
 %}
 %feature("shadow") mfem::FiniteElementSpace::GetEdgeInteriorVDofs %{
 def GetEdgeInteriorVDofs(self, i):
     from  .array import intArray
     vdofs = intArray()
-    _fespace.FiniteElementSpace_GetEdgeInteriorVDofs(self, i, vdofs)
+    $action(self, i, vdofs)
     return vdofs.ToList()
 %}
 
@@ -111,49 +111,49 @@ def GetEdgeInteriorVDofs(self, i):
 def GetBdrElementDofs(self, i):
     from  .array import intArray
     vdofs = intArray()
-    _fespace.FiniteElementSpace_GetBdrElementDofs(self, i, vdofs)
+    $action(self, i, vdofs)
     return vdofs.ToList()
 %}
 %feature("shadow") mfem::FiniteElementSpace::GetElementDofs %{
 def GetElementDofs(self, i):
     from  .array import intArray
     vdofs = intArray()
-    _fespace.FiniteElementSpace_GetElementDofs(self, i, vdofs)
+    $action(self, i, vdofs)
     return vdofs.ToList()
 %}
 %feature("shadow") mfem::FiniteElementSpace::GetFaceDofs %{
 def GetFaceDofs(self, i):
     from  .array import intArray
     vdofs = intArray()
-    _fespace.FiniteElementSpace_GetFaceDofs(self, i, vdofs)
+    $action(self, i, vdofs)
     return vdofs.ToList()
 %}
 %feature("shadow") mfem::FiniteElementSpace::GetEdgeDofs %{
 def GetEdgeDofs(self, i):
     from  .array import intArray
     vdofs = intArray()
-    _fespace.FiniteElementSpace_GetEdgeDofs(self, i, vdofs)
+    $action(self, i, vdofs)
     return vdofs.ToList()
 %}
 %feature("shadow") mfem::FiniteElementSpace::GetVertexDofs %{
 def GetVertexDofs(self, i):
     from  .array import intArray
     vdofs = intArray()
-    _fespace.FiniteElementSpace_GetVertexDofs(self, i, vdofs)
+    $action(self, i, vdofs)
     return vdofs.ToList()
 %}
 %feature("shadow") mfem::FiniteElementSpace::GetElementInteriorDofs %{
 def GetElementInteriorDofs(self, i):
     from  .array import intArray
     vdofs = intArray()
-    _fespace.FiniteElementSpace_GetElementInteriorDofs(self, i, vdofs)
+    $action(self, i, vdofs)
     return vdofs.ToList()
 %}
 %feature("shadow") mfem::FiniteElementSpace::GetEdgeInteriorDofs %{
 def GetEdgeInteriorDofs(self, i):
     from  .array import intArray
     vdofs = intArray()
-    _fespace.FiniteElementSpace_GetEdgeInteriorDofs(self, i, vdofs)
+    $action(self, i, vdofs)
     return vdofs.ToList()
 %}
 

--- a/mfem/_ser/fespace.py
+++ b/mfem/_ser/fespace.py
@@ -658,6 +658,11 @@ class FiniteElementSpace(object):
     Load = _swig_new_instance_method(_fespace.FiniteElementSpace_Load)
     __swig_destroy__ = _fespace.delete_FiniteElementSpace
 
+    def SaveGZ(self, file, precision=8):
+        r"""SaveGZ(FiniteElementSpace self, char const * file, int precision=8)"""
+        return _fespace.FiniteElementSpace_SaveGZ(self, file, precision)
+    SaveGZ = _swig_new_instance_method(_fespace.FiniteElementSpace_SaveGZ)
+
     def Save(self, *args):
         r"""
         Save(FiniteElementSpace self, std::ostream & out)
@@ -718,6 +723,11 @@ class QuadratureSpace(object):
         r"""GetElementIntRule(QuadratureSpace self, int idx) -> IntegrationRule"""
         return _fespace.QuadratureSpace_GetElementIntRule(self, idx)
     GetElementIntRule = _swig_new_instance_method(_fespace.QuadratureSpace_GetElementIntRule)
+
+    def SaveGZ(self, file, precision=8):
+        r"""SaveGZ(QuadratureSpace self, char const * file, int precision=8)"""
+        return _fespace.QuadratureSpace_SaveGZ(self, file, precision)
+    SaveGZ = _swig_new_instance_method(_fespace.QuadratureSpace_SaveGZ)
 
     def Save(self, *args):
         r"""

--- a/mfem/_ser/fespace_wrap.cxx
+++ b/mfem/_ser/fespace_wrap.cxx
@@ -3809,6 +3809,18 @@ SWIGINTERN void mfem_FiniteElementSpace_Save__SWIG_1(mfem::FiniteElementSpace *s
   self -> Save(ofile);
   ofile.close();
   }
+SWIGINTERN void mfem_FiniteElementSpace_SaveGZ(mfem::FiniteElementSpace *self,char const *file,int precision=8){
+  mfem::ofgzstream *ofile = new mfem::ofgzstream(file, true);
+  
+  if (!ofile)
+     {
+        std::cerr << "\nCan not produce output file: " << file << '\n' << std::endl;
+        return;
+      }
+  ofile -> precision(precision);  
+  self -> Save(*ofile);
+  delete ofile;
+  }
 SWIGINTERN void mfem_FiniteElementSpace_Save__SWIG_2(mfem::FiniteElementSpace *self){
   self -> Save(std::cout);
   }
@@ -3822,6 +3834,18 @@ SWIGINTERN void mfem_QuadratureSpace_Save__SWIG_1(mfem::QuadratureSpace *self,ch
   ofile.precision(precision);    
   self -> Save(ofile);
   ofile.close();
+  }
+SWIGINTERN void mfem_QuadratureSpace_SaveGZ(mfem::QuadratureSpace *self,char const *file,int precision=8){
+  mfem::ofgzstream *ofile = new mfem::ofgzstream(file, true);
+  
+  if (!ofile)
+     {
+        std::cerr << "\nCan not produce output file: " << file << '\n' << std::endl;
+        return;
+      }
+  ofile -> precision(precision);  
+  self -> Save(*ofile);
+  delete ofile;
   }
 SWIGINTERN void mfem_QuadratureSpace_Save__SWIG_2(mfem::QuadratureSpace *self){
   self -> Save(std::cout);
@@ -9578,14 +9602,20 @@ SWIGINTERN PyObject *_wrap_FiniteElementSpace_Load(PyObject *SWIGUNUSEDPARM(self
       }
     }
     if (stream3 == 0){
-      if (temp3->isGZ()){
-        in_gz3 = new mfem::ifgzstream(temp3->getFilename());
-        arg3 = in_gz3;
-      } else {
-        in_txt3.open(temp3->getFilename(), std::ifstream::in);
-        in_txt3.precision(temp3->getPrecision());
-        arg3 = &in_txt3;
-      }
+      /*
+            if (temp3->isGZ()){
+        	 in_gz3 = new mfem::ifgzstream(temp3->getFilename());
+               arg3 = in_gz3;
+            } else {
+        	 in_txt3.open(temp3->getFilename(), std::ifstream::in);
+               in_txt3.precision(temp3->getPrecision());
+               arg3 = &in_txt3;
+            }
+           */
+      /* this will auto-detect the input file type */
+      in_gz3 = new mfem::ifgzstream(temp3->getFilename());
+      arg3 = in_gz3;
+      
       if (temp3->isTemporary()){
         delete temp3;
       }
@@ -9613,18 +9643,6 @@ SWIGINTERN PyObject *_wrap_FiniteElementSpace_Load(PyObject *SWIGUNUSEDPARM(self
     }	 
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__FiniteElementCollection, 0 |  0 );
-  {
-    if (stream3) {
-      ret3 = PyLong_FromSsize_t(len3);
-      if (PyErr_Occurred()) {
-        PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
-        return NULL;
-      }
-      delete stream3;    
-      Py_XDECREF(resultobj);   /* Blow away any previous result */
-      resultobj = ret3;    
-    }
-  }
   {
     if (!stream3) {
       if (temp3) {
@@ -9724,6 +9742,70 @@ SWIGINTERN PyObject *_wrap_FiniteElementSpace_Save__SWIG_1(PyObject *SWIGUNUSEDP
   {
     try {
       mfem_FiniteElementSpace_Save__SWIG_1(arg1,(char const *)arg2,arg3);
+    }
+#ifdef  MFEM_USE_EXCEPTIONS
+    catch (mfem::ErrorException &_e) {
+      std::string s("PyMFEM error (mfem::ErrorException): "), s2(_e.what());
+      s = s + s2;    
+      SWIG_exception(SWIG_RuntimeError, s.c_str());
+    }
+#endif
+    
+    catch (Swig::DirectorException &e){
+      SWIG_fail;
+    }    
+    catch (...) {
+      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+    }	 
+  }
+  resultobj = SWIG_Py_Void();
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return resultobj;
+fail:
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_FiniteElementSpace_SaveGZ(PyObject *SWIGUNUSEDPARM(self), PyObject *args, PyObject *kwargs) {
+  PyObject *resultobj = 0;
+  mfem::FiniteElementSpace *arg1 = (mfem::FiniteElementSpace *) 0 ;
+  char *arg2 = (char *) 0 ;
+  int arg3 = (int) 8 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int res2 ;
+  char *buf2 = 0 ;
+  int alloc2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  char * kwnames[] = {
+    (char *)"self",  (char *)"file",  (char *)"precision",  NULL 
+  };
+  
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OO|O:FiniteElementSpace_SaveGZ", kwnames, &obj0, &obj1, &obj2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_mfem__FiniteElementSpace, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "FiniteElementSpace_SaveGZ" "', argument " "1"" of type '" "mfem::FiniteElementSpace *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::FiniteElementSpace * >(argp1);
+  res2 = SWIG_AsCharPtrAndSize(obj1, &buf2, NULL, &alloc2);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "FiniteElementSpace_SaveGZ" "', argument " "2"" of type '" "char const *""'");
+  }
+  arg2 = reinterpret_cast< char * >(buf2);
+  if (obj2) {
+    {
+      if ((PyArray_PyIntAsInt(obj2) == -1) && PyErr_Occurred()) {
+        SWIG_exception_fail(SWIG_TypeError, "Input must be integer");
+      };  
+      arg3 = PyArray_PyIntAsInt(obj2);
+    }
+  }
+  {
+    try {
+      mfem_FiniteElementSpace_SaveGZ(arg1,(char const *)arg2,arg3);
     }
 #ifdef  MFEM_USE_EXCEPTIONS
     catch (mfem::ErrorException &_e) {
@@ -10000,14 +10082,20 @@ SWIGINTERN PyObject *_wrap_new_QuadratureSpace__SWIG_1(PyObject *SWIGUNUSEDPARM(
       }
     }
     if (stream2 == 0){
-      if (temp2->isGZ()){
-        in_gz2 = new mfem::ifgzstream(temp2->getFilename());
-        arg2 = in_gz2;
-      } else {
-        in_txt2.open(temp2->getFilename(), std::ifstream::in);
-        in_txt2.precision(temp2->getPrecision());
-        arg2 = &in_txt2;
-      }
+      /*
+            if (temp2->isGZ()){
+        	 in_gz2 = new mfem::ifgzstream(temp2->getFilename());
+               arg2 = in_gz2;
+            } else {
+        	 in_txt2.open(temp2->getFilename(), std::ifstream::in);
+               in_txt2.precision(temp2->getPrecision());
+               arg2 = &in_txt2;
+            }
+           */
+      /* this will auto-detect the input file type */
+      in_gz2 = new mfem::ifgzstream(temp2->getFilename());
+      arg2 = in_gz2;
+      
       if (temp2->isTemporary()){
         delete temp2;
       }
@@ -10035,18 +10123,6 @@ SWIGINTERN PyObject *_wrap_new_QuadratureSpace__SWIG_1(PyObject *SWIGUNUSEDPARM(
     }	 
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__QuadratureSpace, SWIG_POINTER_NEW |  0 );
-  {
-    if (stream2) {
-      ret2 = PyLong_FromSsize_t(len2);
-      if (PyErr_Occurred()) {
-        PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
-        return NULL;
-      }
-      delete stream2;    
-      Py_XDECREF(resultobj);   /* Blow away any previous result */
-      resultobj = ret2;    
-    }
-  }
   {
     if (!stream2) {
       if (temp2) {
@@ -10535,6 +10611,70 @@ SWIGINTERN PyObject *_wrap_QuadratureSpace_Save__SWIG_1(PyObject *SWIGUNUSEDPARM
   {
     try {
       mfem_QuadratureSpace_Save__SWIG_1(arg1,(char const *)arg2,arg3);
+    }
+#ifdef  MFEM_USE_EXCEPTIONS
+    catch (mfem::ErrorException &_e) {
+      std::string s("PyMFEM error (mfem::ErrorException): "), s2(_e.what());
+      s = s + s2;    
+      SWIG_exception(SWIG_RuntimeError, s.c_str());
+    }
+#endif
+    
+    catch (Swig::DirectorException &e){
+      SWIG_fail;
+    }    
+    catch (...) {
+      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+    }	 
+  }
+  resultobj = SWIG_Py_Void();
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return resultobj;
+fail:
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_QuadratureSpace_SaveGZ(PyObject *SWIGUNUSEDPARM(self), PyObject *args, PyObject *kwargs) {
+  PyObject *resultobj = 0;
+  mfem::QuadratureSpace *arg1 = (mfem::QuadratureSpace *) 0 ;
+  char *arg2 = (char *) 0 ;
+  int arg3 = (int) 8 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int res2 ;
+  char *buf2 = 0 ;
+  int alloc2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  char * kwnames[] = {
+    (char *)"self",  (char *)"file",  (char *)"precision",  NULL 
+  };
+  
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OO|O:QuadratureSpace_SaveGZ", kwnames, &obj0, &obj1, &obj2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_mfem__QuadratureSpace, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "QuadratureSpace_SaveGZ" "', argument " "1"" of type '" "mfem::QuadratureSpace *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::QuadratureSpace * >(argp1);
+  res2 = SWIG_AsCharPtrAndSize(obj1, &buf2, NULL, &alloc2);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "QuadratureSpace_SaveGZ" "', argument " "2"" of type '" "char const *""'");
+  }
+  arg2 = reinterpret_cast< char * >(buf2);
+  if (obj2) {
+    {
+      if ((PyArray_PyIntAsInt(obj2) == -1) && PyErr_Occurred()) {
+        SWIG_exception_fail(SWIG_TypeError, "Input must be integer");
+      };  
+      arg3 = PyArray_PyIntAsInt(obj2);
+    }
+  }
+  {
+    try {
+      mfem_QuadratureSpace_SaveGZ(arg1,(char const *)arg2,arg3);
     }
 #ifdef  MFEM_USE_EXCEPTIONS
     catch (mfem::ErrorException &_e) {
@@ -11573,6 +11713,7 @@ static PyMethodDef SwigMethods[] = {
 	 { "FiniteElementSpace_IsDGSpace", _wrap_FiniteElementSpace_IsDGSpace, METH_O, "FiniteElementSpace_IsDGSpace(FiniteElementSpace self) -> bool"},
 	 { "FiniteElementSpace_Load", (PyCFunction)(void(*)(void))_wrap_FiniteElementSpace_Load, METH_VARARGS|METH_KEYWORDS, "FiniteElementSpace_Load(FiniteElementSpace self, Mesh m, std::istream & input) -> FiniteElementCollection"},
 	 { "delete_FiniteElementSpace", _wrap_delete_FiniteElementSpace, METH_O, "delete_FiniteElementSpace(FiniteElementSpace self)"},
+	 { "FiniteElementSpace_SaveGZ", (PyCFunction)(void(*)(void))_wrap_FiniteElementSpace_SaveGZ, METH_VARARGS|METH_KEYWORDS, "FiniteElementSpace_SaveGZ(FiniteElementSpace self, char const * file, int precision=8)"},
 	 { "FiniteElementSpace_Save", _wrap_FiniteElementSpace_Save, METH_VARARGS, "\n"
 		"FiniteElementSpace_Save(FiniteElementSpace self, std::ostream & out)\n"
 		"FiniteElementSpace_Save(FiniteElementSpace self, char const * file, int precision=8)\n"
@@ -11589,6 +11730,7 @@ static PyMethodDef SwigMethods[] = {
 	 { "QuadratureSpace_GetMesh", _wrap_QuadratureSpace_GetMesh, METH_O, "QuadratureSpace_GetMesh(QuadratureSpace self) -> Mesh"},
 	 { "QuadratureSpace_GetNE", _wrap_QuadratureSpace_GetNE, METH_O, "QuadratureSpace_GetNE(QuadratureSpace self) -> int"},
 	 { "QuadratureSpace_GetElementIntRule", (PyCFunction)(void(*)(void))_wrap_QuadratureSpace_GetElementIntRule, METH_VARARGS|METH_KEYWORDS, "QuadratureSpace_GetElementIntRule(QuadratureSpace self, int idx) -> IntegrationRule"},
+	 { "QuadratureSpace_SaveGZ", (PyCFunction)(void(*)(void))_wrap_QuadratureSpace_SaveGZ, METH_VARARGS|METH_KEYWORDS, "QuadratureSpace_SaveGZ(QuadratureSpace self, char const * file, int precision=8)"},
 	 { "QuadratureSpace_Save", _wrap_QuadratureSpace_Save, METH_VARARGS, "\n"
 		"QuadratureSpace_Save(QuadratureSpace self, std::ostream & out)\n"
 		"QuadratureSpace_Save(QuadratureSpace self, char const * file, int precision=8)\n"
@@ -11739,6 +11881,7 @@ static PyMethodDef SwigMethods_proxydocs[] = {
 	 { "FiniteElementSpace_IsDGSpace", _wrap_FiniteElementSpace_IsDGSpace, METH_O, "IsDGSpace(FiniteElementSpace self) -> bool"},
 	 { "FiniteElementSpace_Load", (PyCFunction)(void(*)(void))_wrap_FiniteElementSpace_Load, METH_VARARGS|METH_KEYWORDS, "Load(FiniteElementSpace self, Mesh m, std::istream & input) -> FiniteElementCollection"},
 	 { "delete_FiniteElementSpace", _wrap_delete_FiniteElementSpace, METH_O, "delete_FiniteElementSpace(FiniteElementSpace self)"},
+	 { "FiniteElementSpace_SaveGZ", (PyCFunction)(void(*)(void))_wrap_FiniteElementSpace_SaveGZ, METH_VARARGS|METH_KEYWORDS, "SaveGZ(FiniteElementSpace self, char const * file, int precision=8)"},
 	 { "FiniteElementSpace_Save", _wrap_FiniteElementSpace_Save, METH_VARARGS, "\n"
 		"Save(FiniteElementSpace self, std::ostream & out)\n"
 		"Save(FiniteElementSpace self, char const * file, int precision=8)\n"
@@ -11755,6 +11898,7 @@ static PyMethodDef SwigMethods_proxydocs[] = {
 	 { "QuadratureSpace_GetMesh", _wrap_QuadratureSpace_GetMesh, METH_O, "GetMesh(QuadratureSpace self) -> Mesh"},
 	 { "QuadratureSpace_GetNE", _wrap_QuadratureSpace_GetNE, METH_O, "GetNE(QuadratureSpace self) -> int"},
 	 { "QuadratureSpace_GetElementIntRule", (PyCFunction)(void(*)(void))_wrap_QuadratureSpace_GetElementIntRule, METH_VARARGS|METH_KEYWORDS, "GetElementIntRule(QuadratureSpace self, int idx) -> IntegrationRule"},
+	 { "QuadratureSpace_SaveGZ", (PyCFunction)(void(*)(void))_wrap_QuadratureSpace_SaveGZ, METH_VARARGS|METH_KEYWORDS, "SaveGZ(QuadratureSpace self, char const * file, int precision=8)"},
 	 { "QuadratureSpace_Save", _wrap_QuadratureSpace_Save, METH_VARARGS, "\n"
 		"Save(QuadratureSpace self, std::ostream & out)\n"
 		"Save(QuadratureSpace self, char const * file, int precision=8)\n"

--- a/mfem/_ser/gridfunc.i
+++ b/mfem/_ser/gridfunc.i
@@ -60,11 +60,11 @@ def GetNodalValues(self, *args):
     from .vector import Vector
     if len(args) == 1:
         vec = Vector()
-        _gridfunc.GridFunction_GetNodalValues(self, vec, args[0])
+        $action(self, vec, args[0])
         vec.thisown = 0
         return vec.GetDataArray()
     else:
-        return _gridfunc.GridFunction_GetNodalValues(self, *args)
+        return $action(self, *args)
 %}
 
 

--- a/mfem/_ser/gridfunc.py
+++ b/mfem/_ser/gridfunc.py
@@ -571,6 +571,11 @@ class GridFunction(mfem._ser.vector.Vector):
         return _gridfunc.GridFunction_Save(self, *args)
     Save = _swig_new_instance_method(_gridfunc.GridFunction_Save)
 
+    def SaveGZ(self, file, precision=8):
+        r"""SaveGZ(GridFunction self, char const * file, int precision=8)"""
+        return _gridfunc.GridFunction_SaveGZ(self, file, precision)
+    SaveGZ = _swig_new_instance_method(_gridfunc.GridFunction_SaveGZ)
+
 # Register GridFunction in _gridfunc:
 _gridfunc.GridFunction_swigregister(GridFunction)
 
@@ -648,6 +653,11 @@ class QuadratureFunction(mfem._ser.vector.Vector):
         """
         return _gridfunc.QuadratureFunction_Save(self, *args)
     Save = _swig_new_instance_method(_gridfunc.QuadratureFunction_Save)
+
+    def SaveGZ(self, file, precision=8):
+        r"""SaveGZ(QuadratureFunction self, char const * file, int precision=8)"""
+        return _gridfunc.QuadratureFunction_SaveGZ(self, file, precision)
+    SaveGZ = _swig_new_instance_method(_gridfunc.QuadratureFunction_SaveGZ)
 
 # Register QuadratureFunction in _gridfunc:
 _gridfunc.QuadratureFunction_swigregister(QuadratureFunction)

--- a/mfem/_ser/gridfunc_wrap.cxx
+++ b/mfem/_ser/gridfunc_wrap.cxx
@@ -3826,6 +3826,17 @@ SWIGINTERN void mfem_GridFunction_Save__SWIG_1(mfem::GridFunction *self,char con
   self -> Save(ofile);
   ofile.close();
   }
+SWIGINTERN void mfem_GridFunction_SaveGZ(mfem::GridFunction *self,char const *file,int precision=8){
+  mfem::ofgzstream *ofile = new mfem::ofgzstream(file, true);
+  if (!ofile)
+     {
+        std::cerr << "\nCan not produce output file: " << file << '\n' << std::endl;
+        return;
+      }
+  ofile ->precision(precision);  
+  self -> Save(*ofile);
+  delete ofile;
+  }
 
 SWIGINTERNINLINE PyObject*
   SWIG_From_bool  (bool value)
@@ -3843,6 +3854,17 @@ SWIGINTERN void mfem_QuadratureFunction_Save__SWIG_1(mfem::QuadratureFunction *s
   ofile.precision(precision);  
   self -> Save(ofile);
   ofile.close();
+  }
+SWIGINTERN void mfem_QuadratureFunction_SaveGZ(mfem::QuadratureFunction *self,char const *file,int precision=8){
+  mfem::ofgzstream *ofile = new mfem::ofgzstream(file, true);
+  if (!ofile)
+     {
+        std::cerr << "\nCan not produce output file: " << file << '\n' << std::endl;
+        return;
+      }
+  ofile ->precision(precision);  
+  self -> Save(*ofile);
+  delete ofile;
   }
 
 
@@ -4077,14 +4099,20 @@ SWIGINTERN PyObject *_wrap_new_GridFunction__SWIG_4(PyObject *SWIGUNUSEDPARM(sel
       }
     }
     if (stream2 == 0){
-      if (temp2->isGZ()){
-        in_gz2 = new mfem::ifgzstream(temp2->getFilename());
-        arg2 = in_gz2;
-      } else {
-        in_txt2.open(temp2->getFilename(), std::ifstream::in);
-        in_txt2.precision(temp2->getPrecision());
-        arg2 = &in_txt2;
-      }
+      /*
+            if (temp2->isGZ()){
+        	 in_gz2 = new mfem::ifgzstream(temp2->getFilename());
+               arg2 = in_gz2;
+            } else {
+        	 in_txt2.open(temp2->getFilename(), std::ifstream::in);
+               in_txt2.precision(temp2->getPrecision());
+               arg2 = &in_txt2;
+            }
+           */
+      /* this will auto-detect the input file type */
+      in_gz2 = new mfem::ifgzstream(temp2->getFilename());
+      arg2 = in_gz2;
+      
       if (temp2->isTemporary()){
         delete temp2;
       }
@@ -4112,18 +4140,6 @@ SWIGINTERN PyObject *_wrap_new_GridFunction__SWIG_4(PyObject *SWIGUNUSEDPARM(sel
     }	 
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__GridFunction, SWIG_POINTER_NEW |  0 );
-  {
-    if (stream2) {
-      ret2 = PyLong_FromSsize_t(len2);
-      if (PyErr_Occurred()) {
-        PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
-        return NULL;
-      }
-      delete stream2;    
-      Py_XDECREF(resultobj);   /* Blow away any previous result */
-      resultobj = ret2;    
-    }
-  }
   {
     if (!stream2) {
       if (temp2) {
@@ -14271,6 +14287,70 @@ fail:
 }
 
 
+SWIGINTERN PyObject *_wrap_GridFunction_SaveGZ(PyObject *SWIGUNUSEDPARM(self), PyObject *args, PyObject *kwargs) {
+  PyObject *resultobj = 0;
+  mfem::GridFunction *arg1 = (mfem::GridFunction *) 0 ;
+  char *arg2 = (char *) 0 ;
+  int arg3 = (int) 8 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int res2 ;
+  char *buf2 = 0 ;
+  int alloc2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  char * kwnames[] = {
+    (char *)"self",  (char *)"file",  (char *)"precision",  NULL 
+  };
+  
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OO|O:GridFunction_SaveGZ", kwnames, &obj0, &obj1, &obj2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_mfem__GridFunction, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "GridFunction_SaveGZ" "', argument " "1"" of type '" "mfem::GridFunction *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::GridFunction * >(argp1);
+  res2 = SWIG_AsCharPtrAndSize(obj1, &buf2, NULL, &alloc2);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "GridFunction_SaveGZ" "', argument " "2"" of type '" "char const *""'");
+  }
+  arg2 = reinterpret_cast< char * >(buf2);
+  if (obj2) {
+    {
+      if ((PyArray_PyIntAsInt(obj2) == -1) && PyErr_Occurred()) {
+        SWIG_exception_fail(SWIG_TypeError, "Input must be integer");
+      };  
+      arg3 = PyArray_PyIntAsInt(obj2);
+    }
+  }
+  {
+    try {
+      mfem_GridFunction_SaveGZ(arg1,(char const *)arg2,arg3);
+    }
+#ifdef  MFEM_USE_EXCEPTIONS
+    catch (mfem::ErrorException &_e) {
+      std::string s("PyMFEM error (mfem::ErrorException): "), s2(_e.what());
+      s = s + s2;    
+      SWIG_exception(SWIG_RuntimeError, s.c_str());
+    }
+#endif
+    
+    catch (Swig::DirectorException &e){
+      SWIG_fail;
+    }    
+    catch (...) {
+      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+    }	 
+  }
+  resultobj = SWIG_Py_Void();
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return resultobj;
+fail:
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return NULL;
+}
+
+
 SWIGINTERN PyObject *GridFunction_swigregister(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *obj;
   if (!SWIG_Python_UnpackTuple(args, "swigregister", 1, 1, &obj)) return NULL;
@@ -14667,14 +14747,20 @@ SWIGINTERN PyObject *_wrap_new_QuadratureFunction__SWIG_4(PyObject *SWIGUNUSEDPA
       }
     }
     if (stream2 == 0){
-      if (temp2->isGZ()){
-        in_gz2 = new mfem::ifgzstream(temp2->getFilename());
-        arg2 = in_gz2;
-      } else {
-        in_txt2.open(temp2->getFilename(), std::ifstream::in);
-        in_txt2.precision(temp2->getPrecision());
-        arg2 = &in_txt2;
-      }
+      /*
+            if (temp2->isGZ()){
+        	 in_gz2 = new mfem::ifgzstream(temp2->getFilename());
+               arg2 = in_gz2;
+            } else {
+        	 in_txt2.open(temp2->getFilename(), std::ifstream::in);
+               in_txt2.precision(temp2->getPrecision());
+               arg2 = &in_txt2;
+            }
+           */
+      /* this will auto-detect the input file type */
+      in_gz2 = new mfem::ifgzstream(temp2->getFilename());
+      arg2 = in_gz2;
+      
       if (temp2->isTemporary()){
         delete temp2;
       }
@@ -14702,18 +14788,6 @@ SWIGINTERN PyObject *_wrap_new_QuadratureFunction__SWIG_4(PyObject *SWIGUNUSEDPA
     }	 
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__QuadratureFunction, SWIG_POINTER_NEW |  0 );
-  {
-    if (stream2) {
-      ret2 = PyLong_FromSsize_t(len2);
-      if (PyErr_Occurred()) {
-        PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
-        return NULL;
-      }
-      delete stream2;    
-      Py_XDECREF(resultobj);   /* Blow away any previous result */
-      resultobj = ret2;    
-    }
-  }
   {
     if (!stream2) {
       if (temp2) {
@@ -16186,6 +16260,70 @@ fail:
 }
 
 
+SWIGINTERN PyObject *_wrap_QuadratureFunction_SaveGZ(PyObject *SWIGUNUSEDPARM(self), PyObject *args, PyObject *kwargs) {
+  PyObject *resultobj = 0;
+  mfem::QuadratureFunction *arg1 = (mfem::QuadratureFunction *) 0 ;
+  char *arg2 = (char *) 0 ;
+  int arg3 = (int) 8 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int res2 ;
+  char *buf2 = 0 ;
+  int alloc2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  char * kwnames[] = {
+    (char *)"self",  (char *)"file",  (char *)"precision",  NULL 
+  };
+  
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OO|O:QuadratureFunction_SaveGZ", kwnames, &obj0, &obj1, &obj2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_mfem__QuadratureFunction, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "QuadratureFunction_SaveGZ" "', argument " "1"" of type '" "mfem::QuadratureFunction *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::QuadratureFunction * >(argp1);
+  res2 = SWIG_AsCharPtrAndSize(obj1, &buf2, NULL, &alloc2);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "QuadratureFunction_SaveGZ" "', argument " "2"" of type '" "char const *""'");
+  }
+  arg2 = reinterpret_cast< char * >(buf2);
+  if (obj2) {
+    {
+      if ((PyArray_PyIntAsInt(obj2) == -1) && PyErr_Occurred()) {
+        SWIG_exception_fail(SWIG_TypeError, "Input must be integer");
+      };  
+      arg3 = PyArray_PyIntAsInt(obj2);
+    }
+  }
+  {
+    try {
+      mfem_QuadratureFunction_SaveGZ(arg1,(char const *)arg2,arg3);
+    }
+#ifdef  MFEM_USE_EXCEPTIONS
+    catch (mfem::ErrorException &_e) {
+      std::string s("PyMFEM error (mfem::ErrorException): "), s2(_e.what());
+      s = s + s2;    
+      SWIG_exception(SWIG_RuntimeError, s.c_str());
+    }
+#endif
+    
+    catch (Swig::DirectorException &e){
+      SWIG_fail;
+    }    
+    catch (...) {
+      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+    }	 
+  }
+  resultobj = SWIG_Py_Void();
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return resultobj;
+fail:
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return NULL;
+}
+
+
 SWIGINTERN PyObject *QuadratureFunction_swigregister(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *obj;
   if (!SWIG_Python_UnpackTuple(args, "swigregister", 1, 1, &obj)) return NULL;
@@ -17050,6 +17188,7 @@ static PyMethodDef SwigMethods[] = {
 		"GridFunction_Save(GridFunction self, std::ostream & out)\n"
 		"GridFunction_Save(GridFunction self, char const * file, int precision=8)\n"
 		""},
+	 { "GridFunction_SaveGZ", (PyCFunction)(void(*)(void))_wrap_GridFunction_SaveGZ, METH_VARARGS|METH_KEYWORDS, "GridFunction_SaveGZ(GridFunction self, char const * file, int precision=8)"},
 	 { "GridFunction_swigregister", GridFunction_swigregister, METH_O, NULL},
 	 { "GridFunction_swiginit", GridFunction_swiginit, METH_VARARGS, NULL},
 	 { "new_QuadratureFunction", _wrap_new_QuadratureFunction, METH_VARARGS, "\n"
@@ -17082,6 +17221,7 @@ static PyMethodDef SwigMethods[] = {
 		"QuadratureFunction_Save(QuadratureFunction self, std::ostream & out)\n"
 		"QuadratureFunction_Save(QuadratureFunction self, char const * file, int precision=8)\n"
 		""},
+	 { "QuadratureFunction_SaveGZ", (PyCFunction)(void(*)(void))_wrap_QuadratureFunction_SaveGZ, METH_VARARGS|METH_KEYWORDS, "QuadratureFunction_SaveGZ(QuadratureFunction self, char const * file, int precision=8)"},
 	 { "QuadratureFunction_swigregister", QuadratureFunction_swigregister, METH_O, NULL},
 	 { "QuadratureFunction_swiginit", QuadratureFunction_swiginit, METH_VARARGS, NULL},
 	 { "__lshift__", _wrap___lshift__, METH_VARARGS, "\n"
@@ -17279,6 +17419,7 @@ static PyMethodDef SwigMethods_proxydocs[] = {
 		"Save(GridFunction self, std::ostream & out)\n"
 		"Save(GridFunction self, char const * file, int precision=8)\n"
 		""},
+	 { "GridFunction_SaveGZ", (PyCFunction)(void(*)(void))_wrap_GridFunction_SaveGZ, METH_VARARGS|METH_KEYWORDS, "SaveGZ(GridFunction self, char const * file, int precision=8)"},
 	 { "GridFunction_swigregister", GridFunction_swigregister, METH_O, NULL},
 	 { "GridFunction_swiginit", GridFunction_swiginit, METH_VARARGS, NULL},
 	 { "new_QuadratureFunction", _wrap_new_QuadratureFunction, METH_VARARGS, "\n"
@@ -17311,6 +17452,7 @@ static PyMethodDef SwigMethods_proxydocs[] = {
 		"Save(QuadratureFunction self, std::ostream & out)\n"
 		"Save(QuadratureFunction self, char const * file, int precision=8)\n"
 		""},
+	 { "QuadratureFunction_SaveGZ", (PyCFunction)(void(*)(void))_wrap_QuadratureFunction_SaveGZ, METH_VARARGS|METH_KEYWORDS, "SaveGZ(QuadratureFunction self, char const * file, int precision=8)"},
 	 { "QuadratureFunction_swigregister", QuadratureFunction_swigregister, METH_O, NULL},
 	 { "QuadratureFunction_swiginit", QuadratureFunction_swiginit, METH_VARARGS, NULL},
 	 { "__lshift__", _wrap___lshift__, METH_VARARGS, "\n"

--- a/mfem/_ser/matrix.py
+++ b/mfem/_ser/matrix.py
@@ -111,6 +111,11 @@ class Matrix(mfem._ser.operators.Operator):
         return _matrix.Matrix_Print(self, *args)
     Print = _swig_new_instance_method(_matrix.Matrix_Print)
 
+    def PrintGZ(self, file, precision=8):
+        r"""PrintGZ(Matrix self, char const * file, int precision=8)"""
+        return _matrix.Matrix_PrintGZ(self, file, precision)
+    PrintGZ = _swig_new_instance_method(_matrix.Matrix_PrintGZ)
+
 # Register Matrix in _matrix:
 _matrix.Matrix_swigregister(Matrix)
 

--- a/mfem/_ser/matrix_wrap.cxx
+++ b/mfem/_ser/matrix_wrap.cxx
@@ -3382,6 +3382,17 @@ SWIGINTERN void mfem_Matrix_Print__SWIG_1(mfem::Matrix *self,char const *file,in
   self -> Print(ofile);
   ofile.close();
   }
+SWIGINTERN void mfem_Matrix_PrintGZ(mfem::Matrix *self,char const *file,int precision=8){
+  mfem::ofgzstream *ofile = new mfem::ofgzstream(file, true);
+  if (!ofile)
+     {
+        std::cerr << "\nCan not produce output file: " << file << '\n' << std::endl;
+        return;
+      }
+  ofile ->precision(precision);  
+  self -> Print(*ofile);
+  delete ofile;
+  }
 
 SWIGINTERNINLINE PyObject*
   SWIG_From_int  (int value)
@@ -4108,6 +4119,70 @@ fail:
 }
 
 
+SWIGINTERN PyObject *_wrap_Matrix_PrintGZ(PyObject *SWIGUNUSEDPARM(self), PyObject *args, PyObject *kwargs) {
+  PyObject *resultobj = 0;
+  mfem::Matrix *arg1 = (mfem::Matrix *) 0 ;
+  char *arg2 = (char *) 0 ;
+  int arg3 = (int) 8 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int res2 ;
+  char *buf2 = 0 ;
+  int alloc2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  char * kwnames[] = {
+    (char *)"self",  (char *)"file",  (char *)"precision",  NULL 
+  };
+  
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OO|O:Matrix_PrintGZ", kwnames, &obj0, &obj1, &obj2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_mfem__Matrix, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "Matrix_PrintGZ" "', argument " "1"" of type '" "mfem::Matrix *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::Matrix * >(argp1);
+  res2 = SWIG_AsCharPtrAndSize(obj1, &buf2, NULL, &alloc2);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "Matrix_PrintGZ" "', argument " "2"" of type '" "char const *""'");
+  }
+  arg2 = reinterpret_cast< char * >(buf2);
+  if (obj2) {
+    {
+      if ((PyArray_PyIntAsInt(obj2) == -1) && PyErr_Occurred()) {
+        SWIG_exception_fail(SWIG_TypeError, "Input must be integer");
+      };  
+      arg3 = PyArray_PyIntAsInt(obj2);
+    }
+  }
+  {
+    try {
+      mfem_Matrix_PrintGZ(arg1,(char const *)arg2,arg3);
+    }
+#ifdef  MFEM_USE_EXCEPTIONS
+    catch (mfem::ErrorException &_e) {
+      std::string s("PyMFEM error (mfem::ErrorException): "), s2(_e.what());
+      s = s + s2;    
+      SWIG_exception(SWIG_RuntimeError, s.c_str());
+    }
+#endif
+    
+    catch (Swig::DirectorException &e){
+      SWIG_fail;
+    }    
+    catch (...) {
+      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+    }	 
+  }
+  resultobj = SWIG_Py_Void();
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return resultobj;
+fail:
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return NULL;
+}
+
+
 SWIGINTERN PyObject *Matrix_swigregister(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *obj;
   if (!SWIG_Python_UnpackTuple(args, "swigregister", 1, 1, &obj)) return NULL;
@@ -4679,6 +4754,7 @@ static PyMethodDef SwigMethods[] = {
 		"Matrix_Print(Matrix self, std::ostream & out=mfem::out, int width_=4)\n"
 		"Matrix_Print(Matrix self, char const * file, int precision=8)\n"
 		""},
+	 { "Matrix_PrintGZ", (PyCFunction)(void(*)(void))_wrap_Matrix_PrintGZ, METH_VARARGS|METH_KEYWORDS, "Matrix_PrintGZ(Matrix self, char const * file, int precision=8)"},
 	 { "Matrix_swigregister", Matrix_swigregister, METH_O, NULL},
 	 { "delete_MatrixInverse", _wrap_delete_MatrixInverse, METH_O, "delete_MatrixInverse(MatrixInverse self)"},
 	 { "MatrixInverse_swigregister", MatrixInverse_swigregister, METH_O, NULL},
@@ -4709,6 +4785,7 @@ static PyMethodDef SwigMethods_proxydocs[] = {
 		"Print(Matrix self, std::ostream & out=mfem::out, int width_=4)\n"
 		"Print(Matrix self, char const * file, int precision=8)\n"
 		""},
+	 { "Matrix_PrintGZ", (PyCFunction)(void(*)(void))_wrap_Matrix_PrintGZ, METH_VARARGS|METH_KEYWORDS, "PrintGZ(Matrix self, char const * file, int precision=8)"},
 	 { "Matrix_swigregister", Matrix_swigregister, METH_O, NULL},
 	 { "delete_MatrixInverse", _wrap_delete_MatrixInverse, METH_O, "delete_MatrixInverse(MatrixInverse self)"},
 	 { "MatrixInverse_swigregister", MatrixInverse_swigregister, METH_O, NULL},

--- a/mfem/_ser/mesh.i
+++ b/mfem/_ser/mesh.i
@@ -165,7 +165,7 @@ if (!SWIG_IsOK(res2)){
 def GetBdrElementVertices(self, i):
     from  .array import intArray
     ivert = intArray()
-    _mesh.Mesh_GetBdrElementVertices(self, i, ivert)
+    $action(self, i, ivert)
     return ivert.ToList()
 %}
 
@@ -174,7 +174,7 @@ def GetBdrElementAdjacentElement(self, bdr_el):
     from mfem.ser import intp
     el = intp()
     info = intp()  
-    _mesh.Mesh_GetBdrElementAdjacentElement(self, bdr_el, el, info)
+    $action(self, bdr_el, el, info)
     return el.value(), info.value()
 %}
 
@@ -182,7 +182,7 @@ def GetBdrElementAdjacentElement(self, bdr_el):
 def GetElementVertices(self, i):
     from  .array import intArray
     ivert = intArray()
-    _mesh.Mesh_GetElementVertices(self, i, ivert)
+    $action(self, i, ivert)
     return ivert.ToList()
 %}
 
@@ -191,7 +191,7 @@ def GetElementEdges(self, i):
     from  .array import intArray
     ia = intArray()
     ib = intArray()      
-    _mesh.Mesh_GetElementEdges(self, i, ia, ib)
+    $action(self, i, ia, ib)
     return ia.ToList(), ib.ToList()      
 %} 
 
@@ -200,7 +200,7 @@ def GetBdrElementEdges(self, i):
     from  .array import intArray
     ia = intArray()
     ib = intArray()      
-    _mesh.Mesh_GetBdrElementEdges(self, i, ia, ib)
+    $action(self, i, ia, ib)
     return ia.ToList(), ib.ToList()
 %} 
 
@@ -209,7 +209,7 @@ def GetFaceEdges(self, i):
     from  .array import intArray
     ia = intArray()
     ib = intArray()      
-    _mesh.Mesh_GetFaceEdges(self, i, ia, ib)
+    $action(self, i, ia, ib)
     return ia.ToList(), ib.ToList()
 %}
 
@@ -217,7 +217,7 @@ def GetFaceEdges(self, i):
 def GetEdgeVertices(self, i):
     from  .array import intArray
     ia = intArray()
-    _mesh.Mesh_GetEdgeVertices(self, i, ia)
+    $action(self, i, ia)
     return ia.ToList()
 %}
 
@@ -225,7 +225,7 @@ def GetEdgeVertices(self, i):
 def GetFaceVertices(self, i):
     from  .array import intArray
     ia = intArray()
-    _mesh.Mesh_GetFaceVertices(self, i, ia)
+    $action(self, i, ia)
     return ia.ToList()
 %}
 
@@ -234,7 +234,7 @@ def GetElementFaces(self, i):
     from  .array import intArray
     ia = intArray()
     ib = intArray()      
-    _mesh.Mesh_GetElementFaces(self, i, ia, ib)
+    $action(self, i, ia, ib)
     return ia.ToList(), ib.ToList()
 %}
 
@@ -243,7 +243,7 @@ def GetBoundingBox(self, ref = 2):
     from  .vector import Vector
     min = Vector()
     max = Vector()      
-    _mesh.Mesh_GetBoundingBox(self, min, max, ref)      
+    $action(self, min, max, ref)      
     return min.GetDataArray().copy(), max.GetDataArray().copy()
 %}
 
@@ -252,35 +252,35 @@ def GetFaceElements(self, Face):
     from mfem.ser import intp
     Elem1 = intp()
     Elem2 = intp()  
-    val = _mesh.Mesh_GetFaceElements(self, Face, Elem1, Elem2)
+    val = $action(self, Face, Elem1, Elem2)
     return Elem1.value(), Elem2.value()
 %}
 %feature("shadow") mfem::Mesh::GetElementTransformation %{
 def GetElementTransformation(self, i):
     from mfem.ser import IsoparametricTransformation
     Tr = IsoparametricTransformation()
-    _mesh.Mesh_GetElementTransformation(self, i, Tr)
+    $action(self, i, Tr)
     return Tr
 %}
 %feature("shadow") mfem::Mesh::GetBdrElementTransformation %{
 def GetBdrElementTransformation(self, i):
     from mfem.ser import IsoparametricTransformation
     Tr = IsoparametricTransformation()
-    _mesh.Mesh_GetBdrElementTransformation(self, i, Tr)
+    $action(self, i, Tr)
     return Tr
 %}
 %feature("shadow") mfem::Mesh::GetFaceTransformation %{
 def GetFaceTransformation(self, i):
     from mfem.ser import IsoparametricTransformation
     Tr = IsoparametricTransformation()
-    _mesh.Mesh_GetFaceTransformation(self, i, Tr)
+    $action(self, i, Tr)
     return Tr
 %}
 %feature("shadow") mfem::Mesh::GetEdgeTransformation %{
 def GetEdgeTransformation(self, i):
     from mfem.ser import IsoparametricTransformation
     Tr = IsoparametricTransformation()
-    _mesh.Mesh_GetEdgeTransformation(self, i, Tr)
+    $action(self, i, Tr)
     return Tr
 %}
 %feature("shadow") mfem::Mesh::GetFaceInfos %{
@@ -289,7 +289,7 @@ def GetFaceInfos(self, i):
     Elem1 = intp()
     Elem2 = intp()  
   
-    _mesh.Mesh_GetFaceInfos(self, i, Elem1, Elem2)
+    $action(self, i, Elem1, Elem2)
     return Elem1.value(), Elem2.value()
 %}
 %feature("shadow") mfem::Mesh::FindPoints %{
@@ -303,7 +303,7 @@ def FindPoints(self, pp, warn=True, inv_trans=None):
     M.Assign(pp)
     elem_ids = mfem.intArray()
     int_points = mfem.IntegrationPointArray()
-    count = _mesh.Mesh_FindPoints(self, M, elem_ids, int_points, warn, inv_trans)
+    count = $action(self, M, elem_ids, int_points, warn, inv_trans)
     elem_ids = elem_ids.ToList()
     return count, elem_ids, int_points
 %}
@@ -319,7 +319,7 @@ def CartesianPartitioning(self, nxyz, return_list=False):
         dd = nxyz
         warnings.warn("CartesianPartitioning argument should be iterable",
 		      DeprecationWarning,)
-    r = _mesh.Mesh_CartesianPartitioning(self, dd)
+    r = $action(self, dd)
 
     if not return_list:
         return r

--- a/mfem/_ser/mesh.i
+++ b/mfem/_ser/mesh.i
@@ -10,8 +10,8 @@
 #include <cmath>
 #include <cstring>
 #include <ctime>
-mfem::Mesh * MeshFromFile(const char *mesh_file, int generate_edges, int refine,
-		      bool fix_orientation = true);
+//mfem::Mesh * MeshFromFile(const char *mesh_file, int generate_edges, int refine,
+//		      bool fix_orientation = true);
 // void mfem:PrintToFile(const char *mesh_file,  const int precision) const;
 #include "numpy/arrayobject.h"
 #include "pycoefficient.hpp"

--- a/mfem/_ser/mesh.py
+++ b/mfem/_ser/mesh.py
@@ -1152,6 +1152,11 @@ class Mesh(object):
         return _mesh.Mesh_PrintInfo(self, *args)
     PrintInfo = _swig_new_instance_method(_mesh.Mesh_PrintInfo)
 
+    def PrintInfoGZ(self, file, precision=8):
+        r"""PrintInfoGZ(Mesh self, char const * file, int precision=8)"""
+        return _mesh.Mesh_PrintInfoGZ(self, file, precision)
+    PrintInfoGZ = _swig_new_instance_method(_mesh.Mesh_PrintInfoGZ)
+
     def Print(self, *args):
         r"""
         Print(Mesh self, std::ostream & out=out)
@@ -1159,6 +1164,11 @@ class Mesh(object):
         """
         return _mesh.Mesh_Print(self, *args)
     Print = _swig_new_instance_method(_mesh.Mesh_Print)
+
+    def PrintGZ(self, file, precision=8):
+        r"""PrintGZ(Mesh self, char const * file, int precision=8)"""
+        return _mesh.Mesh_PrintGZ(self, file, precision)
+    PrintGZ = _swig_new_instance_method(_mesh.Mesh_PrintGZ)
 
     def PrintXG(self, *args):
         r"""
@@ -1168,6 +1178,11 @@ class Mesh(object):
         return _mesh.Mesh_PrintXG(self, *args)
     PrintXG = _swig_new_instance_method(_mesh.Mesh_PrintXG)
 
+    def PrintXGGZ(self, file, precision=8):
+        r"""PrintXGGZ(Mesh self, char const * file, int precision=8)"""
+        return _mesh.Mesh_PrintXGGZ(self, file, precision)
+    PrintXGGZ = _swig_new_instance_method(_mesh.Mesh_PrintXGGZ)
+
     def PrintVTK(self, *args):
         r"""
         PrintVTK(Mesh self, std::ostream & out)
@@ -1176,6 +1191,11 @@ class Mesh(object):
         """
         return _mesh.Mesh_PrintVTK(self, *args)
     PrintVTK = _swig_new_instance_method(_mesh.Mesh_PrintVTK)
+
+    def PrintVTKGZ(self, file, precision=8):
+        r"""PrintVTKGZ(Mesh self, char const * file, int precision=8)"""
+        return _mesh.Mesh_PrintVTKGZ(self, file, precision)
+    PrintVTKGZ = _swig_new_instance_method(_mesh.Mesh_PrintVTKGZ)
 
 # Register Mesh in _mesh:
 _mesh.Mesh_swigregister(Mesh)

--- a/mfem/_ser/mesh_wrap.cxx
+++ b/mfem/_ser/mesh_wrap.cxx
@@ -3384,8 +3384,8 @@ namespace swig {
 #include <cmath>
 #include <cstring>
 #include <ctime>
-mfem::Mesh * MeshFromFile(const char *mesh_file, int generate_edges, int refine,
-		      bool fix_orientation = true);
+//mfem::Mesh * MeshFromFile(const char *mesh_file, int generate_edges, int refine,
+//		      bool fix_orientation = true);
 // void mfem:PrintToFile(const char *mesh_file,  const int precision) const;
 #include "numpy/arrayobject.h"
 #include "pycoefficient.hpp"
@@ -3969,6 +3969,17 @@ SWIGINTERN void mfem_Mesh_PrintInfo__SWIG_1(mfem::Mesh *self,char const *file,in
   self -> PrintInfo(ofile);
   ofile.close();
   }
+SWIGINTERN void mfem_Mesh_PrintInfoGZ(mfem::Mesh *self,char const *file,int precision=8){
+  mfem::ofgzstream *ofile = new mfem::ofgzstream(file, true);
+  if (!ofile)
+     {
+        std::cerr << "\nCan not produce output file: " << file << '\n' << std::endl;
+        return;
+      }
+  ofile ->precision(precision);  
+  self -> PrintInfo(*ofile);
+  delete ofile;
+  }
 SWIGINTERN void mfem_Mesh_Print__SWIG_1(mfem::Mesh *self,char const *file,int precision=8){
   std::ofstream ofile(file);
   if (!ofile)
@@ -3979,6 +3990,17 @@ SWIGINTERN void mfem_Mesh_Print__SWIG_1(mfem::Mesh *self,char const *file,int pr
   ofile.precision(precision);  
   self -> Print(ofile);
   ofile.close();
+  }
+SWIGINTERN void mfem_Mesh_PrintGZ(mfem::Mesh *self,char const *file,int precision=8){
+  mfem::ofgzstream *ofile = new mfem::ofgzstream(file, true);
+  if (!ofile)
+     {
+        std::cerr << "\nCan not produce output file: " << file << '\n' << std::endl;
+        return;
+      }
+  ofile ->precision(precision);  
+  self -> Print(*ofile);
+  delete ofile;
   }
 SWIGINTERN void mfem_Mesh_PrintXG__SWIG_1(mfem::Mesh *self,char const *file,int precision=8){
   std::ofstream ofile(file);
@@ -3991,6 +4013,17 @@ SWIGINTERN void mfem_Mesh_PrintXG__SWIG_1(mfem::Mesh *self,char const *file,int 
   self -> PrintXG(ofile);
   ofile.close();
   }
+SWIGINTERN void mfem_Mesh_PrintXGGZ(mfem::Mesh *self,char const *file,int precision=8){
+  mfem::ofgzstream *ofile = new mfem::ofgzstream(file, true);
+  if (!ofile)
+     {
+        std::cerr << "\nCan not produce output file: " << file << '\n' << std::endl;
+        return;
+      }
+  ofile ->precision(precision);  
+  self -> PrintXG(*ofile);
+  delete ofile;
+  }
 SWIGINTERN void mfem_Mesh_PrintVTK__SWIG_2(mfem::Mesh *self,char const *file,int precision=8){
   std::ofstream ofile(file);
   if (!ofile)
@@ -4001,6 +4034,17 @@ SWIGINTERN void mfem_Mesh_PrintVTK__SWIG_2(mfem::Mesh *self,char const *file,int
   ofile.precision(precision);  
   self -> PrintVTK(ofile);
   ofile.close();
+  }
+SWIGINTERN void mfem_Mesh_PrintVTKGZ(mfem::Mesh *self,char const *file,int precision=8){
+  mfem::ofgzstream *ofile = new mfem::ofgzstream(file, true);
+  if (!ofile)
+     {
+        std::cerr << "\nCan not produce output file: " << file << '\n' << std::endl;
+        return;
+      }
+  ofile ->precision(precision);  
+  self -> PrintVTK(*ofile);
+  delete ofile;
   }
 
 
@@ -8875,14 +8919,20 @@ SWIGINTERN PyObject *_wrap_new_Mesh__SWIG_9(PyObject *SWIGUNUSEDPARM(self), Py_s
       }
     }
     if (stream1 == 0){
-      if (temp1->isGZ()){
-        in_gz1 = new mfem::ifgzstream(temp1->getFilename());
-        arg1 = in_gz1;
-      } else {
-        in_txt1.open(temp1->getFilename(), std::ifstream::in);
-        in_txt1.precision(temp1->getPrecision());
-        arg1 = &in_txt1;
-      }
+      /*
+            if (temp1->isGZ()){
+        	 in_gz1 = new mfem::ifgzstream(temp1->getFilename());
+               arg1 = in_gz1;
+            } else {
+        	 in_txt1.open(temp1->getFilename(), std::ifstream::in);
+               in_txt1.precision(temp1->getPrecision());
+               arg1 = &in_txt1;
+            }
+           */
+      /* this will auto-detect the input file type */
+      in_gz1 = new mfem::ifgzstream(temp1->getFilename());
+      arg1 = in_gz1;
+      
       if (temp1->isTemporary()){
         delete temp1;
       }
@@ -8933,18 +8983,6 @@ SWIGINTERN PyObject *_wrap_new_Mesh__SWIG_9(PyObject *SWIGUNUSEDPARM(self), Py_s
     }	 
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_mfem__Mesh, SWIG_POINTER_NEW |  0 );
-  {
-    if (stream1) {
-      ret1 = PyLong_FromSsize_t(len1);
-      if (PyErr_Occurred()) {
-        PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
-        return NULL;
-      }
-      delete stream1;    
-      Py_XDECREF(resultobj);   /* Blow away any previous result */
-      resultobj = ret1;    
-    }
-  }
   {
     if (!stream1) {
       if (temp1) {
@@ -9145,14 +9183,20 @@ SWIGINTERN PyObject *_wrap_Mesh_Load(PyObject *SWIGUNUSEDPARM(self), PyObject *a
       }
     }
     if (stream2 == 0){
-      if (temp2->isGZ()){
-        in_gz2 = new mfem::ifgzstream(temp2->getFilename());
-        arg2 = in_gz2;
-      } else {
-        in_txt2.open(temp2->getFilename(), std::ifstream::in);
-        in_txt2.precision(temp2->getPrecision());
-        arg2 = &in_txt2;
-      }
+      /*
+            if (temp2->isGZ()){
+        	 in_gz2 = new mfem::ifgzstream(temp2->getFilename());
+               arg2 = in_gz2;
+            } else {
+        	 in_txt2.open(temp2->getFilename(), std::ifstream::in);
+               in_txt2.precision(temp2->getPrecision());
+               arg2 = &in_txt2;
+            }
+           */
+      /* this will auto-detect the input file type */
+      in_gz2 = new mfem::ifgzstream(temp2->getFilename());
+      arg2 = in_gz2;
+      
       if (temp2->isTemporary()){
         delete temp2;
       }
@@ -9203,18 +9247,6 @@ SWIGINTERN PyObject *_wrap_Mesh_Load(PyObject *SWIGUNUSEDPARM(self), PyObject *a
     }	 
   }
   resultobj = SWIG_Py_Void();
-  {
-    if (stream2) {
-      ret2 = PyLong_FromSsize_t(len2);
-      if (PyErr_Occurred()) {
-        PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
-        return NULL;
-      }
-      delete stream2;    
-      Py_XDECREF(resultobj);   /* Blow away any previous result */
-      resultobj = ret2;    
-    }
-  }
   {
     if (!stream2) {
       if (temp2) {
@@ -21494,6 +21526,70 @@ fail:
 }
 
 
+SWIGINTERN PyObject *_wrap_Mesh_PrintInfoGZ(PyObject *SWIGUNUSEDPARM(self), PyObject *args, PyObject *kwargs) {
+  PyObject *resultobj = 0;
+  mfem::Mesh *arg1 = (mfem::Mesh *) 0 ;
+  char *arg2 = (char *) 0 ;
+  int arg3 = (int) 8 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int res2 ;
+  char *buf2 = 0 ;
+  int alloc2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  char * kwnames[] = {
+    (char *)"self",  (char *)"file",  (char *)"precision",  NULL 
+  };
+  
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OO|O:Mesh_PrintInfoGZ", kwnames, &obj0, &obj1, &obj2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_mfem__Mesh, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "Mesh_PrintInfoGZ" "', argument " "1"" of type '" "mfem::Mesh *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::Mesh * >(argp1);
+  res2 = SWIG_AsCharPtrAndSize(obj1, &buf2, NULL, &alloc2);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "Mesh_PrintInfoGZ" "', argument " "2"" of type '" "char const *""'");
+  }
+  arg2 = reinterpret_cast< char * >(buf2);
+  if (obj2) {
+    {
+      if ((PyArray_PyIntAsInt(obj2) == -1) && PyErr_Occurred()) {
+        SWIG_exception_fail(SWIG_TypeError, "Input must be integer");
+      };  
+      arg3 = PyArray_PyIntAsInt(obj2);
+    }
+  }
+  {
+    try {
+      mfem_Mesh_PrintInfoGZ(arg1,(char const *)arg2,arg3);
+    }
+#ifdef  MFEM_USE_EXCEPTIONS
+    catch (mfem::ErrorException &_e) {
+      std::string s("PyMFEM error (mfem::ErrorException): "), s2(_e.what());
+      s = s + s2;    
+      SWIG_exception(SWIG_RuntimeError, s.c_str());
+    }
+#endif
+    
+    catch (Swig::DirectorException &e){
+      SWIG_fail;
+    }    
+    catch (...) {
+      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+    }	 
+  }
+  resultobj = SWIG_Py_Void();
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return resultobj;
+fail:
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return NULL;
+}
+
+
 SWIGINTERN PyObject *_wrap_Mesh_Print__SWIG_1(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
   PyObject *resultobj = 0;
   mfem::Mesh *arg1 = (mfem::Mesh *) 0 ;
@@ -21638,6 +21734,70 @@ fail:
 }
 
 
+SWIGINTERN PyObject *_wrap_Mesh_PrintGZ(PyObject *SWIGUNUSEDPARM(self), PyObject *args, PyObject *kwargs) {
+  PyObject *resultobj = 0;
+  mfem::Mesh *arg1 = (mfem::Mesh *) 0 ;
+  char *arg2 = (char *) 0 ;
+  int arg3 = (int) 8 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int res2 ;
+  char *buf2 = 0 ;
+  int alloc2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  char * kwnames[] = {
+    (char *)"self",  (char *)"file",  (char *)"precision",  NULL 
+  };
+  
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OO|O:Mesh_PrintGZ", kwnames, &obj0, &obj1, &obj2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_mfem__Mesh, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "Mesh_PrintGZ" "', argument " "1"" of type '" "mfem::Mesh *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::Mesh * >(argp1);
+  res2 = SWIG_AsCharPtrAndSize(obj1, &buf2, NULL, &alloc2);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "Mesh_PrintGZ" "', argument " "2"" of type '" "char const *""'");
+  }
+  arg2 = reinterpret_cast< char * >(buf2);
+  if (obj2) {
+    {
+      if ((PyArray_PyIntAsInt(obj2) == -1) && PyErr_Occurred()) {
+        SWIG_exception_fail(SWIG_TypeError, "Input must be integer");
+      };  
+      arg3 = PyArray_PyIntAsInt(obj2);
+    }
+  }
+  {
+    try {
+      mfem_Mesh_PrintGZ(arg1,(char const *)arg2,arg3);
+    }
+#ifdef  MFEM_USE_EXCEPTIONS
+    catch (mfem::ErrorException &_e) {
+      std::string s("PyMFEM error (mfem::ErrorException): "), s2(_e.what());
+      s = s + s2;    
+      SWIG_exception(SWIG_RuntimeError, s.c_str());
+    }
+#endif
+    
+    catch (Swig::DirectorException &e){
+      SWIG_fail;
+    }    
+    catch (...) {
+      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+    }	 
+  }
+  resultobj = SWIG_Py_Void();
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return resultobj;
+fail:
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return NULL;
+}
+
+
 SWIGINTERN PyObject *_wrap_Mesh_PrintXG__SWIG_1(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
   PyObject *resultobj = 0;
   mfem::Mesh *arg1 = (mfem::Mesh *) 0 ;
@@ -21779,6 +21939,70 @@ fail:
     "    mfem::Mesh::PrintXG(std::ostream &) const\n"
     "    mfem::Mesh::PrintXG(char const *,int)\n");
   return 0;
+}
+
+
+SWIGINTERN PyObject *_wrap_Mesh_PrintXGGZ(PyObject *SWIGUNUSEDPARM(self), PyObject *args, PyObject *kwargs) {
+  PyObject *resultobj = 0;
+  mfem::Mesh *arg1 = (mfem::Mesh *) 0 ;
+  char *arg2 = (char *) 0 ;
+  int arg3 = (int) 8 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int res2 ;
+  char *buf2 = 0 ;
+  int alloc2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  char * kwnames[] = {
+    (char *)"self",  (char *)"file",  (char *)"precision",  NULL 
+  };
+  
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OO|O:Mesh_PrintXGGZ", kwnames, &obj0, &obj1, &obj2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_mfem__Mesh, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "Mesh_PrintXGGZ" "', argument " "1"" of type '" "mfem::Mesh *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::Mesh * >(argp1);
+  res2 = SWIG_AsCharPtrAndSize(obj1, &buf2, NULL, &alloc2);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "Mesh_PrintXGGZ" "', argument " "2"" of type '" "char const *""'");
+  }
+  arg2 = reinterpret_cast< char * >(buf2);
+  if (obj2) {
+    {
+      if ((PyArray_PyIntAsInt(obj2) == -1) && PyErr_Occurred()) {
+        SWIG_exception_fail(SWIG_TypeError, "Input must be integer");
+      };  
+      arg3 = PyArray_PyIntAsInt(obj2);
+    }
+  }
+  {
+    try {
+      mfem_Mesh_PrintXGGZ(arg1,(char const *)arg2,arg3);
+    }
+#ifdef  MFEM_USE_EXCEPTIONS
+    catch (mfem::ErrorException &_e) {
+      std::string s("PyMFEM error (mfem::ErrorException): "), s2(_e.what());
+      s = s + s2;    
+      SWIG_exception(SWIG_RuntimeError, s.c_str());
+    }
+#endif
+    
+    catch (Swig::DirectorException &e){
+      SWIG_fail;
+    }    
+    catch (...) {
+      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+    }	 
+  }
+  resultobj = SWIG_Py_Void();
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return resultobj;
+fail:
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return NULL;
 }
 
 
@@ -21983,6 +22207,70 @@ fail:
     "    mfem::Mesh::PrintVTK(std::ostream &,int,int)\n"
     "    mfem::Mesh::PrintVTK(char const *,int)\n");
   return 0;
+}
+
+
+SWIGINTERN PyObject *_wrap_Mesh_PrintVTKGZ(PyObject *SWIGUNUSEDPARM(self), PyObject *args, PyObject *kwargs) {
+  PyObject *resultobj = 0;
+  mfem::Mesh *arg1 = (mfem::Mesh *) 0 ;
+  char *arg2 = (char *) 0 ;
+  int arg3 = (int) 8 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int res2 ;
+  char *buf2 = 0 ;
+  int alloc2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  char * kwnames[] = {
+    (char *)"self",  (char *)"file",  (char *)"precision",  NULL 
+  };
+  
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OO|O:Mesh_PrintVTKGZ", kwnames, &obj0, &obj1, &obj2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_mfem__Mesh, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "Mesh_PrintVTKGZ" "', argument " "1"" of type '" "mfem::Mesh *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::Mesh * >(argp1);
+  res2 = SWIG_AsCharPtrAndSize(obj1, &buf2, NULL, &alloc2);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "Mesh_PrintVTKGZ" "', argument " "2"" of type '" "char const *""'");
+  }
+  arg2 = reinterpret_cast< char * >(buf2);
+  if (obj2) {
+    {
+      if ((PyArray_PyIntAsInt(obj2) == -1) && PyErr_Occurred()) {
+        SWIG_exception_fail(SWIG_TypeError, "Input must be integer");
+      };  
+      arg3 = PyArray_PyIntAsInt(obj2);
+    }
+  }
+  {
+    try {
+      mfem_Mesh_PrintVTKGZ(arg1,(char const *)arg2,arg3);
+    }
+#ifdef  MFEM_USE_EXCEPTIONS
+    catch (mfem::ErrorException &_e) {
+      std::string s("PyMFEM error (mfem::ErrorException): "), s2(_e.what());
+      s = s + s2;    
+      SWIG_exception(SWIG_RuntimeError, s.c_str());
+    }
+#endif
+    
+    catch (Swig::DirectorException &e){
+      SWIG_fail;
+    }    
+    catch (...) {
+      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+    }	 
+  }
+  resultobj = SWIG_Py_Void();
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return resultobj;
+fail:
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return NULL;
 }
 
 
@@ -24046,19 +24334,23 @@ static PyMethodDef SwigMethods[] = {
 		"Mesh_PrintInfo(Mesh self, std::ostream & out=out)\n"
 		"Mesh_PrintInfo(Mesh self, char const * file, int precision=8)\n"
 		""},
+	 { "Mesh_PrintInfoGZ", (PyCFunction)(void(*)(void))_wrap_Mesh_PrintInfoGZ, METH_VARARGS|METH_KEYWORDS, "Mesh_PrintInfoGZ(Mesh self, char const * file, int precision=8)"},
 	 { "Mesh_Print", _wrap_Mesh_Print, METH_VARARGS, "\n"
 		"Mesh_Print(Mesh self, std::ostream & out=out)\n"
 		"Mesh_Print(Mesh self, char const * file, int precision=8)\n"
 		""},
+	 { "Mesh_PrintGZ", (PyCFunction)(void(*)(void))_wrap_Mesh_PrintGZ, METH_VARARGS|METH_KEYWORDS, "Mesh_PrintGZ(Mesh self, char const * file, int precision=8)"},
 	 { "Mesh_PrintXG", _wrap_Mesh_PrintXG, METH_VARARGS, "\n"
 		"Mesh_PrintXG(Mesh self, std::ostream & out=out)\n"
 		"Mesh_PrintXG(Mesh self, char const * file, int precision=8)\n"
 		""},
+	 { "Mesh_PrintXGGZ", (PyCFunction)(void(*)(void))_wrap_Mesh_PrintXGGZ, METH_VARARGS|METH_KEYWORDS, "Mesh_PrintXGGZ(Mesh self, char const * file, int precision=8)"},
 	 { "Mesh_PrintVTK", _wrap_Mesh_PrintVTK, METH_VARARGS, "\n"
 		"Mesh_PrintVTK(Mesh self, std::ostream & out)\n"
 		"Mesh_PrintVTK(Mesh self, std::ostream & out, int ref, int field_data=0)\n"
 		"Mesh_PrintVTK(Mesh self, char const * file, int precision=8)\n"
 		""},
+	 { "Mesh_PrintVTKGZ", (PyCFunction)(void(*)(void))_wrap_Mesh_PrintVTKGZ, METH_VARARGS|METH_KEYWORDS, "Mesh_PrintVTKGZ(Mesh self, char const * file, int precision=8)"},
 	 { "Mesh_swigregister", Mesh_swigregister, METH_O, NULL},
 	 { "Mesh_swiginit", Mesh_swiginit, METH_VARARGS, NULL},
 	 { "__lshift__", _wrap___lshift__, METH_VARARGS, "\n"
@@ -24407,19 +24699,23 @@ static PyMethodDef SwigMethods_proxydocs[] = {
 		"PrintInfo(Mesh self, std::ostream & out=out)\n"
 		"PrintInfo(Mesh self, char const * file, int precision=8)\n"
 		""},
+	 { "Mesh_PrintInfoGZ", (PyCFunction)(void(*)(void))_wrap_Mesh_PrintInfoGZ, METH_VARARGS|METH_KEYWORDS, "PrintInfoGZ(Mesh self, char const * file, int precision=8)"},
 	 { "Mesh_Print", _wrap_Mesh_Print, METH_VARARGS, "\n"
 		"Print(Mesh self, std::ostream & out=out)\n"
 		"Print(Mesh self, char const * file, int precision=8)\n"
 		""},
+	 { "Mesh_PrintGZ", (PyCFunction)(void(*)(void))_wrap_Mesh_PrintGZ, METH_VARARGS|METH_KEYWORDS, "PrintGZ(Mesh self, char const * file, int precision=8)"},
 	 { "Mesh_PrintXG", _wrap_Mesh_PrintXG, METH_VARARGS, "\n"
 		"PrintXG(Mesh self, std::ostream & out=out)\n"
 		"PrintXG(Mesh self, char const * file, int precision=8)\n"
 		""},
+	 { "Mesh_PrintXGGZ", (PyCFunction)(void(*)(void))_wrap_Mesh_PrintXGGZ, METH_VARARGS|METH_KEYWORDS, "PrintXGGZ(Mesh self, char const * file, int precision=8)"},
 	 { "Mesh_PrintVTK", _wrap_Mesh_PrintVTK, METH_VARARGS, "\n"
 		"PrintVTK(Mesh self, std::ostream & out)\n"
 		"PrintVTK(Mesh self, std::ostream & out, int ref, int field_data=0)\n"
 		"PrintVTK(Mesh self, char const * file, int precision=8)\n"
 		""},
+	 { "Mesh_PrintVTKGZ", (PyCFunction)(void(*)(void))_wrap_Mesh_PrintVTKGZ, METH_VARARGS|METH_KEYWORDS, "PrintVTKGZ(Mesh self, char const * file, int precision=8)"},
 	 { "Mesh_swigregister", Mesh_swigregister, METH_O, NULL},
 	 { "Mesh_swiginit", Mesh_swiginit, METH_VARARGS, NULL},
 	 { "__lshift__", _wrap___lshift__, METH_VARARGS, "\n"

--- a/mfem/_ser/ncmesh.py
+++ b/mfem/_ser/ncmesh.py
@@ -370,6 +370,11 @@ class NCMesh(object):
         return _ncmesh.NCMesh_PrintMemoryDetail(self)
     PrintMemoryDetail = _swig_new_instance_method(_ncmesh.NCMesh_PrintMemoryDetail)
 
+    def PrintVertexParentsGZ(self, file, precision=8):
+        r"""PrintVertexParentsGZ(NCMesh self, char const * file, int precision=8)"""
+        return _ncmesh.NCMesh_PrintVertexParentsGZ(self, file, precision)
+    PrintVertexParentsGZ = _swig_new_instance_method(_ncmesh.NCMesh_PrintVertexParentsGZ)
+
     def PrintVertexParents(self, *args):
         r"""
         PrintVertexParents(NCMesh self, std::ostream & out)
@@ -378,6 +383,11 @@ class NCMesh(object):
         """
         return _ncmesh.NCMesh_PrintVertexParents(self, *args)
     PrintVertexParents = _swig_new_instance_method(_ncmesh.NCMesh_PrintVertexParents)
+
+    def PrintCoarseElementsGZ(self, file, precision=8):
+        r"""PrintCoarseElementsGZ(NCMesh self, char const * file, int precision=8)"""
+        return _ncmesh.NCMesh_PrintCoarseElementsGZ(self, file, precision)
+    PrintCoarseElementsGZ = _swig_new_instance_method(_ncmesh.NCMesh_PrintCoarseElementsGZ)
 
     def PrintCoarseElements(self, *args):
         r"""
@@ -395,6 +405,11 @@ class NCMesh(object):
         """
         return _ncmesh.NCMesh_PrintStats(self, *args)
     PrintStats = _swig_new_instance_method(_ncmesh.NCMesh_PrintStats)
+
+    def PrintStatsGZ(self, file, precision=8):
+        r"""PrintStatsGZ(NCMesh self, char const * file, int precision=8)"""
+        return _ncmesh.NCMesh_PrintStatsGZ(self, file, precision)
+    PrintStatsGZ = _swig_new_instance_method(_ncmesh.NCMesh_PrintStatsGZ)
 
 # Register NCMesh in _ncmesh:
 _ncmesh.NCMesh_swigregister(NCMesh)

--- a/mfem/_ser/ncmesh_wrap.cxx
+++ b/mfem/_ser/ncmesh_wrap.cxx
@@ -3621,6 +3621,18 @@ SWIGINTERN void mfem_NCMesh_PrintVertexParents__SWIG_1(mfem::NCMesh *self,char c
   self -> PrintVertexParents(ofile);
   ofile.close();
   }
+SWIGINTERN void mfem_NCMesh_PrintVertexParentsGZ(mfem::NCMesh *self,char const *file,int precision=8){
+  mfem::ofgzstream *ofile = new mfem::ofgzstream(file, true);
+  
+  if (!ofile)
+     {
+        std::cerr << "\nCan not produce output file: " << file << '\n' << std::endl;
+        return;
+      }
+  ofile -> precision(precision);  
+  self -> PrintVertexParents(*ofile);
+  delete ofile;
+  }
 SWIGINTERN void mfem_NCMesh_PrintVertexParents__SWIG_2(mfem::NCMesh *self){
   self -> PrintVertexParents(std::cout);
   }
@@ -3635,6 +3647,18 @@ SWIGINTERN void mfem_NCMesh_PrintCoarseElements__SWIG_1(mfem::NCMesh *self,char 
   self -> PrintCoarseElements(ofile);
   ofile.close();
   }
+SWIGINTERN void mfem_NCMesh_PrintCoarseElementsGZ(mfem::NCMesh *self,char const *file,int precision=8){
+  mfem::ofgzstream *ofile = new mfem::ofgzstream(file, true);
+  
+  if (!ofile)
+     {
+        std::cerr << "\nCan not produce output file: " << file << '\n' << std::endl;
+        return;
+      }
+  ofile -> precision(precision);  
+  self -> PrintCoarseElements(*ofile);
+  delete ofile;
+  }
 SWIGINTERN void mfem_NCMesh_PrintCoarseElements__SWIG_2(mfem::NCMesh *self){
   self -> PrintCoarseElements(std::cout);
   }
@@ -3648,6 +3672,17 @@ SWIGINTERN void mfem_NCMesh_PrintStats__SWIG_1(mfem::NCMesh *self,char const *fi
   ofile.precision(precision);  
   self -> PrintStats(ofile);
   ofile.close();
+  }
+SWIGINTERN void mfem_NCMesh_PrintStatsGZ(mfem::NCMesh *self,char const *file,int precision=8){
+  mfem::ofgzstream *ofile = new mfem::ofgzstream(file, true);
+  if (!ofile)
+     {
+        std::cerr << "\nCan not produce output file: " << file << '\n' << std::endl;
+        return;
+      }
+  ofile ->precision(precision);  
+  self -> PrintStats(*ofile);
+  delete ofile;
   }
 
 SWIGINTERN int
@@ -6763,14 +6798,20 @@ SWIGINTERN PyObject *_wrap_NCMesh_LoadVertexParents(PyObject *SWIGUNUSEDPARM(sel
       }
     }
     if (stream2 == 0){
-      if (temp2->isGZ()){
-        in_gz2 = new mfem::ifgzstream(temp2->getFilename());
-        arg2 = in_gz2;
-      } else {
-        in_txt2.open(temp2->getFilename(), std::ifstream::in);
-        in_txt2.precision(temp2->getPrecision());
-        arg2 = &in_txt2;
-      }
+      /*
+            if (temp2->isGZ()){
+        	 in_gz2 = new mfem::ifgzstream(temp2->getFilename());
+               arg2 = in_gz2;
+            } else {
+        	 in_txt2.open(temp2->getFilename(), std::ifstream::in);
+               in_txt2.precision(temp2->getPrecision());
+               arg2 = &in_txt2;
+            }
+           */
+      /* this will auto-detect the input file type */
+      in_gz2 = new mfem::ifgzstream(temp2->getFilename());
+      arg2 = in_gz2;
+      
       if (temp2->isTemporary()){
         delete temp2;
       }
@@ -6798,18 +6839,6 @@ SWIGINTERN PyObject *_wrap_NCMesh_LoadVertexParents(PyObject *SWIGUNUSEDPARM(sel
     }	 
   }
   resultobj = SWIG_Py_Void();
-  {
-    if (stream2) {
-      ret2 = PyLong_FromSsize_t(len2);
-      if (PyErr_Occurred()) {
-        PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
-        return NULL;
-      }
-      delete stream2;    
-      Py_XDECREF(resultobj);   /* Blow away any previous result */
-      resultobj = ret2;    
-    }
-  }
   {
     if (!stream2) {
       if (temp2) {
@@ -6903,14 +6932,20 @@ SWIGINTERN PyObject *_wrap_NCMesh_LoadCoarseElements(PyObject *SWIGUNUSEDPARM(se
       }
     }
     if (stream2 == 0){
-      if (temp2->isGZ()){
-        in_gz2 = new mfem::ifgzstream(temp2->getFilename());
-        arg2 = in_gz2;
-      } else {
-        in_txt2.open(temp2->getFilename(), std::ifstream::in);
-        in_txt2.precision(temp2->getPrecision());
-        arg2 = &in_txt2;
-      }
+      /*
+            if (temp2->isGZ()){
+        	 in_gz2 = new mfem::ifgzstream(temp2->getFilename());
+               arg2 = in_gz2;
+            } else {
+        	 in_txt2.open(temp2->getFilename(), std::ifstream::in);
+               in_txt2.precision(temp2->getPrecision());
+               arg2 = &in_txt2;
+            }
+           */
+      /* this will auto-detect the input file type */
+      in_gz2 = new mfem::ifgzstream(temp2->getFilename());
+      arg2 = in_gz2;
+      
       if (temp2->isTemporary()){
         delete temp2;
       }
@@ -6938,18 +6973,6 @@ SWIGINTERN PyObject *_wrap_NCMesh_LoadCoarseElements(PyObject *SWIGUNUSEDPARM(se
     }	 
   }
   resultobj = SWIG_Py_Void();
-  {
-    if (stream2) {
-      ret2 = PyLong_FromSsize_t(len2);
-      if (PyErr_Occurred()) {
-        PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
-        return NULL;
-      }
-      delete stream2;    
-      Py_XDECREF(resultobj);   /* Blow away any previous result */
-      resultobj = ret2;    
-    }
-  }
   {
     if (!stream2) {
       if (temp2) {
@@ -7352,6 +7375,70 @@ fail:
 }
 
 
+SWIGINTERN PyObject *_wrap_NCMesh_PrintVertexParentsGZ(PyObject *SWIGUNUSEDPARM(self), PyObject *args, PyObject *kwargs) {
+  PyObject *resultobj = 0;
+  mfem::NCMesh *arg1 = (mfem::NCMesh *) 0 ;
+  char *arg2 = (char *) 0 ;
+  int arg3 = (int) 8 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int res2 ;
+  char *buf2 = 0 ;
+  int alloc2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  char * kwnames[] = {
+    (char *)"self",  (char *)"file",  (char *)"precision",  NULL 
+  };
+  
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OO|O:NCMesh_PrintVertexParentsGZ", kwnames, &obj0, &obj1, &obj2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_mfem__NCMesh, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "NCMesh_PrintVertexParentsGZ" "', argument " "1"" of type '" "mfem::NCMesh *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::NCMesh * >(argp1);
+  res2 = SWIG_AsCharPtrAndSize(obj1, &buf2, NULL, &alloc2);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "NCMesh_PrintVertexParentsGZ" "', argument " "2"" of type '" "char const *""'");
+  }
+  arg2 = reinterpret_cast< char * >(buf2);
+  if (obj2) {
+    {
+      if ((PyArray_PyIntAsInt(obj2) == -1) && PyErr_Occurred()) {
+        SWIG_exception_fail(SWIG_TypeError, "Input must be integer");
+      };  
+      arg3 = PyArray_PyIntAsInt(obj2);
+    }
+  }
+  {
+    try {
+      mfem_NCMesh_PrintVertexParentsGZ(arg1,(char const *)arg2,arg3);
+    }
+#ifdef  MFEM_USE_EXCEPTIONS
+    catch (mfem::ErrorException &_e) {
+      std::string s("PyMFEM error (mfem::ErrorException): "), s2(_e.what());
+      s = s + s2;    
+      SWIG_exception(SWIG_RuntimeError, s.c_str());
+    }
+#endif
+    
+    catch (Swig::DirectorException &e){
+      SWIG_fail;
+    }    
+    catch (...) {
+      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+    }	 
+  }
+  resultobj = SWIG_Py_Void();
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return resultobj;
+fail:
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return NULL;
+}
+
+
 SWIGINTERN PyObject *_wrap_NCMesh_PrintVertexParents__SWIG_2(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
   PyObject *resultobj = 0;
   mfem::NCMesh *arg1 = (mfem::NCMesh *) 0 ;
@@ -7516,6 +7603,70 @@ SWIGINTERN PyObject *_wrap_NCMesh_PrintCoarseElements__SWIG_1(PyObject *SWIGUNUS
   {
     try {
       mfem_NCMesh_PrintCoarseElements__SWIG_1(arg1,(char const *)arg2,arg3);
+    }
+#ifdef  MFEM_USE_EXCEPTIONS
+    catch (mfem::ErrorException &_e) {
+      std::string s("PyMFEM error (mfem::ErrorException): "), s2(_e.what());
+      s = s + s2;    
+      SWIG_exception(SWIG_RuntimeError, s.c_str());
+    }
+#endif
+    
+    catch (Swig::DirectorException &e){
+      SWIG_fail;
+    }    
+    catch (...) {
+      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+    }	 
+  }
+  resultobj = SWIG_Py_Void();
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return resultobj;
+fail:
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_NCMesh_PrintCoarseElementsGZ(PyObject *SWIGUNUSEDPARM(self), PyObject *args, PyObject *kwargs) {
+  PyObject *resultobj = 0;
+  mfem::NCMesh *arg1 = (mfem::NCMesh *) 0 ;
+  char *arg2 = (char *) 0 ;
+  int arg3 = (int) 8 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int res2 ;
+  char *buf2 = 0 ;
+  int alloc2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  char * kwnames[] = {
+    (char *)"self",  (char *)"file",  (char *)"precision",  NULL 
+  };
+  
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OO|O:NCMesh_PrintCoarseElementsGZ", kwnames, &obj0, &obj1, &obj2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_mfem__NCMesh, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "NCMesh_PrintCoarseElementsGZ" "', argument " "1"" of type '" "mfem::NCMesh *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::NCMesh * >(argp1);
+  res2 = SWIG_AsCharPtrAndSize(obj1, &buf2, NULL, &alloc2);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "NCMesh_PrintCoarseElementsGZ" "', argument " "2"" of type '" "char const *""'");
+  }
+  arg2 = reinterpret_cast< char * >(buf2);
+  if (obj2) {
+    {
+      if ((PyArray_PyIntAsInt(obj2) == -1) && PyErr_Occurred()) {
+        SWIG_exception_fail(SWIG_TypeError, "Input must be integer");
+      };  
+      arg3 = PyArray_PyIntAsInt(obj2);
+    }
+  }
+  {
+    try {
+      mfem_NCMesh_PrintCoarseElementsGZ(arg1,(char const *)arg2,arg3);
     }
 #ifdef  MFEM_USE_EXCEPTIONS
     catch (mfem::ErrorException &_e) {
@@ -7813,6 +7964,70 @@ fail:
     "    mfem::NCMesh::PrintStats(std::ostream &) const\n"
     "    mfem::NCMesh::PrintStats(char const *,int)\n");
   return 0;
+}
+
+
+SWIGINTERN PyObject *_wrap_NCMesh_PrintStatsGZ(PyObject *SWIGUNUSEDPARM(self), PyObject *args, PyObject *kwargs) {
+  PyObject *resultobj = 0;
+  mfem::NCMesh *arg1 = (mfem::NCMesh *) 0 ;
+  char *arg2 = (char *) 0 ;
+  int arg3 = (int) 8 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int res2 ;
+  char *buf2 = 0 ;
+  int alloc2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  char * kwnames[] = {
+    (char *)"self",  (char *)"file",  (char *)"precision",  NULL 
+  };
+  
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OO|O:NCMesh_PrintStatsGZ", kwnames, &obj0, &obj1, &obj2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_mfem__NCMesh, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "NCMesh_PrintStatsGZ" "', argument " "1"" of type '" "mfem::NCMesh *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::NCMesh * >(argp1);
+  res2 = SWIG_AsCharPtrAndSize(obj1, &buf2, NULL, &alloc2);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "NCMesh_PrintStatsGZ" "', argument " "2"" of type '" "char const *""'");
+  }
+  arg2 = reinterpret_cast< char * >(buf2);
+  if (obj2) {
+    {
+      if ((PyArray_PyIntAsInt(obj2) == -1) && PyErr_Occurred()) {
+        SWIG_exception_fail(SWIG_TypeError, "Input must be integer");
+      };  
+      arg3 = PyArray_PyIntAsInt(obj2);
+    }
+  }
+  {
+    try {
+      mfem_NCMesh_PrintStatsGZ(arg1,(char const *)arg2,arg3);
+    }
+#ifdef  MFEM_USE_EXCEPTIONS
+    catch (mfem::ErrorException &_e) {
+      std::string s("PyMFEM error (mfem::ErrorException): "), s2(_e.what());
+      s = s + s2;    
+      SWIG_exception(SWIG_RuntimeError, s.c_str());
+    }
+#endif
+    
+    catch (Swig::DirectorException &e){
+      SWIG_fail;
+    }    
+    catch (...) {
+      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+    }	 
+  }
+  resultobj = SWIG_Py_Void();
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return resultobj;
+fail:
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return NULL;
 }
 
 
@@ -10645,11 +10860,13 @@ static PyMethodDef SwigMethods[] = {
 	 { "NCMesh_Trim", _wrap_NCMesh_Trim, METH_O, "NCMesh_Trim(NCMesh self)"},
 	 { "NCMesh_MemoryUsage", _wrap_NCMesh_MemoryUsage, METH_O, "NCMesh_MemoryUsage(NCMesh self) -> long"},
 	 { "NCMesh_PrintMemoryDetail", _wrap_NCMesh_PrintMemoryDetail, METH_O, "NCMesh_PrintMemoryDetail(NCMesh self) -> int"},
+	 { "NCMesh_PrintVertexParentsGZ", (PyCFunction)(void(*)(void))_wrap_NCMesh_PrintVertexParentsGZ, METH_VARARGS|METH_KEYWORDS, "NCMesh_PrintVertexParentsGZ(NCMesh self, char const * file, int precision=8)"},
 	 { "NCMesh_PrintVertexParents", _wrap_NCMesh_PrintVertexParents, METH_VARARGS, "\n"
 		"NCMesh_PrintVertexParents(NCMesh self, std::ostream & out)\n"
 		"NCMesh_PrintVertexParents(NCMesh self, char const * file, int precision=8)\n"
 		"NCMesh_PrintVertexParents(NCMesh self)\n"
 		""},
+	 { "NCMesh_PrintCoarseElementsGZ", (PyCFunction)(void(*)(void))_wrap_NCMesh_PrintCoarseElementsGZ, METH_VARARGS|METH_KEYWORDS, "NCMesh_PrintCoarseElementsGZ(NCMesh self, char const * file, int precision=8)"},
 	 { "NCMesh_PrintCoarseElements", _wrap_NCMesh_PrintCoarseElements, METH_VARARGS, "\n"
 		"NCMesh_PrintCoarseElements(NCMesh self, std::ostream & out)\n"
 		"NCMesh_PrintCoarseElements(NCMesh self, char const * file, int precision=8)\n"
@@ -10659,6 +10876,7 @@ static PyMethodDef SwigMethods[] = {
 		"NCMesh_PrintStats(NCMesh self, std::ostream & out=out)\n"
 		"NCMesh_PrintStats(NCMesh self, char const * file, int precision=8)\n"
 		""},
+	 { "NCMesh_PrintStatsGZ", (PyCFunction)(void(*)(void))_wrap_NCMesh_PrintStatsGZ, METH_VARARGS|METH_KEYWORDS, "NCMesh_PrintStatsGZ(NCMesh self, char const * file, int precision=8)"},
 	 { "NCMesh_swigregister", NCMesh_swigregister, METH_O, NULL},
 	 { "NCMesh_swiginit", NCMesh_swiginit, METH_VARARGS, NULL},
 	 { "new_RefinementArray", _wrap_new_RefinementArray, METH_VARARGS, "\n"
@@ -10813,11 +11031,13 @@ static PyMethodDef SwigMethods_proxydocs[] = {
 	 { "NCMesh_Trim", _wrap_NCMesh_Trim, METH_O, "Trim(NCMesh self)"},
 	 { "NCMesh_MemoryUsage", _wrap_NCMesh_MemoryUsage, METH_O, "MemoryUsage(NCMesh self) -> long"},
 	 { "NCMesh_PrintMemoryDetail", _wrap_NCMesh_PrintMemoryDetail, METH_O, "PrintMemoryDetail(NCMesh self) -> int"},
+	 { "NCMesh_PrintVertexParentsGZ", (PyCFunction)(void(*)(void))_wrap_NCMesh_PrintVertexParentsGZ, METH_VARARGS|METH_KEYWORDS, "PrintVertexParentsGZ(NCMesh self, char const * file, int precision=8)"},
 	 { "NCMesh_PrintVertexParents", _wrap_NCMesh_PrintVertexParents, METH_VARARGS, "\n"
 		"PrintVertexParents(NCMesh self, std::ostream & out)\n"
 		"PrintVertexParents(NCMesh self, char const * file, int precision=8)\n"
 		"PrintVertexParents(NCMesh self)\n"
 		""},
+	 { "NCMesh_PrintCoarseElementsGZ", (PyCFunction)(void(*)(void))_wrap_NCMesh_PrintCoarseElementsGZ, METH_VARARGS|METH_KEYWORDS, "PrintCoarseElementsGZ(NCMesh self, char const * file, int precision=8)"},
 	 { "NCMesh_PrintCoarseElements", _wrap_NCMesh_PrintCoarseElements, METH_VARARGS, "\n"
 		"PrintCoarseElements(NCMesh self, std::ostream & out)\n"
 		"PrintCoarseElements(NCMesh self, char const * file, int precision=8)\n"
@@ -10827,6 +11047,7 @@ static PyMethodDef SwigMethods_proxydocs[] = {
 		"PrintStats(NCMesh self, std::ostream & out=out)\n"
 		"PrintStats(NCMesh self, char const * file, int precision=8)\n"
 		""},
+	 { "NCMesh_PrintStatsGZ", (PyCFunction)(void(*)(void))_wrap_NCMesh_PrintStatsGZ, METH_VARARGS|METH_KEYWORDS, "PrintStatsGZ(NCMesh self, char const * file, int precision=8)"},
 	 { "NCMesh_swigregister", NCMesh_swigregister, METH_O, NULL},
 	 { "NCMesh_swiginit", NCMesh_swiginit, METH_VARARGS, NULL},
 	 { "new_RefinementArray", _wrap_new_RefinementArray, METH_VARARGS, "\n"

--- a/mfem/_ser/operators.py
+++ b/mfem/_ser/operators.py
@@ -224,6 +224,11 @@ class Operator(object):
         """
         return _operators.Operator_PrintMatlab(self, *args)
     PrintMatlab = _swig_new_instance_method(_operators.Operator_PrintMatlab)
+
+    def PrintMatlabGZ(self, file, precision=8):
+        r"""PrintMatlabGZ(Operator self, char const * file, int precision=8)"""
+        return _operators.Operator_PrintMatlabGZ(self, file, precision)
+    PrintMatlabGZ = _swig_new_instance_method(_operators.Operator_PrintMatlabGZ)
     def __disown__(self):
         self.this.disown()
         _operators.disown_Operator(self)

--- a/mfem/_ser/operators_wrap.cxx
+++ b/mfem/_ser/operators_wrap.cxx
@@ -3551,6 +3551,17 @@ SWIGINTERN void mfem_Operator_PrintMatlab__SWIG_1(mfem::Operator *self,char cons
   self -> PrintMatlab(ofile);
   ofile.close();
   }
+SWIGINTERN void mfem_Operator_PrintMatlabGZ(mfem::Operator *self,char const *file,int precision=8){
+  mfem::ofgzstream *ofile = new mfem::ofgzstream(file, true);
+  if (!ofile)
+     {
+        std::cerr << "\nCan not produce output file: " << file << '\n' << std::endl;
+        return;
+      }
+  ofile ->precision(precision);  
+  self -> PrintMatlab(*ofile);
+  delete ofile;
+  }
 
   #define SWIG_From_double   PyFloat_FromDouble 
 
@@ -8150,6 +8161,70 @@ fail:
     "    mfem::Operator::PrintMatlab(std::ostream &,int,int) const\n"
     "    mfem::Operator::PrintMatlab(char const *,int)\n");
   return 0;
+}
+
+
+SWIGINTERN PyObject *_wrap_Operator_PrintMatlabGZ(PyObject *SWIGUNUSEDPARM(self), PyObject *args, PyObject *kwargs) {
+  PyObject *resultobj = 0;
+  mfem::Operator *arg1 = (mfem::Operator *) 0 ;
+  char *arg2 = (char *) 0 ;
+  int arg3 = (int) 8 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int res2 ;
+  char *buf2 = 0 ;
+  int alloc2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  char * kwnames[] = {
+    (char *)"self",  (char *)"file",  (char *)"precision",  NULL 
+  };
+  
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OO|O:Operator_PrintMatlabGZ", kwnames, &obj0, &obj1, &obj2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_mfem__Operator, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "Operator_PrintMatlabGZ" "', argument " "1"" of type '" "mfem::Operator *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::Operator * >(argp1);
+  res2 = SWIG_AsCharPtrAndSize(obj1, &buf2, NULL, &alloc2);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "Operator_PrintMatlabGZ" "', argument " "2"" of type '" "char const *""'");
+  }
+  arg2 = reinterpret_cast< char * >(buf2);
+  if (obj2) {
+    {
+      if ((PyArray_PyIntAsInt(obj2) == -1) && PyErr_Occurred()) {
+        SWIG_exception_fail(SWIG_TypeError, "Input must be integer");
+      };  
+      arg3 = PyArray_PyIntAsInt(obj2);
+    }
+  }
+  {
+    try {
+      mfem_Operator_PrintMatlabGZ(arg1,(char const *)arg2,arg3);
+    }
+#ifdef  MFEM_USE_EXCEPTIONS
+    catch (mfem::ErrorException &_e) {
+      std::string s("PyMFEM error (mfem::ErrorException): "), s2(_e.what());
+      s = s + s2;    
+      SWIG_exception(SWIG_RuntimeError, s.c_str());
+    }
+#endif
+    
+    catch (Swig::DirectorException &e){
+      SWIG_fail;
+    }    
+    catch (...) {
+      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+    }	 
+  }
+  resultobj = SWIG_Py_Void();
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return resultobj;
+fail:
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return NULL;
 }
 
 
@@ -14724,6 +14799,7 @@ static PyMethodDef SwigMethods[] = {
 		"Operator_PrintMatlab(Operator self, std::ostream & out, int n=0, int m=0)\n"
 		"Operator_PrintMatlab(Operator self, char const * file, int precision=8)\n"
 		""},
+	 { "Operator_PrintMatlabGZ", (PyCFunction)(void(*)(void))_wrap_Operator_PrintMatlabGZ, METH_VARARGS|METH_KEYWORDS, "Operator_PrintMatlabGZ(Operator self, char const * file, int precision=8)"},
 	 { "disown_Operator", (PyCFunction)(void(*)(void))_wrap_disown_Operator, METH_VARARGS|METH_KEYWORDS, NULL},
 	 { "Operator_swigregister", Operator_swigregister, METH_O, NULL},
 	 { "Operator_swiginit", Operator_swiginit, METH_VARARGS, NULL},
@@ -14904,6 +14980,7 @@ static PyMethodDef SwigMethods_proxydocs[] = {
 		"PrintMatlab(Operator self, std::ostream & out, int n=0, int m=0)\n"
 		"PrintMatlab(Operator self, char const * file, int precision=8)\n"
 		""},
+	 { "Operator_PrintMatlabGZ", (PyCFunction)(void(*)(void))_wrap_Operator_PrintMatlabGZ, METH_VARARGS|METH_KEYWORDS, "PrintMatlabGZ(Operator self, char const * file, int precision=8)"},
 	 { "disown_Operator", (PyCFunction)(void(*)(void))_wrap_disown_Operator, METH_VARARGS|METH_KEYWORDS, NULL},
 	 { "Operator_swigregister", Operator_swigregister, METH_O, NULL},
 	 { "Operator_swiginit", Operator_swiginit, METH_VARARGS, NULL},

--- a/mfem/_ser/sparsemat.py
+++ b/mfem/_ser/sparsemat.py
@@ -806,6 +806,11 @@ class SparseMatrix(mfem._ser.matrix.AbstractSparseMatrix):
         return _sparsemat.SparseMatrix_Print(self, *args)
     Print = _swig_new_instance_method(_sparsemat.SparseMatrix_Print)
 
+    def PrintGZ(self, file, precision=8):
+        r"""PrintGZ(SparseMatrix self, char const * file, int precision=8)"""
+        return _sparsemat.SparseMatrix_PrintGZ(self, file, precision)
+    PrintGZ = _swig_new_instance_method(_sparsemat.SparseMatrix_PrintGZ)
+
     def PrintMatlab(self, *args):
         r"""
         PrintMatlab(SparseMatrix self, std::ostream & out=mfem::out)
@@ -814,6 +819,11 @@ class SparseMatrix(mfem._ser.matrix.AbstractSparseMatrix):
         return _sparsemat.SparseMatrix_PrintMatlab(self, *args)
     PrintMatlab = _swig_new_instance_method(_sparsemat.SparseMatrix_PrintMatlab)
 
+    def PrintMatlabGZ(self, file, precision=8):
+        r"""PrintMatlabGZ(SparseMatrix self, char const * file, int precision=8)"""
+        return _sparsemat.SparseMatrix_PrintMatlabGZ(self, file, precision)
+    PrintMatlabGZ = _swig_new_instance_method(_sparsemat.SparseMatrix_PrintMatlabGZ)
+
     def PrintMM(self, *args):
         r"""
         PrintMM(SparseMatrix self, std::ostream & out=mfem::out)
@@ -821,6 +831,16 @@ class SparseMatrix(mfem._ser.matrix.AbstractSparseMatrix):
         """
         return _sparsemat.SparseMatrix_PrintMM(self, *args)
     PrintMM = _swig_new_instance_method(_sparsemat.SparseMatrix_PrintMM)
+
+    def PrintMMGZ(self, file, precision=8):
+        r"""PrintMMGZ(SparseMatrix self, char const * file, int precision=8)"""
+        return _sparsemat.SparseMatrix_PrintMMGZ(self, file, precision)
+    PrintMMGZ = _swig_new_instance_method(_sparsemat.SparseMatrix_PrintMMGZ)
+
+    def PrintCSRGZ(self, file, precision=8):
+        r"""PrintCSRGZ(SparseMatrix self, char const * file, int precision=8)"""
+        return _sparsemat.SparseMatrix_PrintCSRGZ(self, file, precision)
+    PrintCSRGZ = _swig_new_instance_method(_sparsemat.SparseMatrix_PrintCSRGZ)
 
     def PrintCSR(self, *args):
         r"""
@@ -831,6 +851,11 @@ class SparseMatrix(mfem._ser.matrix.AbstractSparseMatrix):
         return _sparsemat.SparseMatrix_PrintCSR(self, *args)
     PrintCSR = _swig_new_instance_method(_sparsemat.SparseMatrix_PrintCSR)
 
+    def PrintCSR2GZ(self, file, precision=8):
+        r"""PrintCSR2GZ(SparseMatrix self, char const * file, int precision=8)"""
+        return _sparsemat.SparseMatrix_PrintCSR2GZ(self, file, precision)
+    PrintCSR2GZ = _swig_new_instance_method(_sparsemat.SparseMatrix_PrintCSR2GZ)
+
     def PrintCSR2(self, *args):
         r"""
         PrintCSR2(SparseMatrix self, std::ostream & out)
@@ -839,6 +864,11 @@ class SparseMatrix(mfem._ser.matrix.AbstractSparseMatrix):
         """
         return _sparsemat.SparseMatrix_PrintCSR2(self, *args)
     PrintCSR2 = _swig_new_instance_method(_sparsemat.SparseMatrix_PrintCSR2)
+
+    def PrintInfoGZ(self, file, precision=8):
+        r"""PrintInfoGZ(SparseMatrix self, char const * file, int precision=8)"""
+        return _sparsemat.SparseMatrix_PrintInfoGZ(self, file, precision)
+    PrintInfoGZ = _swig_new_instance_method(_sparsemat.SparseMatrix_PrintInfoGZ)
 
     def PrintInfo(self, *args):
         r"""

--- a/mfem/_ser/sparsemat_wrap.cxx
+++ b/mfem/_ser/sparsemat_wrap.cxx
@@ -3613,6 +3613,17 @@ SWIGINTERN void mfem_SparseMatrix_Print__SWIG_1(mfem::SparseMatrix *self,char co
   self -> Print(ofile);
   ofile.close();
   }
+SWIGINTERN void mfem_SparseMatrix_PrintGZ(mfem::SparseMatrix *self,char const *file,int precision=8){
+  mfem::ofgzstream *ofile = new mfem::ofgzstream(file, true);
+  if (!ofile)
+     {
+        std::cerr << "\nCan not produce output file: " << file << '\n' << std::endl;
+        return;
+      }
+  ofile ->precision(precision);  
+  self -> Print(*ofile);
+  delete ofile;
+  }
 SWIGINTERN void mfem_SparseMatrix_PrintMatlab__SWIG_1(mfem::SparseMatrix *self,char const *file,int precision=8){
   std::ofstream ofile(file);
   if (!ofile)
@@ -3623,6 +3634,17 @@ SWIGINTERN void mfem_SparseMatrix_PrintMatlab__SWIG_1(mfem::SparseMatrix *self,c
   ofile.precision(precision);  
   self -> PrintMatlab(ofile);
   ofile.close();
+  }
+SWIGINTERN void mfem_SparseMatrix_PrintMatlabGZ(mfem::SparseMatrix *self,char const *file,int precision=8){
+  mfem::ofgzstream *ofile = new mfem::ofgzstream(file, true);
+  if (!ofile)
+     {
+        std::cerr << "\nCan not produce output file: " << file << '\n' << std::endl;
+        return;
+      }
+  ofile ->precision(precision);  
+  self -> PrintMatlab(*ofile);
+  delete ofile;
   }
 SWIGINTERN void mfem_SparseMatrix_PrintMM__SWIG_1(mfem::SparseMatrix *self,char const *file,int precision=8){
   std::ofstream ofile(file);
@@ -3635,6 +3657,17 @@ SWIGINTERN void mfem_SparseMatrix_PrintMM__SWIG_1(mfem::SparseMatrix *self,char 
   self -> PrintMM(ofile);
   ofile.close();
   }
+SWIGINTERN void mfem_SparseMatrix_PrintMMGZ(mfem::SparseMatrix *self,char const *file,int precision=8){
+  mfem::ofgzstream *ofile = new mfem::ofgzstream(file, true);
+  if (!ofile)
+     {
+        std::cerr << "\nCan not produce output file: " << file << '\n' << std::endl;
+        return;
+      }
+  ofile ->precision(precision);  
+  self -> PrintMM(*ofile);
+  delete ofile;
+  }
 SWIGINTERN void mfem_SparseMatrix_PrintCSR__SWIG_1(mfem::SparseMatrix *self,char const *file,int precision=8){
   std::ofstream ofile(file);
   if (!ofile)
@@ -3645,6 +3678,18 @@ SWIGINTERN void mfem_SparseMatrix_PrintCSR__SWIG_1(mfem::SparseMatrix *self,char
   ofile.precision(precision);    
   self -> PrintCSR(ofile);
   ofile.close();
+  }
+SWIGINTERN void mfem_SparseMatrix_PrintCSRGZ(mfem::SparseMatrix *self,char const *file,int precision=8){
+  mfem::ofgzstream *ofile = new mfem::ofgzstream(file, true);
+  
+  if (!ofile)
+     {
+        std::cerr << "\nCan not produce output file: " << file << '\n' << std::endl;
+        return;
+      }
+  ofile -> precision(precision);  
+  self -> PrintCSR(*ofile);
+  delete ofile;
   }
 SWIGINTERN void mfem_SparseMatrix_PrintCSR__SWIG_2(mfem::SparseMatrix *self){
   self -> PrintCSR(std::cout);
@@ -3660,6 +3705,18 @@ SWIGINTERN void mfem_SparseMatrix_PrintCSR2__SWIG_1(mfem::SparseMatrix *self,cha
   self -> PrintCSR2(ofile);
   ofile.close();
   }
+SWIGINTERN void mfem_SparseMatrix_PrintCSR2GZ(mfem::SparseMatrix *self,char const *file,int precision=8){
+  mfem::ofgzstream *ofile = new mfem::ofgzstream(file, true);
+  
+  if (!ofile)
+     {
+        std::cerr << "\nCan not produce output file: " << file << '\n' << std::endl;
+        return;
+      }
+  ofile -> precision(precision);  
+  self -> PrintCSR2(*ofile);
+  delete ofile;
+  }
 SWIGINTERN void mfem_SparseMatrix_PrintCSR2__SWIG_2(mfem::SparseMatrix *self){
   self -> PrintCSR2(std::cout);
   }
@@ -3673,6 +3730,18 @@ SWIGINTERN void mfem_SparseMatrix_PrintInfo__SWIG_1(mfem::SparseMatrix *self,cha
   ofile.precision(precision);    
   self -> PrintInfo(ofile);
   ofile.close();
+  }
+SWIGINTERN void mfem_SparseMatrix_PrintInfoGZ(mfem::SparseMatrix *self,char const *file,int precision=8){
+  mfem::ofgzstream *ofile = new mfem::ofgzstream(file, true);
+  
+  if (!ofile)
+     {
+        std::cerr << "\nCan not produce output file: " << file << '\n' << std::endl;
+        return;
+      }
+  ofile -> precision(precision);  
+  self -> PrintInfo(*ofile);
+  delete ofile;
   }
 SWIGINTERN void mfem_SparseMatrix_PrintInfo__SWIG_2(mfem::SparseMatrix *self){
   self -> PrintInfo(std::cout);
@@ -14117,6 +14186,70 @@ fail:
 }
 
 
+SWIGINTERN PyObject *_wrap_SparseMatrix_PrintGZ(PyObject *SWIGUNUSEDPARM(self), PyObject *args, PyObject *kwargs) {
+  PyObject *resultobj = 0;
+  mfem::SparseMatrix *arg1 = (mfem::SparseMatrix *) 0 ;
+  char *arg2 = (char *) 0 ;
+  int arg3 = (int) 8 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int res2 ;
+  char *buf2 = 0 ;
+  int alloc2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  char * kwnames[] = {
+    (char *)"self",  (char *)"file",  (char *)"precision",  NULL 
+  };
+  
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OO|O:SparseMatrix_PrintGZ", kwnames, &obj0, &obj1, &obj2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_mfem__SparseMatrix, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "SparseMatrix_PrintGZ" "', argument " "1"" of type '" "mfem::SparseMatrix *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::SparseMatrix * >(argp1);
+  res2 = SWIG_AsCharPtrAndSize(obj1, &buf2, NULL, &alloc2);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "SparseMatrix_PrintGZ" "', argument " "2"" of type '" "char const *""'");
+  }
+  arg2 = reinterpret_cast< char * >(buf2);
+  if (obj2) {
+    {
+      if ((PyArray_PyIntAsInt(obj2) == -1) && PyErr_Occurred()) {
+        SWIG_exception_fail(SWIG_TypeError, "Input must be integer");
+      };  
+      arg3 = PyArray_PyIntAsInt(obj2);
+    }
+  }
+  {
+    try {
+      mfem_SparseMatrix_PrintGZ(arg1,(char const *)arg2,arg3);
+    }
+#ifdef  MFEM_USE_EXCEPTIONS
+    catch (mfem::ErrorException &_e) {
+      std::string s("PyMFEM error (mfem::ErrorException): "), s2(_e.what());
+      s = s + s2;    
+      SWIG_exception(SWIG_RuntimeError, s.c_str());
+    }
+#endif
+    
+    catch (Swig::DirectorException &e){
+      SWIG_fail;
+    }    
+    catch (...) {
+      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+    }	 
+  }
+  resultobj = SWIG_Py_Void();
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return resultobj;
+fail:
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return NULL;
+}
+
+
 SWIGINTERN PyObject *_wrap_SparseMatrix_PrintMatlab__SWIG_1(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
   PyObject *resultobj = 0;
   mfem::SparseMatrix *arg1 = (mfem::SparseMatrix *) 0 ;
@@ -14258,6 +14391,70 @@ fail:
     "    mfem::SparseMatrix::PrintMatlab(std::ostream &) const\n"
     "    mfem::SparseMatrix::PrintMatlab(char const *,int)\n");
   return 0;
+}
+
+
+SWIGINTERN PyObject *_wrap_SparseMatrix_PrintMatlabGZ(PyObject *SWIGUNUSEDPARM(self), PyObject *args, PyObject *kwargs) {
+  PyObject *resultobj = 0;
+  mfem::SparseMatrix *arg1 = (mfem::SparseMatrix *) 0 ;
+  char *arg2 = (char *) 0 ;
+  int arg3 = (int) 8 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int res2 ;
+  char *buf2 = 0 ;
+  int alloc2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  char * kwnames[] = {
+    (char *)"self",  (char *)"file",  (char *)"precision",  NULL 
+  };
+  
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OO|O:SparseMatrix_PrintMatlabGZ", kwnames, &obj0, &obj1, &obj2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_mfem__SparseMatrix, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "SparseMatrix_PrintMatlabGZ" "', argument " "1"" of type '" "mfem::SparseMatrix *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::SparseMatrix * >(argp1);
+  res2 = SWIG_AsCharPtrAndSize(obj1, &buf2, NULL, &alloc2);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "SparseMatrix_PrintMatlabGZ" "', argument " "2"" of type '" "char const *""'");
+  }
+  arg2 = reinterpret_cast< char * >(buf2);
+  if (obj2) {
+    {
+      if ((PyArray_PyIntAsInt(obj2) == -1) && PyErr_Occurred()) {
+        SWIG_exception_fail(SWIG_TypeError, "Input must be integer");
+      };  
+      arg3 = PyArray_PyIntAsInt(obj2);
+    }
+  }
+  {
+    try {
+      mfem_SparseMatrix_PrintMatlabGZ(arg1,(char const *)arg2,arg3);
+    }
+#ifdef  MFEM_USE_EXCEPTIONS
+    catch (mfem::ErrorException &_e) {
+      std::string s("PyMFEM error (mfem::ErrorException): "), s2(_e.what());
+      s = s + s2;    
+      SWIG_exception(SWIG_RuntimeError, s.c_str());
+    }
+#endif
+    
+    catch (Swig::DirectorException &e){
+      SWIG_fail;
+    }    
+    catch (...) {
+      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+    }	 
+  }
+  resultobj = SWIG_Py_Void();
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return resultobj;
+fail:
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return NULL;
 }
 
 
@@ -14405,6 +14602,70 @@ fail:
 }
 
 
+SWIGINTERN PyObject *_wrap_SparseMatrix_PrintMMGZ(PyObject *SWIGUNUSEDPARM(self), PyObject *args, PyObject *kwargs) {
+  PyObject *resultobj = 0;
+  mfem::SparseMatrix *arg1 = (mfem::SparseMatrix *) 0 ;
+  char *arg2 = (char *) 0 ;
+  int arg3 = (int) 8 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int res2 ;
+  char *buf2 = 0 ;
+  int alloc2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  char * kwnames[] = {
+    (char *)"self",  (char *)"file",  (char *)"precision",  NULL 
+  };
+  
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OO|O:SparseMatrix_PrintMMGZ", kwnames, &obj0, &obj1, &obj2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_mfem__SparseMatrix, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "SparseMatrix_PrintMMGZ" "', argument " "1"" of type '" "mfem::SparseMatrix *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::SparseMatrix * >(argp1);
+  res2 = SWIG_AsCharPtrAndSize(obj1, &buf2, NULL, &alloc2);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "SparseMatrix_PrintMMGZ" "', argument " "2"" of type '" "char const *""'");
+  }
+  arg2 = reinterpret_cast< char * >(buf2);
+  if (obj2) {
+    {
+      if ((PyArray_PyIntAsInt(obj2) == -1) && PyErr_Occurred()) {
+        SWIG_exception_fail(SWIG_TypeError, "Input must be integer");
+      };  
+      arg3 = PyArray_PyIntAsInt(obj2);
+    }
+  }
+  {
+    try {
+      mfem_SparseMatrix_PrintMMGZ(arg1,(char const *)arg2,arg3);
+    }
+#ifdef  MFEM_USE_EXCEPTIONS
+    catch (mfem::ErrorException &_e) {
+      std::string s("PyMFEM error (mfem::ErrorException): "), s2(_e.what());
+      s = s + s2;    
+      SWIG_exception(SWIG_RuntimeError, s.c_str());
+    }
+#endif
+    
+    catch (Swig::DirectorException &e){
+      SWIG_fail;
+    }    
+    catch (...) {
+      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+    }	 
+  }
+  resultobj = SWIG_Py_Void();
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return resultobj;
+fail:
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return NULL;
+}
+
+
 SWIGINTERN PyObject *_wrap_SparseMatrix_PrintCSR__SWIG_1(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
   PyObject *resultobj = 0;
   mfem::SparseMatrix *arg1 = (mfem::SparseMatrix *) 0 ;
@@ -14438,6 +14699,70 @@ SWIGINTERN PyObject *_wrap_SparseMatrix_PrintCSR__SWIG_1(PyObject *SWIGUNUSEDPAR
   {
     try {
       mfem_SparseMatrix_PrintCSR__SWIG_1(arg1,(char const *)arg2,arg3);
+    }
+#ifdef  MFEM_USE_EXCEPTIONS
+    catch (mfem::ErrorException &_e) {
+      std::string s("PyMFEM error (mfem::ErrorException): "), s2(_e.what());
+      s = s + s2;    
+      SWIG_exception(SWIG_RuntimeError, s.c_str());
+    }
+#endif
+    
+    catch (Swig::DirectorException &e){
+      SWIG_fail;
+    }    
+    catch (...) {
+      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+    }	 
+  }
+  resultobj = SWIG_Py_Void();
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return resultobj;
+fail:
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_SparseMatrix_PrintCSRGZ(PyObject *SWIGUNUSEDPARM(self), PyObject *args, PyObject *kwargs) {
+  PyObject *resultobj = 0;
+  mfem::SparseMatrix *arg1 = (mfem::SparseMatrix *) 0 ;
+  char *arg2 = (char *) 0 ;
+  int arg3 = (int) 8 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int res2 ;
+  char *buf2 = 0 ;
+  int alloc2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  char * kwnames[] = {
+    (char *)"self",  (char *)"file",  (char *)"precision",  NULL 
+  };
+  
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OO|O:SparseMatrix_PrintCSRGZ", kwnames, &obj0, &obj1, &obj2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_mfem__SparseMatrix, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "SparseMatrix_PrintCSRGZ" "', argument " "1"" of type '" "mfem::SparseMatrix *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::SparseMatrix * >(argp1);
+  res2 = SWIG_AsCharPtrAndSize(obj1, &buf2, NULL, &alloc2);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "SparseMatrix_PrintCSRGZ" "', argument " "2"" of type '" "char const *""'");
+  }
+  arg2 = reinterpret_cast< char * >(buf2);
+  if (obj2) {
+    {
+      if ((PyArray_PyIntAsInt(obj2) == -1) && PyErr_Occurred()) {
+        SWIG_exception_fail(SWIG_TypeError, "Input must be integer");
+      };  
+      arg3 = PyArray_PyIntAsInt(obj2);
+    }
+  }
+  {
+    try {
+      mfem_SparseMatrix_PrintCSRGZ(arg1,(char const *)arg2,arg3);
     }
 #ifdef  MFEM_USE_EXCEPTIONS
     catch (mfem::ErrorException &_e) {
@@ -14652,6 +14977,70 @@ fail:
 }
 
 
+SWIGINTERN PyObject *_wrap_SparseMatrix_PrintCSR2GZ(PyObject *SWIGUNUSEDPARM(self), PyObject *args, PyObject *kwargs) {
+  PyObject *resultobj = 0;
+  mfem::SparseMatrix *arg1 = (mfem::SparseMatrix *) 0 ;
+  char *arg2 = (char *) 0 ;
+  int arg3 = (int) 8 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int res2 ;
+  char *buf2 = 0 ;
+  int alloc2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  char * kwnames[] = {
+    (char *)"self",  (char *)"file",  (char *)"precision",  NULL 
+  };
+  
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OO|O:SparseMatrix_PrintCSR2GZ", kwnames, &obj0, &obj1, &obj2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_mfem__SparseMatrix, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "SparseMatrix_PrintCSR2GZ" "', argument " "1"" of type '" "mfem::SparseMatrix *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::SparseMatrix * >(argp1);
+  res2 = SWIG_AsCharPtrAndSize(obj1, &buf2, NULL, &alloc2);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "SparseMatrix_PrintCSR2GZ" "', argument " "2"" of type '" "char const *""'");
+  }
+  arg2 = reinterpret_cast< char * >(buf2);
+  if (obj2) {
+    {
+      if ((PyArray_PyIntAsInt(obj2) == -1) && PyErr_Occurred()) {
+        SWIG_exception_fail(SWIG_TypeError, "Input must be integer");
+      };  
+      arg3 = PyArray_PyIntAsInt(obj2);
+    }
+  }
+  {
+    try {
+      mfem_SparseMatrix_PrintCSR2GZ(arg1,(char const *)arg2,arg3);
+    }
+#ifdef  MFEM_USE_EXCEPTIONS
+    catch (mfem::ErrorException &_e) {
+      std::string s("PyMFEM error (mfem::ErrorException): "), s2(_e.what());
+      s = s + s2;    
+      SWIG_exception(SWIG_RuntimeError, s.c_str());
+    }
+#endif
+    
+    catch (Swig::DirectorException &e){
+      SWIG_fail;
+    }    
+    catch (...) {
+      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+    }	 
+  }
+  resultobj = SWIG_Py_Void();
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return resultobj;
+fail:
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return NULL;
+}
+
+
 SWIGINTERN PyObject *_wrap_SparseMatrix_PrintCSR2__SWIG_2(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
   PyObject *resultobj = 0;
   mfem::SparseMatrix *arg1 = (mfem::SparseMatrix *) 0 ;
@@ -14816,6 +15205,70 @@ SWIGINTERN PyObject *_wrap_SparseMatrix_PrintInfo__SWIG_1(PyObject *SWIGUNUSEDPA
   {
     try {
       mfem_SparseMatrix_PrintInfo__SWIG_1(arg1,(char const *)arg2,arg3);
+    }
+#ifdef  MFEM_USE_EXCEPTIONS
+    catch (mfem::ErrorException &_e) {
+      std::string s("PyMFEM error (mfem::ErrorException): "), s2(_e.what());
+      s = s + s2;    
+      SWIG_exception(SWIG_RuntimeError, s.c_str());
+    }
+#endif
+    
+    catch (Swig::DirectorException &e){
+      SWIG_fail;
+    }    
+    catch (...) {
+      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+    }	 
+  }
+  resultobj = SWIG_Py_Void();
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return resultobj;
+fail:
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_SparseMatrix_PrintInfoGZ(PyObject *SWIGUNUSEDPARM(self), PyObject *args, PyObject *kwargs) {
+  PyObject *resultobj = 0;
+  mfem::SparseMatrix *arg1 = (mfem::SparseMatrix *) 0 ;
+  char *arg2 = (char *) 0 ;
+  int arg3 = (int) 8 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int res2 ;
+  char *buf2 = 0 ;
+  int alloc2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  char * kwnames[] = {
+    (char *)"self",  (char *)"file",  (char *)"precision",  NULL 
+  };
+  
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OO|O:SparseMatrix_PrintInfoGZ", kwnames, &obj0, &obj1, &obj2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_mfem__SparseMatrix, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "SparseMatrix_PrintInfoGZ" "', argument " "1"" of type '" "mfem::SparseMatrix *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::SparseMatrix * >(argp1);
+  res2 = SWIG_AsCharPtrAndSize(obj1, &buf2, NULL, &alloc2);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "SparseMatrix_PrintInfoGZ" "', argument " "2"" of type '" "char const *""'");
+  }
+  arg2 = reinterpret_cast< char * >(buf2);
+  if (obj2) {
+    {
+      if ((PyArray_PyIntAsInt(obj2) == -1) && PyErr_Occurred()) {
+        SWIG_exception_fail(SWIG_TypeError, "Input must be integer");
+      };  
+      arg3 = PyArray_PyIntAsInt(obj2);
+    }
+  }
+  {
+    try {
+      mfem_SparseMatrix_PrintInfoGZ(arg1,(char const *)arg2,arg3);
     }
 #ifdef  MFEM_USE_EXCEPTIONS
     catch (mfem::ErrorException &_e) {
@@ -15909,24 +16362,30 @@ static PyMethodDef SwigMethods[] = {
 		"SparseMatrix_Print(SparseMatrix self, std::ostream & out=mfem::out, int width_=4)\n"
 		"SparseMatrix_Print(SparseMatrix self, char const * file, int precision=8)\n"
 		""},
+	 { "SparseMatrix_PrintGZ", (PyCFunction)(void(*)(void))_wrap_SparseMatrix_PrintGZ, METH_VARARGS|METH_KEYWORDS, "SparseMatrix_PrintGZ(SparseMatrix self, char const * file, int precision=8)"},
 	 { "SparseMatrix_PrintMatlab", _wrap_SparseMatrix_PrintMatlab, METH_VARARGS, "\n"
 		"SparseMatrix_PrintMatlab(SparseMatrix self, std::ostream & out=mfem::out)\n"
 		"SparseMatrix_PrintMatlab(SparseMatrix self, char const * file, int precision=8)\n"
 		""},
+	 { "SparseMatrix_PrintMatlabGZ", (PyCFunction)(void(*)(void))_wrap_SparseMatrix_PrintMatlabGZ, METH_VARARGS|METH_KEYWORDS, "SparseMatrix_PrintMatlabGZ(SparseMatrix self, char const * file, int precision=8)"},
 	 { "SparseMatrix_PrintMM", _wrap_SparseMatrix_PrintMM, METH_VARARGS, "\n"
 		"SparseMatrix_PrintMM(SparseMatrix self, std::ostream & out=mfem::out)\n"
 		"SparseMatrix_PrintMM(SparseMatrix self, char const * file, int precision=8)\n"
 		""},
+	 { "SparseMatrix_PrintMMGZ", (PyCFunction)(void(*)(void))_wrap_SparseMatrix_PrintMMGZ, METH_VARARGS|METH_KEYWORDS, "SparseMatrix_PrintMMGZ(SparseMatrix self, char const * file, int precision=8)"},
+	 { "SparseMatrix_PrintCSRGZ", (PyCFunction)(void(*)(void))_wrap_SparseMatrix_PrintCSRGZ, METH_VARARGS|METH_KEYWORDS, "SparseMatrix_PrintCSRGZ(SparseMatrix self, char const * file, int precision=8)"},
 	 { "SparseMatrix_PrintCSR", _wrap_SparseMatrix_PrintCSR, METH_VARARGS, "\n"
 		"SparseMatrix_PrintCSR(SparseMatrix self, std::ostream & out)\n"
 		"SparseMatrix_PrintCSR(SparseMatrix self, char const * file, int precision=8)\n"
 		"SparseMatrix_PrintCSR(SparseMatrix self)\n"
 		""},
+	 { "SparseMatrix_PrintCSR2GZ", (PyCFunction)(void(*)(void))_wrap_SparseMatrix_PrintCSR2GZ, METH_VARARGS|METH_KEYWORDS, "SparseMatrix_PrintCSR2GZ(SparseMatrix self, char const * file, int precision=8)"},
 	 { "SparseMatrix_PrintCSR2", _wrap_SparseMatrix_PrintCSR2, METH_VARARGS, "\n"
 		"SparseMatrix_PrintCSR2(SparseMatrix self, std::ostream & out)\n"
 		"SparseMatrix_PrintCSR2(SparseMatrix self, char const * file, int precision=8)\n"
 		"SparseMatrix_PrintCSR2(SparseMatrix self)\n"
 		""},
+	 { "SparseMatrix_PrintInfoGZ", (PyCFunction)(void(*)(void))_wrap_SparseMatrix_PrintInfoGZ, METH_VARARGS|METH_KEYWORDS, "SparseMatrix_PrintInfoGZ(SparseMatrix self, char const * file, int precision=8)"},
 	 { "SparseMatrix_PrintInfo", _wrap_SparseMatrix_PrintInfo, METH_VARARGS, "\n"
 		"SparseMatrix_PrintInfo(SparseMatrix self, std::ostream & out)\n"
 		"SparseMatrix_PrintInfo(SparseMatrix self, char const * file, int precision=8)\n"
@@ -16153,24 +16612,30 @@ static PyMethodDef SwigMethods_proxydocs[] = {
 		"Print(SparseMatrix self, std::ostream & out=mfem::out, int width_=4)\n"
 		"Print(SparseMatrix self, char const * file, int precision=8)\n"
 		""},
+	 { "SparseMatrix_PrintGZ", (PyCFunction)(void(*)(void))_wrap_SparseMatrix_PrintGZ, METH_VARARGS|METH_KEYWORDS, "PrintGZ(SparseMatrix self, char const * file, int precision=8)"},
 	 { "SparseMatrix_PrintMatlab", _wrap_SparseMatrix_PrintMatlab, METH_VARARGS, "\n"
 		"PrintMatlab(SparseMatrix self, std::ostream & out=mfem::out)\n"
 		"PrintMatlab(SparseMatrix self, char const * file, int precision=8)\n"
 		""},
+	 { "SparseMatrix_PrintMatlabGZ", (PyCFunction)(void(*)(void))_wrap_SparseMatrix_PrintMatlabGZ, METH_VARARGS|METH_KEYWORDS, "PrintMatlabGZ(SparseMatrix self, char const * file, int precision=8)"},
 	 { "SparseMatrix_PrintMM", _wrap_SparseMatrix_PrintMM, METH_VARARGS, "\n"
 		"PrintMM(SparseMatrix self, std::ostream & out=mfem::out)\n"
 		"PrintMM(SparseMatrix self, char const * file, int precision=8)\n"
 		""},
+	 { "SparseMatrix_PrintMMGZ", (PyCFunction)(void(*)(void))_wrap_SparseMatrix_PrintMMGZ, METH_VARARGS|METH_KEYWORDS, "PrintMMGZ(SparseMatrix self, char const * file, int precision=8)"},
+	 { "SparseMatrix_PrintCSRGZ", (PyCFunction)(void(*)(void))_wrap_SparseMatrix_PrintCSRGZ, METH_VARARGS|METH_KEYWORDS, "PrintCSRGZ(SparseMatrix self, char const * file, int precision=8)"},
 	 { "SparseMatrix_PrintCSR", _wrap_SparseMatrix_PrintCSR, METH_VARARGS, "\n"
 		"PrintCSR(SparseMatrix self, std::ostream & out)\n"
 		"PrintCSR(SparseMatrix self, char const * file, int precision=8)\n"
 		"PrintCSR(SparseMatrix self)\n"
 		""},
+	 { "SparseMatrix_PrintCSR2GZ", (PyCFunction)(void(*)(void))_wrap_SparseMatrix_PrintCSR2GZ, METH_VARARGS|METH_KEYWORDS, "PrintCSR2GZ(SparseMatrix self, char const * file, int precision=8)"},
 	 { "SparseMatrix_PrintCSR2", _wrap_SparseMatrix_PrintCSR2, METH_VARARGS, "\n"
 		"PrintCSR2(SparseMatrix self, std::ostream & out)\n"
 		"PrintCSR2(SparseMatrix self, char const * file, int precision=8)\n"
 		"PrintCSR2(SparseMatrix self)\n"
 		""},
+	 { "SparseMatrix_PrintInfoGZ", (PyCFunction)(void(*)(void))_wrap_SparseMatrix_PrintInfoGZ, METH_VARARGS|METH_KEYWORDS, "PrintInfoGZ(SparseMatrix self, char const * file, int precision=8)"},
 	 { "SparseMatrix_PrintInfo", _wrap_SparseMatrix_PrintInfo, METH_VARARGS, "\n"
 		"PrintInfo(SparseMatrix self, std::ostream & out)\n"
 		"PrintInfo(SparseMatrix self, char const * file, int precision=8)\n"

--- a/mfem/_ser/stable3d.py
+++ b/mfem/_ser/stable3d.py
@@ -143,6 +143,11 @@ class STable3D(object):
         return _stable3d.STable3D_Print(self, *args)
     Print = _swig_new_instance_method(_stable3d.STable3D_Print)
 
+    def PrintGZ(self, file, precision=8):
+        r"""PrintGZ(STable3D self, char const * file, int precision=8)"""
+        return _stable3d.STable3D_PrintGZ(self, file, precision)
+    PrintGZ = _swig_new_instance_method(_stable3d.STable3D_PrintGZ)
+
 # Register STable3D in _stable3d:
 _stable3d.STable3D_swigregister(STable3D)
 

--- a/mfem/_ser/stable3d_wrap.cxx
+++ b/mfem/_ser/stable3d_wrap.cxx
@@ -3358,6 +3358,17 @@ SWIGINTERN void mfem_STable3D_Print__SWIG_1(mfem::STable3D *self,char const *fil
   self -> Print(ofile);
   ofile.close();
   }
+SWIGINTERN void mfem_STable3D_PrintGZ(mfem::STable3D *self,char const *file,int precision=8){
+  mfem::ofgzstream *ofile = new mfem::ofgzstream(file, true);
+  if (!ofile)
+     {
+        std::cerr << "\nCan not produce output file: " << file << '\n' << std::endl;
+        return;
+      }
+  ofile ->precision(precision);  
+  self -> Print(*ofile);
+  delete ofile;
+  }
 
 
 /* ---------------------------------------------------
@@ -4507,6 +4518,70 @@ fail:
 }
 
 
+SWIGINTERN PyObject *_wrap_STable3D_PrintGZ(PyObject *SWIGUNUSEDPARM(self), PyObject *args, PyObject *kwargs) {
+  PyObject *resultobj = 0;
+  mfem::STable3D *arg1 = (mfem::STable3D *) 0 ;
+  char *arg2 = (char *) 0 ;
+  int arg3 = (int) 8 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int res2 ;
+  char *buf2 = 0 ;
+  int alloc2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  char * kwnames[] = {
+    (char *)"self",  (char *)"file",  (char *)"precision",  NULL 
+  };
+  
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OO|O:STable3D_PrintGZ", kwnames, &obj0, &obj1, &obj2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_mfem__STable3D, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "STable3D_PrintGZ" "', argument " "1"" of type '" "mfem::STable3D *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::STable3D * >(argp1);
+  res2 = SWIG_AsCharPtrAndSize(obj1, &buf2, NULL, &alloc2);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "STable3D_PrintGZ" "', argument " "2"" of type '" "char const *""'");
+  }
+  arg2 = reinterpret_cast< char * >(buf2);
+  if (obj2) {
+    {
+      if ((PyArray_PyIntAsInt(obj2) == -1) && PyErr_Occurred()) {
+        SWIG_exception_fail(SWIG_TypeError, "Input must be integer");
+      };  
+      arg3 = PyArray_PyIntAsInt(obj2);
+    }
+  }
+  {
+    try {
+      mfem_STable3D_PrintGZ(arg1,(char const *)arg2,arg3);
+    }
+#ifdef  MFEM_USE_EXCEPTIONS
+    catch (mfem::ErrorException &_e) {
+      std::string s("PyMFEM error (mfem::ErrorException): "), s2(_e.what());
+      s = s + s2;    
+      SWIG_exception(SWIG_RuntimeError, s.c_str());
+    }
+#endif
+    
+    catch (Swig::DirectorException &e){
+      SWIG_fail;
+    }    
+    catch (...) {
+      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+    }	 
+  }
+  resultobj = SWIG_Py_Void();
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return resultobj;
+fail:
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return NULL;
+}
+
+
 SWIGINTERN PyObject *STable3D_swigregister(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *obj;
   if (!SWIG_Python_UnpackTuple(args, "swigregister", 1, 1, &obj)) return NULL;
@@ -4547,6 +4622,7 @@ static PyMethodDef SwigMethods[] = {
 		"STable3D_Print(STable3D self, std::ostream & out=out)\n"
 		"STable3D_Print(STable3D self, char const * file, int precision=8)\n"
 		""},
+	 { "STable3D_PrintGZ", (PyCFunction)(void(*)(void))_wrap_STable3D_PrintGZ, METH_VARARGS|METH_KEYWORDS, "STable3D_PrintGZ(STable3D self, char const * file, int precision=8)"},
 	 { "STable3D_swigregister", STable3D_swigregister, METH_O, NULL},
 	 { "STable3D_swiginit", STable3D_swiginit, METH_VARARGS, NULL},
 	 { NULL, NULL, 0, NULL }
@@ -4581,6 +4657,7 @@ static PyMethodDef SwigMethods_proxydocs[] = {
 		"Print(STable3D self, std::ostream & out=out)\n"
 		"Print(STable3D self, char const * file, int precision=8)\n"
 		""},
+	 { "STable3D_PrintGZ", (PyCFunction)(void(*)(void))_wrap_STable3D_PrintGZ, METH_VARARGS|METH_KEYWORDS, "PrintGZ(STable3D self, char const * file, int precision=8)"},
 	 { "STable3D_swigregister", STable3D_swigregister, METH_O, NULL},
 	 { "STable3D_swiginit", STable3D_swiginit, METH_VARARGS, NULL},
 	 { NULL, NULL, 0, NULL }

--- a/mfem/_ser/table.py
+++ b/mfem/_ser/table.py
@@ -291,6 +291,11 @@ class Table(object):
         return _table.Table_Print(self, *args)
     Print = _swig_new_instance_method(_table.Table_Print)
 
+    def PrintGZ(self, file, precision=8):
+        r"""PrintGZ(Table self, char const * file, int precision=8)"""
+        return _table.Table_PrintGZ(self, file, precision)
+    PrintGZ = _swig_new_instance_method(_table.Table_PrintGZ)
+
     def PrintMatlab(self, *args):
         r"""
         PrintMatlab(Table self, std::ostream & out)
@@ -298,6 +303,16 @@ class Table(object):
         """
         return _table.Table_PrintMatlab(self, *args)
     PrintMatlab = _swig_new_instance_method(_table.Table_PrintMatlab)
+
+    def PrintMatlabGZ(self, file, precision=8):
+        r"""PrintMatlabGZ(Table self, char const * file, int precision=8)"""
+        return _table.Table_PrintMatlabGZ(self, file, precision)
+    PrintMatlabGZ = _swig_new_instance_method(_table.Table_PrintMatlabGZ)
+
+    def SaveGZ(self, file, precision=8):
+        r"""SaveGZ(Table self, char const * file, int precision=8)"""
+        return _table.Table_SaveGZ(self, file, precision)
+    SaveGZ = _swig_new_instance_method(_table.Table_SaveGZ)
 
     def Save(self, *args):
         r"""

--- a/mfem/_ser/table_wrap.cxx
+++ b/mfem/_ser/table_wrap.cxx
@@ -2979,6 +2979,17 @@ SWIGINTERN void mfem_Table_Print__SWIG_1(mfem::Table *self,char const *file,int 
   self -> Print(ofile);
   ofile.close();
   }
+SWIGINTERN void mfem_Table_PrintGZ(mfem::Table *self,char const *file,int precision=8){
+  mfem::ofgzstream *ofile = new mfem::ofgzstream(file, true);
+  if (!ofile)
+     {
+        std::cerr << "\nCan not produce output file: " << file << '\n' << std::endl;
+        return;
+      }
+  ofile ->precision(precision);  
+  self -> Print(*ofile);
+  delete ofile;
+  }
 SWIGINTERN void mfem_Table_PrintMatlab__SWIG_1(mfem::Table *self,char const *file,int precision=8){
   std::ofstream ofile(file);
   if (!ofile)
@@ -2990,6 +3001,17 @@ SWIGINTERN void mfem_Table_PrintMatlab__SWIG_1(mfem::Table *self,char const *fil
   self -> PrintMatlab(ofile);
   ofile.close();
   }
+SWIGINTERN void mfem_Table_PrintMatlabGZ(mfem::Table *self,char const *file,int precision=8){
+  mfem::ofgzstream *ofile = new mfem::ofgzstream(file, true);
+  if (!ofile)
+     {
+        std::cerr << "\nCan not produce output file: " << file << '\n' << std::endl;
+        return;
+      }
+  ofile ->precision(precision);  
+  self -> PrintMatlab(*ofile);
+  delete ofile;
+  }
 SWIGINTERN void mfem_Table_Save__SWIG_1(mfem::Table *self,char const *file,int precision=8){
   std::ofstream ofile(file);
   if (!ofile)
@@ -3000,6 +3022,18 @@ SWIGINTERN void mfem_Table_Save__SWIG_1(mfem::Table *self,char const *file,int p
   ofile.precision(precision);    
   self -> Save(ofile);
   ofile.close();
+  }
+SWIGINTERN void mfem_Table_SaveGZ(mfem::Table *self,char const *file,int precision=8){
+  mfem::ofgzstream *ofile = new mfem::ofgzstream(file, true);
+  
+  if (!ofile)
+     {
+        std::cerr << "\nCan not produce output file: " << file << '\n' << std::endl;
+        return;
+      }
+  ofile -> precision(precision);  
+  self -> Save(*ofile);
+  delete ofile;
   }
 SWIGINTERN void mfem_Table_Save__SWIG_2(mfem::Table *self){
   self -> Save(std::cout);
@@ -5779,14 +5813,20 @@ SWIGINTERN PyObject *_wrap_Table_Load(PyObject *SWIGUNUSEDPARM(self), PyObject *
       }
     }
     if (stream2 == 0){
-      if (temp2->isGZ()){
-        in_gz2 = new mfem::ifgzstream(temp2->getFilename());
-        arg2 = in_gz2;
-      } else {
-        in_txt2.open(temp2->getFilename(), std::ifstream::in);
-        in_txt2.precision(temp2->getPrecision());
-        arg2 = &in_txt2;
-      }
+      /*
+            if (temp2->isGZ()){
+        	 in_gz2 = new mfem::ifgzstream(temp2->getFilename());
+               arg2 = in_gz2;
+            } else {
+        	 in_txt2.open(temp2->getFilename(), std::ifstream::in);
+               in_txt2.precision(temp2->getPrecision());
+               arg2 = &in_txt2;
+            }
+           */
+      /* this will auto-detect the input file type */
+      in_gz2 = new mfem::ifgzstream(temp2->getFilename());
+      arg2 = in_gz2;
+      
       if (temp2->isTemporary()){
         delete temp2;
       }
@@ -5811,18 +5851,6 @@ SWIGINTERN PyObject *_wrap_Table_Load(PyObject *SWIGUNUSEDPARM(self), PyObject *
     }	 
   }
   resultobj = SWIG_Py_Void();
-  {
-    if (stream2) {
-      ret2 = PyLong_FromSsize_t(len2);
-      if (PyErr_Occurred()) {
-        PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
-        return NULL;
-      }
-      delete stream2;    
-      Py_XDECREF(resultobj);   /* Blow away any previous result */
-      resultobj = ret2;    
-    }
-  }
   {
     if (!stream2) {
       if (temp2) {
@@ -6265,6 +6293,67 @@ fail:
 }
 
 
+SWIGINTERN PyObject *_wrap_Table_PrintGZ(PyObject *SWIGUNUSEDPARM(self), PyObject *args, PyObject *kwargs) {
+  PyObject *resultobj = 0;
+  mfem::Table *arg1 = (mfem::Table *) 0 ;
+  char *arg2 = (char *) 0 ;
+  int arg3 = (int) 8 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int res2 ;
+  char *buf2 = 0 ;
+  int alloc2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  char * kwnames[] = {
+    (char *)"self",  (char *)"file",  (char *)"precision",  NULL 
+  };
+  
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OO|O:Table_PrintGZ", kwnames, &obj0, &obj1, &obj2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_mfem__Table, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "Table_PrintGZ" "', argument " "1"" of type '" "mfem::Table *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::Table * >(argp1);
+  res2 = SWIG_AsCharPtrAndSize(obj1, &buf2, NULL, &alloc2);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "Table_PrintGZ" "', argument " "2"" of type '" "char const *""'");
+  }
+  arg2 = reinterpret_cast< char * >(buf2);
+  if (obj2) {
+    {
+      if ((PyArray_PyIntAsInt(obj2) == -1) && PyErr_Occurred()) {
+        SWIG_exception_fail(SWIG_TypeError, "Input must be integer");
+      };  
+      arg3 = PyArray_PyIntAsInt(obj2);
+    }
+  }
+  {
+    try {
+      mfem_Table_PrintGZ(arg1,(char const *)arg2,arg3);
+    }
+#ifdef  MFEM_USE_EXCEPTIONS
+    catch (mfem::ErrorException &_e) {
+      std::string s("PyMFEM error (mfem::ErrorException): "), s2(_e.what());
+      s = s + s2;    
+      SWIG_exception(SWIG_RuntimeError, s.c_str());
+    }
+#endif
+    
+    catch (...) {
+      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+    }	 
+  }
+  resultobj = SWIG_Py_Void();
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return resultobj;
+fail:
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return NULL;
+}
+
+
 SWIGINTERN PyObject *_wrap_Table_PrintMatlab__SWIG_1(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
   PyObject *resultobj = 0;
   mfem::Table *arg1 = (mfem::Table *) 0 ;
@@ -6403,6 +6492,67 @@ fail:
 }
 
 
+SWIGINTERN PyObject *_wrap_Table_PrintMatlabGZ(PyObject *SWIGUNUSEDPARM(self), PyObject *args, PyObject *kwargs) {
+  PyObject *resultobj = 0;
+  mfem::Table *arg1 = (mfem::Table *) 0 ;
+  char *arg2 = (char *) 0 ;
+  int arg3 = (int) 8 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int res2 ;
+  char *buf2 = 0 ;
+  int alloc2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  char * kwnames[] = {
+    (char *)"self",  (char *)"file",  (char *)"precision",  NULL 
+  };
+  
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OO|O:Table_PrintMatlabGZ", kwnames, &obj0, &obj1, &obj2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_mfem__Table, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "Table_PrintMatlabGZ" "', argument " "1"" of type '" "mfem::Table *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::Table * >(argp1);
+  res2 = SWIG_AsCharPtrAndSize(obj1, &buf2, NULL, &alloc2);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "Table_PrintMatlabGZ" "', argument " "2"" of type '" "char const *""'");
+  }
+  arg2 = reinterpret_cast< char * >(buf2);
+  if (obj2) {
+    {
+      if ((PyArray_PyIntAsInt(obj2) == -1) && PyErr_Occurred()) {
+        SWIG_exception_fail(SWIG_TypeError, "Input must be integer");
+      };  
+      arg3 = PyArray_PyIntAsInt(obj2);
+    }
+  }
+  {
+    try {
+      mfem_Table_PrintMatlabGZ(arg1,(char const *)arg2,arg3);
+    }
+#ifdef  MFEM_USE_EXCEPTIONS
+    catch (mfem::ErrorException &_e) {
+      std::string s("PyMFEM error (mfem::ErrorException): "), s2(_e.what());
+      s = s + s2;    
+      SWIG_exception(SWIG_RuntimeError, s.c_str());
+    }
+#endif
+    
+    catch (...) {
+      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+    }	 
+  }
+  resultobj = SWIG_Py_Void();
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return resultobj;
+fail:
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return NULL;
+}
+
+
 SWIGINTERN PyObject *_wrap_Table_Save__SWIG_1(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
   PyObject *resultobj = 0;
   mfem::Table *arg1 = (mfem::Table *) 0 ;
@@ -6436,6 +6586,67 @@ SWIGINTERN PyObject *_wrap_Table_Save__SWIG_1(PyObject *SWIGUNUSEDPARM(self), Py
   {
     try {
       mfem_Table_Save__SWIG_1(arg1,(char const *)arg2,arg3);
+    }
+#ifdef  MFEM_USE_EXCEPTIONS
+    catch (mfem::ErrorException &_e) {
+      std::string s("PyMFEM error (mfem::ErrorException): "), s2(_e.what());
+      s = s + s2;    
+      SWIG_exception(SWIG_RuntimeError, s.c_str());
+    }
+#endif
+    
+    catch (...) {
+      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+    }	 
+  }
+  resultobj = SWIG_Py_Void();
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return resultobj;
+fail:
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_Table_SaveGZ(PyObject *SWIGUNUSEDPARM(self), PyObject *args, PyObject *kwargs) {
+  PyObject *resultobj = 0;
+  mfem::Table *arg1 = (mfem::Table *) 0 ;
+  char *arg2 = (char *) 0 ;
+  int arg3 = (int) 8 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int res2 ;
+  char *buf2 = 0 ;
+  int alloc2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  char * kwnames[] = {
+    (char *)"self",  (char *)"file",  (char *)"precision",  NULL 
+  };
+  
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OO|O:Table_SaveGZ", kwnames, &obj0, &obj1, &obj2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_mfem__Table, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "Table_SaveGZ" "', argument " "1"" of type '" "mfem::Table *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::Table * >(argp1);
+  res2 = SWIG_AsCharPtrAndSize(obj1, &buf2, NULL, &alloc2);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "Table_SaveGZ" "', argument " "2"" of type '" "char const *""'");
+  }
+  arg2 = reinterpret_cast< char * >(buf2);
+  if (obj2) {
+    {
+      if ((PyArray_PyIntAsInt(obj2) == -1) && PyErr_Occurred()) {
+        SWIG_exception_fail(SWIG_TypeError, "Input must be integer");
+      };  
+      arg3 = PyArray_PyIntAsInt(obj2);
+    }
+  }
+  {
+    try {
+      mfem_Table_SaveGZ(arg1,(char const *)arg2,arg3);
     }
 #ifdef  MFEM_USE_EXCEPTIONS
     catch (mfem::ErrorException &_e) {
@@ -7156,10 +7367,13 @@ static PyMethodDef SwigMethods[] = {
 		"Table_Print(Table self, std::ostream & out=mfem::out, int width=4)\n"
 		"Table_Print(Table self, char const * file, int precision=8)\n"
 		""},
+	 { "Table_PrintGZ", (PyCFunction)(void(*)(void))_wrap_Table_PrintGZ, METH_VARARGS|METH_KEYWORDS, "Table_PrintGZ(Table self, char const * file, int precision=8)"},
 	 { "Table_PrintMatlab", _wrap_Table_PrintMatlab, METH_VARARGS, "\n"
 		"Table_PrintMatlab(Table self, std::ostream & out)\n"
 		"Table_PrintMatlab(Table self, char const * file, int precision=8)\n"
 		""},
+	 { "Table_PrintMatlabGZ", (PyCFunction)(void(*)(void))_wrap_Table_PrintMatlabGZ, METH_VARARGS|METH_KEYWORDS, "Table_PrintMatlabGZ(Table self, char const * file, int precision=8)"},
+	 { "Table_SaveGZ", (PyCFunction)(void(*)(void))_wrap_Table_SaveGZ, METH_VARARGS|METH_KEYWORDS, "Table_SaveGZ(Table self, char const * file, int precision=8)"},
 	 { "Table_Save", _wrap_Table_Save, METH_VARARGS, "\n"
 		"Table_Save(Table self, std::ostream & out)\n"
 		"Table_Save(Table self, char const * file, int precision=8)\n"
@@ -7259,10 +7473,13 @@ static PyMethodDef SwigMethods_proxydocs[] = {
 		"Print(Table self, std::ostream & out=mfem::out, int width=4)\n"
 		"Print(Table self, char const * file, int precision=8)\n"
 		""},
+	 { "Table_PrintGZ", (PyCFunction)(void(*)(void))_wrap_Table_PrintGZ, METH_VARARGS|METH_KEYWORDS, "PrintGZ(Table self, char const * file, int precision=8)"},
 	 { "Table_PrintMatlab", _wrap_Table_PrintMatlab, METH_VARARGS, "\n"
 		"PrintMatlab(Table self, std::ostream & out)\n"
 		"PrintMatlab(Table self, char const * file, int precision=8)\n"
 		""},
+	 { "Table_PrintMatlabGZ", (PyCFunction)(void(*)(void))_wrap_Table_PrintMatlabGZ, METH_VARARGS|METH_KEYWORDS, "PrintMatlabGZ(Table self, char const * file, int precision=8)"},
+	 { "Table_SaveGZ", (PyCFunction)(void(*)(void))_wrap_Table_SaveGZ, METH_VARARGS|METH_KEYWORDS, "SaveGZ(Table self, char const * file, int precision=8)"},
 	 { "Table_Save", _wrap_Table_Save, METH_VARARGS, "\n"
 		"Save(Table self, std::ostream & out)\n"
 		"Save(Table self, char const * file, int precision=8)\n"

--- a/mfem/_ser/vector.py
+++ b/mfem/_ser/vector.py
@@ -515,6 +515,16 @@ class Vector(object):
         return _vector.Vector_Print(self, *args)
     Print = _swig_new_instance_method(_vector.Vector_Print)
 
+    def PrintGZ(self, file, precision=8):
+        r"""PrintGZ(Vector self, char const * file, int precision=8)"""
+        return _vector.Vector_PrintGZ(self, file, precision)
+    PrintGZ = _swig_new_instance_method(_vector.Vector_PrintGZ)
+
+    def Print_HYPREGZ(self, file, precision=8):
+        r"""Print_HYPREGZ(Vector self, char const * file, int precision=8)"""
+        return _vector.Vector_Print_HYPREGZ(self, file, precision)
+    Print_HYPREGZ = _swig_new_instance_method(_vector.Vector_Print_HYPREGZ)
+
     def Print_HYPRE(self, *args):
         r"""
         Print_HYPRE(Vector self, std::ostream & out)

--- a/mfem/_ser/vector_wrap.cxx
+++ b/mfem/_ser/vector_wrap.cxx
@@ -3297,6 +3297,17 @@ SWIGINTERN void mfem_Vector_Print__SWIG_1(mfem::Vector *self,char const *file,in
   self -> Print(ofile);
   ofile.close();
   }
+SWIGINTERN void mfem_Vector_PrintGZ(mfem::Vector *self,char const *file,int precision=8){
+  mfem::ofgzstream *ofile = new mfem::ofgzstream(file, true);
+  if (!ofile)
+     {
+        std::cerr << "\nCan not produce output file: " << file << '\n' << std::endl;
+        return;
+      }
+  ofile ->precision(precision);  
+  self -> Print(*ofile);
+  delete ofile;
+  }
 SWIGINTERN void mfem_Vector_Print_HYPRE__SWIG_1(mfem::Vector *self,char const *file,int precision=8){
   std::ofstream ofile(file);
   if (!ofile)
@@ -3307,6 +3318,18 @@ SWIGINTERN void mfem_Vector_Print_HYPRE__SWIG_1(mfem::Vector *self,char const *f
   ofile.precision(precision);    
   self -> Print_HYPRE(ofile);
   ofile.close();
+  }
+SWIGINTERN void mfem_Vector_Print_HYPREGZ(mfem::Vector *self,char const *file,int precision=8){
+  mfem::ofgzstream *ofile = new mfem::ofgzstream(file, true);
+  
+  if (!ofile)
+     {
+        std::cerr << "\nCan not produce output file: " << file << '\n' << std::endl;
+        return;
+      }
+  ofile -> precision(precision);  
+  self -> Print_HYPRE(*ofile);
+  delete ofile;
   }
 SWIGINTERN void mfem_Vector_Print_HYPRE__SWIG_2(mfem::Vector *self){
   self -> Print_HYPRE(std::cout);
@@ -4413,14 +4436,20 @@ SWIGINTERN PyObject *_wrap_Vector_Load__SWIG_1(PyObject *SWIGUNUSEDPARM(self), P
       }
     }
     if (stream2 == 0){
-      if (temp2->isGZ()){
-        in_gz2 = new mfem::ifgzstream(temp2->getFilename());
-        arg2 = in_gz2;
-      } else {
-        in_txt2.open(temp2->getFilename(), std::ifstream::in);
-        in_txt2.precision(temp2->getPrecision());
-        arg2 = &in_txt2;
-      }
+      /*
+            if (temp2->isGZ()){
+        	 in_gz2 = new mfem::ifgzstream(temp2->getFilename());
+               arg2 = in_gz2;
+            } else {
+        	 in_txt2.open(temp2->getFilename(), std::ifstream::in);
+               in_txt2.precision(temp2->getPrecision());
+               arg2 = &in_txt2;
+            }
+           */
+      /* this will auto-detect the input file type */
+      in_gz2 = new mfem::ifgzstream(temp2->getFilename());
+      arg2 = in_gz2;
+      
       if (temp2->isTemporary()){
         delete temp2;
       }
@@ -4451,18 +4480,6 @@ SWIGINTERN PyObject *_wrap_Vector_Load__SWIG_1(PyObject *SWIGUNUSEDPARM(self), P
     }	 
   }
   resultobj = SWIG_Py_Void();
-  {
-    if (stream2) {
-      ret2 = PyLong_FromSsize_t(len2);
-      if (PyErr_Occurred()) {
-        PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
-        return NULL;
-      }
-      delete stream2;    
-      Py_XDECREF(resultobj);   /* Blow away any previous result */
-      resultobj = ret2;    
-    }
-  }
   {
     if (!stream2) {
       if (temp2) {
@@ -4551,14 +4568,20 @@ SWIGINTERN PyObject *_wrap_Vector_Load__SWIG_2(PyObject *SWIGUNUSEDPARM(self), P
       }
     }
     if (stream2 == 0){
-      if (temp2->isGZ()){
-        in_gz2 = new mfem::ifgzstream(temp2->getFilename());
-        arg2 = in_gz2;
-      } else {
-        in_txt2.open(temp2->getFilename(), std::ifstream::in);
-        in_txt2.precision(temp2->getPrecision());
-        arg2 = &in_txt2;
-      }
+      /*
+            if (temp2->isGZ()){
+        	 in_gz2 = new mfem::ifgzstream(temp2->getFilename());
+               arg2 = in_gz2;
+            } else {
+        	 in_txt2.open(temp2->getFilename(), std::ifstream::in);
+               in_txt2.precision(temp2->getPrecision());
+               arg2 = &in_txt2;
+            }
+           */
+      /* this will auto-detect the input file type */
+      in_gz2 = new mfem::ifgzstream(temp2->getFilename());
+      arg2 = in_gz2;
+      
       if (temp2->isTemporary()){
         delete temp2;
       }
@@ -4583,18 +4606,6 @@ SWIGINTERN PyObject *_wrap_Vector_Load__SWIG_2(PyObject *SWIGUNUSEDPARM(self), P
     }	 
   }
   resultobj = SWIG_Py_Void();
-  {
-    if (stream2) {
-      ret2 = PyLong_FromSsize_t(len2);
-      if (PyErr_Occurred()) {
-        PyErr_SetString(PyExc_RuntimeError, "Error occured when writing IOString");
-        return NULL;
-      }
-      delete stream2;    
-      Py_XDECREF(resultobj);   /* Blow away any previous result */
-      resultobj = ret2;    
-    }
-  }
   {
     if (!stream2) {
       if (temp2) {
@@ -9560,6 +9571,67 @@ fail:
 }
 
 
+SWIGINTERN PyObject *_wrap_Vector_PrintGZ(PyObject *SWIGUNUSEDPARM(self), PyObject *args, PyObject *kwargs) {
+  PyObject *resultobj = 0;
+  mfem::Vector *arg1 = (mfem::Vector *) 0 ;
+  char *arg2 = (char *) 0 ;
+  int arg3 = (int) 8 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int res2 ;
+  char *buf2 = 0 ;
+  int alloc2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  char * kwnames[] = {
+    (char *)"self",  (char *)"file",  (char *)"precision",  NULL 
+  };
+  
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OO|O:Vector_PrintGZ", kwnames, &obj0, &obj1, &obj2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_mfem__Vector, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "Vector_PrintGZ" "', argument " "1"" of type '" "mfem::Vector *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::Vector * >(argp1);
+  res2 = SWIG_AsCharPtrAndSize(obj1, &buf2, NULL, &alloc2);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "Vector_PrintGZ" "', argument " "2"" of type '" "char const *""'");
+  }
+  arg2 = reinterpret_cast< char * >(buf2);
+  if (obj2) {
+    {
+      if ((PyArray_PyIntAsInt(obj2) == -1) && PyErr_Occurred()) {
+        SWIG_exception_fail(SWIG_TypeError, "Input must be integer");
+      };  
+      arg3 = PyArray_PyIntAsInt(obj2);
+    }
+  }
+  {
+    try {
+      mfem_Vector_PrintGZ(arg1,(char const *)arg2,arg3);
+    }
+#ifdef  MFEM_USE_EXCEPTIONS
+    catch (mfem::ErrorException &_e) {
+      std::string s("PyMFEM error (mfem::ErrorException): "), s2(_e.what());
+      s = s + s2;    
+      SWIG_exception(SWIG_RuntimeError, s.c_str());
+    }
+#endif
+    
+    catch (...) {
+      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+    }	 
+  }
+  resultobj = SWIG_Py_Void();
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return resultobj;
+fail:
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return NULL;
+}
+
+
 SWIGINTERN PyObject *_wrap_Vector_Print_HYPRE__SWIG_1(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
   PyObject *resultobj = 0;
   mfem::Vector *arg1 = (mfem::Vector *) 0 ;
@@ -9593,6 +9665,67 @@ SWIGINTERN PyObject *_wrap_Vector_Print_HYPRE__SWIG_1(PyObject *SWIGUNUSEDPARM(s
   {
     try {
       mfem_Vector_Print_HYPRE__SWIG_1(arg1,(char const *)arg2,arg3);
+    }
+#ifdef  MFEM_USE_EXCEPTIONS
+    catch (mfem::ErrorException &_e) {
+      std::string s("PyMFEM error (mfem::ErrorException): "), s2(_e.what());
+      s = s + s2;    
+      SWIG_exception(SWIG_RuntimeError, s.c_str());
+    }
+#endif
+    
+    catch (...) {
+      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+    }	 
+  }
+  resultobj = SWIG_Py_Void();
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return resultobj;
+fail:
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_Vector_Print_HYPREGZ(PyObject *SWIGUNUSEDPARM(self), PyObject *args, PyObject *kwargs) {
+  PyObject *resultobj = 0;
+  mfem::Vector *arg1 = (mfem::Vector *) 0 ;
+  char *arg2 = (char *) 0 ;
+  int arg3 = (int) 8 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int res2 ;
+  char *buf2 = 0 ;
+  int alloc2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  char * kwnames[] = {
+    (char *)"self",  (char *)"file",  (char *)"precision",  NULL 
+  };
+  
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OO|O:Vector_Print_HYPREGZ", kwnames, &obj0, &obj1, &obj2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_mfem__Vector, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "Vector_Print_HYPREGZ" "', argument " "1"" of type '" "mfem::Vector *""'"); 
+  }
+  arg1 = reinterpret_cast< mfem::Vector * >(argp1);
+  res2 = SWIG_AsCharPtrAndSize(obj1, &buf2, NULL, &alloc2);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "Vector_Print_HYPREGZ" "', argument " "2"" of type '" "char const *""'");
+  }
+  arg2 = reinterpret_cast< char * >(buf2);
+  if (obj2) {
+    {
+      if ((PyArray_PyIntAsInt(obj2) == -1) && PyErr_Occurred()) {
+        SWIG_exception_fail(SWIG_TypeError, "Input must be integer");
+      };  
+      arg3 = PyArray_PyIntAsInt(obj2);
+    }
+  }
+  {
+    try {
+      mfem_Vector_Print_HYPREGZ(arg1,(char const *)arg2,arg3);
     }
 #ifdef  MFEM_USE_EXCEPTIONS
     catch (mfem::ErrorException &_e) {
@@ -10045,6 +10178,8 @@ static PyMethodDef SwigMethods[] = {
 		"Vector_Print(Vector self, std::ostream & out=mfem::out, int width=8)\n"
 		"Vector_Print(Vector self, char const * file, int precision=8)\n"
 		""},
+	 { "Vector_PrintGZ", (PyCFunction)(void(*)(void))_wrap_Vector_PrintGZ, METH_VARARGS|METH_KEYWORDS, "Vector_PrintGZ(Vector self, char const * file, int precision=8)"},
+	 { "Vector_Print_HYPREGZ", (PyCFunction)(void(*)(void))_wrap_Vector_Print_HYPREGZ, METH_VARARGS|METH_KEYWORDS, "Vector_Print_HYPREGZ(Vector self, char const * file, int precision=8)"},
 	 { "Vector_Print_HYPRE", _wrap_Vector_Print_HYPRE, METH_VARARGS, "\n"
 		"Vector_Print_HYPRE(Vector self, std::ostream & out)\n"
 		"Vector_Print_HYPRE(Vector self, char const * file, int precision=8)\n"
@@ -10193,6 +10328,8 @@ static PyMethodDef SwigMethods_proxydocs[] = {
 		"Print(Vector self, std::ostream & out=mfem::out, int width=8)\n"
 		"Print(Vector self, char const * file, int precision=8)\n"
 		""},
+	 { "Vector_PrintGZ", (PyCFunction)(void(*)(void))_wrap_Vector_PrintGZ, METH_VARARGS|METH_KEYWORDS, "PrintGZ(Vector self, char const * file, int precision=8)"},
+	 { "Vector_Print_HYPREGZ", (PyCFunction)(void(*)(void))_wrap_Vector_Print_HYPREGZ, METH_VARARGS|METH_KEYWORDS, "Print_HYPREGZ(Vector self, char const * file, int precision=8)"},
 	 { "Vector_Print_HYPRE", _wrap_Vector_Print_HYPRE, METH_VARARGS, "\n"
 		"Print_HYPRE(Vector self, std::ostream & out)\n"
 		"Print_HYPRE(Vector self, char const * file, int precision=8)\n"

--- a/mfem/common/io_stream_typemap.i
+++ b/mfem/common/io_stream_typemap.i
@@ -135,6 +135,18 @@ void method(const char *file, int precision=8){
   self -> method(ofile);
   ofile.close();
   }
+void method ## GZ(const char *file, int precision=8){
+  mfem::ofgzstream *ofile = new mfem::ofgzstream(file, true);
+  
+  if (!ofile)
+     {
+        std::cerr << "\nCan not produce output file: " << file << '\n' << std::endl;
+        return;
+      }
+  ofile -> precision(precision);  
+  self -> method(*ofile);
+  delete ofile;
+  }
 void method(void){
   self -> method(std::cout);
   }
@@ -154,6 +166,17 @@ void method(const char *file, int precision=8){
   ofile.precision(precision);  
   self -> method(ofile);
   ofile.close();
+  }
+void method ## GZ(const char *file, int precision=8){
+  mfem::ofgzstream *ofile = new mfem::ofgzstream(file, true);
+  if (!ofile)
+     {
+        std::cerr << "\nCan not produce output file: " << file << '\n' << std::endl;
+        return;
+      }
+  ofile ->precision(precision);  
+  self -> method(*ofile);
+  delete ofile;
   }
 };
 %enddef
@@ -209,6 +232,7 @@ void method(const char *file, int precision=8){
       }
    }
    if (stream == 0){
+     /*
       if (temp->isGZ()){
   	 in_gz = new mfem::ifgzstream(temp->getFilename());
          $1 = in_gz;
@@ -217,6 +241,11 @@ void method(const char *file, int precision=8){
          in_txt.precision(temp->getPrecision());
          $1 = &in_txt;
       }
+     */
+      /* this will auto-detect the input file type */
+      in_gz = new mfem::ifgzstream(temp->getFilename());
+      $1 = in_gz;
+     
       if (temp->isTemporary()){
          delete temp;
       }
@@ -264,7 +293,7 @@ void method(const char *file, int precision=8){
      }
   }  
  }
-
+/*
 %typemap(argout) T {
   if (stream$argnum) {  
     ret$argnum = PyLong_FromSsize_t(len$argnum);
@@ -273,9 +302,10 @@ void method(const char *file, int precision=8){
        return NULL;
     }
     delete stream$argnum;    
-    Py_XDECREF($result);   /* Blow away any previous result */
+    Py_XDECREF($result);   // Blow away any previous result
     $result = ret$argnum;    
   }
 }
+*/
 %enddef
 

--- a/setup.py
+++ b/setup.py
@@ -426,7 +426,7 @@ def cmake_make_mfem(serial=True):
 
         if enable_strumpack:
             cmake_opts['DMFEM_USE_STRUMPACK'] = '1'
-            cmake_opts['STRUMPACK_DIR'] = strumpack_prefix
+            cmake_opts['DSTRUMPACK_DIR'] = strumpack_prefix
         if enable_pumi:
             cmake_opts['DMFEM_USE_PUMI'] = '1'
             cmake_opts['DPUMI_DIR'] = pumi_prefix

--- a/test/test_datacollection.py
+++ b/test/test_datacollection.py
@@ -1,0 +1,87 @@
+from __future__ import print_function
+
+import io
+import gzip
+
+import mfem.ser as mfem
+import numpy as np
+
+import os
+from os.path import expanduser, join
+import sys
+import numpy as np
+import io
+from mfem import path as mfem_path
+
+if len(sys.argv) > 1 and sys.argv[1] == '-p':   
+    import mfem.par as mfem
+    use_parallel = True
+    from mfem.common.mpi_debug import nicePrint as print
+    from mpi4py import MPI
+    myid  = MPI.COMM_WORLD.rank
+    
+else:
+    import mfem.ser as mfem
+    use_parallel = False
+    myid = 0
+
+def check(a, b, msg):
+    assert len(a) == len(b), msg
+    assert np.sum(np.abs(a-b)) == 0, msg
+
+def check_mesh(m1, m2, msg):
+    assert m1.GetNE() == m2.GetNE(), msg
+    assert m1.GetNBE() == m2.GetNBE(), msg
+    assert m1.GetNV() == m2.GetNV(), msg
+
+def run_test():    
+    mesh = mfem.Mesh(10, 10, "TRIANGLE")
+
+    fec = mfem.H1_FECollection(1, mesh.Dimension())
+    fespace = mfem.FiniteElementSpace(mesh, fec)
+
+    gf = mfem.GridFunction(fespace)
+    gf.Assign(1.0)
+    odata = gf.GetDataArray().copy()
+
+    visit_dc = mfem.VisItDataCollection("test_gf", mesh)
+    visit_dc.RegisterField("gf", gf)
+    visit_dc.Save()
+
+    mesh2 = mfem.Mesh("test_gf_000000/mesh.000000")
+    check_mesh(mesh, mesh2, ".mesh2 does not agree with original")
+
+    gf2 = mfem.GridFunction(mesh2, "test_gf_000000/gf.000000")
+    odata2 = gf2.GetDataArray().copy()
+    check(odata, odata2, "odata2 file does not agree with original")
+
+    visit_dc = mfem.VisItDataCollection("test_gf_gz", mesh)
+    visit_dc.SetCompression(True)
+    visit_dc.RegisterField("gf", gf)
+    visit_dc.Save()
+
+    with gzip.open("test_gf_gz_000000/mesh.000000", 'rt') as f:
+       sio = io.StringIO(f.read())
+    mesh3 = mfem.Mesh(sio)
+    check_mesh(mesh, mesh3, ".mesh3 does not agree with original")
+
+    with gzip.open("test_gf_gz_000000/gf.000000", 'rt') as f:
+       sio = io.StringIO(f.read())
+
+    # This is where the error is:
+    gf3 = mfem.GridFunction(mesh3, sio)
+    odata3 = gf3.GetDataArray()
+    check(odata, odata3, "gf3 file does not agree with original")
+
+    mesh4 = mfem.Mesh("test_gf_gz_000000/mesh.000000")
+    check_mesh(mesh, mesh4, ".mesh4 does not agree with original")
+
+    gf4 = mfem.GridFunction(mesh3, "test_gf_gz_000000/gf.000000")
+    odata4 = gf4.GetDataArray()
+
+    check(odata, odata4, "gf3 file does not agree with original")
+
+    print("PASSED")    
+
+if __name__=='__main__':
+    run_test()

--- a/test/test_gz.py
+++ b/test/test_gz.py
@@ -88,6 +88,13 @@ def run_test():
 
     check_mesh(mesh, mesh2, ".mesh.gz does not agree with original")
 
+    mesh3 = mfem.Mesh()    
+    mesh.PrintGZ("out_test_gz3.mesh")
+    mesh3.Load("out_test_gz3.mesh")
+
+    check_mesh(mesh, mesh3, ".mesh (unexplcit GZ) does not agree with original")
+    
+
     o = io.StringIO()        
     mesh2 = mfem.Mesh()    
     mesh.Print(o)


### PR DESCRIPTION
This pull will addresses the following issues
* GridFunction(std::istream &) is called, it did not return a proper object when the argument is IOString. 
* When the filename is passed it is interpreted as a filename. When the file is compressed it does not detect it automatically.
* Some routines generated using &feature("shadow") did not work in subclasses
* STRUMPACK_DIR was not passed properly to CMake in setup.py

It also adds
* PrintGZ (and similar methods) to GridFunction, Mesh, and other classes which generate a compressed file.

https://github.com/mfem/PyMFEM/issues/81
https://github.com/mfem/PyMFEM/issues/80