### PR TITLE
added qspace.i

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,7 @@ Additionally, the installer supports building MFEM with specific options togethe
 
 ## Requirement
 ```
-six, numpy, swig
-mpi4py (for --with-parallel)
+numpy, swig  + mpi4py (for --with-parallel)
 
 ```
 ## Install
@@ -62,9 +61,16 @@ $ python setup.py install --help
 ```
 ## Install from github source
 ```
+# Clone this repo
 git clone https://github.com/mfem/PyMFEM.git
+
+# Build & Install
+pip install ./PyMFEM --verbosel # build both MFEM and PyMFEM
+  *or*
 cd PyMFEM
 python setup.py install # build both MFEM and PyMFEM
+
+# Run test
 cd test
 python test_examples.py -serial
 ```  

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ tpc = ax1.tripcolor(triang, sol, shading='gouraud')
 fig1.colorbar(tpc)
 plt.show()
 ```
-![](https://raw.githubusercontent.com/mfem/PyMFEM/pip_install_dev/docs/example_image.png)
+![](https://raw.githubusercontent.com/mfem/PyMFEM/master/docs/example_image.png)
 
 
 ## License

--- a/mfem/__init__.py
+++ b/mfem/__init__.py
@@ -20,5 +20,5 @@ def debug_print(message):
 
     print(message)
 
-__version__ = '4.4.0.1'
+__version__ = '4.4.0.2'
 

--- a/mfem/_par/qspace.i
+++ b/mfem/_par/qspace.i
@@ -1,0 +1,29 @@
+%module(package="mfem._ser") qspace
+%{
+#include "mfem.hpp"
+#include "../common/io_stream.hpp"  
+#include "pyoperator.hpp"
+#include "../common/pycoefficient.hpp"  
+#include "numpy/arrayobject.h"    
+%}
+
+%include "../common/existing_mfem_headers.i"
+#ifdef FILE_EXISTS_FEM_QSPACE
+
+%init %{
+import_array();
+%}
+%include "exception.i"
+%import "fe.i"
+%import "fe_fixed_order.i"
+%import "element.i"
+%import "mesh.i"
+%include "../common/typemap_macros.i"
+%include "../common/exception.i"
+
+%include "fem/qspace.hpp"
+
+#endif
+
+
+

--- a/mfem/_par/setup.py
+++ b/mfem/_par/setup.py
@@ -109,7 +109,7 @@ def get_extensions():
               "hypre", "restriction", "prestriction",
               "fespacehierarchy", "multigrid", "constraints",
               "transfer", "dist_solver", "std_vectors", "auxiliary",
-              "tmop", "tmop_amr", "tmop_tools"]
+              "tmop", "tmop_amr", "tmop_tools", "qspace"]
 
     if add_pumi == '1':
         from setup_local import puminc, pumilib

--- a/mfem/_ser/qspace.i
+++ b/mfem/_ser/qspace.i
@@ -1,0 +1,29 @@
+%module(package="mfem._ser") qspace
+%{
+#include "mfem.hpp"
+#include "../common/io_stream.hpp"  
+#include "pyoperator.hpp"
+#include "../common/pycoefficient.hpp"  
+#include "numpy/arrayobject.h"    
+%}
+
+%include "../common/existing_mfem_headers.i"
+#ifdef FILE_EXISTS_FEM_QSPACE
+
+%init %{
+import_array();
+%}
+%include "exception.i"
+%import "fe.i"
+%import "fe_fixed_order.i"
+%import "element.i"
+%import "mesh.i"
+%include "../common/typemap_macros.i"
+%include "../common/exception.i"
+
+%include "fem/qspace.hpp"
+
+#endif
+
+
+

--- a/mfem/_ser/setup.py
+++ b/mfem/_ser/setup.py
@@ -93,7 +93,7 @@ def get_extensions():
               "nonlininteg", "nonlinearform", "restriction",
               "fespacehierarchy", "multigrid", "constraints",
               "transfer", "std_vectors",
-              "tmop", "tmop_amr", "tmop_tools"]
+              "tmop", "tmop_amr", "tmop_tools", "qspace"]
 
     if add_cuda == '1':
         from setup_local import cudainc        

--- a/mfem/par.py
+++ b/mfem/par.py
@@ -72,6 +72,7 @@ from  mfem._par.fespacehierarchy import *
 from  mfem._par.multigrid import *
 from  mfem._par.constraints import *
 from  mfem._par.transfer import *
+from  mfem._par.qspace import *
 
 from  mfem._par.fe_base import *
 from  mfem._par.fe_h1 import *

--- a/mfem/ser.py
+++ b/mfem/ser.py
@@ -55,6 +55,7 @@ from  mfem._ser.fespacehierarchy import *
 from  mfem._ser.multigrid import *
 from  mfem._ser.constraints import *
 from  mfem._ser.transfer import *
+from  mfem._ser.qspace import *
 
 from  mfem._ser.fe_base import *
 from  mfem._ser.fe_h1 import *

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 numpy>=1.19.4; python_version<"3.7"
 numpy>=1.20.0; python_version>="3.7"
 scipy
-six>1.13.0
 swig==4.0.2
 

--- a/setup.py
+++ b/setup.py
@@ -223,7 +223,7 @@ def abspath(path):
 
 def external_install_prefix(verbose=True):
     if verbose:
-        print("running external_install_prefix with this parameters", sys.argv, sys.prefix)
+        print("running external_install_prefix with this parameters", sys.argv, sys.prefix, site.getusersitepackages())
     if '--user' in sys.argv:
         paths = (site.getusersitepackages(),)
     else:

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ from subprocess import DEVNULL
 import multiprocessing
 from multiprocessing import Pool
 # force fork instead of spawn on MacOS to avoid race condition on mfem/__init__.py
-if platform  == "darwin":
+if platform == "darwin":
     multiprocessing.set_start_method("fork")
 
 from setuptools import setup, find_packages
@@ -135,7 +135,8 @@ mpicxx_command = 'mpic++' if os.getenv(
 cxx11_flag = '-std=c++11' if os.getenv(
     "CXX11FLAG") is None else os.getenv("CXX11FLAG")
 
-use_unverifed_SSL = False if os.getenv("unverifedSSL") is None else os.getenv("unverifiedSSL")
+use_unverifed_SSL = False if os.getenv(
+    "unverifedSSL") is None else os.getenv("unverifiedSSL")
 
 # meta data
 
@@ -149,6 +150,7 @@ def version():
         if mo:
             return mo.group(1)
     raise RuntimeError('Unable to find version string in %s.' % (VERSIONFILE,))
+
 
 def long_description():
     with open(os.path.join(rootdir, 'README.md'), encoding='utf-8') as f:
@@ -217,6 +219,7 @@ metadata = {'name': 'mfem',
 
 def abspath(path):
     return os.path.abspath(os.path.expanduser(path))
+
 
 def external_install_prefix(verbose=True):
     if '--user' in sys.argv:
@@ -931,8 +934,34 @@ def generate_wrapper():
         make_call(command2)
         os.chdir(pwd)
 
+    def update_header_exists(mfem_source):
+        import re
+
+        print("updating the list of existing headers")
+        list_of_headers = []
+        L = len(mfem_source.split(os.sep))
+        for (dirpath, dirnames, filenames) in os.walk(mfem_source):
+            for filename in filenames:
+                if filename.endswith('.hpp'):
+                    dirs = dirpath.split(os.sep)[L:]
+                    dirs.append(filename[:-4])
+                    tmp = '_'.join(dirs)
+                    xx = re.split('_|-', tmp)
+                    new_name = 'FILE_EXISTS_'+'_'.join([x.upper() for x in xx])
+                    if new_name not in list_of_headers:
+                        list_of_headers.append(new_name)
+
+        pwd = chdir(os.path.join(rootdir, 'mfem', 'common'))
+        fid = open('existing_mfem_headers.i', 'w')
+        for x in list_of_headers:
+            fid.write("#define " + x + "\n")
+        fid.close()
+        os.chdir(pwd)
+
     mfemser = mfems_prefix
     mfempar = mfemp_prefix
+
+    update_header_exists(mfem_source)
 
     swigflag = '-Wall -c++ -python -fastproxy -olddefs -keyword'.split(' ')
 
@@ -1378,6 +1407,7 @@ def configure_bdist(self):
     mfem_prefix = ext_prefix
     mfems_prefix = os.path.join(ext_prefix, 'ser')
     mfemp_prefix = os.path.join(ext_prefix, 'par')
+
 
 class Install(_install):
     '''

--- a/setup.py
+++ b/setup.py
@@ -222,6 +222,8 @@ def abspath(path):
 
 
 def external_install_prefix(verbose=True):
+    if verbose:
+        print("running external_install_prefix with this parameters", sys.argv, sys.prefix)
     if '--user' in sys.argv:
         paths = (site.getusersitepackages(),)
     else:


### PR DESCRIPTION
This PR is trying to address a situation when refactoring MFEM header files.

For example, the issue reported in https://github.com/mfem/PyMFEM/issues/151 happens because a class written in one header file is moved to a new header file. qspace.hpp in this case. We need to add corresponding *.i file (_ser/qspace.i and _par/qspace.i in this case) to handle this. But, at the same time, we want to maintain PyMFEM master branch compatible with MFEM release version. 

In this PR, a routine to create a list of MFEM .hpp files is added in setup.py, The result is, then, written to mfem/common/existing_mfem_headers.i as a banch of #define. In qspace.i, this information  is used to to check if it is being built with a version of MFEM which includes qspace.hpp or not.