### PR TITLE
mfem.jit extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,9 @@ $ python setup.py install --help
 # Clone this repo
 git clone https://github.com/mfem/PyMFEM.git
 
+# (Optional) Clean dependencies
+cd PyMFEM; python setup.py clean --all;cd ..
+
 # Build & Install
 pip install ./PyMFEM --verbosel # build both MFEM and PyMFEM
   *or*

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -1,4 +1,14 @@
 	<<<  Change Log. >>>
+2023 01.
+        * Improved mfem.jit decorator to create Numba JITed coefficient.
+	  (note, this involves an incompatible API change)
+
+           - parameter is passed as a numpy-like array to a user function (not as
+	     a CPointer object).
+	   - automatically creates two coefficients which return real and imaginary
+	     part, repsectively, when complex=True.
+	   - user function can use other MFEM coefficient as a variable (using dependency keyword)
+
 2022 03.
         * Added --cuda-arch option to specify the compute cuda archtecture
 

--- a/docs/manual.txt
+++ b/docs/manual.txt
@@ -107,6 +107,7 @@ to find more details of the MFEM library.
      
 
   4-2) mfem::Coefficient
+     ## Using Python function for function coefficient
        PyCoefficient is derived from FunctionCoefficient
        PyCoefficientT is time-dependent version
        VectorPyCoefficient  is derived from VectorFunctionCoefficient
@@ -141,22 +142,73 @@ to find more details of the MFEM library.
           Note: the argument is first tested if it can be converted using
 	        np.array(x,  dtype=float)
 
+      ## Just-in-time compilation of Python coefficient
        Function coefficient written in Python can be JITed using Numba. To use
        this feature, one can either use mfem.jit.* decorators or instantiate
        NumberFunction (or Vector/MatrixNumbaFunction) and call GenerateCoefficient
-       in most case, the first one is convenient. 
+       in most case, the first one is convenient.
 
-       -Example-
+       mfem.jit decorators uses the following syntax
+
+       sdim = mesh.SpaceDimension()
+       @scalar(td=False, params={}, complex=False, dependency=None, interface='simple',
+               sdim=None, debug=False)
+       @vector(vdim=None, shape=None, td=False, params={}, complex=False, dependency=None,
+               interface='simple', sdim=None, debug=False)
+       @matrix(height=None, width=None, shape=None, td=False, params={}, complex=False, dependency=None,
+                interface='simple', sdim=None, debug=False)
+
+            shape: shape of return value (following form can be used too)
+               vdim: length of vector coefficient
+               height/width: height and width of matrix coefficient
+
+            td: time-dependence (False: stationary, True: time-dependent
+            complex: complex coefficient. if ture, it returns a tuple of coefficient
+            depenency: dependency to other coefficient
+            interface: calling proceture
+               'simple': vector/matric function returns the result by value more pythonic.
+               'c++': vector/matric function returns the result by parameter like C++
+               other options: one can pass a tuple of (caller, signature) pair to create a custom
+                   interface
+            sdim: space dimension (optional)
+            debug: extra debug print
+
+       -- Example (1) --
        (Using jit decorator -- see more example in ex1 and ex24)
        >>>  @mfem.jit.scalar()
             def c12(ptx):
                 return s_func0(ptx[0], ptx[1],  ptx[2])
-       >>>  @mfem.jit.vector()
+
+       For vector/matrxi, we can use the following two forms of arguments
+       >>>  @mfem.jit.vector(shape=(3,))
+            def f_exact(x):
+                return np.array((1 + kappa**2)*sin(kappa * x[1])
+                                (1 + kappa**2)*sin(kappa * x[2])
+                                (1 + kappa**2)*sin(kappa * x[0]))
+       >>>  @mfem.jit.vector(shape=(3,), interface="c++")
             def f_exact(x, out):
                out[0] = (1 + kappa**2)*sin(kappa * x[1])
                out[1] = (1 + kappa**2)*sin(kappa * x[2])
                out[2] = (1 + kappa**2)*sin(kappa * x[0])
-       >>> x.ProjectCoefficient(f_exact)       
+	       
+       >>> x.ProjectCoefficient(f_exact)
+
+       -- Example (2) : complex coefficient 
+
+       mfem.jited coefficient can return a complex number. It will create
+       two coefficients for real and imaginary
+       
+       >>>  @mfem.jit.scalar(complex=True)
+            def c12(ptx):
+                return ptx[0] + 1j*ptx[1]
+       >>> x.ProjectCoefficient(c12.real)  # project real coefficient
+       >>> x.ProjectCoefficient(c12.imag)  # project imaginary coefficient       
+
+       -- Example (3) : dependency
+       mfem.jited coefficient can use other coefficient in the funciton
+       >>>  @mfem.jit.vector(vdim=3, complex=True, dependency=(E, B))
+            def P(ptx):
+                return E.dot(B)
 
        (Using NumbaFunction object)
        For example, to use Numba compiled function, one can use

--- a/examples/ex13p.py
+++ b/examples/ex13p.py
@@ -7,6 +7,8 @@
 
    See c++ version in the MFEM library for more detail 
 '''
+from numpy import sin, cos, exp
+import numpy as np
 import sys
 import mfem.par as mfem
 from mfem.par import intArray, doubleArray
@@ -16,8 +18,6 @@ from mpi4py import MPI
 num_procs = MPI.COMM_WORLD.size
 myid = MPI.COMM_WORLD.rank
 
-import numpy as np
-from numpy import sin, cos, exp
 
 ser_ref_levels = 2
 par_ref_levels = 1

--- a/examples/ex15p.py
+++ b/examples/ex15p.py
@@ -83,12 +83,13 @@ t_final = args.t_final
 visualization = args.visualization
 if myid == 0:
     parser.print_options(args)
-    
+
 alpha = 0.02
 
 device = mfem.Device('cpu')
 if myid == 0:
     device.Print()
+
 
 def front(x, y, z, t, dim):
     r = sqrt(x**2 + y**2 + z**2)

--- a/examples/ex17p.py
+++ b/examples/ex17p.py
@@ -170,9 +170,9 @@ if (kappa < 0):
     args.kappa = kappa
 if (myid == 0):
     parser.print_options(args)
-    
+
 device = mfem.Device('cpu')
-if myid == 0:            
+if myid == 0:
     device.Print()
 
 # 2. Read the mesh from the given mesh file.

--- a/examples/ex18_common.py
+++ b/examples/ex18_common.py
@@ -179,7 +179,7 @@ class FaceIntegrator(mfem.NonlinearFormIntegrator):
         super(FaceIntegrator, self).__init__()
 
         self.fluxNA = np.atleast_2d(self.fluxN.GetDataArray())
-        
+
     def AssembleFaceVector(self, el1, el2, Tr, elfun, elvect):
         num_equation = globals()['num_equation']
         # Compute the term <F.n(u),[w]> on the interior faces.
@@ -211,12 +211,12 @@ class FaceIntegrator(mfem.NonlinearFormIntegrator):
             intorder += 1
 
         ir = mfem.IntRules.Get(Tr.GetGeometryType(), int(intorder))
-        
+
         mat1A = elvect1_mat.GetDataArray()
         mat2A = elvect2_mat.GetDataArray()
         shape1A = np.atleast_2d(self.shape1.GetDataArray())
         shape2A = np.atleast_2d(self.shape2.GetDataArray())
-        
+
         for i in range(ir.GetNPoints()):
             ip = ir.IntPoint(i)
             Tr.Loc1.Transform(ip, self.eip1)
@@ -381,7 +381,7 @@ def ComputePressure(state, dim):
 
     specific_heat_ratio = globals()["specific_heat_ratio"]
     #den_vel2 = np.sum(den_vel**2)/den
-    den_vel2 = (state[1:1+dim].Norml2())**2/den    
+    den_vel2 = (state[1:1+dim].Norml2())**2/den
     pres = (specific_heat_ratio - 1.0) * (den_energy - 0.5 * den_vel2)
 
     return pres

--- a/examples/ex18p.py
+++ b/examples/ex18p.py
@@ -76,7 +76,7 @@ if myid == 0:
     parser.print_options(args)
 
 device = mfem.Device('cpu')
-if myid == 0:            
+if myid == 0:
     device.Print()
 
 ex18_common.num_equation = 4

--- a/examples/ex19p.py
+++ b/examples/ex19p.py
@@ -81,9 +81,9 @@ def ex19_main(args):
         parser.print_options(args)
 
     device = mfem.Device('cpu')
-    if myid == 0:            
+    if myid == 0:
         device.Print()
-        
+
     meshfile = expanduser(join(dirname(__file__), '..', 'data', args.mesh))
     mesh = mfem.Mesh(meshfile, 1, 1)
     dim = mesh.Dimension()
@@ -416,8 +416,8 @@ class ReferenceConfiguration(mfem.VectorPyCoefficient):
 
 if __name__ == '__main__':
     if mfem.is_HYPRE_USING_CUDA():
-       print("\n".join(["", "As of mfem-4.3 and hypre-2.22.0 (July 2021) this example",
-                        "is NOT supported with the CUDA version of hypre.", ""]))
-       exit(255)
-    
+        print("\n".join(["", "As of mfem-4.3 and hypre-2.22.0 (July 2021) this example",
+                         "is NOT supported with the CUDA version of hypre.", ""]))
+        exit(255)
+
     ex19_main(args)

--- a/examples/ex1p.py
+++ b/examples/ex1p.py
@@ -79,7 +79,7 @@ def run(order=1, static_cond=False,
     a = mfem.ParBilinearForm(fespace)
     if pa:
         a.SetAssemblyLevel(mfem.AssemblyLevel_PARTIAL)
-        
+
     a.AddDomainIntegrator(mfem.DiffusionIntegrator(one))
 
     if static_cond:
@@ -96,12 +96,12 @@ def run(order=1, static_cond=False,
         if mfem.UsesTensorBasis(fespace):
             if algebraic_ceed:
                 assert False, "not supported"
-                #prec = new ceed::AlgebraicSolver(a, ess_tdof_list);
+                # prec = new ceed::AlgebraicSolver(a, ess_tdof_list);
             else:
                 prec = mfem.OperatorJacobiSmoother(a, ess_tdof_list)
     else:
         prec = mfem.HypreBoomerAMG()
-        
+
     cg = mfem.CGSolver(MPI.COMM_WORLD)
     cg.SetRelTol(1e-12)
     cg.SetMaxIter(200)
@@ -118,6 +118,7 @@ def run(order=1, static_cond=False,
 
     pmesh.Print(mesh_name, 8)
     x.Save(sol_name, 8)
+
 
 if __name__ == "__main__":
     parser = ArgParser(description='Ex1 (Laplace Problem)')

--- a/examples/ex20p.py
+++ b/examples/ex20p.py
@@ -70,9 +70,9 @@ def run(order=1,
         else:
             h += 0.5 * k_ * q * q
         return h
-    
+
     device = mfem.Device('cpu')
-    if myid == 0:        
+    if myid == 0:
         device.Print()
 
     # 2. Create and Initialize the Symplectic Integration Solver

--- a/examples/ex21p.py
+++ b/examples/ex21p.py
@@ -22,9 +22,9 @@ def run(order=1,
         serial_ref_levels=0):
 
     device = mfem.Device('cpu')
-    if myid == 0:    
+    if myid == 0:
         device.Print()
-    
+
     # 2. Read the mesh from the given mesh file. We can handle triangular,
     #    quadrilateral, tetrahedral, and hexahedral meshes with the same code.
     mesh = mfem.Mesh(meshfile, 1, 1)

--- a/examples/ex22.py
+++ b/examples/ex22.py
@@ -110,19 +110,19 @@ def run(mesh_file="",
 
         # mfem.jit.vector can either turn numpy array (defualt) or pass
         # the result using the second argment (interface="c++")
-        @mfem.jit.vector()
+        @mfem.jit.vector(vdim=sdim)
         def u1_real_exact(x):
             alpha = (epsilon * omega - 1j * sigma)
             kappa = sqrt(mu * omega * alpha)
             return np.array([exp(-1j * kappa * x[dim - 1]).real, 0.0, 0.0])
 
-        @mfem.jit.vector()
+        @mfem.jit.vector(vdim=sdim)
         def u1_imag_exact(x):
             alpha = (epsilon * omega - 1j * sigma)
             kappa = sqrt(mu * omega * alpha)
             return np.array([exp(-1j * kappa * x[dim - 1]).imag, 0.0, 0.0])
 
-        @mfem.jit.vector(interface="c++")
+        @mfem.jit.vector(vdim=sdim, interface="c++")
         def u2_real_exact(x, out):
             alpha = (epsilon * omega - 1j * sigma)
             kappa = sqrt(mu * omega * alpha)
@@ -130,7 +130,7 @@ def run(mesh_file="",
                 out[i] = 0
             out[dim-1] = exp(-1j * kappa * x[dim - 1]).real
 
-        @mfem.jit.vector(interface="c++")
+        @mfem.jit.vector(vdim=sdim, interface="c++")
         def u2_imag_exact(x, out):
             alpha = (epsilon * omega - 1j * sigma)
             kappa = sqrt(mu * omega * alpha)

--- a/examples/ex22.py
+++ b/examples/ex22.py
@@ -108,23 +108,21 @@ def run(mesh_file="",
             kappa = sqrt(mu * omega * alpha)
             return exp(-1j * kappa * x[dim - 1]).imag
 
+        # mfem.jit.vector can either turn numpy array (defualt) or pass
+        # the result using the second argment (interface="c++")
         @mfem.jit.vector()
-        def u1_real_exact(x, out):
+        def u1_real_exact(x):
             alpha = (epsilon * omega - 1j * sigma)
             kappa = sqrt(mu * omega * alpha)
-            out[0] = exp(-1j * kappa * x[dim - 1]).real
-            out[1] = 0
-            out[2] = 0
+            return np.array([exp(-1j * kappa * x[dim - 1]).real, 0.0, 0.0])
 
         @mfem.jit.vector()
-        def u1_imag_exact(x, out):
+        def u1_imag_exact(x):
             alpha = (epsilon * omega - 1j * sigma)
             kappa = sqrt(mu * omega * alpha)
-            out[0] = exp(-1j * kappa * x[dim - 1]).imag
-            out[1] = 0
-            out[2] = 0
+            return np.array([exp(-1j * kappa * x[dim - 1]).imag, 0.0, 0.0])
 
-        @mfem.jit.vector()
+        @mfem.jit.vector(interface="c++")
         def u2_real_exact(x, out):
             alpha = (epsilon * omega - 1j * sigma)
             kappa = sqrt(mu * omega * alpha)
@@ -132,7 +130,7 @@ def run(mesh_file="",
                 out[i] = 0
             out[dim-1] = exp(-1j * kappa * x[dim - 1]).real
 
-        @mfem.jit.vector()
+        @mfem.jit.vector(interface="c++")
         def u2_imag_exact(x, out):
             alpha = (epsilon * omega - 1j * sigma)
             kappa = sqrt(mu * omega * alpha)

--- a/examples/ex22p.py
+++ b/examples/ex22p.py
@@ -46,7 +46,7 @@ def run(mesh_file="",
     #    CUDA, OCCA, RAJA and OpenMP based on command line options.
     device = mfem.Device(device)
     if myid == 0:
-        device.Print()    
+        device.Print()
 
     # 3. Read the mesh from the given mesh file. We can handle triangular,
     #    quadrilateral, tetrahedral, hexahedral, surface and volume meshes

--- a/examples/ex24.py
+++ b/examples/ex24.py
@@ -88,28 +88,31 @@ def run(order=1,
                 return sin(x[0]) * sin(x[1])
             return 0.0
 
-        @mfem.jit.vector(sdim=sdim, vdim=dim)
-        def gradp_coef(x, out, sdim_, dim_):
-            if sdim_ == 3:
+        @mfem.jit.vector(sdim=sdim, shape=(dim,))
+        def gradp_coef(x):
+            out = np.zeros(shape, dtype=np.float)
+            if sdim == 3:
                 out[0] = cos(x[0]) * sin(x[1]) * sin(x[2])
                 out[1] = sin(x[0]) * cos(x[1]) * sin(x[2])
                 out[2] = sin(x[0]) * sin(x[1]) * cos(x[2])
-            elif sdim_ == 2:
+            elif sdim == 2:
                 out[0] = cos(x[0]) * sin(x[1])
                 out[1] = sin(x[0]) * cos(x[1])
-                if dim_ == 3:
+                if shape[0] == 3:
                     out[2] = 0.0
+            return out
 
-        @mfem.jit.vector(sdim=sdim, vdim=dim)
-        def v_coef(x, out, sdim_, dim_):
-            if sdim_ == 3:
+        @mfem.jit.vector(sdim=sdim, vdim=dim, interface="c++")
+        def v_coef(x, out):
+            out = np.zeros(shape, dtype=np.float)
+            if shape[0] == 3:
                 out[0] = sin(kappa * x[1])
                 out[1] = sin(kappa * x[2])
                 out[2] = sin(kappa * x[0])
             else:
                 out[0] = sin(kappa * x[1])
                 out[1] = sin(kappa * x[0])
-                if dim_ == 3:
+                if shape[0] == 3:
                     out[2] = 0.0
 
         @mfem.jit.scalar()
@@ -120,14 +123,14 @@ def run(order=1,
                 return -2.0 * sin(x[0]) * sin(x[1])
             return 0.0
 
-        @mfem.jit.vector(sdim=sdim, vdim=dim)
-        def curlv_coef(x, out, sdim_, dim_):
-            if sdim_ == 3:
+        @mfem.jit.vector(sdim=sdim, shape=(dim,), interface="c++")
+        def curlv_coef(x, out):
+            if shape[0] == 3:
                 out[0] = -kappa * cos(kappa * x[2])
                 out[1] = -kappa * cos(kappa * x[0])
                 out[2] = -kappa * cos(kappa * x[1])
             else:
-                for i in range(dim_):
+                for i in range(shape[0]):
                     out[i] = 0.0
 
         @mfem.jit.scalar()

--- a/examples/ex24.py
+++ b/examples/ex24.py
@@ -88,24 +88,24 @@ def run(order=1,
                 return sin(x[0]) * sin(x[1])
             return 0.0
 
-        @mfem.jit.vector(sdim=sdim, shape=(dim,))
+        @mfem.jit.vector(shape=(sdim,))
         def gradp_coef(x):
             out = np.zeros(shape, dtype=np.float)
-            if sdim == 3:
+            if dim == 3:
                 out[0] = cos(x[0]) * sin(x[1]) * sin(x[2])
                 out[1] = sin(x[0]) * cos(x[1]) * sin(x[2])
                 out[2] = sin(x[0]) * sin(x[1]) * cos(x[2])
-            elif sdim == 2:
+            elif dim == 2:
                 out[0] = cos(x[0]) * sin(x[1])
                 out[1] = sin(x[0]) * cos(x[1])
-                if shape[0] == 3:
+                if len(x) == 3:
                     out[2] = 0.0
             return out
 
-        @mfem.jit.vector(sdim=sdim, vdim=dim, interface="c++")
+        @mfem.jit.vector(vdim=sdim, interface="c++")
         def v_coef(x, out):
             out = np.zeros(shape, dtype=np.float)
-            if shape[0] == 3:
+            if dim == 3:
                 out[0] = sin(kappa * x[1])
                 out[1] = sin(kappa * x[2])
                 out[2] = sin(kappa * x[0])
@@ -123,14 +123,14 @@ def run(order=1,
                 return -2.0 * sin(x[0]) * sin(x[1])
             return 0.0
 
-        @mfem.jit.vector(sdim=sdim, shape=(dim,), interface="c++")
+        @mfem.jit.vector(shape=(sdim,), interface="c++")
         def curlv_coef(x, out):
-            if shape[0] == 3:
+            if dim == 3:
                 out[0] = -kappa * cos(kappa * x[2])
                 out[1] = -kappa * cos(kappa * x[0])
                 out[2] = -kappa * cos(kappa * x[1])
             else:
-                for i in range(shape[0]):
+                for i in range(len(out)):
                     out[i] = 0.0
 
         @mfem.jit.scalar()

--- a/examples/ex24p.py
+++ b/examples/ex24p.py
@@ -98,29 +98,29 @@ def run(order=1,
                 return sin(x[0]) * sin(x[1])
             return 0.0
 
-        @mfem.jit.vector(sdim=sdim, vdim=dim)
-        def gradp_coef(x, out, sdim_, dim_):
-            if sdim_ == 3:
+        @mfem.jit.vector(sdim=sdim, shape=(sdim,), interface="c++")
+        def gradp_coef(x, out):
+            if dim == 3:
                 out[0] = cos(x[0]) * sin(x[1]) * sin(x[2])
                 out[1] = sin(x[0]) * cos(x[1]) * sin(x[2])
                 out[2] = sin(x[0]) * sin(x[1]) * cos(x[2])
-            elif sdim_ == 2:
+            else:
                 out[0] = cos(x[0]) * sin(x[1])
                 out[1] = sin(x[0]) * cos(x[1])
-                if dim_ == 3:
+                if sdim == 3:
                     out[2] = 0.0
 
-        @mfem.jit.vector(sdim=sdim, vdim=dim)
-        def v_coef(x, out, sdim_, dim_):
-            if sdim_ == 3:
+        @mfem.jit.vector(sdim=sdim, shape=(sdim,))
+        def v_coef(x):
+            out = np.zeros(sdim)
+            if dim == 3:
                 out[0] = sin(kappa * x[1])
                 out[1] = sin(kappa * x[2])
                 out[2] = sin(kappa * x[0])
             else:
                 out[0] = sin(kappa * x[1])
                 out[1] = sin(kappa * x[0])
-                if dim_ == 3:
-                    out[2] = 0.0
+            return out
 
         @mfem.jit.scalar()
         def cdiv_gradp_coeff(x):
@@ -130,15 +130,14 @@ def run(order=1,
                 return -2.0 * sin(x[0]) * sin(x[1])
             return 0.0
 
-        @mfem.jit.vector(sdim=sdim, vdim=dim)
-        def curlv_coef(x, out, sdim_, dim_):
-            if sdim_ == 3:
+        @mfem.jit.vector(sdim=sdim, shape=(dim,))
+        def curlv_coef(x):
+            out = np.zeros(shape)
+            if shape[0] == 3:
                 out[0] = -kappa * cos(kappa * x[2])
                 out[1] = -kappa * cos(kappa * x[0])
                 out[2] = -kappa * cos(kappa * x[1])
-            else:
-                for i in range(dim_):
-                    out[i] = 0.0
+            return out
 
         @mfem.jit.scalar()
         def divgradp_coef(x):

--- a/examples/ex27p.py
+++ b/examples/ex27p.py
@@ -326,7 +326,8 @@ def run(order=1,
         visualization=True):
 
     device = mfem.Device('cpu')
-    if myid == 0: device.Print()
+    if myid == 0:
+        device.Print()
 
     if kappa < 0 and not h1:
         kappa = (order+1.0)**2

--- a/examples/ex28p.py
+++ b/examples/ex28p.py
@@ -55,7 +55,8 @@ def run(order=1,
         visualization=True):
 
     device = mfem.Device('cpu')
-    if myid == 0: device.Print()
+    if myid == 0:
+        device.Print()
 
     # 2. Build a trapezoidal mesh with a single quadrilateral element, where
     #    'offset' determines how far off it is from a rectangle.
@@ -212,12 +213,12 @@ def run(order=1,
 
 
 if __name__ == "__main__":
-    
+
     if mfem.is_HYPRE_USING_CUDA():
-       print("\n".join(["", "As of mfem-4.3 and hypre-2.22.0 (July 2021) this example",
-                        "is NOT supported with the CUDA version of hypre.", ""]))
-       exit(255)
-    
+        print("\n".join(["", "As of mfem-4.3 and hypre-2.22.0 (July 2021) this example",
+                         "is NOT supported with the CUDA version of hypre.", ""]))
+        exit(255)
+
     from mfem.common.arg_parser import ArgParser
 
     parser = ArgParser(

--- a/examples/ex29p.py
+++ b/examples/ex29p.py
@@ -104,7 +104,8 @@ def run(order=3,
         visualization=True):
 
     device = mfem.Device('cpu')
-    if myid == 0: device.Print()
+    if myid == 0:
+        device.Print()
 
     # 2. Construct a quadrilateral or triangular mesh with the topology of a
     #    cylindrical surface.

--- a/examples/ex3.py
+++ b/examples/ex3.py
@@ -40,7 +40,7 @@ def run(order=1,
                              sin(kappa*x[2]),
                              sin(kappa*x[0])))
 
-        @mfem.jit.vector(interface="c++style")
+        @mfem.jit.vector(interface="c++")
         def f_exact(x, out):
             out[0] = (1 + kappa**2)*sin(kappa * x[1])
             out[1] = (1 + kappa**2)*sin(kappa * x[2])

--- a/examples/ex3.py
+++ b/examples/ex3.py
@@ -30,13 +30,17 @@ def run(order=1,
     sdim = mesh.SpaceDimension()
 
     if numba:
-        @mfem.jit.vector()
-        def E_exact(x, out):
-            out[0] = sin(kappa*x[1])
-            out[1] = sin(kappa*x[2])
-            out[2] = sin(kappa*x[0])
+        #
+        #  mfem.jit supports two interface. interface=simple allows for
+        #  returning a numpy array. 
+        #
+        @mfem.jit.vector(interface="simple")
+        def E_exact(x):
+            return np.array((sin(kappa*x[1]),
+                             sin(kappa*x[2]),
+                             sin(kappa*x[0])))
 
-        @mfem.jit.vector()
+        @mfem.jit.vector(interface="c++style")
         def f_exact(x, out):
             out[0] = (1 + kappa**2)*sin(kappa * x[1])
             out[1] = (1 + kappa**2)*sin(kappa * x[2])

--- a/examples/ex3.py
+++ b/examples/ex3.py
@@ -32,15 +32,15 @@ def run(order=1,
     if numba:
         #
         #  mfem.jit supports two interface. interface=simple allows for
-        #  returning a numpy array. 
+        #  returning a numpy array.
         #
-        @mfem.jit.vector(interface="simple")
+        @mfem.jit.vector(vdim=3, interface="simple")
         def E_exact(x):
             return np.array((sin(kappa*x[1]),
                              sin(kappa*x[2]),
                              sin(kappa*x[0])))
 
-        @mfem.jit.vector(interface="c++")
+        @mfem.jit.vector(vdim=3, interface="c++")
         def f_exact(x, out):
             out[0] = (1 + kappa**2)*sin(kappa * x[1])
             out[1] = (1 + kappa**2)*sin(kappa * x[2])

--- a/examples/ex30.py
+++ b/examples/ex30.py
@@ -44,7 +44,7 @@ def singular_coeff(p):
     r = np.sqrt((x - xc)**2.0 + (y - yc)**2)
     num = - (alpha - alpha**3 * (r**2 - r0**2))
     denom = (r * (alpha**2 * r0**2 + alpha**2 * r**2 -
-                 2 * alpha**2 * r0 * r + 1.0))**2
+                  2 * alpha**2 * r0 * r + 1.0))**2
     denom = max([denom, 1e-8])
     return num / denom
 

--- a/examples/ex30p.py
+++ b/examples/ex30p.py
@@ -49,7 +49,7 @@ def singular_coeff(p):
     r = np.sqrt((x - xc)**2.0 + (y - yc)**2)
     num = - (alpha - alpha**3 * (r**2 - r0**2))
     denom = (r * (alpha**2 * r0**2 + alpha**2 * r**2 -
-                 2 * alpha**2 * r0 * r + 1.0))**2
+                  2 * alpha**2 * r0 * r + 1.0))**2
     denom = max([denom, 1e-8])
     return num / denom
 
@@ -64,7 +64,8 @@ def run(nc_limit=1,
         nc_simplices=True):
 
     device = mfem.Device('cpu')
-    if myid == 0: device.Print()
+    if myid == 0:
+        device.Print()
 
     mesh = mfem.Mesh(meshfile, 1, 1)
 

--- a/examples/ex31p.py
+++ b/examples/ex31p.py
@@ -86,9 +86,9 @@ def run(order=1,
     #     when compiling it.
     if numba:
         params = {"dim": dim, "kappa": pi*freq}
-        E = mfem.jit.vector(sdim=3, params=params)(E_exact)
-        CurlE = mfem.jit.vector(sdim=3, params=params)(CurlE_exact)
-        f = mfem.jit.vector(sdim=3, params=params)(f_exact)
+        E = mfem.jit.vector(vdim=3, params=params)(E_exact)
+        CurlE = mfem.jit.vector(vdim=3, params=params)(CurlE_exact)
+        f = mfem.jit.vector(vdim=3, params=params)(f_exact)
     else:
         pass  # ToDo provide regular example.
 
@@ -321,7 +321,8 @@ def make_socketstrema():
     return sock
 
 
-def E_exact(x, E):
+def E_exact(x):
+    E = np.zeros(vdim)
     if dim == 1:
         E[0] = 1.1 * sin(kappa * x[0] + 0.0 * pi)
         E[1] = 1.2 * sin(kappa * x[0] + 0.4 * pi)
@@ -337,9 +338,11 @@ def E_exact(x, E):
 
         for i in range(3):
             E[i] = E[i]*cos(kappa * x[2])
+    return E
 
 
-def CurlE_exact(x, dE):
+def CurlE_exact(x):
+    dE = np.zeros(vdim)
     if dim == 1:
         c4 = cos(kappa * x[0] + 0.4 * pi)
         c9 = cos(kappa * x[0] + 0.9 * pi)
@@ -375,9 +378,11 @@ def CurlE_exact(x, dE):
         dE[2] = -sqrt1_2 * (1.1 * c0 - 1.2 * c4) * ck
         for i in range(3):
             dE[i] = dE[i]*kappa
+    return dE
 
 
-def f_exact(x, f):
+def f_exact(x):
+    f = np.zeros(vdim, dtype=np.float)
     if dim == 1:
         s0 = sin(kappa * x[0] + 0.0 * pi)
         s4 = sin(kappa * x[0] + 0.4 * pi)
@@ -422,6 +427,7 @@ def f_exact(x, f):
         f[2] = (0.6 * sqrt2 * s4 * ck -
                 sqrt2 * kappa * kappa * (0.55 * c0 + 0.6 * c4) * sk
                 + 1.3 * (2.0 + kappa * kappa) * s9 * ck)
+    return f
 
 
 if __name__ == "__main__":

--- a/examples/ex7.py
+++ b/examples/ex7.py
@@ -137,17 +137,17 @@ a.FormLinearSystem(empty_tdof_list, x, b, A, X, B)
 AA = mfem.OperatorHandle2SparseMatrix(A)
 
 try:
-   umf_solver = mfem.UMFPackSolver()
+    umf_solver = mfem.UMFPackSolver()
 except:
-   umf_solver = None
+    umf_solver = None
 
 if umf_solver is None:
-   M = mfem.GSSmoother(AA)
-   mfem.PCG(AA, M, B, X, 1, 200, 1e-12, 0.0)
+    M = mfem.GSSmoother(AA)
+    mfem.PCG(AA, M, B, X, 1, 200, 1e-12, 0.0)
 else:
-   umf_solver.Control[mfem.UMFPACK_ORDERING] = mfem.UMFPACK_ORDERING_METIS    
-   umf_solver.SetOperator(AA);
-   umf_solver.Mult(B, X);
+    umf_solver.Control[mfem.UMFPACK_ORDERING] = mfem.UMFPACK_ORDERING_METIS
+    umf_solver.SetOperator(AA)
+    umf_solver.Mult(B, X)
 
 # 10. Recover the solution as a finite element grid function.
 a.RecoverFEMSolution(X, b, x)

--- a/examples/ex9.py
+++ b/examples/ex9.py
@@ -66,7 +66,7 @@ def run(ref_levels=2,
 
     device = mfem.Device(device)
     device.Print()
-    
+
     # 2. Read the mesh from the given mesh file. We can handle geometrically
     #    periodic meshes in this code.
 

--- a/mfem/_par/coefficient.i
+++ b/mfem/_par/coefficient.i
@@ -47,6 +47,37 @@ import_array();
 
 %ignore Function;
 
+namespace mfem {
+%pythonprepend MatrixConstantCoefficient::MatrixConstantCoefficient(const DenseMatrix &m) %{
+   try:
+      import numpy as np
+      value = np.array(m, copy=False, dtype=float)
+      can_np_array = True
+   except:
+      can_np_array = False
+
+   if can_np_array:
+      v = mfem._par.vector.Vector(np.transpose(value).flatten())
+      m = mfem._par.densemat.DenseMatrix(v.GetData(), value.shape[0], value.shape[1])       
+      self._value = (v,m)
+   else:
+      pass 
+%}
+%pythonprepend VectorConstantCoefficient::VectorConstantCoefficient(const Vector &v) %{
+   try:
+      import numpy as np
+      value = np.array(v, copy=False, dtype=float).flatten()
+      can_np_array = True
+   except:
+      can_np_array = False
+
+   if can_np_array:
+      v = mfem._par.vector.Vector(value)
+      self._value = v
+   else:
+      pass 
+%}
+}
 %include "../common/coefficient_common.i"
 
 %feature("notabstract") mfem::VectorFunctionCoefficient;
@@ -200,18 +231,18 @@ class PyCoefficientT(PyCoefficientBase):
        return self.EvalValue(x.GetDataArray(), t)
    def EvalValue(self, x, t):
        return 0.0
-	 
+         
 class VectorPyCoefficient(VectorPyCoefficientBase):
    def __init__(self, dim):
        self.vdim = dim
        VectorPyCoefficientBase.__init__(self, dim, 0)
    def _EvalPy(self, x, V):
        v = self.EvalValue(x.GetDataArray())
-       V.Assign(v)	 
+       V.Assign(v)       
 
    def _EvalPyT(self, x, t, V):
        v = self.EvalValue(x.GetDataArray())
-       V.Assign(v)	 	 
+       V.Assign(v)               
 
    def EvalValue(self, x):
        return [0,0,0]
@@ -226,7 +257,7 @@ class VectorPyCoefficientT(VectorPyCoefficientBase):
 
    def _EvalPyT(self, x, t, V):
        v = self.EvalValue(x.GetDataArray(), t)
-       V.Assign(v)	 	 	 
+       V.Assign(v)                       
 
    def EvalValue(self, x, t):
        return [0.0,0.0,0.0]
@@ -237,7 +268,7 @@ class MatrixPyCoefficient(MatrixPyCoefficientBase):
        MatrixPyCoefficientBase.__init__(self, dim, 0)
    def _EvalPy(self, x, K):
        k = self.EvalValue(x.GetDataArray())
-       K.Assign(k)	 	 	 	 	 	 
+       K.Assign(k)                                               
 
    def EvalValue(self, x):
        return np.array([[0,0,0], [0,0,0], [0,0,0]])
@@ -248,10 +279,10 @@ class MatrixPyCoefficientT(MatrixPyCoefficientBase):
        MatrixPyCoefficientBase.__init__(self, dim, 1)
    def _EvalPyT(self, x, t, K):
        k = self.EvalValue(x.GetDataArray(), t)
-       K.Assign(k)	 	 	 	 	 	 
+       K.Assign(k)                                               
 
    def EvalValue(self, x, t):
        return np.array([[0.0,0.0,0.0], [0.0,0.0,0.0], [0.0,0.0,0.0]])
-	 
+         
 %}
 

--- a/mfem/_par/coefficient.i
+++ b/mfem/_par/coefficient.i
@@ -46,65 +46,19 @@ import_array();
 %import "../common/exception_director.i"
 
 %ignore Function;
-//%ignore DeltaCoefficient;
-%feature("notabstract") VectorFunctionCoefficient;
-%feature("notabstract") VectorConstantCoefficient;
-%feature("notabstract") VectorDeltaCoefficient;
-%feature("notabstract") MatrixFunctionCoefficient;
-%feature("notabstract") MatrixConstantCoefficient;
+
+%include "../common/coefficient_common.i"
+
+%feature("notabstract") mfem::VectorFunctionCoefficient;
+%feature("notabstract") mfem::VectorConstantCoefficient;
+%feature("notabstract") mfem::VectorDeltaCoefficient;
+%feature("notabstract") mfem::MatrixArrayCoefficient;
+%feature("notabstract") mfem::MatrixFunctionCoefficient;
+%feature("notabstract") mfem::MatrixConstantCoefficient;
 %feature("notabstract") mfem::CurlGridFunctionCoefficient;
 %feature("notabstract") mfem::SymmetricMatrixConstantCoefficient;
+%feature("notabstract") mfem::SymmetricMatrixFunctionCoefficient;
 %feature("notabstract") mfem::VectorQuadratureFunctionCoefficient;
-
-namespace mfem {
-%pythonprepend MatrixConstantCoefficient::MatrixConstantCoefficient(const DenseMatrix &m) %{
-   try:
-      import numpy as np
-      value = np.array(m, copy=False, dtype=float)
-      can_np_array = True
-   except:
-      can_np_array = False
-
-   if can_np_array:
-      v = mfem._par.vector.Vector(np.transpose(value).flatten())
-      m = mfem._par.densemat.DenseMatrix(v.GetData(), value.shape[0], value.shape[1])       
-      self._value = (v,m)
-   else:
-      pass 
-%}
-%pythonprepend VectorConstantCoefficient::VectorConstantCoefficient(const Vector &v) %{
-   try:
-      import numpy as np
-      value = np.array(v, copy=False, dtype=float).flatten()
-      can_np_array = True
-   except:
-      can_np_array = False
-
-   if can_np_array:
-      v = mfem._par.vector.Vector(value)
-      self._value = v
-   else:
-      pass 
-%}
-%pythonprepend DeltaCoefficient::SetWeight %{
-    w.thisown=0 
-%}
-%pythonprepend VectorArrayCoefficient::Set %{ 
-    c.thisown=0 
-%}
-%pythonprepend MatrixArrayCoefficient::Set %{ 
-    c.thisown=0 
-%}
-%pythonappend VectorRestrictedCoefficient::VectorRestrictedCoefficient %{
-    self._ref_to_vc = vc
-%}
-%pythonappend RestrictedCoefficient::RestrictedCoefficient %{
-    self._ref_to_c = c_
-%}
-%pythonappend MatrixRestrictedCoefficient::MatrixRestrictedCoefficient %{
-    self._ref_to_mc = mc
-%}
-}
 
 %exception {
     try { $action }

--- a/mfem/_ser/coefficient.i
+++ b/mfem/_ser/coefficient.i
@@ -45,65 +45,18 @@ import_array();
 %import "../common/exception_director.i"
 
 %ignore Function;
-//%ignore DeltaCoefficient;
-namespace mfem {
-%pythonprepend MatrixConstantCoefficient::MatrixConstantCoefficient(const DenseMatrix &m) %{
-   try:
-      import numpy as np
-      value = np.array(m, copy=False, dtype=float)
-      can_np_array = True
-   except:
-      can_np_array = False
 
-   if can_np_array:
-      v = mfem._ser.vector.Vector(np.transpose(value).flatten())
-      m = mfem._ser.densemat.DenseMatrix(v.GetData(), value.shape[0], value.shape[1])       
-      self._value = (v,m)
-   else:
-      pass 
-%}
-%pythonprepend VectorConstantCoefficient::VectorConstantCoefficient(const Vector &v) %{
-   try:
-      import numpy as np
-      value = np.array(v, copy=False, dtype=float).flatten()
-      can_np_array = True
-   except:
-      can_np_array = False
-
-   if can_np_array:
-      v = mfem._ser.vector.Vector(value)
-      self._value = v
-   else:
-      pass 
-%}
-%pythonprepend DeltaCoefficient::SetWeight %{
-    w.thisown=0 
-%}
-%pythonprepend VectorArrayCoefficient::Set %{ 
-    c.thisown=0 
-%}
-%pythonprepend MatrixArrayCoefficient::Set %{ 
-    c.thisown=0 
-%}
-%pythonappend VectorRestrictedCoefficient::VectorRestrictedCoefficient %{
-    self._ref_to_vc = vc
-%}
-%pythonappend RestrictedCoefficient::RestrictedCoefficient %{
-    self._ref_to_c = c_
-%}
-%pythonappend MatrixRestrictedCoefficient::MatrixRestrictedCoefficient %{
-    self._ref_to_mc = mc
-%}
-  
-}
+%include "../common/coefficient_common.i"
 
 %feature("notabstract") mfem::VectorFunctionCoefficient;
 %feature("notabstract") mfem::VectorConstantCoefficient;
 %feature("notabstract") mfem::VectorDeltaCoefficient;
+%feature("notabstract") mfem::MatrixArrayCoefficient;
 %feature("notabstract") mfem::MatrixFunctionCoefficient;
 %feature("notabstract") mfem::MatrixConstantCoefficient;
 %feature("notabstract") mfem::CurlGridFunctionCoefficient;
 %feature("notabstract") mfem::SymmetricMatrixConstantCoefficient;
+%feature("notabstract") mfem::SymmetricMatrixFunctionCoefficient;
 %feature("notabstract") mfem::VectorQuadratureFunctionCoefficient;
 
 /*

--- a/mfem/_ser/coefficient.i
+++ b/mfem/_ser/coefficient.i
@@ -46,6 +46,37 @@ import_array();
 
 %ignore Function;
 
+namespace mfem {
+%pythonprepend MatrixConstantCoefficient::MatrixConstantCoefficient(const DenseMatrix &m) %{
+   try:
+      import numpy as np
+      value = np.array(m, copy=False, dtype=float)
+      can_np_array = True
+   except:
+      can_np_array = False
+
+   if can_np_array:
+      v = mfem._ser.vector.Vector(np.transpose(value).flatten())
+      m = mfem._ser.densemat.DenseMatrix(v.GetData(), value.shape[0], value.shape[1])       
+      self._value = (v,m)
+   else:
+      pass 
+%}
+%pythonprepend VectorConstantCoefficient::VectorConstantCoefficient(const Vector &v) %{
+   try:
+      import numpy as np
+      value = np.array(v, copy=False, dtype=float).flatten()
+      can_np_array = True
+   except:
+      can_np_array = False
+
+   if can_np_array:
+      v = mfem._ser.vector.Vector(value)
+      self._value = v
+   else:
+      pass 
+%}
+}
 %include "../common/coefficient_common.i"
 
 %feature("notabstract") mfem::VectorFunctionCoefficient;

--- a/mfem/common/bilininteg_ext.i
+++ b/mfem/common/bilininteg_ext.i
@@ -227,6 +227,10 @@ namespace mfem {
     self._coeff = args
 %}
 
+%pythonappend MixedCurlIntegrator::MixedCurlIntegrator %{
+    self._coeff = args
+%}
+
 %pythonappend VectorFEMassIntegrator::VectorFEMassIntegrator %{
     self._coeff = args
 %}

--- a/mfem/common/coefficient_common.i
+++ b/mfem/common/coefficient_common.i
@@ -1,33 +1,4 @@
 namespace mfem {
-%pythonprepend MatrixConstantCoefficient::MatrixConstantCoefficient(const DenseMatrix &m) %{
-   try:
-      import numpy as np
-      value = np.array(m, copy=False, dtype=float)
-      can_np_array = True
-   except:
-      can_np_array = False
-
-   if can_np_array:
-      v = mfem._ser.vector.Vector(np.transpose(value).flatten())
-      m = mfem._ser.densemat.DenseMatrix(v.GetData(), value.shape[0], value.shape[1])       
-      self._value = (v,m)
-   else:
-      pass 
-%}
-%pythonprepend VectorConstantCoefficient::VectorConstantCoefficient(const Vector &v) %{
-   try:
-      import numpy as np
-      value = np.array(v, copy=False, dtype=float).flatten()
-      can_np_array = True
-   except:
-      can_np_array = False
-
-   if can_np_array:
-      v = mfem._ser.vector.Vector(value)
-      self._value = v
-   else:
-      pass 
-%}
 %pythonappend PWCoefficient::PWCoefficient  %{
     if len(args) > 1:
        self._link = args[1]

--- a/mfem/common/coefficient_common.i
+++ b/mfem/common/coefficient_common.i
@@ -1,0 +1,318 @@
+namespace mfem {
+%pythonprepend MatrixConstantCoefficient::MatrixConstantCoefficient(const DenseMatrix &m) %{
+   try:
+      import numpy as np
+      value = np.array(m, copy=False, dtype=float)
+      can_np_array = True
+   except:
+      can_np_array = False
+
+   if can_np_array:
+      v = mfem._ser.vector.Vector(np.transpose(value).flatten())
+      m = mfem._ser.densemat.DenseMatrix(v.GetData(), value.shape[0], value.shape[1])       
+      self._value = (v,m)
+   else:
+      pass 
+%}
+%pythonprepend VectorConstantCoefficient::VectorConstantCoefficient(const Vector &v) %{
+   try:
+      import numpy as np
+      value = np.array(v, copy=False, dtype=float).flatten()
+      can_np_array = True
+   except:
+      can_np_array = False
+
+   if can_np_array:
+      v = mfem._ser.vector.Vector(value)
+      self._value = v
+   else:
+      pass 
+%}
+%pythonappend PWCoefficient::PWCoefficient  %{
+    if len(args) > 1:
+       self._link = args[1]
+%}
+%pythonappend GridFunctionCoefficient::GridFunctionCoefficient  %{
+    if len(args) > 0:
+       self._link = args[0]
+%}
+%pythonprepend GridFunctionCoefficient::SetGridFunction %{
+    self._link = gf
+%}
+%pythonappend TransformedCoefficient::TransformedCoefficient  %{
+    self._link = [x for x in args if isinstance(x, Coefficient)]
+%}
+%pythonprepend DeltaCoefficient::SetWeight %{
+    self._linkw = w
+%}
+%pythonappend RestrictedCoefficient::RestrictedCoefficient %{
+    self._ref_to_c = c_
+%}
+%pythonappend PWVectorCoefficient::PWVectorCoefficient %{
+    if len(args) > 2:
+       self._link = args[2]      
+%}
+%pythonprepend VectorArrayCoefficient::Set %{ 
+    c.thisown=0 
+%}
+%pythonprepend VectorGridFunctionCoefficient::VectorGridFunctionCoefficient %{
+    if len(args) > 0:
+       self._link = args[0]
+%}
+%pythonprepend VectorGridFunctionCoefficient::SetGridFunction %{
+    self._link = gf
+%}
+%pythonprepend GradientGridFunctionCoefficient::GradientGridFunctionCoefficient %{
+    self._link = gf    
+%}
+%pythonprepend GradientGridFunctionCoefficient::SetGridFunction %{
+    self._link = gf
+%}
+%pythonprepend CurlGridFunctionCoefficient::CurlGridFunctionCoefficient %{
+    self._link = gf        
+%}
+%pythonprepend CurlGridFunctionCoefficient::SetGridFunction %{
+    self._link = gf
+%}
+%pythonprepend DivergenceGridFunctionCoefficient::DivergenceGridFunctionCoefficient %{
+    self._link = gf    
+%}
+%pythonprepend DivergenceGridFunctionCoefficient::SetGridFunction %{
+    self._link = gf
+%}
+%pythonappend VectorRestrictedCoefficient::VectorRestrictedCoefficient %{
+    self._ref_to_vc = vc
+%}
+
+%pythonprepend MatrixArrayCoefficient::Set %{ 
+    c.thisown=0 
+%}
+  
+%pythonappend MatrixRestrictedCoefficient::MatrixRestrictedCoefficient %{
+    self._ref_to_mc = mc
+%}
+
+%pythonappend SumCoefficient::SumCoefficient %{
+    if len(args) > 0 and isinstance(agrs[0], Coefficient):
+          self.linkA = args[0]
+    if len(args) > 1 and isinstance(agrs[1], Coefficient):
+          self.linkB = args[0]
+
+%}
+%pythonappend SumCoefficient::SetACoef %{
+    self.linkA = A    
+%}    
+%pythonappend SumCoefficient::SetBCoef %{
+    self.linkB = B    
+%}    
+  
+%pythonappend ProductCoefficient::ProductCoefficient %{
+    if len(args) > 0 and isinstance(args[0], Coefficient):
+       self._linkA = args[0]
+    if len(args) > 1 and isinstance(args[1], Coefficient):
+       self._linkB = args[1]
+%}  
+%pythonappend ProductCoefficient::SetACoef %{
+       self._linkA = A    
+%}
+%pythonappend ProductCoefficient::SetBCoef %{
+       self._linkB = B    
+%}
+
+  
+%pythonappend RatioCoefficient::RatioCoefficient %{
+    if len(args) > 0 and isinstance(args[0], Coefficient):
+       self._linkA = args[0]
+    if len(args) > 1 and isinstance(args[1], Coefficient):
+       self._linkB = args[1]
+%}  
+%pythonappend RatioCoefficient::SetACoef %{
+       self._linkA = A    
+%}
+%pythonappend RatioCoefficient::SetBCoef %{
+       self._linkB = B    
+%}
+
+%pythonappend PowerCoefficient::PowerCoefficient %{
+    self._linkA = A
+%}  
+%pythonappend PowerCoefficient::SetACoef %{
+    self._linkA = A
+%}    
+  
+%pythonappend InnerProductCoefficient::InnerProductCoefficient %{
+    self._linkA = A
+    self._linkB = B
+%}  
+%pythonappend InnerProductCoefficient::SetACoef %{
+    self._linkA = A
+%}    
+%pythonappend InnerProductCoefficient::SetBCoef %{
+    self._linkB = B
+%}    
+  
+
+%pythonappend VectorRotProductCoefficient::VectorRotProductCoefficient %{
+    self._linkA = A
+    self._linkB = B
+%}  
+%pythonappend VectorRotProductCoefficient::SetACoef %{
+    self._linkA = A
+%}    
+%pythonappend VectorRotProductCoefficient::SetBCoef %{
+    self._linkB = B
+%}    
+  
+  
+%pythonappend DeterminantCoefficient::DeterminantCoefficient %{
+    self.linkA = A
+%}    
+%pythonappend DeterminantCoefficient::SetACoef%{
+    self.linkA = A
+%}    
+
+%pythonappend VectorSumCoefficient::VectorSumCoefficient %{
+    if len(args) > 1:
+        self.linkA = args[0]
+        self.linkB = args[1]
+    if len(args) > 2:
+       if isinstance(agrs[2], Coefficient):
+          self.linkAlphaCoef = args[2]
+    if len(args) > 3:	    
+       if isinstance(agrs[3], Coefficient):
+          self.linkBetaCoef = args[3]	
+%}
+%pythonappend VectorSumCoefficient::SetACoef %{
+    self.linkA = A_    
+%}    
+%pythonappend VectorSumCoefficient::SetBCoef %{
+    self.linkB = B_    
+%}    
+%pythonappend VectorSumCoefficient::SetAlphaCoef %{
+    self.linkAlpha = A_    
+%}    
+%pythonappend VectorSumCoefficient::SetBetaCoef %{
+    self.linkBeta = B_    
+%}
+  
+%pythonappend ScalarVectorProductCoefficient::ScalarVectorProductCoefficient %{
+    if isinstance(args[0], Coefficient):
+        self._linkA = args[0]
+    if isinstance(args[1], VectorCoefficient):    
+        self._linkB = args[1]
+%}    
+%pythonappend ScalarVectorProductCoefficient::SetACoef %{
+    self._linkA = A
+%}    
+%pythonappend ScalarVectorProductCoefficient::SetBCoef %{
+    self._linkB = B
+%}
+  
+%pythonappend NormalizedVectorCoefficient::NormalizedVectorCoefficient%{
+    self._linkA = A
+%}    
+%pythonappend NormalizedVectorCoefficient::SetACoef %{
+    self._linkA = A
+%}
+  
+%pythonappend VectorCrossProductCoefficient::VectorCrossProductCoefficient %{
+    self._linkA = A
+    self._linkB = B
+%}  
+%pythonappend VectorCrossProductCoefficient::SetACoef %{
+    self._linkA = A
+%}    
+%pythonappend VectorCrossProductCoefficient::SetBCoef %{
+    self._linkB = B
+%}    
+
+%pythonappend MatrixVectorProductCoefficient::MatrixVectorProductCoefficient %{
+    self._linkA = A
+    self._linkB = B
+%}    
+%pythonappend MatrixVectorProductCoefficient::SetACoef %{
+    self._linkA = A
+%}    
+%pythonappend MatrixVectorProductCoefficient::SetBCoef %{
+    self._linkB = B
+%}    
+
+%pythonappend MatrixSumCoefficient::MatrixSumCoefficient %{
+    self._linkA = A
+    self._linkB = B
+%}
+%pythonappend MatrixSumCoefficient::SetACoef %{
+    self._linkA = A
+%}
+%pythonappend MatrixSumCoefficient::SetBCoef %{
+    self._linkB = B
+%}
+%pythonappend MatrixProductCoefficient::MatrixProductCoefficient %{
+    self._linkA = A
+    self._linkB = B
+%}    
+%pythonappend MatrixProductCoefficient::SetACoef %{
+    self._linkA = A
+%}    
+%pythonappend MatrixProductCoefficient::SetBCoef %{
+    self._linkB = B
+%}    
+%pythonappend ScalarMatrixProductCoefficient::ScalarMatrixProductCoefficient %{
+    if isinstance(args[0], Coefficient):
+        self._linkA = args[0]
+    if isinstance(args[1], MatrixCoefficient):    
+        self._linkB = args[1]
+%}
+%pythonappend ScalarMatrixProductCoefficient::SetACoef %{
+    self._linkA = A
+%}
+%pythonappend ScalarMatrixProductCoefficient::SetBCoef %{
+    self._linkB = B
+%}
+									      
+%pythonappend TransposeMatrixCoefficient::TransposeMatrixCoefficient%{
+   self._link = A
+%}
+%pythonappend TransposeMatrixCoefficient::SetACoef %{
+   self._link = A  
+%}
+%pythonappend InverseMatrixCoefficient::InverseMatrixCoefficient%{
+   self._link = A
+%}
+%pythonappend InverseMatrixCoefficient::SetACoef%{
+   self._link = A
+%}
+%pythonappend OuterProductCoefficient::OuterProductCoefficient%{
+   self._linkA = A
+   self._linkB = B
+%}
+%pythonappend OuterProductCoefficient::SetACoef%{
+   self._linkA = A
+%}
+%pythonappend OuterProductCoefficient::SetBCoef%{
+   self._linkB = B
+%}
+  
+%pythonappend CrossCrossCoefficient::CrossCrossCoefficient%{
+    if isinstance(args[0], Coefficient):
+        self._linkA = args[0]
+    if isinstance(args[1], VectorCoefficient):    
+        self._linkK = args[1]
+%}
+%pythonappend CrossCrossCoefficient::SetACoef%{
+    self._linkA = A
+%}
+%pythonappend CrossCrossCoefficient::SetKCoef%{
+    self._linkK = K
+%}
+
+%pythonappend QuadratureFunctionCoefficient::QuadratureFunctionCoefficient %{
+    self._linkQF = qf
+%}
+  
+%pythonappend VectorQuadratureFunctionCoefficient::VectorQuadratureFunctionCoefficient %{
+    self._linkQF = qf
+%}
+  
+
+}

--- a/mfem/common/numba_coefficient.i
+++ b/mfem/common/numba_coefficient.i
@@ -975,6 +975,7 @@ MatrixNumbaCoefficient* GenerateMatrixNumbaCoefficient(PyObject *numba_func, int
   using std::placeholders::_2;
   using std::placeholders::_3;
   //mfem::DenseMatrix &m = mfem::DenseMatrix(width, height);
+
   MatrixNumbaFunction2 *func_wrap = new MatrixNumbaFunction2(numba_func, width*height, td);
   if (td) {
           switch(mode){
@@ -1093,7 +1094,7 @@ try:
                 return ff
             return dec
 
-        def scalar(self, sdim=3, td=False, params={}, complex=False, dependency=None,
+        def scalar(self, sdim=3, td=False, params=None, complex=False, dependency=None,
                    interface="simple", debug=False):
             if dependency is None:
                 dependency = []

--- a/mfem/common/numba_coefficient.i
+++ b/mfem/common/numba_coefficient.i
@@ -735,7 +735,7 @@ class ScalarNumbaFunction2 : public NumbaFunctionBase {
 
     // FunctionCoefficient
     // mode   (0: real, 1: complex real part, 2: complex imag part)
-ScalarNumbaCoefficient* GenerateScalarNumbaCoefficient(PyObject *numba_func,  bool td, int mode){
+ScalarNumbaCoefficient* GenerateScalarNumbaCoefficient(PyObject *numba_func,  bool td, int mode, int sdim){
       using std::placeholders::_1;
       using std::placeholders::_2;
 
@@ -752,7 +752,7 @@ ScalarNumbaCoefficient* GenerateScalarNumbaCoefficient(PyObject *numba_func,  bo
             func_wrap->set_obj2(std::bind(&ScalarNumbaFunction2::callti, func_wrap, _1, _2));
             break;
           }
-          return new ScalarNumbaCoefficient(func_wrap->get_obj2(), func_wrap);
+          return new ScalarNumbaCoefficient(func_wrap->get_obj2(), func_wrap, sdim);
       } else {
           switch(mode){
           case 0:
@@ -765,7 +765,7 @@ ScalarNumbaCoefficient* GenerateScalarNumbaCoefficient(PyObject *numba_func,  bo
             func_wrap->set_obj1(std::bind(&ScalarNumbaFunction2::calli, func_wrap, _1));
             break;
           }
-          return new ScalarNumbaCoefficient(func_wrap->get_obj1(), func_wrap);
+          return new ScalarNumbaCoefficient(func_wrap->get_obj1(), func_wrap, sdim);
       }
 }
 // VectorFunctionCoefficient
@@ -848,7 +848,7 @@ class VectorNumbaFunction2 : public NumbaFunctionBase {
     std::function<void(const mfem::Vector &, mfem::Vector &)> get_obj1(){return obj1;}
     std::function<void(const mfem::Vector &, double, mfem::Vector &)> get_obj2(){return obj2;}
 };
-VectorNumbaCoefficient* GenerateVectorNumbaCoefficient(PyObject *numba_func, int vdim, bool td, int mode){
+VectorNumbaCoefficient* GenerateVectorNumbaCoefficient(PyObject *numba_func, int vdim, bool td, int mode, int sdim){
       using std::placeholders::_1;
       using std::placeholders::_2;
       using std::placeholders::_3;
@@ -868,7 +868,7 @@ VectorNumbaCoefficient* GenerateVectorNumbaCoefficient(PyObject *numba_func, int
             func_wrap->create_outc();
             break;
           }
-          return new VectorNumbaCoefficient(vdim, func_wrap->get_obj2(), func_wrap);
+          return new VectorNumbaCoefficient(vdim, func_wrap->get_obj2(), func_wrap, sdim);
       } else {
           switch(mode){
           case 0:
@@ -883,7 +883,7 @@ VectorNumbaCoefficient* GenerateVectorNumbaCoefficient(PyObject *numba_func, int
             func_wrap->create_outc();
             break;
           }
-          return new VectorNumbaCoefficient(vdim, func_wrap->get_obj1(), func_wrap);
+          return new VectorNumbaCoefficient(vdim, func_wrap->get_obj1(), func_wrap, sdim);
       }
 }
 
@@ -970,7 +970,7 @@ class MatrixNumbaFunction2 : public NumbaFunctionBase {
 
 };
 
-MatrixNumbaCoefficient* GenerateMatrixNumbaCoefficient(PyObject *numba_func, int width, int height, bool td, int mode){
+MatrixNumbaCoefficient* GenerateMatrixNumbaCoefficient(PyObject *numba_func, int width, int height, bool td, int mode, int sdim){
   using std::placeholders::_1;
   using std::placeholders::_2;
   using std::placeholders::_3;
@@ -990,7 +990,7 @@ MatrixNumbaCoefficient* GenerateMatrixNumbaCoefficient(PyObject *numba_func, int
             func_wrap->create_outc();
             break;
           }
-            return new MatrixNumbaCoefficient(width, func_wrap->get_obj2(), func_wrap);
+          return new MatrixNumbaCoefficient(width, func_wrap->get_obj2(), func_wrap, sdim);
    } else {
           switch(mode){
           case 0:
@@ -1005,7 +1005,7 @@ MatrixNumbaCoefficient* GenerateMatrixNumbaCoefficient(PyObject *numba_func, int
             func_wrap->create_outc();
             break;
           }
-          return new MatrixNumbaCoefficient(width, func_wrap->get_obj1(), func_wrap);
+          return new MatrixNumbaCoefficient(width, func_wrap->get_obj1(), func_wrap, sdim);
       }
 }
 
@@ -1149,14 +1149,14 @@ try:
                 ff = cfunc(caller_sig)(caller_func)
 
                 if complex:
-                     coeff = GenerateScalarNumbaCoefficient(ff, td, 1)
+                     coeff = GenerateScalarNumbaCoefficient(ff, td, 1, sdim)
                      coeff.SetOutComplex(setting["output"])
 
-                     coeff.real = GenerateScalarNumbaCoefficient(ff, td, 1)
-                     coeff.imag = GenerateScalarNumbaCoefficient(ff, td, 2)
+                     coeff.real = GenerateScalarNumbaCoefficient(ff, td, 1, sdim)
+                     coeff.imag = GenerateScalarNumbaCoefficient(ff, td, 2, sdim)
                      coeffs = (coeff, coeff.real, coeff.imag)
                 else:
-                     coeff = GenerateScalarNumbaCoefficient(ff, td, 0)
+                     coeff = GenerateScalarNumbaCoefficient(ff, td, 0, sdim)
                      coeff.SetOutComplex(setting["output"])
                      coeffs = (coeff, )
 
@@ -1241,14 +1241,14 @@ try:
                 ff = cfunc(caller_sig)(caller_func)
 
                 if complex:
-                     coeff = GenerateVectorNumbaCoefficient(ff, shape[0], td, 1)
+                     coeff = GenerateVectorNumbaCoefficient(ff, shape[0], td, 1, sdim)
                      coeff.SetOutComplex(setting["output"])
 
-                     coeff.real = GenerateVectorNumbaCoefficient(ff, shape[0], td, 1)
-                     coeff.imag = GenerateVectorNumbaCoefficient(ff, shape[0], td, 2)
+                     coeff.real = GenerateVectorNumbaCoefficient(ff, shape[0], td, 1, sdim)
+                     coeff.imag = GenerateVectorNumbaCoefficient(ff, shape[0], td, 2, sdim)
                      coeffs = (coeff, coeff.real, coeff.imag)
                 else:
-                     coeff =  GenerateVectorNumbaCoefficient(ff, shape[0], td, 0)
+                     coeff =  GenerateVectorNumbaCoefficient(ff, shape[0], td, 0, sdim)
                      coeff.SetOutComplex(setting["output"])
                      coeffs = (coeff, )
 
@@ -1328,15 +1328,15 @@ try:
                 ff = cfunc(caller_sig)(caller_func)
 
                 if complex:
-                     coeff = GenerateMatrixNumbaCoefficient(ff, shape[0], shape[1], td, 1)
+                     coeff = GenerateMatrixNumbaCoefficient(ff, shape[0], shape[1], td, 1, sdim)
                      coeff.SetOutComplex(setting["output"])
 
-                     coeff.real = GenerateMatrixNumbaCoefficient(ff, shape[0], shape[1], td, 1)
-                     coeff.imag = GenerateMatrixNumbaCoefficient(ff, shape[0], shape[1], td, 2)
+                     coeff.real = GenerateMatrixNumbaCoefficient(ff, shape[0], shape[1], td, 1, sdim)
+                     coeff.imag = GenerateMatrixNumbaCoefficient(ff, shape[0], shape[1], td, 2, sdim)
                      coeffs = (coeff, coeff.real, coeff.imag)
 
                 else:
-                     coeff = GenerateMatrixNumbaCoefficient(ff, shape[0], shape[1], td, 0)
+                     coeff = GenerateMatrixNumbaCoefficient(ff, shape[0], shape[1], td, 0, sdim)
                      coeff.SetOutComplex(setting["output"])
                      coeffs = (coeff, )
 

--- a/mfem/common/numba_coefficient.i
+++ b/mfem/common/numba_coefficient.i
@@ -1375,7 +1375,7 @@ try:
 
             if width is not None and shape is None:
                 shape = (width, height)
-            if vdim is None and shape is not None:
+            if height is None and width is None and shape is not None:
                 width = shape[0]
                 height = shape[1]
             assert height == shape[0], "height and shape[0] are not consistent"

--- a/mfem/common/numba_coefficient.i
+++ b/mfem/common/numba_coefficient.i
@@ -3,7 +3,7 @@
 #  using numba JIT function for mfem::FunctionCoefficient
 #
 (1) Using NumberFunction object  ---
-(2) Using mfem.jit decorator
+(2) Using mfem.jit decorator (recommended)
 
 --- (1) Using NumberFunction object  ---
 
@@ -62,24 +62,67 @@ def m_func(ptx, t, out, sdim, vdim):
 c = MatrixNumbaFunction(m_func, sdim, ndim, True).GenerateCoefficient()
 
 --- (2) mfem.jit decorator ---
+#
+#  This is a recommended way to use numba-compiled coefficient. It has
+#     1) a simpler interface using mfem.jit decorator
+#     2) dependecy support
+#     3) complex function (a coefficient which returns complex)
+#     4) ptx and out are already processed using carray (no need to call it)
+#
+(usage)
+sdim = mesh.SpaceDimension()
+@scalar(sdim, td=False, params={}, complex=False, dependencies=None)
+@vector(sdim, shape=None, td=False, params={}, complex=False, dependencies=None)
+@matrix(sdim, shape=None, td=False, params={}, complex=False, dependencies=None)
+
+(examples)
 # scalar coefficient
-@mfem.jit.scalar()
+sdim = mesh.SpaceDimension()
+
+@mfem.jit.scalar(sdim)
 def c12(ptx):
-    return s_func0(ptx[0], ptx[1],  ptx[2])
+    return ptx[0] * ptx[sdim-1]  ### note sdim is defined when this is compiled
+
+@mfem.jit.scalar(dependencies=((Er, Ei), density), complex=True))
+def c12(ptx, E, density):
+    return ptx[0] * (density * E[0].real + 1j*density.E[0].imag
+
 
 # vectorr coefficient
-@mfem.jit.vector()
+@mfem.jit.vector(sdim, shape = (3,))
 def f_exact(x, out):
     out[0] = (1 + kappa**2)*sin(kappa * x[1])
     out[1] = (1 + kappa**2)*sin(kappa * x[2])
     out[2] = (1 + kappa**2)*sin(kappa * x[0])
 
-# passing GridFunctin or VectorGridFunction coefficient
-@mfem.jit.vector(dependencies=E)
-def f_exact(x, out, E=None):
+# passing Scalar/Vector/Matrix coefficient including GridFunctionCoefficients
+# (Er, Ei) means complex number (GF for real and imaginary parts)
+# density is double.
+
+@mfem.jit.vector(sdim, dependencies=((Er, Ei), density), complex=True)
+def f_exact(x, E, density, out):
     out[0] = (1 + kappa**2)*sin(kappa * x[1])
     out[1] = (1 + kappa**2)*sin(kappa * x[2])
     out[2] = (1 + kappa**2)*sin(kappa * x[0])
+
+if return_complex=True, use .real and. imag as real and imaginary part
+coefficient
+   f_exact.real
+   f_exact.imag
+otherwise
+   f_exact is coefficient
+
+# vectorr coefficient
+@mfem.jit.matrix(3, shape = (3,3))
+def f_exact(x, out):
+    for i in range(ndim):
+        for j in range(ndim):
+            out_array[i, j] = i*m + j
+
+    out[0] = (1 + kappa**2)*sin(kappa * x[1])
+    out[1] = (1 + kappa**2)*sin(kappa * x[2])
+    out[2] = (1 + kappa**2)*sin(kappa * x[0])
+
 
 Then, decorated function can be used as function coefficient
 x.ProjectCoefficient(f_exact)       
@@ -97,48 +140,14 @@ x.ProjectCoefficient(f_exact)
 %}
 
 %inline %{
-classe FunctionCoefficeintExtra : public mfem::FunctionCoefficient{
-
- private:
-  mfem::Array<double> data;
-
- public:
-  void SetParams(mfem::Coefficient *coeff[], int num_coeff,
-		 mfem::VectorCoefficient *vcoeff[], int num_vcoeff)
-		 mfem::MatrixCoefficient *mcoeff[], int num_mcoeff){
-  }
-  double * PrepParams(){
-  }
-  virtual double Eval(ElementTransformation &T,
-		      const IntegrationPoint &ip){
-      double x[3];
-      Vector transip(x, 3);
-
-      T.Transform(ip, transip);
-
-      if (Function)
-      {
-         return Function(transip);
-      }
-      else
-      {
-         return TDFunction(transip, GetTime());
-      }
-  }
-
-  FunctionCoefficeintExtra::~FunctionCoefficeintExtra(){
-    if (data){
-      ~data;
-    }
-  }
-
-};
- 
 class NumbaFunctionBase{
  protected:
     void *address_;
     int  sdim_;
     bool td_;
+    double data[256];
+    double *data_ptr[16];
+    int datacount=0;
  public:
     NumbaFunctionBase(PyObject *input, int sdim, bool td): sdim_(sdim), td_(td){
        PyObject* module = PyImport_ImportModule("numba.core.ccallback");
@@ -164,6 +173,16 @@ class NumbaFunctionBase{
     double print_add(){
        std::cout << address_ << '\n';
        return 0;
+    }
+    double *GetData(){
+      return data;
+    }
+    double **GetPointer(){
+      return data_ptr;
+    }
+    
+    void SetDataCount(int x){
+      return datacount=x;
     }
     virtual ~NumbaFunctionBase(){}    
 };
@@ -215,8 +234,7 @@ class NumbaFunction : public NumbaFunctionBase {
         }
       }
    }
-};
- 
+}; 
 // VectorFunctionCoefficient     
 class VectorNumbaFunction : public NumbaFunctionBase {
  private:
@@ -350,24 +368,552 @@ class MatrixNumbaFunction : NumbaFunctionBase {
       }
     }
 };
+
+//
+//  NumbaCoefficeintBase  (hold list of coefficients which is used as a parameter for function coefficient)
+//
+classe NumbaCoefficeintBase:
+ private:
+  int num_coeffs;
+  int num_vcoeffs;
+  int num_mcoeffs;
+  int num_dep = 0;
+  int kinds[16];       // for now upto 16 coefficients
+  int iscomplex[16];   // for now upto 16 coefficients
+  mfem::Coefficient *coeff;
+  mfem::VectorCoefficient *vcoeff[];
+  mfem::MatrizCoefficient *mcoeff[];
+
+ protected:
+  NumbaFunctionBase *obj;
+
+ public:
+    NumbaCoefficeintBase(NumbaFunctionBase *in_obj): obj(in_obj){}
+
+  int ParamSize(){
+    return size;
+  }
+  void SetParams(mfem::Coefficient *in_coeff[], int in_num_coeffs,
+		 mfem::VectorCoefficient *in_vcoeff[], int in_num_vcoeffs,
+		 mfem::MatrixCoefficient *in_mcoeff[], int in_num_mcoeffs){
+    int size = 0;
+
+    size += in_num_coeffs;
+    for (int i = 0; i < in_num_vcoeffs; i++){
+      size += vcoeff[i].GetVdim();
+    }
+    for (int i = 0; i < in_num_mcoeffs; i++){
+      size += mcoeff[i].GetHeight() * mcoeff[i].GetWidth();
+    }
+    coeff = in_coeff;
+    vcoeff = in_vcoeff;
+    mcoeff = in_mcoeff;
+
+    num_coeffs = in_num_coeffs;
+    num_vcoeffs = in_num_vcoeffs;
+    num_mcoeffs = in_num_mcoeffs;
+
+    obj.SetDataCount(in_num_coeffs + in_num_vcoeffs + in_num_mcoeffs);
+
+    MFEM_ASSERT(size < 256, "dependency dim must be less than 256");
+    MFEM_ASSERT(in_num_coeffs + in_num_vcoeffs + in_num_mcoeffs) < 16, "dependency must be upto 16");
+  }
+
+  void PrepParams(ElementTransformation &T,
+		  const IntegrationPoint &ip){
+
+    int vdim, h, w = 0;
+    int idx = 0;
+    int inc = 0;
+    double *data = obj.GetData();
+    double **data_ptr=obj.GetPointer();
+    
+    int s_counter = 0;
+    int v_counter = 0;
+    int m_counter = 0;
+    int counter = 0;
+    for (int i = 0; i < num_dep; i++){
+        switch(kinds[i]){
+	case 0:// scalar
+           data[idx] = coeff[s_counter].Eval(T, ip);
+	   data_ptr[counter] = &data[idx];
+	     
+	   idx ++;	   
+	   s_counter ++;
+	   counter ++;
+
+	   
+	   if (iscomplex[i] == 1){
+               data[idx] = coeff[s_counter].Eval(T, ip);
+   	       data_ptr[counter] = &data[idx];
+		 
+	       idx ++	       
+   	       s_counter ++;
+   	       counter ++;	       
+	   }
+	   break;
+	case 1:// vector
+           vdim = vcoeff[i].GetVdim();
+           mfem::Vector V(vdim);
+	   vcoeff[v_counter].Eval(V, T, ip);
+	   
+	   data_ptr[counter] = &data[idx];	   
+	   for (int j = 0; j < vdim; ++){
+	     data[idx] =  V[j];
+	     idx ++;
+	   }
+	   v_counter ++;
+	   counter ++;
+	   
+	   if (iscomplex[i] == 1){	   
+	      vcoeff[v_counter].Eval(V, T, ip);
+
+	      data_ptr[counter] = &data[idx];	   	      
+	      for (int j = 0; j < vdim; ++){
+	          data[idx] =  V[j];
+		  idx ++;
+	      }
+	      v_counter ++;
+    	      counter ++;	      
+	   }
+	   break;
+	case 2:// matrix
+ 	   w = coeff[v_counter].Width();
+  	   h = coeff[v_counter].Height();
+           mfem::DenseMatrix M(h, w);	  
+	   mcoeff[m_counter].Eval(V, T, ip);
+
+	   data_ptr[counter] = &data[idx];
+           for (int jj = 0; jj < w; jj++){
+ 	      for (int ii = 0; ii < h; ii++){
+  	         data[idx] =  M(ii, jj);
+	         idx ++;
+	      }
+	   }
+	   m_counter ++;
+ 	   counter ++;
+	   
+	   if (iscomplex[i] == 1){
+  	      mcoeff[m_counter].Eval(V, T, ip);
+	      data_ptr[counter] = &data[idx];	      
+	      for (int jj = 0; jj < w; jj++){
+		for (int ii = 0; ii < h; ii++){
+		  data[idx] =  M(ii, jj);
+		  idx ++;
+		}
+	      }
+	      m_counter ++;
+    	      counter ++;	      	      
+	   }
+           break;
+	}
+    }
+  }
+  void SetKinds(PyObject *kinds_){
+  if (PyList_Check(kinds_)) {
+     int ll = PyList_Size(kinds_);
+     if (ll > 16){
+       PyErr_SetString(PyExc_ValueError, "Dependecy must be less than 16");
+       return 
+     }
+     for (int i = 0; i < ll; i++) {
+        PyObject *s = PyList_GetItem(kinds_, i);
+        kinds[i] = (int)PyInt_AsLong(s);
+     }
+     num_dep = ll;
+  } else if (PyTuple_Check(kinds_)) {
+     int ll = PyTuple_Size(kinds_);
+     for (int i = 0; i < ll; i++) {
+        PyObject *s = PyTuple_GetItem(kinds_,i);
+        kinds[i] = (int)PyInt_AsLong(s);
+     }
+     if (ll > 16){
+       PyErr_SetString(PyExc_ValueError, "Dependecy must be less than 16");
+       return 
+     }
+     num_dep = ll;     
+  } else {
+    PyErr_SetString(PyExc_ValueError, "Expecting a list/tuple");
+  }
+  }
+  void SetIsComplex(PyObject *isComplex_){
+  if (PyList_Check(isComplex_)) {
+     int ll = PyList_Size(isComplex_);
+     if (ll > 16){
+       PyErr_SetString(PyExc_ValueError, "Dependecy must be less than 16");
+       return 
+     }
+     for (int i = 0; i < ll; i++) {
+        PyObject *s = PyList_GetItem(isComplex_, i);
+        isComplex[i] = (int)PyInt_AsLong(s);
+     }
+     num_dep = ll;
+  } else if (PyTuple_Check(isComplex_)) {
+     int ll = PyTuple_Size(kinds_);
+     for (int i = 0; i < ll; i++) {
+        PyObject *s = PyTuple_GetItem(isComplex_,i);
+        isComplex[i] = (int)PyInt_AsLong(s);
+     }
+     num_dep = ll;     
+     if (ll > 16){
+       PyErr_SetString(PyExc_ValueError, "Dependecy must be less than 16");
+       return 
+     }
+  } else {
+    PyErr_SetString(PyExc_ValueError, "Expecting a list/tuple");
+  }
+  }
+  virtual ~NumbaCoefficeintBase(){delete obj;}
+};
+
+classe ScalaNumbaCoefficeint : public mfem::FunctionCoefficient,
+  public NumbaCoefficeintBase {
+ public:
+  ScalarNumbaCoefficeint(std::function<double(const Vector &)> F,
+			   NumbaFunctionBase *in_obj)
+    : FunctionCoefficient(std::move(F)), NumbaCoefficeintBase(in_obj){}
+  ScalarNumbaCoefficient(std::function<double(const Vector &, double)> TDF,
+ 			   NumbaFunctionBase *in_obj)
+   : FunctionCoefficient(std::move(TDF)), NumbaCoefficeintBase(in_obj){}
+  
+ virtual double Eval(ElementTransformation &T,
+		      const IntegrationPoint &ip){
+   PrepParams(T, ip);
+   return mfem::FunctionCoefficient::Eval(T, ip);
+};
+classe VectorNumbaCoefficeint : public mfem::VectorFunctionCoefficient,
+  public NumbaCoefficeintBase {
+ public:
+ VectorNumbaCoefficeint(int dim, std::function<double(const Vector &, DenseMatrix &)> F,
+		        NumbaFunctionBase *in_obj)
+   : VectorFunctionCoefficient(dim, std::move(F)), NumbaCoefficeintBase(in_obj){}
+ VectorNumbaCoefficient(int dim, std::function<double(const Vector &, double, DenseMatrix &)> TDF,
+   		        NumbaFunctionBase *in_obj)
+    : VectorFunctionCoefficient(dim, std::move(TDF)), NumbaCoefficeintBase(in_obj){}
+  
+  virtual double Eval(Vector &V, ElementTransformation &T,
+		      const IntegrationPoint &ip){
+   PrepParams(T, ip);
+   return mfem::VectorFunctionCoefficient::Eval(V, T, ip);
+};
+classe MatrixNumbaCoefficeint : public mfem::MatrixFunctionCoefficient,
+  public NumbaCoefficeintBase {
+ public:
+ MatrixNumbaCoefficeint(int dim, std::function<double(const Vector &, DenseMatrix &)> F,
+   			NumbaFunctionBase *in_obj)
+   : MatrixFunctionCoefficient(dim, std::move(F)), NumbaCoefficeintBase(in_obj){}
+ MatrixNumbaCoefficient(int dim, std::function<double(const Vector &, double, DenseMatrix &)> TDF,
+   			NumbaFunctionBase *in_obj)
+    : MatrixFunctionCoefficient(dim, std::move(TDF)), NumbaCoefficeintBase(in_obj){}
+  
+  virtual double Eval(DenseMatrix &K, ElementTransformation &T,
+		      const IntegrationPoint &ip){
+    PrepParams(T, ip);
+    return mfem::MatrixFunctionCoefficient::Eval(K, T, ip);
+};
+
+//  NumberFunction Implementation 2 (this is used for mfem.jit )
+class ScalarNumbaFunction2 : public NumbaFunctionBase {
+ private:
+    std::function<double(const mfem::Vector &)> obj1;
+    std::function<double(const mfem::Vector &, double t)> obj2;
+
+ public:
+    ScalarNumbaFunction2(PyObject *input):
+       NumbaFunctionBase(input, 3, false){}
+    
+    ScalarNumbaFunction2(PyObject *input, bool td):
+       NumbaFunctionBase(input, 3, td){}
+
+    double call(const mfem::Vector &x){
+      return ((double (*)(double *, double *))address_)(x.GetData(), data);
+    }
+    double callt(const mfem::Vector &x, double t){
+      return ((double (*)(double *, double, double *))address_)(x.GetData(), t, data);
+    }
+    // complex real part
+    double callr(const mfem::Vector &x){
+      std::complex<double> ret;
+      ret = ((std::complex<double> (*)(double *, double *))address_)(x.GetData(), data);
+      return ret.real;
+    }
+    double calltr(const mfem::Vector &x, double t){
+      std::complex<double> ret;            
+      ret = ((std::complex<double> (*)(double *, double, double *))address_)(x.GetData(), t, data);
+      return ret.real;      
+    }
+    // complex imag part
+    double calli(const mfem::Vector &x){
+      std::complex<double> ret;
+      ret = ((std::complex<double> (*)(double *, double *))address_)(x.GetData(), data);
+      return ret.imag;
+    }
+    double callti(const mfem::Vector &x, double t){
+      std::complex<double> ret;            
+      ret = ((std::complex<double> (*)(double *, double, double*, int))address_)(x.GetData(), t, data);
+      return ret.imag;      
+    }
+};
+    // FunctionCoefficient
+    // mode   (0: real, 1: complex real part, 2: complex imag part)
+ScalarNumbaCoefficient* GenerateScalarNumbaCoefficient(PyObject *numba_func,  bool td, int mode){    
+      using std::placeholders::_1;
+      using std::placeholders::_2;
+
+      ScalarNumbaFunction2 *func_wrap = new ScalarNumbaFunction2(numba_func, td);            
+      if (td_) {
+	  switch(mode){
+	  case 0:
+	    obj2 = std::bind(&NumbaFunction2::callt, this, _1, _2);
+	    break;
+	  case 1:
+	    obj2 = std::bind(&NumbaFunction2::calltr, this, _1, _2);
+	    break;	    
+	  case 2:
+	    obj2 = std::bind(&NumbaFunction2::callti, this, _1, _2);
+	    break;	    
+          }
+          return ScalarNumbaCoefficient(obj2, func_wrap);	  
+      } else {
+	  switch(mode){
+	  case 0:
+	    obj1 = std::bind(&NumbaFunction2::call, this, _1);
+	    break;	    	    
+	  case 1:
+	    obj1 = std::bind(&NumbaFunction2::callr, this, _1);
+	    break;	    	    
+	  case 2:
+	    obj1 = std::bind(&NumbaFunction2::calli, this, _1);
+	    break;	    
+          }
+          return ScalarNumbaCoefficient(obj1, func_wrap);
+      }    
+}
+// VectorFunctionCoefficient     
+class VectorNumbaFunction2 : public NumbaFunctionBase {
+ private:
+  std::function<void(const mfem::Vector &, mfem::Vector &)> obj1;
+  std::function<void(const mfem::Vector &, double, mfem::Vector &)> obj2;
+  int vdim_;
+  std::complex<double> *outc == nulptr;
+ public: 
+    VectorNumbaFunction2(PyObject *input, int vdim):
+       NumbaFunctionBase(input, 3, false), vdim_(vdim){}
+    
+    VectorNumbaFunction2(PyObject *input, int vdim, bool td):
+       NumbaFunctionBase(input, 3, td), vdim_(vdim){}
+
+    ~VectorNumbaFunction2(){delete [] outc};
+
+    void call(const mfem::Vector &x, mfem::Vector &out){
+      out = 0.0;
+      return ((void (*) (double *, double *))address_)(x.GetData(), 
+						       out.GetData());
+       
+    }
+    void callt(const mfem::Vector &x, double t, mfem::Vector &out){
+      out = 0.0;      
+      return ((void (*) (double *, double,  double *))address_)(x.GetData(),
+						                t,
+								out.GetData());
+    }
+    void callr(const mfem::Vector &x, mfem::Vector &out){
+      out = 0.0;
+      ((void (*) (double *, double *))address_)(x.GetData(), out.GetData());
+      for for (int i = 0; i < vdim_; i++) {
+	out[i] = outc[i].real;
+      }
+    }
+    void calltr(const mfem::Vector &x, double t, mfem::Vector &out){
+      out = 0.0;      
+      ((void (*) (double *, double,  std::complex<double> *))address_)(x.GetData(), t, outc);
+      for for (int i = 0; i < vdim_; i++) {
+	out[i] = outc[i].real;
+      }
+    }
+    void calli(const mfem::Vector &x, mfem::Vector &out){
+      out = 0.0;
+      ((void (*) (double *, double *))address_)(x.GetData(), outc);
+      for for (int i = 0; i < vdim_; i++) {
+	out[i] = outc[i].imag;
+      }
+       
+    }
+    void callti(const mfem::Vector &x, double t, mfem::Vector &out){
+      out = 0.0;
+      ((void (*) (double *, double,  std::complex<double> *))address_)(x.GetData(), t, outc);
+      for for (int i = 0; i < vdim_; i++) {
+	out[i] = outc[i].imag;
+      }
+    }
+    void create_outc(){
+       outc = new complex<double>[vdim_];
+    }
+};
+ 
+VectorNumbaCoefficient* GenerateVectorNumbaCoefficient(PyObject *numba_func, int vdim, bool td, int mode){
+      using std::placeholders::_1;
+      using std::placeholders::_2;
+      using std::placeholders::_3;
+      
+      VectorNumbaFunction2 *func_wrap = new VectorNumbaFunction2(numba_func, vdim, td);      
+      if (td_) {
+	  switch(mode){
+	  case 0:
+	    obj1 = std::bind(&VectorNumbaFunction2::callt, this, _1, _2, _3);
+	    break;
+	  case 1:
+	    obj1 = std::bind(&VectorNumbaFunction2::calltr, this, _1, _2, _3);
+            func_wrap->create_outc();	    	    
+	    break;	    
+	  case 2:
+	    obj1 = std::bind(&VectorNumbaFunction2::callti, this, _1, _2, _3);
+            func_wrap->create_outc();	    	    	    
+	    break;	    
+          }
+          return new VectorNumbaCoefficientExtra(vdim_, obj1, func_wrap);	  	  
+      } else {
+	  switch(mode){
+	  case 0:
+	    obj2 = std::bind(&VectorNumbaFunction2::call, this, _1, _2);
+	    break;	    	    
+	  case 1:
+	    obj2 = std::bind(&VectorNumbaFunction2::callr, this, _1, _2);
+            func_wrap->create_outc();	    	    	    	    
+	    break;	    	    
+	  case 2:
+	    obj2 = std::bind(&VectorNumbaFunction2::calli, this, _1, _2);
+            func_wrap->create_outc();	    	    	    	    	    
+	    break;		    
+          }
+          return new VectorNumbaCoefficient(vdim_, obj2, func_wrap);	  
+      }    
+}
+
+// MatrixFunctionCoefficient
+class MatrixNumbaFunction2 : NumbaFunctionBase {
+ private:
+  std::function<void(const mfem::Vector &, mfem::DenseMatrix &)> obj1;
+  std::function<void(const mfem::Vector &, double, mfem::DenseMatrix &)> obj2;
+  int vdim_;
+  complex<double> *outc;
+ public:
+    MatrixNumbaFunction2(PyObject *input, int vdim)
+       NumbaFunctionBase(input, 3, false), vim_(vdim){}
+    MatrixNumbaFunction2(PyObject *input, int vdim, bool td):
+       NumbaFunctionBase(input, 3, td), vdim_(vdim){}
+    ~MatrixNumbaFunction2(){delete [] outc};
+
+    void call(const mfem::Vector &x, mfem::DenseMatrix &out){
+      out = 0.0;
+      return ((void (*) (double *, double *))address_)(x.GetData(), 
+						       out.GetData());
+       
+    }
+    void callt(const mfem::Vector &x, double t, mfem::DenseMatrix &out){
+      out = 0.0;      
+      return ((void (*) (double *, double,  double *))address_)(x.GetData(),
+						                t,
+								out.GetData());
+    }
+    void callr(const mfem::Vector &x, mfem::DenseMatrix &out){
+      out = 0.0;
+      ((void (*) (double *, double *))address_)(x.GetData(), out.GetData());
+      for for (int i = 0; i < vdim_; i++) {
+	out[i] = outc[i].real;
+      }
+    }
+    void calltr(const mfem::Vector &x, double t, mfem::DenseMatrix &out){
+      out = 0.0;      
+      ((void (*) (double *, double,  std::complex<double> *))address_)(x.GetData(), t, outc);
+      for for (int i = 0; i < vdim_; i++) {
+	out[i] = outc[i].real;
+      }
+    }
+    void calli(const mfem::Vector &x, mfem::DenseMatrix &out){
+      out = 0.0;
+      ((void (*) (double *, double *))address_)(x.GetData(), outc);
+      for for (int i = 0; i < vdim_; i++) {
+	out[i] = outc[i].imag;
+      }
+       
+    }
+    void callti(const mfem::Vector &x, double t, mfem::DenseMatrix &out){
+      out = 0.0;
+      ((void (*) (double *, double,  std::complex<double> *))address_)(x.GetData(), t, outc);
+      for for (int i = 0; i < vdim_; i++) {
+	out[i] = outc[i].imag;
+      }
+    }
+    void create_outc(){
+       outc = new complex<double>[vdim_];
+    }
+};
+   
+MatrixNumbaCoefficient* GenerateMatrixNumbaCoefficient(PyObject *numba_func, int vdim, bool td, int mode){
+  using std::placeholders::_1;
+  using std::placeholders::_2;
+  using std::placeholders::_3;
+
+  MatrixNumbaFunction2 *func_wrap = new MatrixNumbaFunction2(numba_func, vdim, td);
+  if (td_) {
+	  switch(mode){
+	  case 0:
+	    obj1 = std::bind(&MatrixNumbaFunction2::callt, func_wrap, _1, _2, _3);
+	    break;
+	  case 1:
+	    obj1 = std::bind(&MatrixNumbaFunction2::calltr, func_wrap, _1, _2, _3);
+            func_wrap->create_outc();	    
+	    break;
+	  case 2:
+	    obj1 = std::bind(&MatrixNumbaFunction2::callti, func_wrap, _1, _2, _3);
+            func_wrap->create_outc();
+	    break;
+          }
+          return new MatrixNumbaCoefficient(vdim_, obj1, func_wrap);	  	  
+   } else {
+	  switch(mode){
+	  case 0:
+	    obj2 = std::bind(&MatrixNumbaFunction2::call, func_wrap, _1, _2);
+	    break;
+	  case 1:
+	    obj2 = std::bind(&MatrixNumbaFunction2::callr, func_wrap, _1, _2);
+            func_wrap->create_outc();	    
+	    break;
+	  case 2:
+	    obj2 = std::bind(&MatrixNumbaFunction2::calli, func_wrap, _1, _2);
+            func_wrap->create_outc();	    	    
+	    break;
+          }
+          return new MatrixNumbaCoefficient(vdim_, obj2, func_wrap);	  
+      }    
+}
  
 %}
 
 %newobject NumbaFunction::GenerateCoefficient;
-%newobject NumbaFunction::GenerateCoefficientT;
 %newobject VectorNumbaFunction::GenerateCoefficient;
-%newobject VectorNumbaFunction::GenerateCoefficientT;
 %newobject MatrixNumbaFunction::GenerateCoefficient;
-%newobject MatrixNumbaFunction::GenerateCoefficientT;
+%newobject GenerateScalarNumbaCoefficient;
+%newobject GenerateVectorNumbaCoefficient;
+%newobject GenerateMatrixNumbaCoefficient;
 
 %pythoncode %{
+
+from mfem.commmon.numba_coefficient_utils import (generate_caller_scaler,
+						  generate_caller_array,
+						  generate_signature_scalar,
+						  generate_signature_array,
+						  get_setting)
+						  
+
 try:
     from numba import cfunc, types, carray
     scalar_sig = types.double(types.CPointer(types.double),
-			  types.intc)
+			      types.intc,)
     scalar_sig_t = types.double(types.CPointer(types.double),
-			    types.double,
-			    types.intc)
+				types.double,
+				types.intc,)
     vector_sig = types.void(types.CPointer(types.double),
 			types.CPointer(types.double),
 			types.intc,
@@ -380,9 +926,16 @@ try:
   
     matrix_sig = vector_sig
     matrix_sig_t = vector_sig_t
+
+
       
     from inspect import signature
-      
+
+    class ComplexCoefficient()
+        def __init__(self):
+            self.real = None
+	    self.imag = None
+
     class _JIT(object):
         def _copy_func_and_apply_params(self, f, params):
             import copy
@@ -408,80 +961,162 @@ try:
                 return ff
             return dec
 
-        def scalar(self, sdim=3, td=False, params={}):
+        def scalar(self, sdim=3, td=False, params={}, complex=False, dependencies=None):
+            if dependencies is None:
+                dependencies = []
+            if params is None:
+                params = {}
+            params["sdim"] = sdim
+			
             def dec(func):
-                l = len(signature(func).parameters)
-                if l == 1 and not td:
-                    sig = types.double(types.CPointer(types.double))
-                    use_0 = 1
-                elif l == 2 and not td:
-                    sig = scalar_sig
-                    use_0 = 0			  
-                elif l == 2 and td:
-                    sig = types.double(types.CPointer(types.double),
-                    types.double)
-                    use_0 = 1			  			  
-                elif l == 3 and td:
-                    sig = scalar_sig_t
-                    use_0 = 0			  			  			  
-                from numba import cfunc
+	        from numba import cfunc, njit
+			
+		setting = get_setting(1, complex, dependencies)
+
+		sig = generate_signature_scalar(setting)
+			
                 gfunc=self._copy_func_and_apply_params(func, params)
-                ff = cfunc(sig)(gfunc)
-                coeff = NumbaFunction(ff, sdim, td).GenerateCoefficient(use_0)
+                ff = ngit(sig)(gfunc)
+			
+                if td
+                    caller_sig = types.double(types.CPointer(types.double),
+				       types.double, 
+				       types.CPointer(types.double))
+		else:
+                    caller_sig = types.double(types.CPointer(types.double),
+                                        types.CPointer(types.double))
+
+	        exec(generate_caller_scaler(settings))  # this defines _caller_func
+	        callar_params = {"inner_func": _caller_func,  "sdim": sdim}}
+                caller_func = self._copy_func_and_apply_params(_caller_func, caller_params)
+                ff = cfunc(caller_sig)(caller_func)		      
+                 
+ 	        if complex:
+                     coeff = ComplexCoefficient()
+		     coeff.real = GenerateScalarNumbaCoefficient(ff, td, 1)
+		     coeff.imag = GenerateScalarNumbaCoefficient(ff, td, 2)		       
+	             coeffs = (coeff.real, coeff.imag)
+                else:
+		     coeff = GenerateScalarNumbaCoefficient(ff, td, 0)		       
+	             coeffs = (coeff, )
+
+                for c in coeffs:
+	             c.SetParams(setting["s_coeffs"], len(setting["s_coeffs"]),
+		                 setting["v_coeffs"], len(setting["v_coeffs"]),
+				 setting["m_coeffs"], len(setting["m_coeffs"]),)
+		     c.SetIsComplex(setting["iscomplex"])
+                     c.SetKinds(setting["kinds"])			
                 return coeff
             return dec
-        def vector(self, sdim=3, vdim=-1, td=False, params={}):
-            vdim = sdim if vdim==-1 else vdim
+			
+        def vector(self, sdim, shape=None, td=False, params=None, complex=False, dependencies=None):
+            shape = (sdim, ) if shape is None else shape
+            if dependencies is None:
+                dependencies = []
+            if params is None:
+                params = {}
+            params["sdim"] = sdim
+            params["shape"] = shape
+
             def dec(func):
-                l = len(signature(func).parameters)
-                if l == 2 and not td:
-                    sig = types.void(types.CPointer(types.double),
-                                     types.CPointer(types.double),)
-                    use_0 = 1
-                elif l == 4 and not td:
-                    sig = vector_sig
-                    use_0 = 0			  
-                elif l == 3 and td:
-                    sig = types.void(types.CPointer(types.double),
-                                     types.CPointer(types.double),
-                                     types.double)
-                    use_0 = 1			  			  
-                elif l == 5 and td:
-                    sig = vector_sig_t
-                    use_0 = 0			  			  			  
+	        from numba import cfunc, njit
+
+                #l = len(signature(func).parameters) - len(dependencies)
+		setting = get_setting(shape[0], complex, dependencies)
+
+		sig = generate_signature_array(setting)
+			
+                gfunc=self._copy_func_and_apply_params(func, params)
+                ff = ngit(sig)(gfunc)
+  
+                if td
+                    caller_sig = types.double(types.CPointer(types.double),
+					      types.double,
+					      types.CPointer(types.double),
+					      types.CPointer(types.double))
+		else:
+                    caller_sig = types.double(types.CPointer(types.double),
+					      types.CPointer(types.double),
+					      types.CPointer(types.double))	      
+  
+	        exec(generate_caller_array(settings))  # this defines _caller_func
+	        callar_params = {'inner_func': _caller_func,  "sdim": sdim}}
+                caller_func = self._copy_func_and_apply_params(_caller_func, caller_params)
+                ff = cfunc(caller_sig)(caller_func)		      
+
+		      
+ 	        if complex:
+                     coeff = ComplexCoefficient()
+	             coeff.real = GenerateVectorNumbaCoefficient(ff, shape[0], td, 1)
+		     coeff.imag = GenerateVectorNumbaCoefficient(ff, shape[0], td, 2)
+	             coeffs = (coeff.real, coeff.imag)
                 else:
-                    assert False, "Unsupported signature type"
-                from numba import cfunc
-                gfunc=self._copy_func_and_apply_params(func, params)		      
-                ff = cfunc(sig)(gfunc)
-                coeff = VectorNumbaFunction(ff, sdim, vdim, td).GenerateCoefficient(use_0)
+		     coeff =  GenerateVectorNumbaCoefficient(ff, shape[0], td, 0)
+	             coeffs = (coeff, )
+
+                for c in coeffs:
+	             c.SetParams(setting["s_coeffs"], len(setting["s_coeffs"]),
+		                 setting["v_coeffs"], len(setting["v_coeffs"]),
+				 setting["m_coeffs"], len(setting["m_coeffs"]),)
+		     c.SetIsComplex(setting["iscomplex"])
+                     c.SetKinds(setting["kinds"])			
                 return coeff
             return dec
-        def matrix(self, sdim=3, vdim=-1, td=False, params={}):
-            vdim = sdim if vdim==-1 else vdim				   
+
+        def matrix(self, sdim, shape=None, td=False, params=None, complex=False, dependencies=None):
+            shape = (sdim, sdim) if shape is None else
+	    assert shape[0] == shape[1], "must be squre matrix"
+
+            if dependencies is None:
+                dependencies = []
+            if params is None:
+                params = {}
+            params["sdim"] = sdim
+            params["shape"] = shape
+
             def dec(func):
-                l = len(signature(func).parameters)
-                if l == 2 and not td:
-                    sig = types.void(types.CPointer(types.double),
-                                     types.CPointer(types.double),)
-                    use_0 = 1
-                elif l == 4 and not td:
-                    sig = matrix_sig
-                    use_0 = 0			  
-                elif l == 3 and td:
-                    sig = types.void(types.CPointer(types.double),
-                                     types.CPointer(types.double),
-                                     types.double)
-                    use_0 = 1			  			  
-                elif l == 5 and td:
-                    sig = matrix_sig_t
-                    use_0 = 0			  			  			  
-                else:
-                    assert False, "Unsupported signature type"
-                from numba import cfunc
+	        from numba import cfunc, njit
+
+                #l = len(signature(func).parameters) - len(dependencies)
+					   
+		setting = get_setting((shape[0],shape[1]), complex, dependencies)
+
+		sig = generate_signature_array(setting)
+			
                 gfunc=self._copy_func_and_apply_params(func, params)
-                ff = cfunc(sig)(gfunc)
-                coeff = MatrixNumbaFunction(ff, sdim, vdim, td).GenerateCoefficient(use_0)
+                ff = ngit(sig)(gfunc)
+  
+                if td
+                    caller_sig = types.double(types.CPointer(types.double),
+					      types.double,
+					      types.CPointer(types.double),
+					      types.CPointer(types.double))
+		else:
+                    caller_sig = types.double(types.CPointer(types.double),
+					      types.CPointer(types.double),
+					      types.CPointer(types.double))	      
+  
+	        exec(generate_caller_array(settings))  # this defines _caller_func
+		      callar_params = {"inner_func": _caller_func, "sdim": sdim}
+                caller_func = self._copy_func_and_apply_params(_caller_func, caller_params)
+                ff = cfunc(caller_sig)(caller_func)		      
+
+		      
+ 	        if complex:
+                     coeff = ComplexCoefficient()
+	             coeff.real = GenerateMatrixNumbaCoefficient(ff, shape[0], td, 1)
+		     coeff.imag = GenerateMatrixNumbaCoefficient(ff, shape[0], td, 2)
+	             coeffs = (coeff.real, coeff.imag)
+                else:
+   		     coeff = GenerateMatrixNumbaCoefficient(ff, shape[0], td, 0)
+	             coeffs = (coeff, )
+
+                for c in coeffs:
+	             c.SetParams(setting["s_coeffs"], len(setting["s_coeffs"]),
+		                 setting["v_coeffs"], len(setting["v_coeffs"]),
+				 setting["m_coeffs"], len(setting["m_coeffs"]),)
+		     c.SetIsComplex(setting["iscomplex"])
+                     c.SetKinds(setting["kinds"])			
                 return coeff
             return dec
     jit = _JIT()

--- a/mfem/common/numba_coefficient.i
+++ b/mfem/common/numba_coefficient.i
@@ -73,9 +73,9 @@ c = MatrixNumbaFunction(m_func, sdim, ndim, True).GenerateCoefficient()
 sdim = mesh.SpaceDimension()
 @scalar(sdim, td=False, params={}, complex=False, dependency=None, interface='simple',
         debug=False)
-@vector(sdim, shape=None, td=False, params={}, complex=False, dependency=None, 
+@vector(sdim, shape=None, td=False, params={}, complex=False, dependency=None,
         interface='simple', debug=False)
-@matrix(sdim, shape=None, td=False, params={}, complex=False, dependency=None, 
+@matrix(sdim, shape=None, td=False, params={}, complex=False, dependency=None,
         interface='simple', debug=False)
 
 sdim: space dimenstion
@@ -85,7 +85,7 @@ complex: complex coefficient
 depenency: dependency to other coefficient
 interface: calling proceture
    'simple': vector/matric function returns the result by value more pythonic.
-   'c++style': vector/matric function returns the result by parameter like C++
+   'c++': vector/matric function returns the result by parameter like C++
     other options: one can pass a tuple of (caller, signature) pair to create a custom
                    interface
 debug: extra debug print
@@ -1065,8 +1065,10 @@ try:
                 return coeff
             return dec
 
-        def vector(self, sdim=3, shape=None, td=False, params=None,
+        def vector(self, sdim=3, vdim=None, shape=None, td=False, params=None,
                    complex=False, dependency=None, interface="simple", debug=False):
+            if vdim is not None:
+                shape = (vdim, )
             shape = (sdim, ) if shape is None else shape
             if dependency is None:
                 dependency = []
@@ -1082,7 +1084,7 @@ try:
 
                 if interface == "simple":
                     sig = generate_signature_array(setting)
-                elif interface == "c++style":
+                elif interface == "c++":
                     sig = generate_signature_array_oldstyle(setting)
                 else:
                     sig = interface[1](setting)
@@ -1110,7 +1112,7 @@ try:
 
                 if interface == "simple":
                     caller_txt = generate_caller_array(setting)
-                elif interface == "c++style":
+                elif interface == "c++":
                     caller_txt = generate_caller_array_oldstyle(setting)
                 else:
                     caller_txt = interface[0](setting)
@@ -1119,8 +1121,13 @@ try:
                      print("(DEBUG) generated caller function:", caller_txt)
 
                 exec(caller_txt, globals(), locals())
-                caller_params = {"inner_func": ff, "sdim": sdim, "np":np,
+
+                caller_params = {"inner_func": ff, "sdim": sdim, "np":np, "shape":shape,
                                  "carray":carray, "farray":farray}
+
+                if vdim is not None:
+                    caller_params["vdim"] = vdim
+
                 caller_func = self._copy_func_and_apply_params(locals()["_caller"], caller_params)
                 ff = cfunc(caller_sig)(caller_func)
 
@@ -1161,7 +1168,7 @@ try:
 
                 if interface == "simple":
                     sig = generate_signature_array(setting)
-                elif interface == "c++style":
+                elif interface == "c++":
                     sig = generate_signature_array_oldstyle(setting)
                 else:
                     sig = interface[1](setting)
@@ -1188,7 +1195,7 @@ try:
 
                 if interface == "simple":
                     caller_txt = generate_caller_array(setting)
-                elif interface == "c++style":
+                elif interface == "c++":
                     caller_txt = generate_caller_array_oldstyle(setting)
                 else:
                     caller_txt = interface[0](setting)
@@ -1198,7 +1205,7 @@ try:
 
                 exec(caller_txt, globals(), locals())
 
-                caller_params = {"inner_func": ff, "sdim": sdim, "np":np,
+                caller_params = {"inner_func": ff, "sdim": sdim, "np":np, "shape":shape,
                                  "carray":carray, "farray":farray}
                 caller_func = self._copy_func_and_apply_params(locals()["_caller"], caller_params)
                 ff = cfunc(caller_sig)(caller_func)

--- a/mfem/common/numba_coefficient.i
+++ b/mfem/common/numba_coefficient.i
@@ -98,9 +98,14 @@ def f_exact(x, out):
 # passing Scalar/Vector/Matrix coefficient including GridFunctionCoefficients
 # (Er, Ei) means complex number (GF for real and imaginary parts)
 # density is double.
+<<<<<<< HEAD
 
 @mfem.jit.vector(sdim, dependencies=((Er, Ei), density), complex=True)
 def f_exact(x, E, density, out):
+=======
+@mfem.jit.vector(dependencies=((Er, Ei), density), return_complex=True)
+def f_exact(x, out, E=None):
+>>>>>>> 4d4d254 ((WIP)....)
     out[0] = (1 + kappa**2)*sin(kappa * x[1])
     out[1] = (1 + kappa**2)*sin(kappa * x[2])
     out[2] = (1 + kappa**2)*sin(kappa * x[0])
@@ -112,6 +117,7 @@ coefficient
 otherwise
    f_exact is coefficient
 
+<<<<<<< HEAD
 # vectorr coefficient
 @mfem.jit.matrix(3, shape = (3,3))
 def f_exact(x, out):
@@ -124,6 +130,8 @@ def f_exact(x, out):
     out[2] = (1 + kappa**2)*sin(kappa * x[0])
 
 
+=======
+>>>>>>> 4d4d254 ((WIP)....)
 Then, decorated function can be used as function coefficient
 x.ProjectCoefficient(f_exact)       
 
@@ -200,6 +208,7 @@ class NumbaFunction : public NumbaFunctionBase {
        NumbaFunctionBase(input, sdim, td){}
 
     double call0(const mfem::Vector &x){
+<<<<<<< HEAD
       return ((double (*)(double *))address_)(x.GetData());
     }
     double call(const mfem::Vector &x){
@@ -210,7 +219,20 @@ class NumbaFunction : public NumbaFunctionBase {
     }
     double callt(const mfem::Vector &x, double t){
       return ((double (*)(double *, double, int))address_)(x.GetData(), t, sdim_);
+=======
+      return ((double (*)(double *, void **, int))address_)(x.GetData(), data);
     }
+    double call(const mfem::Vector &x){
+      return ((double (*)(double *, void**, int, int))address_)(x.GetData(), data, sdim_);
+    }
+    double call0t(const mfem::Vector &x, double t){
+      return ((double (*)(double *, double, int))address_)(x.GetData(), t, data);
+    }
+    double callt(const mfem::Vector &x, double t){
+      return ((double (*)(double *, double, int, int))address_)(x.GetData(), t, data, sdim_);
+>>>>>>> 4d4d254 ((WIP)....)
+    }
+    
 
     // FunctionCoefficient
     mfem::FunctionCoefficient* GenerateCoefficient(int use_0=0){

--- a/mfem/common/numba_coefficient.i
+++ b/mfem/common/numba_coefficient.i
@@ -71,9 +71,12 @@ c = MatrixNumbaFunction(m_func, sdim, ndim, True).GenerateCoefficient()
 #
 (usage)
 sdim = mesh.SpaceDimension()
-@scalar(sdim, td=False, params={}, complex=False, dependency=None, interface='simple')
-@vector(sdim, shape=None, td=False, params={}, complex=False, dependency=None, interface='simple')
-@matrix(sdim, shape=None, td=False, params={}, complex=False, dependency=None, interface='simple')
+@scalar(sdim, td=False, params={}, complex=False, dependency=None, interface='simple',
+        debug=False)
+@vector(sdim, shape=None, td=False, params={}, complex=False, dependency=None, 
+        interface='simple', debug=False)
+@matrix(sdim, shape=None, td=False, params={}, complex=False, dependency=None, 
+        interface='simple', debug=False)
 
 sdim: space dimenstion
 shape: shape of return value
@@ -85,6 +88,7 @@ interface: calling proceture
    'c++style': vector/matric function returns the result by parameter like C++
     other options: one can pass a tuple of (caller, signature) pair to create a custom
                    interface
+debug: extra debug print
 
 (examples)
 # scalar coefficient
@@ -989,7 +993,7 @@ try:
             return dec
 
         def scalar(self, sdim=3, td=False, params={}, complex=False, dependency=None,
-                   interface="default"):
+                   interface="default", debug=False):
             if dependency is None:
                 dependency = []
             if params is None:
@@ -1007,6 +1011,9 @@ try:
                     sig = generate_signature_scalar(setting)
                 else:
                     sig = interface[1](setting)
+
+                if debug:
+                    print("(DEBUG) signature for function:", sig)
 
                 gfunc=self._copy_func_and_apply_params(func, params)
                 ff = njit(sig)(gfunc)
@@ -1030,6 +1037,9 @@ try:
                      caller_txt = generate_caller_scalar(setting)
                 else:
                   caller_txt = interface[0](setting)
+
+                if debug:
+                     print("(DEBUG) generated caller function:", caller_txt)
 
                 exec(caller_txt, globals(), locals())
                 caller_params = {"inner_func": ff,  "sdim": sdim,
@@ -1056,7 +1066,7 @@ try:
             return dec
 
         def vector(self, sdim=3, shape=None, td=False, params=None,
-                   complex=False, dependency=None, interface="simple"):
+                   complex=False, dependency=None, interface="simple", debug=False):
             shape = (sdim, ) if shape is None else shape
             if dependency is None:
                 dependency = []
@@ -1077,6 +1087,9 @@ try:
                 else:
                     sig = interface[1](setting)
 
+                if debug:
+                    print("(DEBUG) signature for function:", sig)
+
                 gfunc=self._copy_func_and_apply_params(func, params)
                 ff = njit(sig)(gfunc)
 
@@ -1096,13 +1109,16 @@ try:
                                             types.CPointer(outtype))
 
                 if interface == "simple":
-                    caller_text = generate_caller_array(setting)
+                    caller_txt = generate_caller_array(setting)
                 elif interface == "c++style":
-                    caller_text = generate_caller_array_oldstyle(setting)
+                    caller_txt = generate_caller_array_oldstyle(setting)
                 else:
-                    caller_text = interface[0](setting)
+                    caller_txt = interface[0](setting)
 
-                exec(caller_text, globals(), locals())
+                if debug:
+                     print("(DEBUG) generated caller function:", caller_txt)
+
+                exec(caller_txt, globals(), locals())
                 caller_params = {"inner_func": ff, "sdim": sdim, "np":np,
                                  "carray":carray, "farray":farray}
                 caller_func = self._copy_func_and_apply_params(locals()["_caller"], caller_params)
@@ -1127,7 +1143,7 @@ try:
             return dec
 
         def matrix(self, sdim=3, shape=None, td=False, params=None,
-                   complex=False, dependency=None, interface="simple"):
+                   complex=False, dependency=None, interface="simple", debug=False):
             shape = (sdim, sdim) if shape is None else shape
             assert shape[0] == shape[1], "must be squre matrix"
 
@@ -1150,6 +1166,9 @@ try:
                 else:
                     sig = interface[1](setting)
 
+                if debug:
+                    print("(DEBUG) signature for function:", sig)
+
                 gfunc=self._copy_func_and_apply_params(func, params)
                 ff = njit(sig)(gfunc)
 
@@ -1168,13 +1187,16 @@ try:
                                             types.CPointer(outtype))
 
                 if interface == "simple":
-                    caller_text = generate_caller_array(setting)
+                    caller_txt = generate_caller_array(setting)
                 elif interface == "c++style":
-                    caller_text = generate_caller_array_oldstyle(setting)
+                    caller_txt = generate_caller_array_oldstyle(setting)
                 else:
-                    caller_text = interface[0](setting)
+                    caller_txt = interface[0](setting)
 
-                exec(caller_text, globals(), locals())
+                if debug:
+                     print("(DEBUG) generated caller function:", caller_txt)
+
+                exec(caller_txt, globals(), locals())
 
                 caller_params = {"inner_func": ff, "sdim": sdim, "np":np,
                                  "carray":carray, "farray":farray}

--- a/mfem/common/numba_coefficient.i
+++ b/mfem/common/numba_coefficient.i
@@ -1186,7 +1186,7 @@ try:
                                                    setting["ns_coeffs"],
                                                    setting["nv_coeffs"],
                                                    setting["nm_coeffs"])
-
+                     c._dependency_link = dependency
                 return coeff
             return dec
 
@@ -1278,7 +1278,7 @@ try:
                                                    setting["ns_coeffs"],
                                                    setting["nv_coeffs"],
                                                    setting["nm_coeffs"])
-
+                     c._dependency_link = dependency
                 return coeff
             return dec
 
@@ -1366,6 +1366,7 @@ try:
                                                    setting["ns_coeffs"],
                                                    setting["nv_coeffs"],
                                                    setting["nm_coeffs"])
+                     c._dependency_link = dependency
                 return coeff
             return dec
     jit = _JIT()

--- a/mfem/common/numba_coefficient.i
+++ b/mfem/common/numba_coefficient.i
@@ -62,11 +62,21 @@ def m_func(ptx, t, out, sdim, vdim):
 c = MatrixNumbaFunction(m_func, sdim, ndim, True).GenerateCoefficient()
 
 --- (2) mfem.jit decorator ---
+# scalar coefficient
 @mfem.jit.scalar()
 def c12(ptx):
     return s_func0(ptx[0], ptx[1],  ptx[2])
+
+# vectorr coefficient
 @mfem.jit.vector()
 def f_exact(x, out):
+    out[0] = (1 + kappa**2)*sin(kappa * x[1])
+    out[1] = (1 + kappa**2)*sin(kappa * x[2])
+    out[2] = (1 + kappa**2)*sin(kappa * x[0])
+
+# passing GridFunctin or VectorGridFunction coefficient
+@mfem.jit.vector(dependencies=E)
+def f_exact(x, out, E=None):
     out[0] = (1 + kappa**2)*sin(kappa * x[1])
     out[1] = (1 + kappa**2)*sin(kappa * x[2])
     out[2] = (1 + kappa**2)*sin(kappa * x[0])

--- a/mfem/common/numba_coefficient.i
+++ b/mfem/common/numba_coefficient.i
@@ -708,7 +708,7 @@ class VectorNumbaFunction2 : public NumbaFunctionBase {
     }
     void callr(const mfem::Vector &x, mfem::Vector &out){
       out = 0.0;
-      ((void (*) (double *, void **, double *))address_)(x.GetData(), (void **)data_ptr, out.GetData());
+      ((void (*) (double *, void **, std::complex<double> *))address_)(x.GetData(), (void **)data_ptr, outc);
       for (int i = 0; i < vdim_; i++) {
         out[i] = outc[i].real();
       }
@@ -730,7 +730,7 @@ class VectorNumbaFunction2 : public NumbaFunctionBase {
     }
     void callti(const mfem::Vector &x, double t, mfem::Vector &out){
       out = 0.0;
-      ((void (*) (double *, double, void**,  std::complex<double> *))address_)(x.GetData(), t, (void**)data_ptr,  outc);
+      ((void (*) (double *, double, void**, std::complex<double> *))address_)(x.GetData(), t, (void**)data_ptr,  outc);
       for (int i = 0; i < vdim_; i++) {
         out[i] = outc[i].imag();
       }
@@ -867,7 +867,7 @@ MatrixNumbaCoefficient* GenerateMatrixNumbaCoefficient(PyObject *numba_func, int
   using std::placeholders::_1;
   using std::placeholders::_2;
   using std::placeholders::_3;
-
+  //mfem::DenseMatrix &m = mfem::DenseMatrix(width, height);
   MatrixNumbaFunction2 *func_wrap = new MatrixNumbaFunction2(numba_func, width*height, td);
   if (td) {
           switch(mode){
@@ -883,7 +883,7 @@ MatrixNumbaCoefficient* GenerateMatrixNumbaCoefficient(PyObject *numba_func, int
             func_wrap->create_outc();
             break;
           }
-          return new MatrixNumbaCoefficient(width, func_wrap->get_obj2(), func_wrap);
+            return new MatrixNumbaCoefficient(width, func_wrap->get_obj2(), func_wrap);
    } else {
           switch(mode){
           case 0:
@@ -984,7 +984,7 @@ try:
             def dec(func):
                 from numba import cfunc, njit
 
-                setting = get_setting(1, complex, dependencies)
+                setting = get_setting(1, complex, dependencies, td)
 
                 sig = generate_signature_scalar(setting)
 
@@ -1041,7 +1041,7 @@ try:
             def dec(func):
                 from numba import cfunc, njit
 
-                setting = get_setting(shape[0], complex, dependencies)
+                setting = get_setting(shape, complex, dependencies, td)
 
                 sig = generate_signature_array(setting)
 
@@ -1063,7 +1063,7 @@ try:
                                             types.CPointer(types.voidptr),
                                             types.CPointer(outtype))
 
-                exec(generate_caller_scalar(setting), globals(), locals())
+                exec(generate_caller_array(setting), globals(), locals())
                 caller_params = {"inner_func": ff, "sdim": sdim, "np":np,
                                  "carray":carray, "farray":farray}
                 caller_func = self._copy_func_and_apply_params(locals()["_caller"], caller_params)
@@ -1101,7 +1101,7 @@ try:
             def dec(func):
                 from numba import cfunc, njit
 
-                setting = get_setting((shape[0],shape[1]), complex, dependencies)
+                setting = get_setting(shape, complex, dependencies, td)
 
                 sig = generate_signature_array(setting)
 

--- a/mfem/common/numba_coefficient.i
+++ b/mfem/common/numba_coefficient.i
@@ -81,7 +81,7 @@ sdim = mesh.SpaceDimension()
 sdim: space dimenstion
 shape: shape of return value
 td: time-dependence (False: stationary, True: time-dependent
-complex: complex coefficient
+complex: complex coefficient. if ture, it returns a tuple of coefficient
 depenency: dependency to other coefficient
 interface: calling proceture
    'simple': vector/matric function returns the result by value more pythonic.
@@ -962,10 +962,10 @@ try:
 
     from inspect import signature
 
-    class ComplexCoefficient(object):
-        def __init__(self):
-            self.real = None
-            self.imag = None
+    def IsNumbaCoefficient(obj):
+        return (isinstance(obj, ScalarNumbaCoefficient) or
+                isinstance(obj, VectorNumbaCoefficient) or
+                isinstance(obj, MatrixNumbaCoefficient))
 
     class _JIT(object):
         def _copy_func_and_apply_params(self, f, params):
@@ -1048,10 +1048,10 @@ try:
                 ff = cfunc(caller_sig)(caller_func)
 
                 if complex:
-                     coeff = ComplexCoefficient()
                      coeff.real = GenerateScalarNumbaCoefficient(ff, td, 1)
                      coeff.imag = GenerateScalarNumbaCoefficient(ff, td, 2)
                      coeffs = (coeff.real, coeff.imag)
+                     coeff = coeffs
                 else:
                      coeff = GenerateScalarNumbaCoefficient(ff, td, 0)
                      coeffs = (coeff, )
@@ -1132,10 +1132,10 @@ try:
                 ff = cfunc(caller_sig)(caller_func)
 
                 if complex:
-                     coeff = ComplexCoefficient()
                      coeff.real = GenerateVectorNumbaCoefficient(ff, shape[0], td, 1)
                      coeff.imag = GenerateVectorNumbaCoefficient(ff, shape[0], td, 2)
                      coeffs = (coeff.real, coeff.imag)
+                     coeff = coeffs
                 else:
                      coeff =  GenerateVectorNumbaCoefficient(ff, shape[0], td, 0)
                      coeffs = (coeff, )
@@ -1211,10 +1211,10 @@ try:
                 ff = cfunc(caller_sig)(caller_func)
 
                 if complex:
-                     coeff = ComplexCoefficient()
                      coeff.real = GenerateMatrixNumbaCoefficient(ff, shape[0], shape[1], td, 1)
                      coeff.imag = GenerateMatrixNumbaCoefficient(ff, shape[0], shape[1], td, 2)
                      coeffs = (coeff.real, coeff.imag)
+                     coeff = coeffs
                 else:
                      coeff = GenerateMatrixNumbaCoefficient(ff, shape[0], shape[1], td, 0)
                      coeffs = (coeff, )

--- a/mfem/common/numba_coefficient.i
+++ b/mfem/common/numba_coefficient.i
@@ -1033,7 +1033,7 @@ try:
             return dec
 
         def vector(self, sdim=3, shape=None, td=False, params=None,
-                   complex=False, dependencies=None, newinterface=True):
+                   complex=False, dependencies=None, newinterface=False):
             shape = (sdim, ) if shape is None else shape
             if dependencies is None:
                 dependencies = []
@@ -1100,7 +1100,7 @@ try:
             return dec
 
         def matrix(self, sdim=3, shape=None, td=False, params=None,
-                   complex=False, dependencies=None, newinterface=True):
+                   complex=False, dependencies=None, newinterface=False):
             shape = (sdim, sdim) if shape is None else shape
             assert shape[0] == shape[1], "must be squre matrix"
 

--- a/mfem/common/numba_coefficient.i
+++ b/mfem/common/numba_coefficient.i
@@ -98,10 +98,9 @@ x.ProjectCoefficient(f_exact)
 
 %inline %{
 classe FunctionCoefficeintExtra : public mfem::FunctionCoefficient{
+
  private:
   mfem::Array<double> data;
-
-
 
  public:
   void SetParams(mfem::Coefficient *coeff[], int num_coeff,
@@ -126,11 +125,13 @@ classe FunctionCoefficeintExtra : public mfem::FunctionCoefficient{
          return TDFunction(transip, GetTime());
       }
   }
+
   FunctionCoefficeintExtra::~FunctionCoefficeintExtra(){
     if (data){
       ~data;
     }
   }
+
 };
  
 class NumbaFunctionBase{

--- a/mfem/common/numba_coefficient.i
+++ b/mfem/common/numba_coefficient.i
@@ -1052,7 +1052,7 @@ class MatrixNumbaFunction2 : public NumbaFunctionBase {
 
 };
 
-MatrixNumbaCoefficient* GenerateMatrixNumbaCoefficient(PyObject *numba_func, int width, int height, bool td, int mode){
+MatrixNumbaCoefficient* GenerateMatrixNumbaCoefficient(PyObject *numba_func, int height,  int width, bool td, int mode){
   using std::placeholders::_1;
   using std::placeholders::_2;
   using std::placeholders::_3;
@@ -1074,7 +1074,7 @@ MatrixNumbaCoefficient* GenerateMatrixNumbaCoefficient(PyObject *numba_func, int
             func_wrap->create_outc();
             break;
           }
-          return new MatrixNumbaCoefficient(width, func_wrap->get_obj2(), func_wrap);
+          return new MatrixNumbaCoefficient(height, width, func_wrap->get_obj2(), func_wrap);
    } else {
           switch(mode){
           case 0:
@@ -1089,7 +1089,7 @@ MatrixNumbaCoefficient* GenerateMatrixNumbaCoefficient(PyObject *numba_func, int
             func_wrap->create_outc();
             break;
           }
-          return new MatrixNumbaCoefficient(width, func_wrap->get_obj1(), func_wrap);
+          return new MatrixNumbaCoefficient(height, width, func_wrap->get_obj1(), func_wrap);
       }
 }
 
@@ -1367,8 +1367,8 @@ try:
         def matrix(self, height=None, width=None, shape=None, td=False, params=None,
                    complex=False, dependency=None, interface="simple", sdim=None, debug=False):
 
-            if (width is None and heigth is not None or
-                width is not None and heigth is None) :
+            if (width is None and height is not None or
+                width is not None and height is None) :
                 assert False, "height and width must be used together"
 
             assert (width is not None or shape is not None), "w/h or shape must be given"

--- a/mfem/common/numba_coefficient.i
+++ b/mfem/common/numba_coefficient.i
@@ -1,5 +1,5 @@
 /*
-# 
+#
 #  using numba JIT function for mfem::FunctionCoefficient
 #
 (1) Using NumberFunction object  ---
@@ -125,7 +125,7 @@ def f_exact(x, out):
 
 
 Then, decorated function can be used as function coefficient
-x.ProjectCoefficient(f_exact)       
+x.ProjectCoefficient(f_exact)
 
 */
 
@@ -145,7 +145,7 @@ void NumbaFunctionBase::SetUserFunction(PyObject *input){
        if (!module){
            PyErr_SetString(PyExc_RuntimeError, "Can not load numba.core.ccallback module");
            return;
-       }      
+       }
        PyObject* cls = PyObject_GetAttrString(module, "CFunc");
        if (!cls){
            PyErr_SetString(PyExc_RuntimeError, "Can not load CFunc");
@@ -157,7 +157,7 @@ void NumbaFunctionBase::SetUserFunction(PyObject *input){
            return;
        }
        PyObject *address = PyObject_GetAttrString(input, "address");
-       void *ptr = PyLong_AsVoidPtr(address); 
+       void *ptr = PyLong_AsVoidPtr(address);
        Py_DECREF(address);
        address_ = ptr;
 }
@@ -170,7 +170,7 @@ class NumbaFunction : public NumbaFunctionBase {
  public:
     NumbaFunction(PyObject *input, int sdim):
        NumbaFunctionBase(input, sdim, false){}
-    
+
     NumbaFunction(PyObject *input, int sdim, bool td):
        NumbaFunctionBase(input, sdim, td){}
 
@@ -192,7 +192,7 @@ class NumbaFunction : public NumbaFunctionBase {
       using std::placeholders::_1;
       using std::placeholders::_2;
       if (use_0==0) {
-	if (td_) {
+        if (td_) {
             obj2 = std::bind(&NumbaFunction::callt, this, _1, _2);
             return new mfem::FunctionCoefficient(obj2);
         } else {
@@ -200,58 +200,58 @@ class NumbaFunction : public NumbaFunctionBase {
            return new mfem::FunctionCoefficient(obj1);
         }
       } else {
-	if (td_) {
-	  obj2 = std::bind(&NumbaFunction::call0t, this, _1, _2);
+        if (td_) {
+          obj2 = std::bind(&NumbaFunction::call0t, this, _1, _2);
             return new mfem::FunctionCoefficient(obj2);
         } else {
-	  obj1 = std::bind(&NumbaFunction::call0, this, _1);
+          obj1 = std::bind(&NumbaFunction::call0, this, _1);
            return new mfem::FunctionCoefficient(obj1);
         }
       }
    }
-}; 
-// VectorFunctionCoefficient     
+};
+// VectorFunctionCoefficient
 class VectorNumbaFunction : public NumbaFunctionBase {
  private:
   std::function<void(const mfem::Vector &, mfem::Vector &)> obj1;
   std::function<void(const mfem::Vector &, double, mfem::Vector &)> obj2;
   int vdim_;
-    
+
  public:
     VectorNumbaFunction(PyObject *input, int sdim, int vdim):
        NumbaFunctionBase(input, sdim, false), vdim_(vdim){}
-    
+
     VectorNumbaFunction(PyObject *input, int sdim, int vdim, bool td):
        NumbaFunctionBase(input, sdim, td), vdim_(vdim){}
 
-      
+
     void call(const mfem::Vector &x, mfem::Vector &out){
       out = 0.0;
-      return ((void (*) (double *, double *, int, int))address_)(x.GetData(), 
-    							      out.GetData(),
+      return ((void (*) (double *, double *, int, int))address_)(x.GetData(),
+                                                              out.GetData(),
                                                               sdim_,
-							      vdim_);      
-       
+                                                              vdim_);
+
     }
     void callt(const mfem::Vector &x, double t, mfem::Vector &out){
-      out = 0.0;      
+      out = 0.0;
       return ((void (*) (double *, double,  double *, int, int))address_)(x.GetData(),
-							              t,
-								      out.GetData(),
-								      sdim_,
-	 							      vdim_);            
+                                                                      t,
+                                                                      out.GetData(),
+                                                                      sdim_,
+                                                                      vdim_);
     }
     void call0(const mfem::Vector &x, mfem::Vector &out){
       out = 0.0;
-      return ((void (*) (double *, double *))address_)(x.GetData(), 
-						       out.GetData());
-       
+      return ((void (*) (double *, double *))address_)(x.GetData(),
+                                                       out.GetData());
+
     }
     void call0t(const mfem::Vector &x, double t, mfem::Vector &out){
-      out = 0.0;      
+      out = 0.0;
       return ((void (*) (double *, double,  double *))address_)(x.GetData(),
-						                t,
-								out.GetData());
+                                                                t,
+                                                                out.GetData());
     }
 
     mfem::VectorFunctionCoefficient* GenerateCoefficient(int use_0=0){
@@ -260,20 +260,20 @@ class VectorNumbaFunction : public NumbaFunctionBase {
       using std::placeholders::_3;
       if (use_0 == 0){
          if (td_) {
-    	   obj2 = std::bind(&VectorNumbaFunction::callt, this, _1, _2, _3);
-	   return new mfem::VectorFunctionCoefficient(vdim_, obj2);
+           obj2 = std::bind(&VectorNumbaFunction::callt, this, _1, _2, _3);
+           return new mfem::VectorFunctionCoefficient(vdim_, obj2);
          } else {
-    	   obj1 = std::bind(&VectorNumbaFunction::call, this, _1, _2);
-	   return new mfem::VectorFunctionCoefficient(vdim_, obj1);
+           obj1 = std::bind(&VectorNumbaFunction::call, this, _1, _2);
+           return new mfem::VectorFunctionCoefficient(vdim_, obj1);
          }
       } else {
-         if (td_) {	
-    	   obj2 = std::bind(&VectorNumbaFunction::call0t, this, _1, _2, _3);
-	   return new mfem::VectorFunctionCoefficient(vdim_, obj2);
+         if (td_) {
+           obj2 = std::bind(&VectorNumbaFunction::call0t, this, _1, _2, _3);
+           return new mfem::VectorFunctionCoefficient(vdim_, obj2);
          } else {
-    	   obj1 = std::bind(&VectorNumbaFunction::call0, this, _1, _2);
-	   return new mfem::VectorFunctionCoefficient(vdim_, obj1);
-	 }
+           obj1 = std::bind(&VectorNumbaFunction::call0, this, _1, _2);
+           return new mfem::VectorFunctionCoefficient(vdim_, obj1);
+         }
       }
    }
 };
@@ -283,7 +283,7 @@ class MatrixNumbaFunction : NumbaFunctionBase {
   std::function<void(const mfem::Vector &, mfem::DenseMatrix &)> obj1;
   std::function<void(const mfem::Vector &, double, mfem::DenseMatrix &)> obj2;
   int vdim_;
-    
+
  public:
     MatrixNumbaFunction(PyObject *input, int sdim, int vdim):
        NumbaFunctionBase(input, sdim, false), vdim_(vdim){}
@@ -292,52 +292,52 @@ class MatrixNumbaFunction : NumbaFunctionBase {
 
     void call(const mfem::Vector &x, mfem::DenseMatrix &out){
       out = 0.0;
-      return ((void (*) (double *, double *, int, int))address_)(x.GetData(), 
-    							      out.GetData(),
+      return ((void (*) (double *, double *, int, int))address_)(x.GetData(),
+                                                              out.GetData(),
                                                               sdim_,
-							      vdim_);      
-       
+                                                              vdim_);
+
     }
     void callt(const mfem::Vector &x, double t, mfem::DenseMatrix &out){
       out = 0.0;
       return ((void (*) (double *, double,  double *, int, int))address_)(x.GetData(),
-							              t,
-								      out.GetData(),
-								      sdim_,
-	 							      vdim_);            
+                                                                      t,
+                                                                      out.GetData(),
+                                                                      sdim_,
+                                                                      vdim_);
     }
     void call0(const mfem::Vector &x, mfem::DenseMatrix &out){
       out = 0.0;
-      return ((void (*) (double *, double *))address_)(x.GetData(), 
-						       out.GetData());
-       
+      return ((void (*) (double *, double *))address_)(x.GetData(),
+                                                       out.GetData());
+
     }
     void call0t(const mfem::Vector &x, double t, mfem::DenseMatrix &out){
       out = 0.0;
       return ((void (*) (double *, double,  double *))address_)(x.GetData(),
-						                t,
-							        out.GetData());
+                                                                t,
+                                                                out.GetData());
     }
-       
+
     mfem::MatrixFunctionCoefficient* GenerateCoefficient(int use_0=0){
       using std::placeholders::_1;
       using std::placeholders::_2;
       using std::placeholders::_3;
       if (use_0 == 0) {
       if (td_) {
- 	obj2 = std::bind(&MatrixNumbaFunction::callt, this, _1, _2, _3);
-	return new mfem::MatrixFunctionCoefficient(vdim_, obj2);
+        obj2 = std::bind(&MatrixNumbaFunction::callt, this, _1, _2, _3);
+        return new mfem::MatrixFunctionCoefficient(vdim_, obj2);
       } else {
-	obj1 = std::bind(&MatrixNumbaFunction::call, this, _1, _2);
-	return new mfem::MatrixFunctionCoefficient(vdim_, obj1);
+        obj1 = std::bind(&MatrixNumbaFunction::call, this, _1, _2);
+        return new mfem::MatrixFunctionCoefficient(vdim_, obj1);
       }
       } else {
       if (td_) {
- 	obj2 = std::bind(&MatrixNumbaFunction::call0t, this, _1, _2, _3);
-	return new mfem::MatrixFunctionCoefficient(vdim_, obj2);
+        obj2 = std::bind(&MatrixNumbaFunction::call0t, this, _1, _2, _3);
+        return new mfem::MatrixFunctionCoefficient(vdim_, obj2);
       } else {
-	obj1 = std::bind(&MatrixNumbaFunction::call0, this, _1, _2);
-	return new mfem::MatrixFunctionCoefficient(vdim_, obj1);
+        obj1 = std::bind(&MatrixNumbaFunction::call0, this, _1, _2);
+        return new mfem::MatrixFunctionCoefficient(vdim_, obj1);
       }
 
       }
@@ -348,20 +348,36 @@ class MatrixNumbaFunction : NumbaFunctionBase {
 //  NumbaCoefficientBase  (hold list of coefficients which is used as a parameter for function coefficient)
 //
 void NumbaCoefficientBase::SetParams(mfem::Coefficient *in_coeff[], int in_num_coeffs,
-				     mfem::VectorCoefficient *in_vcoeff[], int in_num_vcoeffs,
-				     mfem::MatrixCoefficient *in_mcoeff[], int in_num_mcoeffs){
+                                     mfem::VectorCoefficient *in_vcoeff[], int in_num_vcoeffs,
+                                     mfem::MatrixCoefficient *in_mcoeff[], int in_num_mcoeffs){
     int size = 0;
 
-    size += in_num_coeffs;
+    if ((in_num_coeffs + in_num_vcoeffs + in_num_mcoeffs) > 16){
+        throw std::invalid_argument("dependency dim must be up to 16");
+    }
+    if (in_num_mcoeffs > 16){
+        throw std::invalid_argument("dependency dim must be up to 16");
+    }
+    if (in_num_vcoeffs > 16){
+        throw std::invalid_argument("dependency dim must be up to 16");
+    }
+    if (in_num_coeffs > 16){
+        throw std::invalid_argument("dependency dim must be up to 16");
+    }
+
+
+    for (int i = 0; i < in_num_coeffs; i++){
+      coeff[i] = in_coeff[i];
+      size ++;
+    }
     for (int i = 0; i < in_num_vcoeffs; i++){
+      vcoeff[i] = in_vcoeff[i];
       size += vcoeff[i] -> GetVDim();
     }
     for (int i = 0; i < in_num_mcoeffs; i++){
+      mcoeff[i] = in_mcoeff[i];
       size += mcoeff[i] -> GetHeight() * mcoeff[i] -> GetWidth();
     }
-    coeff = in_coeff;
-    vcoeff = in_vcoeff;
-    mcoeff = in_mcoeff;
 
     num_coeffs = in_num_coeffs;
     num_vcoeffs = in_num_vcoeffs;
@@ -371,107 +387,104 @@ void NumbaCoefficientBase::SetParams(mfem::Coefficient *in_coeff[], int in_num_c
 
     using std::invalid_argument;
     if (size > 256){
-        throw std::invalid_argument("dependency dim must be less than 256");      
-    }
-    if ((in_num_coeffs + in_num_vcoeffs + in_num_mcoeffs) > 16){
-        throw std::invalid_argument("dependency dim must be up to 16");        
+        throw std::invalid_argument("dependency dim must be less than 256");
     }
 
   }
 
 void NumbaCoefficientBase::PrepParams(mfem::ElementTransformation &T,
-			       const mfem::IntegrationPoint &ip){
+                               const mfem::IntegrationPoint &ip){
 
     int vdim, h, w = 0;
     int idx = 0;
     double *data = obj -> GetData();
     double **data_ptr=obj ->GetPointer();
-    
+
     int s_counter = 0;
     int v_counter = 0;
     int m_counter = 0;
     int counter = 0;
     for (int i = 0; i < num_dep; i++){
         switch(kinds[i]){
-	case 0:// scalar
-	  {
+        case 0:// scalar
+          {
            data[idx] = coeff[s_counter]->Eval(T, ip);
-	   data_ptr[counter] = &data[idx];
-	     
-	   idx ++;	   
-	   s_counter ++;
-	   counter ++;
+           data_ptr[counter] = &data[idx];
 
-	   
-	   if (iscomplex[i] == 1){
+           idx ++;
+           s_counter ++;
+           counter ++;
+
+
+           if (iscomplex[i] == 1){
                data[idx] = coeff[s_counter]->Eval(T, ip);
-   	       data_ptr[counter] = &data[idx];
-		 
-	       idx ++;	       
-   	       s_counter ++;
-   	       counter ++;	       
-	   }
-	   break;
-	  }
-	case 1:// vector
-	  {
+               data_ptr[counter] = &data[idx];
+
+               idx ++;
+               s_counter ++;
+               counter ++;
+           }
+           break;
+          }
+        case 1:// vector
+          {
            vdim = vcoeff[i]->GetVDim();
            mfem::Vector V(vdim);
-	   vcoeff[v_counter]->Eval(V, T, ip);
-	   
-	   data_ptr[counter] = &data[idx];	   
-	   for (int j = 0; j < vdim; j++){
-	     data[idx] =  V[j];
-	     idx ++;
-	   }
-	   v_counter ++;
-	   counter ++;
-	   
-	   if (iscomplex[i] == 1){	   
-	      vcoeff[v_counter]->Eval(V, T, ip);
+           vcoeff[v_counter]->Eval(V, T, ip);
 
-	      data_ptr[counter] = &data[idx];	   	      
-	      for (int j = 0; j < vdim; j++){
-	          data[idx] =  V[j];
-		  idx ++;
-	      }
-	      v_counter ++;
-    	      counter ++;	      
-	   }
-	   break;
-	  }
-	case 2:// matrix
-	  {
- 	   w = mcoeff[m_counter]->GetWidth();
-  	   h = mcoeff[m_counter]->GetHeight();
-           mfem::DenseMatrix M(h, w);	  
-	   mcoeff[m_counter]->Eval(M, T, ip);
+           data_ptr[counter] = &data[idx];
+           for (int j = 0; j < vdim; j++){
+             data[idx] =  V[j];
+             idx ++;
+           }
+           v_counter ++;
+           counter ++;
 
-	   data_ptr[counter] = &data[idx];
-           for (int jj = 0; jj < w; jj++){
- 	      for (int ii = 0; ii < h; ii++){
-  	         data[idx] =  M(ii, jj);
-	         idx ++;
-	      }
-	   }
-	   m_counter ++;
- 	   counter ++;
-	   
-	   if (iscomplex[i] == 1){
-  	      mcoeff[m_counter]->Eval(M, T, ip);
-	      data_ptr[counter] = &data[idx];	      
-	      for (int jj = 0; jj < w; jj++){
-		for (int ii = 0; ii < h; ii++){
-		  data[idx] =  M(ii, jj);
-		  idx ++;
-		}
-	      }
-	      m_counter ++;
-    	      counter ++;	      	      
-	   }
+           if (iscomplex[i] == 1){
+              vcoeff[v_counter]->Eval(V, T, ip);
+
+              data_ptr[counter] = &data[idx];
+              for (int j = 0; j < vdim; j++){
+                  data[idx] =  V[j];
+                  idx ++;
+              }
+              v_counter ++;
+              counter ++;
+           }
            break;
-	  }
-	}
+          }
+        case 2:// matrix
+          {
+           w = mcoeff[m_counter]->GetWidth();
+           h = mcoeff[m_counter]->GetHeight();
+           mfem::DenseMatrix M(h, w);
+           mcoeff[m_counter]->Eval(M, T, ip);
+
+           data_ptr[counter] = &data[idx];
+           for (int jj = 0; jj < w; jj++){
+              for (int ii = 0; ii < h; ii++){
+                 data[idx] =  M(ii, jj);
+                 idx ++;
+              }
+           }
+           m_counter ++;
+           counter ++;
+
+           if (iscomplex[i] == 1){
+              mcoeff[m_counter]->Eval(M, T, ip);
+              data_ptr[counter] = &data[idx];
+              for (int jj = 0; jj < w; jj++){
+                for (int ii = 0; ii < h; ii++){
+                  data[idx] =  M(ii, jj);
+                  idx ++;
+                }
+              }
+              m_counter ++;
+              counter ++;
+           }
+           break;
+          }
+        }
     }
 }
 void NumbaCoefficientBase::SetKinds(PyObject *kinds_){
@@ -479,7 +492,7 @@ void NumbaCoefficientBase::SetKinds(PyObject *kinds_){
      int ll = PyList_Size(kinds_);
      if (ll > 16){
        PyErr_SetString(PyExc_ValueError, "Dependecy must be less than 16");
-       return; 
+       return;
      }
      for (int i = 0; i < ll; i++) {
         PyObject *s = PyList_GetItem(kinds_, i);
@@ -494,9 +507,9 @@ void NumbaCoefficientBase::SetKinds(PyObject *kinds_){
      }
      if (ll > 16){
        PyErr_SetString(PyExc_ValueError, "Dependecy must be less than 16");
-       return; 
+       return;
      }
-     num_dep = ll;     
+     num_dep = ll;
   } else {
     PyErr_SetString(PyExc_ValueError, "Expecting a list/tuple");
   }
@@ -519,10 +532,10 @@ void NumbaCoefficientBase::SetIsComplex(PyObject *isComplex_){
         PyObject *s = PyTuple_GetItem(isComplex_,i);
         iscomplex[i] = (int)PyInt_AsLong(s);
      }
-     num_dep = ll;     
+     num_dep = ll;
      if (ll > 16){
        PyErr_SetString(PyExc_ValueError, "Dependecy must be less than 16");
-       return; 
+       return;
      }
   } else {
     PyErr_SetString(PyExc_ValueError, "Expecting a list/tuple");
@@ -531,21 +544,21 @@ void NumbaCoefficientBase::SetIsComplex(PyObject *isComplex_){
 
 
 double ScalarNumbaCoefficient::Eval(mfem::ElementTransformation &T,
-				  const mfem::IntegrationPoint &ip){
+                                  const mfem::IntegrationPoint &ip){
    PrepParams(T, ip);
    return mfem::FunctionCoefficient::Eval(T, ip);
 }
 
 void VectorNumbaCoefficient::Eval(mfem::Vector &V,
-				  mfem::ElementTransformation &T,
-				  const mfem::IntegrationPoint &ip){
+                                  mfem::ElementTransformation &T,
+                                  const mfem::IntegrationPoint &ip){
    PrepParams(T, ip);
    return mfem::VectorFunctionCoefficient::Eval(V, T, ip);
   }
 
 void MatrixNumbaCoefficient :: Eval(mfem::DenseMatrix &K,
-				    mfem::ElementTransformation &T,
-				    const mfem::IntegrationPoint &ip){
+                                    mfem::ElementTransformation &T,
+                                    const mfem::IntegrationPoint &ip){
     PrepParams(T, ip);
     return mfem::MatrixFunctionCoefficient::Eval(K, T, ip);
   }
@@ -553,20 +566,17 @@ void MatrixNumbaCoefficient :: Eval(mfem::DenseMatrix &K,
 //  NumberFunction Implementation 2 (this is used for mfem.jit )
 class ScalarNumbaFunction2 : public NumbaFunctionBase {
  private:
-    std::function<double(const mfem::Vector &)> obj1 = nullptr;
-    std::function<double(const mfem::Vector &, double t)> obj2 = nullptr;
+  std::function<double(const mfem::Vector &)> obj1;
+  std::function<double(const mfem::Vector &, double t)> obj2;
 
  public:
     ScalarNumbaFunction2(PyObject *input):
        NumbaFunctionBase(input, 3, false){}
-    
+
     ScalarNumbaFunction2(PyObject *input, bool td):
        NumbaFunctionBase(input, 3, td){}
 
-    ~ScalarNumbaFunction2(){
-	 delete obj1;
-	 delete obj2;
-    }
+    ~ScalarNumbaFunction2(){}
 
     double call(const mfem::Vector &x){
       return ((double (*)(double *, double *))address_)(x.GetData(), data);
@@ -581,9 +591,9 @@ class ScalarNumbaFunction2 : public NumbaFunctionBase {
       return ret.real();
     }
     double calltr(const mfem::Vector &x, double t){
-      std::complex<double> ret;            
+      std::complex<double> ret;
       ret = ((std::complex<double> (*)(double *, double, double *))address_)(x.GetData(), t, data);
-      return ret.real();      
+      return ret.real();
     }
     // complex imag part
     double calli(const mfem::Vector &x){
@@ -592,9 +602,9 @@ class ScalarNumbaFunction2 : public NumbaFunctionBase {
       return ret.imag();
     }
     double callti(const mfem::Vector &x, double t){
-      std::complex<double> ret;            
+      std::complex<double> ret;
       ret = ((std::complex<double> (*)(double *, double, double*))address_)(x.GetData(), t, data);
-      return ret.imag();      
+      return ret.imag();
     }
     void set_obj1(std::function<double(const mfem::Vector &)> obj1_){
       obj1 = obj1_;
@@ -604,54 +614,54 @@ class ScalarNumbaFunction2 : public NumbaFunctionBase {
     };
     std::function<double(const mfem::Vector &)> get_obj1(){ return obj1; }
     std::function<double(const mfem::Vector &, double )> get_obj2(){return obj2; }
-}; 
+};
 
     // FunctionCoefficient
     // mode   (0: real, 1: complex real part, 2: complex imag part)
-ScalarNumbaCoefficient* GenerateScalarNumbaCoefficient(PyObject *numba_func,  bool td, int mode){    
+ScalarNumbaCoefficient* GenerateScalarNumbaCoefficient(PyObject *numba_func,  bool td, int mode){
       using std::placeholders::_1;
       using std::placeholders::_2;
 
-      ScalarNumbaFunction2 *func_wrap = new ScalarNumbaFunction2(numba_func, td);            
+      ScalarNumbaFunction2 *func_wrap = new ScalarNumbaFunction2(numba_func, td);
       if (td) {
-	  switch(mode){
-	  case 0:
-	    func_wrap->set_obj2(std::bind(&ScalarNumbaFunction2::callt, func_wrap, _1, _2));
-	    break;
-	  case 1:
-	    func_wrap->set_obj2(std::bind(&ScalarNumbaFunction2::calltr, func_wrap, _1, _2));
-	    break;	    
-	  case 2:
-	    func_wrap->set_obj2(std::bind(&ScalarNumbaFunction2::callti, func_wrap, _1, _2));
-	    break;	    
+          switch(mode){
+          case 0:
+            func_wrap->set_obj2(std::bind(&ScalarNumbaFunction2::callt, func_wrap, _1, _2));
+            break;
+          case 1:
+            func_wrap->set_obj2(std::bind(&ScalarNumbaFunction2::calltr, func_wrap, _1, _2));
+            break;
+          case 2:
+            func_wrap->set_obj2(std::bind(&ScalarNumbaFunction2::callti, func_wrap, _1, _2));
+            break;
           }
-          return new ScalarNumbaCoefficient(func_wrap->get_obj2(), func_wrap);	  
+          return new ScalarNumbaCoefficient(func_wrap->get_obj2(), func_wrap);
       } else {
-	  switch(mode){
-	  case 0:
-	    func_wrap->set_obj1(std::bind(&ScalarNumbaFunction2::call, func_wrap, _1));
-	    break;	    	    
-	  case 1:
-	    func_wrap->set_obj1(std::bind(&ScalarNumbaFunction2::callr, func_wrap, _1));
-	    break;	    	    
-	  case 2:
-	    func_wrap->set_obj1(std::bind(&ScalarNumbaFunction2::calli, func_wrap, _1));
-	    break;	    
+          switch(mode){
+          case 0:
+            func_wrap->set_obj1(std::bind(&ScalarNumbaFunction2::call, func_wrap, _1));
+            break;
+          case 1:
+            func_wrap->set_obj1(std::bind(&ScalarNumbaFunction2::callr, func_wrap, _1));
+            break;
+          case 2:
+            func_wrap->set_obj1(std::bind(&ScalarNumbaFunction2::calli, func_wrap, _1));
+            break;
           }
           return new ScalarNumbaCoefficient(func_wrap->get_obj1(), func_wrap);
-      }    
+      }
 }
-// VectorFunctionCoefficient     
+// VectorFunctionCoefficient
 class VectorNumbaFunction2 : public NumbaFunctionBase {
  private:
-  std::function<void(const mfem::Vector &, mfem::Vector &)> obj1 = nullptr;
-  std::function<void(const mfem::Vector &, double, mfem::Vector &)> obj2 = nullptr;
+  std::function<void(const mfem::Vector &, mfem::Vector &)> obj1;
+  std::function<void(const mfem::Vector &, double, mfem::Vector &)> obj2;
   int vdim_;
   std::complex<double> *outc = nullptr;
- public: 
+ public:
     VectorNumbaFunction2(PyObject *input, int vdim)
        : NumbaFunctionBase(input, 3, false), vdim_(vdim){}
-    
+
     VectorNumbaFunction2(PyObject *input, int vdim, bool td)
        : NumbaFunctionBase(input, 3, td), vdim_(vdim){}
 
@@ -661,43 +671,43 @@ class VectorNumbaFunction2 : public NumbaFunctionBase {
 
     void call(const mfem::Vector &x, mfem::Vector &out){
       out = 0.0;
-      return ((void (*) (double *, double *))address_)(x.GetData(), 
-						       out.GetData());
-       
+      return ((void (*) (double *, double *))address_)(x.GetData(),
+                                                       out.GetData());
+
     }
     void callt(const mfem::Vector &x, double t, mfem::Vector &out){
-      out = 0.0;      
+      out = 0.0;
       return ((void (*) (double *, double,  double *))address_)(x.GetData(),
-						                t,
-								out.GetData());
+                                                                t,
+                                                                out.GetData());
     }
     void callr(const mfem::Vector &x, mfem::Vector &out){
       out = 0.0;
       ((void (*) (double *, double *))address_)(x.GetData(), out.GetData());
       for (int i = 0; i < vdim_; i++) {
-	out[i] = outc[i].real();
+        out[i] = outc[i].real();
       }
     }
     void calltr(const mfem::Vector &x, double t, mfem::Vector &out){
-      out = 0.0;      
+      out = 0.0;
       ((void (*) (double *, double,  std::complex<double> *))address_)(x.GetData(), t, outc);
       for (int i = 0; i < vdim_; i++) {
-	out[i] = outc[i].real();
+        out[i] = outc[i].real();
       }
     }
     void calli(const mfem::Vector &x, mfem::Vector &out){
       out = 0.0;
       ((void (*) (double *, std::complex<double> *))address_)(x.GetData(), outc);
       for (int i = 0; i < vdim_; i++) {
-	out[i] = outc[i].imag();
+        out[i] = outc[i].imag();
       }
-       
+
     }
     void callti(const mfem::Vector &x, double t, mfem::Vector &out){
       out = 0.0;
       ((void (*) (double *, double,  std::complex<double> *))address_)(x.GetData(), t, outc);
       for (int i = 0; i < vdim_; i++) {
-	out[i] = outc[i].imag();
+        out[i] = outc[i].imag();
       }
     }
     void create_outc(){
@@ -710,45 +720,45 @@ class VectorNumbaFunction2 : public NumbaFunctionBase {
       obj2 = obj2_;
     };
     std::function<void(const mfem::Vector &, mfem::Vector &)> get_obj1(){return obj1;}
-    std::function<void(const mfem::Vector &, double, mfem::Vector &)> get_obj2(){return obj2;}    
-}; 
+    std::function<void(const mfem::Vector &, double, mfem::Vector &)> get_obj2(){return obj2;}
+};
 VectorNumbaCoefficient* GenerateVectorNumbaCoefficient(PyObject *numba_func, int vdim, bool td, int mode){
       using std::placeholders::_1;
       using std::placeholders::_2;
       using std::placeholders::_3;
-      
-      VectorNumbaFunction2 *func_wrap = new VectorNumbaFunction2(numba_func, vdim, td);      
+
+      VectorNumbaFunction2 *func_wrap = new VectorNumbaFunction2(numba_func, vdim, td);
       if (td) {
-	  switch(mode){
-	  case 0:
-	    func_wrap->set_obj2(std::bind(&VectorNumbaFunction2::callt, func_wrap, _1, _2, _3));
-	    break;
-	  case 1:
-	    func_wrap->set_obj2(std::bind(&VectorNumbaFunction2::calltr, func_wrap, _1, _2, _3));
-            func_wrap->create_outc();	    	    
-	    break;	    
-	  case 2:
-	    func_wrap->set_obj2(std::bind(&VectorNumbaFunction2::callti, func_wrap, _1, _2, _3));
-            func_wrap->create_outc();	    	    	    
-	    break;	    
+          switch(mode){
+          case 0:
+            func_wrap->set_obj2(std::bind(&VectorNumbaFunction2::callt, func_wrap, _1, _2, _3));
+            break;
+          case 1:
+            func_wrap->set_obj2(std::bind(&VectorNumbaFunction2::calltr, func_wrap, _1, _2, _3));
+            func_wrap->create_outc();
+            break;
+          case 2:
+            func_wrap->set_obj2(std::bind(&VectorNumbaFunction2::callti, func_wrap, _1, _2, _3));
+            func_wrap->create_outc();
+            break;
           }
-          return new VectorNumbaCoefficient(vdim, func_wrap->get_obj2(), func_wrap);	  	  
+          return new VectorNumbaCoefficient(vdim, func_wrap->get_obj2(), func_wrap);
       } else {
-	  switch(mode){
-	  case 0:
-	    func_wrap->set_obj1(std::bind(&VectorNumbaFunction2::call, func_wrap, _1, _2));
-	    break;	    	    
-	  case 1:
-	    func_wrap->set_obj1(std::bind(&VectorNumbaFunction2::callr, func_wrap, _1, _2));
-            func_wrap->create_outc();	    	    	    	    
-	    break;	    	    
-	  case 2:
-	    func_wrap->set_obj1(std::bind(&VectorNumbaFunction2::calli, func_wrap, _1, _2));
-            func_wrap->create_outc();	    	    	    	    	    
-	    break;		    
+          switch(mode){
+          case 0:
+            func_wrap->set_obj1(std::bind(&VectorNumbaFunction2::call, func_wrap, _1, _2));
+            break;
+          case 1:
+            func_wrap->set_obj1(std::bind(&VectorNumbaFunction2::callr, func_wrap, _1, _2));
+            func_wrap->create_outc();
+            break;
+          case 2:
+            func_wrap->set_obj1(std::bind(&VectorNumbaFunction2::calli, func_wrap, _1, _2));
+            func_wrap->create_outc();
+            break;
           }
-          return new VectorNumbaCoefficient(vdim, func_wrap->get_obj1(), func_wrap);	  
-      }    
+          return new VectorNumbaCoefficient(vdim, func_wrap->get_obj1(), func_wrap);
+      }
 }
 
 // MatrixFunctionCoefficient
@@ -769,22 +779,22 @@ class MatrixNumbaFunction2 : public NumbaFunctionBase {
 
     void call(const mfem::Vector &x, mfem::DenseMatrix &out){
       out = 0.0;
-      return ((void (*) (double *, double *))address_)(x.GetData(), 
-						       out.GetData());
-       
+      return ((void (*) (double *, double *))address_)(x.GetData(),
+                                                       out.GetData());
+
     }
     void callt(const mfem::Vector &x, double t, mfem::DenseMatrix &out){
-      out = 0.0;      
+      out = 0.0;
       return ((void (*) (double *, double,  double *))address_)(x.GetData(),
-						                t,
-								out.GetData());
+                                                                t,
+                                                                out.GetData());
     }
     void callr(const mfem::Vector &x, mfem::DenseMatrix &out){
       out = 0.0;
       ((void (*) (double *, std::complex<double> *))address_)(x.GetData(), outc);
-      double *outptr = out.GetData();            
+      double *outptr = out.GetData();
       for (int i = 0; i < vdim_; i++) {
-	outptr[i] = outc[i].real();
+        outptr[i] = outc[i].real();
       }
     }
     void calltr(const mfem::Vector &x, double t, mfem::DenseMatrix &out){
@@ -792,24 +802,24 @@ class MatrixNumbaFunction2 : public NumbaFunctionBase {
       ((void (*) (double *, double,  std::complex<double> *))address_)(x.GetData(), t, outc);
       double *outptr = out.GetData();
       for (int i = 0; i < vdim_; i++) {
-	outptr[i] = outc[i].real();
+        outptr[i] = outc[i].real();
       }
     }
     void calli(const mfem::Vector &x, mfem::DenseMatrix &out){
       out = 0.0;
       ((void (*) (double *, std::complex<double> *))address_)(x.GetData(), outc);
-      double *outptr = out.GetData();      
+      double *outptr = out.GetData();
       for (int i = 0; i < vdim_; i++) {
-	outptr[i] = outc[i].imag();
+        outptr[i] = outc[i].imag();
       }
-       
+
     }
     void callti(const mfem::Vector &x, double t, mfem::DenseMatrix &out){
       out = 0.0;
       ((void (*) (double *, double,  std::complex<double> *))address_)(x.GetData(), t, outc);
-      double *outptr = out.GetData();            
+      double *outptr = out.GetData();
       for (int i = 0; i < vdim_; i++) {
-	outptr[i] = outc[i].imag();
+        outptr[i] = outc[i].imag();
       }
     }
     void create_outc(){
@@ -822,10 +832,10 @@ class MatrixNumbaFunction2 : public NumbaFunctionBase {
       obj2 = obj2_;
     };
     std::function<void(const mfem::Vector &, mfem::DenseMatrix &)> get_obj1(){return obj1;}
-    std::function<void(const mfem::Vector &, double, mfem::DenseMatrix &)> get_obj2(){return obj2;}    
-    
+    std::function<void(const mfem::Vector &, double, mfem::DenseMatrix &)> get_obj2(){return obj2;}
+
 };
-   
+
 MatrixNumbaCoefficient* GenerateMatrixNumbaCoefficient(PyObject *numba_func, int vdim, bool td, int mode){
   using std::placeholders::_1;
   using std::placeholders::_2;
@@ -833,36 +843,36 @@ MatrixNumbaCoefficient* GenerateMatrixNumbaCoefficient(PyObject *numba_func, int
 
   MatrixNumbaFunction2 *func_wrap = new MatrixNumbaFunction2(numba_func, vdim, td);
   if (td) {
-	  switch(mode){
-	  case 0:
-	    func_wrap->set_obj2(std::bind(&MatrixNumbaFunction2::callt, func_wrap, _1, _2, _3));
-	    break;
-	  case 1:
-	    func_wrap->set_obj2(std::bind(&MatrixNumbaFunction2::calltr, func_wrap, _1, _2, _3));
-            func_wrap->create_outc();	    
-	    break;
-	  case 2:
-	    func_wrap->set_obj2(std::bind(&MatrixNumbaFunction2::callti, func_wrap, _1, _2, _3));
+          switch(mode){
+          case 0:
+            func_wrap->set_obj2(std::bind(&MatrixNumbaFunction2::callt, func_wrap, _1, _2, _3));
+            break;
+          case 1:
+            func_wrap->set_obj2(std::bind(&MatrixNumbaFunction2::calltr, func_wrap, _1, _2, _3));
             func_wrap->create_outc();
-	    break;
+            break;
+          case 2:
+            func_wrap->set_obj2(std::bind(&MatrixNumbaFunction2::callti, func_wrap, _1, _2, _3));
+            func_wrap->create_outc();
+            break;
           }
-          return new MatrixNumbaCoefficient(vdim, func_wrap->get_obj2(), func_wrap);	  	  
+          return new MatrixNumbaCoefficient(vdim, func_wrap->get_obj2(), func_wrap);
    } else {
-	  switch(mode){
-	  case 0:
-	    func_wrap->set_obj1(std::bind(&MatrixNumbaFunction2::call, func_wrap, _1, _2));
-	    break;
-	  case 1:
-	    func_wrap->set_obj1(std::bind(&MatrixNumbaFunction2::callr, func_wrap, _1, _2));
-            func_wrap->create_outc();	    
-	    break;
-	  case 2:
-	    func_wrap->set_obj1(std::bind(&MatrixNumbaFunction2::calli, func_wrap, _1, _2));
-            func_wrap->create_outc();	    	    
-	    break;
+          switch(mode){
+          case 0:
+            func_wrap->set_obj1(std::bind(&MatrixNumbaFunction2::call, func_wrap, _1, _2));
+            break;
+          case 1:
+            func_wrap->set_obj1(std::bind(&MatrixNumbaFunction2::callr, func_wrap, _1, _2));
+            func_wrap->create_outc();
+            break;
+          case 2:
+            func_wrap->set_obj1(std::bind(&MatrixNumbaFunction2::calli, func_wrap, _1, _2));
+            func_wrap->create_outc();
+            break;
           }
-          return new MatrixNumbaCoefficient(vdim, func_wrap->get_obj1(), func_wrap);	  
-      }    
+          return new MatrixNumbaCoefficient(vdim, func_wrap->get_obj1(), func_wrap);
+      }
 }
 %}
 
@@ -875,48 +885,48 @@ MatrixNumbaCoefficient* GenerateMatrixNumbaCoefficient(PyObject *numba_func, int
 
 %pythoncode %{
 
-from mfem.commmon.numba_coefficient_utils import (generate_caller_scalar,
-						  generate_caller_array,
-						  generate_signature_scalar,
-						  generate_signature_array,
-						  get_setting)
-						  
+from mfem.common.numba_coefficient_utils import (generate_caller_scalar,
+                                                 generate_caller_array,
+                                                 generate_signature_scalar,
+                                                 generate_signature_array,
+                                                 get_setting)
+
 
 try:
     from numba import cfunc, types, carray
     scalar_sig = types.double(types.CPointer(types.double),
-			      types.intc,)
+                              types.intc,)
     scalar_sig_t = types.double(types.CPointer(types.double),
-				types.double,
-				types.intc,)
+                                types.double,
+                                types.intc,)
     vector_sig = types.void(types.CPointer(types.double),
-			types.CPointer(types.double),
-			types.intc,
-			types.intc)
+                        types.CPointer(types.double),
+                        types.intc,
+                        types.intc)
     vector_sig_t = types.void(types.CPointer(types.double),
-			  types.double,
+                          types.double,
                           types.CPointer(types.double),
-			  types.intc,
-			  types.intc)
-  
+                          types.intc,
+                          types.intc)
+
     matrix_sig = vector_sig
     matrix_sig_t = vector_sig_t
 
 
-      
+
     from inspect import signature
 
-    class ComplexCoefficient()
+    class ComplexCoefficient(object):
         def __init__(self):
             self.real = None
-	    self.imag = None
+            self.imag = None
 
     class _JIT(object):
         def _copy_func_and_apply_params(self, f, params):
             import copy
             import types
             import functools
-  
+
             """Based on https://stackoverflow.com/a/13503277/2988730 (@unutbu)"""
             globals = f.__globals__.copy()
             for k in params:
@@ -942,48 +952,48 @@ try:
             if params is None:
                 params = {}
             params["sdim"] = sdim
-			
-            def dec(func):
-	        from numba import cfunc, njit
-			
-		setting = get_setting(1, complex, dependencies)
 
-		sig = generate_signature_scalar(setting)
-			
+            def dec(func):
+                from numba import cfunc, njit
+
+                setting = get_setting(1, complex, dependencies)
+
+                sig = generate_signature_scalar(setting)
+
                 gfunc=self._copy_func_and_apply_params(func, params)
                 ff = ngit(sig)(gfunc)
-			
-                if td
+
+                if td:
                     caller_sig = types.double(types.CPointer(types.double),
-				       types.double, 
-				       types.CPointer(types.double))
-		else:
+                                       types.double,
+                                       types.CPointer(types.double))
+                else:
                     caller_sig = types.double(types.CPointer(types.double),
                                         types.CPointer(types.double))
 
-	        exec(generate_caller_scalar(settings))  # this defines _caller_func
-	        callar_params = {"inner_func": _caller_func,  "sdim": sdim}}
+                exec(generate_caller_scalar(settings))  #this defines _caller_func
+                callar_params = {"inner_func": ff,  "sdim": sdim}
                 caller_func = self._copy_func_and_apply_params(_caller_func, caller_params)
-                ff = cfunc(caller_sig)(caller_func)		      
-                 
- 	        if complex:
+                ff = cfunc(caller_sig)(caller_func)
+
+                if complex:
                      coeff = ComplexCoefficient()
-		     coeff.real = GenerateScalarNumbaCoefficient(ff, td, 1)
-		     coeff.imag = GenerateScalarNumbaCoefficient(ff, td, 2)		       
-	             coeffs = (coeff.real, coeff.imag)
+                     coeff.real = GenerateScalarNumbaCoefficient(ff, td, 1)
+                     coeff.imag = GenerateScalarNumbaCoefficient(ff, td, 2)
+                     coeffs = (coeff.real, coeff.imag)
                 else:
-		     coeff = GenerateScalarNumbaCoefficient(ff, td, 0)		       
-	             coeffs = (coeff, )
+                     coeff = GenerateScalarNumbaCoefficient(ff, td, 0)
+                     coeffs = (coeff, )
 
                 for c in coeffs:
-	             c.SetParams(setting["s_coeffs"], len(setting["s_coeffs"]),
-		                 setting["v_coeffs"], len(setting["v_coeffs"]),
-				 setting["m_coeffs"], len(setting["m_coeffs"]),)
-		     c.SetIsComplex(setting["iscomplex"])
-                     c.SetKinds(setting["kinds"])			
+                     c.SetParams(setting["s_coeffs"], len(setting["s_coeffs"]),
+                                 setting["v_coeffs"], len(setting["v_coeffs"]),
+                                 setting["m_coeffs"], len(setting["m_coeffs"]),)
+                     c.SetIsComplex(setting["iscomplex"])
+                     c.SetKinds(setting["kinds"])
                 return coeff
             return dec
-			
+
         def vector(self, sdim, shape=None, td=False, params=None, complex=False, dependencies=None):
             shape = (sdim, ) if shape is None else shape
             if dependencies is None:
@@ -994,53 +1004,52 @@ try:
             params["shape"] = shape
 
             def dec(func):
-	        from numba import cfunc, njit
+                from numba import cfunc, njit
 
-                #l = len(signature(func).parameters) - len(dependencies)
-		setting = get_setting(shape[0], complex, dependencies)
+                setting = get_setting(shape[0], complex, dependencies)
 
-		sig = generate_signature_array(setting)
-			
+                sig = generate_signature_array(setting)
+
                 gfunc=self._copy_func_and_apply_params(func, params)
                 ff = ngit(sig)(gfunc)
-  
-                if td
-                    caller_sig = types.double(types.CPointer(types.double),
-					      types.double,
-					      types.CPointer(types.double),
-					      types.CPointer(types.double))
-		else:
-                    caller_sig = types.double(types.CPointer(types.double),
-					      types.CPointer(types.double),
-					      types.CPointer(types.double))	      
-  
-	        exec(generate_caller_array(settings))  # this defines _caller_func
-	        callar_params = {'inner_func': _caller_func,  "sdim": sdim}}
-                caller_func = self._copy_func_and_apply_params(_caller_func, caller_params)
-                ff = cfunc(caller_sig)(caller_func)		      
 
-		      
- 	        if complex:
-                     coeff = ComplexCoefficient()
-	             coeff.real = GenerateVectorNumbaCoefficient(ff, shape[0], td, 1)
-		     coeff.imag = GenerateVectorNumbaCoefficient(ff, shape[0], td, 2)
-	             coeffs = (coeff.real, coeff.imag)
+                if td:
+                    caller_sig = types.double(types.CPointer(types.double),
+                                              types.double,
+                                              types.CPointer(types.double),
+                                              types.CPointer(types.double))
                 else:
-		     coeff =  GenerateVectorNumbaCoefficient(ff, shape[0], td, 0)
-	             coeffs = (coeff, )
+                    caller_sig = types.double(types.CPointer(types.double),
+                                              types.CPointer(types.double),
+                                              types.CPointer(types.double))
+
+                exec(generate_caller_array(settings))  # this defines _caller_func
+                callar_params = {"inner_func": _caller_func, "sdim": sdim}
+                caller_func = self._copy_func_and_apply_params(_caller_func, caller_params)
+                ff = cfunc(caller_sig)(caller_func)
+
+
+                if complex:
+                     coeff = ComplexCoefficient()
+                     coeff.real = GenerateVectorNumbaCoefficient(ff, shape[0], td, 1)
+                     coeff.imag = GenerateVectorNumbaCoefficient(ff, shape[0], td, 2)
+                     coeffs = (coeff.real, coeff.imag)
+                else:
+                     coeff =  GenerateVectorNumbaCoefficient(ff, shape[0], td, 0)
+                     coeffs = (coeff, )
 
                 for c in coeffs:
-	             c.SetParams(setting["s_coeffs"], len(setting["s_coeffs"]),
-		                 setting["v_coeffs"], len(setting["v_coeffs"]),
-				 setting["m_coeffs"], len(setting["m_coeffs"]),)
-		     c.SetIsComplex(setting["iscomplex"])
-                     c.SetKinds(setting["kinds"])			
+                     c.SetParams(setting["s_coeffs"], len(setting["s_coeffs"]),
+                                 setting["v_coeffs"], len(setting["v_coeffs"]),
+                                 setting["m_coeffs"], len(setting["m_coeffs"]),)
+                     c.SetIsComplex(setting["iscomplex"])
+                     c.SetKinds(setting["kinds"])
                 return coeff
             return dec
 
         def matrix(self, sdim, shape=None, td=False, params=None, complex=False, dependencies=None):
-            shape = (sdim, sdim) if shape is None else
-	    assert shape[0] == shape[1], "must be squre matrix"
+            shape = (sdim, sdim) if shape is None else shape
+            assert shape[0] == shape[1], "must be squre matrix"
 
             if dependencies is None:
                 dependencies = []
@@ -1050,48 +1059,46 @@ try:
             params["shape"] = shape
 
             def dec(func):
-	        from numba import cfunc, njit
+                from numba import cfunc, njit
 
-                #l = len(signature(func).parameters) - len(dependencies)
-					   
-		setting = get_setting((shape[0],shape[1]), complex, dependencies)
+                setting = get_setting((shape[0],shape[1]), complex, dependencies)
 
-		sig = generate_signature_array(setting)
-			
+                sig = generate_signature_array(setting)
+
                 gfunc=self._copy_func_and_apply_params(func, params)
                 ff = ngit(sig)(gfunc)
-  
-                if td
-                    caller_sig = types.double(types.CPointer(types.double),
-					      types.double,
-					      types.CPointer(types.double),
-					      types.CPointer(types.double))
-		else:
-                    caller_sig = types.double(types.CPointer(types.double),
-					      types.CPointer(types.double),
-					      types.CPointer(types.double))	      
-  
-	        exec(generate_caller_array(settings))  # this defines _caller_func
-		      callar_params = {"inner_func": _caller_func, "sdim": sdim}
-                caller_func = self._copy_func_and_apply_params(_caller_func, caller_params)
-                ff = cfunc(caller_sig)(caller_func)		      
 
-		      
- 	        if complex:
-                     coeff = ComplexCoefficient()
-	             coeff.real = GenerateMatrixNumbaCoefficient(ff, shape[0], td, 1)
-		     coeff.imag = GenerateMatrixNumbaCoefficient(ff, shape[0], td, 2)
-	             coeffs = (coeff.real, coeff.imag)
+                if td:
+                    caller_sig = types.double(types.CPointer(types.double),
+                                              types.double,
+                                              types.CPointer(types.double),
+                                              types.CPointer(types.double))
                 else:
-   		     coeff = GenerateMatrixNumbaCoefficient(ff, shape[0], td, 0)
-	             coeffs = (coeff, )
+                    caller_sig = types.double(types.CPointer(types.double),
+                                              types.CPointer(types.double),
+                                              types.CPointer(types.double))
+
+                exec(generate_caller_array(settings))  # this defines _caller_func
+                callar_params = {"inner_func": _caller_func, "sdim": sdim}
+                caller_func = self._copy_func_and_apply_params(_caller_func, caller_params)
+                ff = cfunc(caller_sig)(caller_func)
+
+
+                if complex:
+                     coeff = ComplexCoefficient()
+                     coeff.real = GenerateMatrixNumbaCoefficient(ff, shape[0], td, 1)
+                     coeff.imag = GenerateMatrixNumbaCoefficient(ff, shape[0], td, 2)
+                     coeffs = (coeff.real, coeff.imag)
+                else:
+                     coeff = GenerateMatrixNumbaCoefficient(ff, shape[0], td, 0)
+                     coeffs = (coeff, )
 
                 for c in coeffs:
-	             c.SetParams(setting["s_coeffs"], len(setting["s_coeffs"]),
-		                 setting["v_coeffs"], len(setting["v_coeffs"]),
-				 setting["m_coeffs"], len(setting["m_coeffs"]),)
-		     c.SetIsComplex(setting["iscomplex"])
-                     c.SetKinds(setting["kinds"])			
+                     c.SetParams(setting["s_coeffs"], len(setting["s_coeffs"]),
+                                 setting["v_coeffs"], len(setting["v_coeffs"]),
+                                 setting["m_coeffs"], len(setting["m_coeffs"]),)
+                     c.SetIsComplex(setting["iscomplex"])
+                     c.SetKinds(setting["kinds"])
                 return coeff
             return dec
     jit = _JIT()

--- a/mfem/common/numba_coefficient.i
+++ b/mfem/common/numba_coefficient.i
@@ -97,6 +97,36 @@ x.ProjectCoefficient(f_exact)
 %}
 
 %inline %{
+classe FunctionCoefficeintExtra : public mfem::FunctionCoefficient{
+
+
+
+
+ public:
+  void SetParams(mfem::Coefficient *coeff[], int num_coeff,
+		 mfem::VectorCoefficient *vcoeff[], int num_vcoeff)
+		 mfem::MatrixCoefficient *mcoeff[], int num_mcoeff){
+  }
+  double * PrepParams(){
+  }
+  virtual double Eval(ElementTransformation &T,
+		      const IntegrationPoint &ip){
+      double x[3];
+      Vector transip(x, 3);
+
+      T.Transform(ip, transip);
+
+      if (Function)
+      {
+         return Function(transip);
+      }
+      else
+      {
+         return TDFunction(transip, GetTime());
+      }
+  }
+};
+ 
 class NumbaFunctionBase{
  protected:
     void *address_;

--- a/mfem/common/numba_coefficient.i
+++ b/mfem/common/numba_coefficient.i
@@ -718,7 +718,6 @@ class ScalarNumbaFunction2 : public NumbaFunctionBase {
     }
     // complex real part
     double callr(const mfem::Vector &x){
-      std::complex<double> ret;
       ret = ((std::complex<double> (*)(double *, void**))address_)(x.GetData(), (void **)data_ptr);
       return ret.real();
     }
@@ -732,7 +731,6 @@ class ScalarNumbaFunction2 : public NumbaFunctionBase {
       return ret.imag();
     }
     double callti(const mfem::Vector &x, double t){
-      std::complex<double> ret;
       ret = ((std::complex<double> (*)(double *, double, void **))address_)(x.GetData(), t, (void **)data_ptr);
       return ret.imag();
     }
@@ -1158,7 +1156,7 @@ try:
                   caller_txt = interface[0](setting)
 
                 if debug:
-                     print("(DEBUG) generated caller function:", caller_txt)
+                     print("(DEBUG) generated caller function:\n", caller_txt)
 
                 exec(caller_txt, globals(), locals())
                 caller_params = {"inner_func": ff,  "sdim": sdim,
@@ -1245,7 +1243,7 @@ try:
                     caller_txt = interface[0](setting)
 
                 if debug:
-                     print("(DEBUG) generated caller function:", caller_txt)
+                     print("(DEBUG) generated caller function:\n", caller_txt)
 
                 exec(caller_txt, globals(), locals())
 
@@ -1336,7 +1334,7 @@ try:
                     caller_txt = interface[0](setting)
 
                 if debug:
-                     print("(DEBUG) generated caller function:", caller_txt)
+                     print("(DEBUG) generated caller function:\n", caller_txt)
 
                 exec(caller_txt, globals(), locals())
 

--- a/mfem/common/numba_coefficient.i
+++ b/mfem/common/numba_coefficient.i
@@ -98,14 +98,9 @@ def f_exact(x, out):
 # passing Scalar/Vector/Matrix coefficient including GridFunctionCoefficients
 # (Er, Ei) means complex number (GF for real and imaginary parts)
 # density is double.
-<<<<<<< HEAD
 
 @mfem.jit.vector(sdim, dependencies=((Er, Ei), density), complex=True)
 def f_exact(x, E, density, out):
-=======
-@mfem.jit.vector(dependencies=((Er, Ei), density), return_complex=True)
-def f_exact(x, out, E=None):
->>>>>>> 4d4d254 ((WIP)....)
     out[0] = (1 + kappa**2)*sin(kappa * x[1])
     out[1] = (1 + kappa**2)*sin(kappa * x[2])
     out[2] = (1 + kappa**2)*sin(kappa * x[0])
@@ -117,7 +112,6 @@ coefficient
 otherwise
    f_exact is coefficient
 
-<<<<<<< HEAD
 # vectorr coefficient
 @mfem.jit.matrix(3, shape = (3,3))
 def f_exact(x, out):
@@ -130,8 +124,6 @@ def f_exact(x, out):
     out[2] = (1 + kappa**2)*sin(kappa * x[0])
 
 
-=======
->>>>>>> 4d4d254 ((WIP)....)
 Then, decorated function can be used as function coefficient
 x.ProjectCoefficient(f_exact)       
 
@@ -208,7 +200,6 @@ class NumbaFunction : public NumbaFunctionBase {
        NumbaFunctionBase(input, sdim, td){}
 
     double call0(const mfem::Vector &x){
-<<<<<<< HEAD
       return ((double (*)(double *))address_)(x.GetData());
     }
     double call(const mfem::Vector &x){
@@ -219,20 +210,7 @@ class NumbaFunction : public NumbaFunctionBase {
     }
     double callt(const mfem::Vector &x, double t){
       return ((double (*)(double *, double, int))address_)(x.GetData(), t, sdim_);
-=======
-      return ((double (*)(double *, void **, int))address_)(x.GetData(), data);
     }
-    double call(const mfem::Vector &x){
-      return ((double (*)(double *, void**, int, int))address_)(x.GetData(), data, sdim_);
-    }
-    double call0t(const mfem::Vector &x, double t){
-      return ((double (*)(double *, double, int))address_)(x.GetData(), t, data);
-    }
-    double callt(const mfem::Vector &x, double t){
-      return ((double (*)(double *, double, int, int))address_)(x.GetData(), t, data, sdim_);
->>>>>>> 4d4d254 ((WIP)....)
-    }
-    
 
     // FunctionCoefficient
     mfem::FunctionCoefficient* GenerateCoefficient(int use_0=0){

--- a/mfem/common/numba_coefficient.i
+++ b/mfem/common/numba_coefficient.i
@@ -98,7 +98,8 @@ x.ProjectCoefficient(f_exact)
 
 %inline %{
 classe FunctionCoefficeintExtra : public mfem::FunctionCoefficient{
-
+ private:
+  mfem::Array<double> data;
 
 
 
@@ -124,6 +125,11 @@ classe FunctionCoefficeintExtra : public mfem::FunctionCoefficient{
       {
          return TDFunction(transip, GetTime());
       }
+  }
+  FunctionCoefficeintExtra::~FunctionCoefficeintExtra(){
+    if (data){
+      ~data;
+    }
   }
 };
  

--- a/mfem/common/numba_coefficient_utils.py
+++ b/mfem/common/numba_coefficient_utils.py
@@ -104,40 +104,49 @@ def _process_dependencies(dependencies):
     iscomplex = []
     sizes = []
     kinds = []
+    s_coeffs = []
+    v_coeffs = []
+    m_coeffs = []        
     for x in dependencies:
         if isinstance(x, tuple):
             iscomplex.append(True)
-            xx = x[0] if x[0] is not None else x[1]
-            if xx is None:
-                assert False, "dependency is None"
+            xx = x[0]
+            if xx[0] is None or xx[1] is None:
+                assert False, "dependency has to have both real imaginary parts defined"
             if isinstacne(xx], Coefficient):
-                sizes.append(2)
                 kinds.append(0)
+                s_coeffs.append(x[0])
+                s_coeffs.append(x[1])                
             elif isinstacne(xx, VectorCoefficient):
-                sizes.append(xx.GetVdim()*2)
-                kinds.append(1)                
+                assert x[0].GetVdim() == x[1].GetVdim() "real and imaginary has to have the same vdim"
+                kinds.append(1)
+                v_coeffs.append(x[0])
+                v_coeffs.append(x[1])                
             elif isinstacne(xx, MatrixCoefficient):
-                sizes.append(xx.GetHeight()*xx.GetWidth()*2)
+                assert x[0].Height() == x[1].Height() "real and imaginary has to have the same vdim"
+                assert x[0].Width() == x[1].Width() "real and imaginary has to have the same vdim"
                 kinds.append(2)
+                m_coeffs.append(x[0])
+                m_coeffs.append(x[1])                
             else:
                 assert False, "unknown coefficient type" + str(type(xx))
         else:
             iscomplex.append(False)
-            xx = x[0] if x[0] is not None else x[1]
-            if xx is None:
-                assert False, "dependency is None"
-            if isinstacne(xx], Coefficient):
+            if isinstacne(x, Coefficient):
                 sizes.append(1)
-                kinds.append(0)                
-            elif isinstacne(xx, VectorCoefficient):
-                sizes.append(xx.GetVdim())
+                kinds.append(0)
+                s_coeffs.append(x)                
+            elif isinstacne(x, VectorCoefficient):
+                sizes.append(x.GetVdim())
                 kinds.append(1)
-            elif isinstacne(xx, MatrixCoefficient):
-                sizes.append(xx.GetHeight()*xx.GetWidth())
-                kinds.append(2)            
+                v_coeffs.append(x)
+            elif isinstacne(x, MatrixCoefficient):
+                sizes.append(x.GetHeight()*xx.GetWidth())
+                kinds.append(2)
+                m_coeffs.append(x)                
             else:
                 assert False, "unknown coefficient type" + str(type(xx))
-    return iscomplex, sizes, kinds
+    return iscomplex, sizes, kinds, s_coeffs, v_coeffs, m_coeffs
 
 def get_setting(iscomplex=False, dependencies=None):
     setting = {}
@@ -146,11 +155,13 @@ def get_setting(iscomplex=False, dependencies=None):
     else:
         setting['output'] = 1
 
-    iscomplex, sizes, kinds = _process_dependencies(dependencies):
+    iscomplex, sizes, kinds, s_coeffs, v_coeffs, m_coeffs = _process_dependencies(dependencies)
 
     setting['iscomplex'] = iscomplex
     setting['kinds'] = kinds
-    setting['sizes'] = sizes
+    setting['s_coeffs'] = s_coeffs
+    setting['v_coeffs'] = v_coeffs
+    setting['m_coeffs'] = m_coeffs
     return setting
 
 

--- a/mfem/common/numba_coefficient_utils.py
+++ b/mfem/common/numba_coefficient_utils.py
@@ -1,0 +1,157 @@
+'''
+ subroutines for numba_coefficeint 
+'''
+def generate_caller_scaler(settings):
+    '''
+    generate a callder function on the fly
+
+    ex)
+    if setting is {"input": (2, 1), "output": 2}
+
+    def _caller(ptx, data):
+        arr0 = data[0]+1j*data[0+1]
+        arr2 = data[2]
+        params = (arr0,arr2,)
+        return (inner_func(ptx, *params))
+
+    here inner_func is a function user provided.
+
+    '''
+    text = ['def _caller(ptx, data):']
+    count = 0
+
+    params_line = '    params = ('        
+    for s in settings["input"]:
+        if s == 2:
+            t = '    arr'+str(count) + ' = data[' + str(count) + ']+1j*data[' + str(count) +'+1]'
+            params_line += 'arr'+str(count)+','
+            count = count + 2
+        else:
+            t = '    arr'+str(count) + ' = data[' + str(count) + ']'
+            params_line += 'arr'+str(count)+','
+            count = count + 1
+        text.append(t)
+    params_line += ')'
+
+    text.append(params_line)
+    text.append("    return (inner_func(ptx, *params))")
+    return '\n'.join(text)
+	      
+def generate_signature_scalar(setting):
+    '''
+    generate a signature to numba-compile a user scalar function
+
+    ex)
+    if setting is {"input": (2, 1), "output": 2}
+  
+    output : types.complex128(CPointer(types.double), types.complex128,types.double,)
+
+    '''
+
+    sig = ''
+    if setting['output'] == 1:
+        sig += 'types.float64(CPointer(types.double, '
+    else:
+        sig += 'types.complex128(CPointer(types.double), '
+
+    for s in setting['input']:
+        if s == 1:
+            sig += 'types.double,'
+        else:
+            sig += 'types.complex128,'
+
+    sig = sig + ")"
+    return sig
+
+def generate_signature_array(setting):
+    '''
+    generate a signature to numba-compile a user vector/matrix function
+
+    ex)
+    if setting is {"input": (2, 1), "output": 2}
+  
+    output : types.void(CPointer(types.double), types.complex128, types.double, 
+                        CPointer(types.complex128))
+
+    '''
+    sig = ''
+    sig += 'types.void(CPointer(types.double, '
+    for s in setting['input']:
+        if s == 1:
+            sig += 'types.double,'
+        else:
+            sig += 'types.complex128,'
+
+    if setting['output'] == 1:
+        sig += 'CPointer(types.double), '
+    else:
+        sig += 'CPointer(types.complex128), '
+
+
+    sig = sig + ")"
+    return sig
+	      
+def _process_dependencies(dependencies):
+    from mfem import mfem_mode
+    if mfem_mode == 'serial'
+        import mfem.ser import (Coefficient,
+                                VectorCoefficient,
+                                MatrixCoefficient)      
+    else:
+        import mfem.par import (Coefficient,
+                                VectorCoefficient,
+                                MatrixCoefficient)      
+    iscomplex = []
+    sizes = []
+    kinds = []
+    for x in dependencies:
+        if isinstance(x, tuple):
+            iscomplex.append(True)
+            xx = x[0] if x[0] is not None else x[1]
+            if xx is None:
+                assert False, "dependency is None"
+            if isinstacne(xx], Coefficient):
+                sizes.append(2)
+                kinds.append(0)
+            elif isinstacne(xx, VectorCoefficient):
+                sizes.append(xx.GetVdim()*2)
+                kinds.append(1)                
+            elif isinstacne(xx, MatrixCoefficient):
+                sizes.append(xx.GetHeight()*xx.GetWidth()*2)
+                kinds.append(2)
+            else:
+                assert False, "unknown coefficient type" + str(type(xx))
+        else:
+            iscomplex.append(False)
+            xx = x[0] if x[0] is not None else x[1]
+            if xx is None:
+                assert False, "dependency is None"
+            if isinstacne(xx], Coefficient):
+                sizes.append(1)
+                kinds.append(0)                
+            elif isinstacne(xx, VectorCoefficient):
+                sizes.append(xx.GetVdim())
+                kinds.append(1)
+            elif isinstacne(xx, MatrixCoefficient):
+                sizes.append(xx.GetHeight()*xx.GetWidth())
+                kinds.append(2)            
+            else:
+                assert False, "unknown coefficient type" + str(type(xx))
+    return iscomplex, sizes, kinds
+
+def get_setting(iscomplex=False, dependencies=None):
+    setting = {}
+    if iscomplex:
+        setting['output'] = 2
+    else:
+        setting['output'] = 1
+
+    iscomplex, sizes, kinds = _process_dependencies(dependencies):
+
+    setting['iscomplex'] = iscomplex
+    setting['kinds'] = kinds
+    setting['sizes'] = sizes
+    return setting
+
+
+

--- a/mfem/common/numba_coefficient_utils.py
+++ b/mfem/common/numba_coefficient_utils.py
@@ -36,15 +36,22 @@ def generate_caller_scalar(setting):
     params_line = '    params = ('
 
     for s, kind, size in zip(setting['iscomplex'], setting['kinds'], setting["sizes"]):
+        if not isinstance(size, tuple):
+            size = (size, )
+
         if s:
             t1 = '    arrr' + \
                 str(count) + ' = farray(data[' + \
-                str(count) + "], ("+str(size) + "), np.float64)"
+                str(count) + "], "+str(size) + ", np.float64)"
             t2 = '    arri' + \
                 str(count) + ' = farray(data[' + \
-                str(count+1) + "], ("+str(size) + "), np.float64)"
+                str(count+1) + "], "+str(size) + ", np.float64)"
             t3 = '    arr'+str(count) + ' = arrr' + \
                 str(count) + "+1j*arri" + str(count)
+
+            if len(size)==1 and size[0] == 1:
+                t1 += '[0]'
+                t2 += '[0]'
 
             text.extend((t1, t2, t3))
             params_line += 'arr'+str(count)+','
@@ -52,7 +59,11 @@ def generate_caller_scalar(setting):
         else:
             t = '    arr' + \
                 str(count) + ' = farray(data[' + \
-                str(count) + "], ("+str(size) + "), np.float64)"
+                str(count) + "], "+str(size) + ", np.float64)"
+
+            if len(size)==1 and size[0] == 1:
+                t += '[0]'
+
             text.append(t)
 
             params_line += 'arr'+str(count)+','
@@ -95,15 +106,21 @@ def generate_caller_array_oldstyle(setting):
     params_line = '    params = ('
 
     for s, kind, size in zip(setting['iscomplex'], setting['kinds'], setting["sizes"]):
+        if not isinstance(size, tuple):
+            size = (size, )
+
         if s:
-            if not isinstance(size, tuple):
-                size = (size, )
             t1 = '    arrr' + \
                 str(count) + ' = farray(data[' + \
                 str(count) + "], "+str(size) + ", np.float64)"
             t2 = '    arri' + \
                 str(count) + ' = farray(data[' + \
                 str(count+1) + "], "+str(size) + ", np.float64)"
+
+            if len(size)==1 and size[0] == 1:
+                t1 += '[0]'
+                t2 += '[0]'
+
             t3 = '    arr'+str(count) + ' = arrr' + \
                 str(count) + "+1j*arri" + str(count)
 
@@ -113,7 +130,11 @@ def generate_caller_array_oldstyle(setting):
         else:
             t = '    arr' + \
                 str(count) + ' = farray(data[' + \
-                str(count) + "], ("+str(size) + "), np.float64)"
+                str(count) + "], "+str(size) + ", np.float64)"
+
+            if len(size)==1 and size[0] == 1:
+                t += '[0]'
+
             text.append(t)
 
             params_line += 'arr'+str(count)+','
@@ -174,15 +195,21 @@ def generate_caller_array(setting):
     params_line = '    params = ('
 
     for s, kind, size in zip(setting['iscomplex'], setting['kinds'], setting["sizes"]):
+        if not isinstance(size, tuple):
+            size = (size, )
+
         if s:
-            if not isinstance(size, tuple):
-                size = (size, )
             t1 = '    arrr' + \
                 str(count) + ' = farray(data[' + \
                 str(count) + "], "+str(size) + ", np.float64)"
             t2 = '    arri' + \
                 str(count) + ' = farray(data[' + \
                 str(count+1) + "], "+str(size) + ", np.float64)"
+
+            if len(size)==1 and size[0] == 1:
+                t1 += '[0]'
+                t2 += '[0]'
+
             t3 = '    arr'+str(count) + ' = arrr' + \
                 str(count) + "+1j*arri" + str(count)
 
@@ -192,7 +219,11 @@ def generate_caller_array(setting):
         else:
             t = '    arr' + \
                 str(count) + ' = farray(data[' + \
-                str(count) + "], ("+str(size) + "), np.float64)"
+                str(count) + "], "+str(size) + ", np.float64)"
+
+            if len(size)==1 and size[0] == 1:
+                t += '[0]'
+
             text.append(t)
 
             params_line += 'arr'+str(count)+','

--- a/mfem/common/numba_coefficient_utils.py
+++ b/mfem/common/numba_coefficient_utils.py
@@ -1,6 +1,8 @@
 '''
- subroutines for numba_coefficeint 
+ subroutines for numba_coefficeint
 '''
+
+
 def generate_caller_scaler(settings):
     '''
     generate a callder function on the fly
@@ -20,10 +22,12 @@ def generate_caller_scaler(settings):
     text = ['def _caller(ptx, data):']
     count = 0
 
-    params_line = '    params = ('        
+    params_line = '    params = ('
     for s in settings["input"]:
         if s == 2:
-            t = '    arr'+str(count) + ' = data[' + str(count) + ']+1j*data[' + str(count) +'+1]'
+            t = '    arr' + \
+                str(count) + ' = data[' + str(count) + \
+                    ']+1j*data[' + str(count) + '+1]'
             params_line += 'arr'+str(count)+','
             count = count + 2
         else:
@@ -36,15 +40,17 @@ def generate_caller_scaler(settings):
     text.append(params_line)
     text.append("    return (inner_func(ptx, *params))")
     return '\n'.join(text)
-	      
+
+
 def generate_signature_scalar(setting):
     '''
     generate a signature to numba-compile a user scalar function
 
     ex)
     if setting is {"input": (2, 1), "output": 2}
-  
-    output : types.complex128(CPointer(types.double), types.complex128,types.double,)
+
+    output : types.complex128(CPointer(types.double),
+                              types.complex128,types.double,)
 
     '''
 
@@ -63,14 +69,15 @@ def generate_signature_scalar(setting):
     sig = sig + ")"
     return sig
 
+
 def generate_signature_array(setting):
     '''
     generate a signature to numba-compile a user vector/matrix function
 
     ex)
     if setting is {"input": (2, 1), "output": 2}
-  
-    output : types.void(CPointer(types.double), types.complex128, types.double, 
+
+    output : types.void(CPointer(types.double), types.complex128, types.double,
                         CPointer(types.complex128))
 
     '''
@@ -87,65 +94,67 @@ def generate_signature_array(setting):
     else:
         sig += 'CPointer(types.complex128), '
 
-
     sig = sig + ")"
     return sig
-	      
+
+
 def _process_dependencies(dependencies):
     from mfem import mfem_mode
     if mfem_mode == 'serial'
-        import mfem.ser import (Coefficient,
+        import mfem.ser import (Coefficient
+        import
                                 VectorCoefficient,
-                                MatrixCoefficient)      
+                                MatrixCoefficient)
     else:
-        import mfem.par import (Coefficient,
+        import mfem.par import (Coefficient
+        import
                                 VectorCoefficient,
-                                MatrixCoefficient)      
+                                MatrixCoefficient)
     iscomplex = []
     sizes = []
     kinds = []
     s_coeffs = []
     v_coeffs = []
-    m_coeffs = []        
+    m_coeffs = []
     for x in dependencies:
         if isinstance(x, tuple):
             iscomplex.append(True)
             xx = x[0]
-            if xx[0] is None or xx[1] is None:
+            if x[0] is None or x[1] is None:
                 assert False, "dependency has to have both real imaginary parts defined"
-            if isinstacne(xx], Coefficient):
-                kinds.append(0)
-                s_coeffs.append(x[0])
-                s_coeffs.append(x[1])                
-            elif isinstacne(xx, VectorCoefficient):
+            if isinstacne(xx, VectorCoefficient):
                 assert x[0].GetVdim() == x[1].GetVdim() "real and imaginary has to have the same vdim"
-                kinds.append(1)
-                v_coeffs.append(x[0])
-                v_coeffs.append(x[1])                
-            elif isinstacne(xx, MatrixCoefficient):
+            if isinstacne(xx, MatrixCoefficient):
+                assert x[0].Height() == x[0].Width() "matrix must be square"
                 assert x[0].Height() == x[1].Height() "real and imaginary has to have the same vdim"
                 assert x[0].Width() == x[1].Width() "real and imaginary has to have the same vdim"
-                kinds.append(2)
-                m_coeffs.append(x[0])
-                m_coeffs.append(x[1])                
-            else:
-                assert False, "unknown coefficient type" + str(type(xx))
         else:
             iscomplex.append(False)
-            if isinstacne(x, Coefficient):
-                sizes.append(1)
+            xx = x
+            if isinstacne(xx, MatrixCoefficient):
+                assert xx.Height() == xx.Width() "matrix must be square"
+
+        if isinstacne(xx], Coefficient):
                 kinds.append(0)
-                s_coeffs.append(x)                
-            elif isinstacne(x, VectorCoefficient):
-                sizes.append(x.GetVdim())
+                sizes.append(1)
+                s_coeffs.append(xx)
+                if iscomplex[-1]:
+                    s_coeffs.append(x[1])
+        elif isinstacne(x, VectorCoefficient):
                 kinds.append(1)
-                v_coeffs.append(x)
-            elif isinstacne(x, MatrixCoefficient):
-                sizes.append(x.GetHeight()*xx.GetWidth())
+                sizes.append(xx.GetVdim())
+                v_coeffs.append(xx)
+                if iscomplex[-1]:
+                    v_coeffs.append(x[1])
+        elif isinstacne(xx, MatrixCoefficient):
                 kinds.append(2)
-                m_coeffs.append(x)                
-            else:
-                assert False, "unknown coefficient type" + str(type(xx))
+                sizes.append(xx.GetHeight()*xx.GetWidth())
+                m_coeffs.append(xx)
+                if iscomplex[-1]:
+                    m_coeffs.append(x[1])
+        else:
+            assert False, "unknown coefficient type" + str(type(xx))
+
     return iscomplex, sizes, kinds, s_coeffs, v_coeffs, m_coeffs
 
 def get_setting(iscomplex=False, dependencies=None):
@@ -163,6 +172,3 @@ def get_setting(iscomplex=False, dependencies=None):
     setting['v_coeffs'] = v_coeffs
     setting['m_coeffs'] = m_coeffs
     return setting
-
-
-

--- a/mfem/common/numba_coefficient_utils.py
+++ b/mfem/common/numba_coefficient_utils.py
@@ -12,7 +12,7 @@ def generate_caller_scalar(setting):
         {"isdepcomplex": (True, False), "kinds": (1, 0),
                        "output": True, size: (10, 1)}
 
-    def _caller(ptx, data):
+    def _caller(ptx, sdim, data):
         ptx = farray(ptx, (sdim,), np.float64)      # for position
         arr0r = farray(data[0], (10,), np.float64)
         arr0i = farray(data[1], (10,), np.float64)
@@ -27,9 +27,9 @@ def generate_caller_scalar(setting):
 
     '''
     if setting['td']:
-        text = ['def _caller(ptx, t, data):']
+        text = ['def _caller(ptx, sdim, t, data):']
     else:
-        text = ['def _caller(ptx, data):']
+        text = ['def _caller(ptx, sdim, data):']
 
     text.append("    ptx = farray(ptx, (sdim,), np.float64)")
     count = 0
@@ -49,7 +49,8 @@ def generate_caller_scalar(setting):
             t3 = '    arr'+str(count) + ' = arrr' + \
                 str(count) + "+1j*arri" + str(count)
 
-            if len(size) == 1 and size[0] == 1:
+            #if len(size) == 1 and size[0] == 1:
+            if kind == 0:
                 t1 += '[0]'
                 t2 += '[0]'
 
@@ -61,7 +62,8 @@ def generate_caller_scalar(setting):
                 str(count) + ' = farray(data[' + \
                 str(count) + "], "+str(size) + ", np.float64)"
 
-            if len(size) == 1 and size[0] == 1:
+            #if len(size) == 1 and size[0] == 1:
+            if kind == 0:            
                 t += '[0]'
 
             text.append(t)
@@ -86,7 +88,7 @@ def generate_caller_array_oldstyle(setting):
     if setting is
         {"isdepcomplex": (True, False), "kinds": (1, 0),
                        "output": True, size: ((3, 3), 1), outsize: (2, 2) }
-    def _caller(ptx, data, out_):
+    def _caller(ptx, sdim, data, out_):
         ptx = farray(ptx, (sdim,), np.float64)      # for position
         arr0r = farray(data[0], (3, 3), np.float64)
         arr0i = farray(data[1], (3, 3), np.float64)
@@ -98,9 +100,9 @@ def generate_caller_array_oldstyle(setting):
     here inner_func is a function user provided.
     '''
     if setting['td']:
-        text = ['def _caller(ptx, t, data, out_):']
+        text = ['def _caller(ptx, sdim, t, data, out_):']
     else:
-        text = ['def _caller(ptx, data, out_):']
+        text = ['def _caller(ptx, sdim, data, out_):']
     text.append("    ptx = farray(ptx, (sdim,), np.float64)")
     count = 0
     params_line = '    params = ('
@@ -117,7 +119,8 @@ def generate_caller_array_oldstyle(setting):
                 str(count) + ' = farray(data[' + \
                 str(count+1) + "], "+str(size) + ", np.float64)"
 
-            if len(size) == 1 and size[0] == 1:
+            #if len(size) == 1 and size[0] == 1:
+            if kind == 0:                
                 t1 += '[0]'
                 t2 += '[0]'
 
@@ -132,7 +135,8 @@ def generate_caller_array_oldstyle(setting):
                 str(count) + ' = farray(data[' + \
                 str(count) + "], "+str(size) + ", np.float64)"
 
-            if len(size) == 1 and size[0] == 1:
+            #if len(size) == 1 and size[0] == 1:
+            if kind == 0:                                        
                 t += '[0]'
 
             text.append(t)
@@ -159,14 +163,14 @@ def generate_caller_array_oldstyle(setting):
 
 def generate_caller_array(setting):
     '''
-    generate a callder function on the fly
+    generate a following callder function from setting
 
     ex)
     if setting is
         {"isdepcomplex": (True, False), "kinds": (1, 0),
                        "output": True, size: ((3, 3), 1), outsize: (2, 2) }
 
-    def _caller(ptx, data, out_):
+    def _caller(ptx, sdim, data, out_):
         ptx = farray(ptx, (sdim,), np.float64)      # for position
         arr0r = farray(data[0], (3, 3), np.float64)
         arr0i = farray(data[1], (3, 3), np.float64)
@@ -187,9 +191,9 @@ def generate_caller_array(setting):
 
     '''
     if setting['td']:
-        text = ['def _caller(ptx, t, data, out_):']
+        text = ['def _caller(ptx, sdim, t, data, out_):']
     else:
-        text = ['def _caller(ptx, data, out_):']
+        text = ['def _caller(ptx, sdim, data, out_):']
     text.append("    ptx = farray(ptx, (sdim,), np.float64)")
     count = 0
     params_line = '    params = ('
@@ -206,7 +210,8 @@ def generate_caller_array(setting):
                 str(count) + ' = farray(data[' + \
                 str(count+1) + "], "+str(size) + ", np.float64)"
 
-            if len(size) == 1 and size[0] == 1:
+            #if len(size) == 1 and size[0] == 1:
+            if kind == 0:                                
                 t1 += '[0]'
                 t2 += '[0]'
 
@@ -221,7 +226,8 @@ def generate_caller_array(setting):
                 str(count) + ' = farray(data[' + \
                 str(count) + "], "+str(size) + ", np.float64)"
 
-            if len(size) == 1 and size[0] == 1:
+            #if len(size) == 1 and size[0] == 1:
+            if kind == 0:                                                
                 t += '[0]'
 
             text.append(t)

--- a/mfem/common/numba_coefficient_utils.py
+++ b/mfem/common/numba_coefficient_utils.py
@@ -27,7 +27,7 @@ def generate_caller_scalar(settings):
 
     '''
     text = ['def _caller(ptx, data):']
-    text.append("    ptx = numba.carray(ptx, (sdim,), np.float64)"]
+    text.append("    ptx = numba.carray(ptx, (sdim,), np.float64)")
     count = 0
     params_line = '    params = ('
 
@@ -35,12 +35,12 @@ def generate_caller_scalar(settings):
         if s:
             t1 = '    arrr' + \
                 str(count) + ' = numba.carray[data[' + \
-                    str(count) + "], ("+str(size) + "), np.float64)"
+                str(count) + "], ("+str(size) + "), np.float64)"
             t2 = '    arri' + \
                 str(count) + ' = numba.carray[data[' + \
-                    str(count+1) + "], ("+str(size) + "), np.float64)"
+                str(count+1) + "], ("+str(size) + "), np.float64)"
             t3 = '    arr'+str(count) + ' = arrr' + \
-                               str(count) + "+1j*arri" + str(count)
+                str(count) + "+1j*arri" + str(count)
 
             text.extend((t1, t2, t3))
             params_line += 'arr'+str(count)+','
@@ -48,7 +48,7 @@ def generate_caller_scalar(settings):
         else:
             t = '    arr' + \
                 str(count) + ' = numba.carray[data[' + \
-                    str(count) + "], ("+str(size) + "), np.float64)"
+                str(count) + "], ("+str(size) + "), np.float64)"
             text.append(t)
 
             params_line += 'arr'+str(count)+','
@@ -89,7 +89,7 @@ def generate_caller_array(settings):
 
     '''
     text = ['def _caller(ptx, data):']
-    text.append("    ptx = numba.carray(ptx, (sdim,), np.float64)"]
+    text.append("    ptx = numba.carray(ptx, (sdim,), np.float64)")
     count = 0
     params_line = '    params = ('
 
@@ -99,12 +99,12 @@ def generate_caller_array(settings):
                 size = (size, )
             t1 = '    arrr' + \
                 str(count) + ' = numba.carray[data[' + \
-                    str(count) + "], "+str(size) + ", np.float64)"
+                str(count) + "], "+str(size) + ", np.float64)"
             t2 = '    arri' + \
                 str(count) + ' = numba.carray[data[' + \
-                    str(count+1) + "], "+str(size) + ", np.float64)"
+                str(count+1) + "], "+str(size) + ", np.float64)"
             t3 = '    arr'+str(count) + ' = arrr' + \
-                               str(count) + "+1j*arri" + str(count)
+                str(count) + "+1j*arri" + str(count)
 
             text.extend((t1, t2, t3))
             params_line += 'arr'+str(count)+','
@@ -112,23 +112,23 @@ def generate_caller_array(settings):
         else:
             t = '    arr' + \
                 str(count) + ' = numba.carray[data[' + \
-                    str(count) + "], ("+str(size) + "), np.float64)"
+                str(count) + "], ("+str(size) + "), np.float64)"
             text.append(t)
 
             params_line += 'arr'+str(count)+','
             count = count + 1
 
     if output:
-       t1 = '    outr = numba.carray[data[' + \
-           str(count) + "], "+str(outsize) + ", np.float64)"
-       t2 = '    outi = numba.carray[data[' + \
-           str(count+1) + "], "+str(outsize) + ", np.float64)"
-       t3 = '    out = outr+1j*outi'
-       text.extend((t1, t2, t3))
+        t1 = '    outr = numba.carray[data[' + \
+            str(count) + "], "+str(outsize) + ", np.float64)"
+        t2 = '    outi = numba.carray[data[' + \
+            str(count+1) + "], "+str(outsize) + ", np.float64)"
+        t3 = '    out = outr+1j*outi'
+        text.extend((t1, t2, t3))
     else:
-       t1 = '    out = numba.carray[data[' + \
-           str(count) + "], "+str(outsize) + ", np.float64)"
-       text.append(t)
+        t1 = '    out = numba.carray[data[' + \
+            str(count) + "], "+str(outsize) + ", np.float64)"
+        text.append(t)
 
     params_line += 'out)'
 
@@ -218,16 +218,14 @@ def generate_signature_array(setting):
 
 def _process_dependencies(dependencies):
     from mfem import mfem_mode
-    if mfem_mode == 'serial'
-        import mfem.ser import (Coefficient
-        import
-                                VectorCoefficient,
-                                MatrixCoefficient)
+    if mfem_mode == 'serial':
+        from mfem.ser import (Coefficient,
+                              VectorCoefficient,
+                              MatrixCoefficient)
     else:
-        import mfem.par import (Coefficient
-        import
-                                VectorCoefficient,
-                                MatrixCoefficient)
+        from mfem.par import (Coefficient,
+                              VectorCoefficient,
+                              MatrixCoefficient)
     iscomplex = []
     sizes = []
     kinds = []
@@ -240,40 +238,44 @@ def _process_dependencies(dependencies):
             xx = x[0]
             if x[0] is None or x[1] is None:
                 assert False, "dependency has to have both real imaginary parts defined"
-            if isinstacne(xx, VectorCoefficient):
-                assert x[0].GetVdim() == x[1].GetVdim() "real and imaginary has to have the same vdim"
-            if isinstacne(xx, MatrixCoefficient):
-                assert x[0].Height() == x[0].Width() "matrix must be square"
-                assert x[0].Height() == x[1].Height() "real and imaginary has to have the same vdim"
-                assert x[0].Width() == x[1].Width() "real and imaginary has to have the same vdim"
+            if isinstance(xx, VectorCoefficient):
+                assert x[0].GetVdim() == x[1].GetVdim(
+                ), "real and imaginary has to have the same vdim"
+            if isinstance(xx, MatrixCoefficient):
+                h1, w1 = x[0].Height(), x[0].Width()
+                h2, w2 = x[1].Height(), x[1].Width()
+                assert h1 == w1, "matrix must be square"
+                assert h1 == h2, "real and imaginary has to have the same vdim"
+                assert w1 == w2, "real and imaginary has to have the same vdim"
         else:
             iscomplex.append(False)
             xx = x
-            if isinstacne(xx, MatrixCoefficient):
-                assert xx.Height() == xx.Width() "matrix must be square"
+            if isinstance(xx, MatrixCoefficient):
+                assert xx.Height() == xx.Width(), "matrix must be square"
 
-        if isinstacne(xx], Coefficient):
-                kinds.append(0)
-                sizes.append(1)
-                s_coeffs.append(xx)
-                if iscomplex[-1]:
-                    s_coeffs.append(x[1])
-        elif isinstacne(x, VectorCoefficient):
-                kinds.append(1)
-                sizes.append(xx.GetVdim())
-                v_coeffs.append(xx)
-                if iscomplex[-1]:
-                    v_coeffs.append(x[1])
-        elif isinstacne(xx, MatrixCoefficient):
-                kinds.append(2)
-                sizes.append(xx.GetHeight()*xx.GetWidth())
-                m_coeffs.append(xx)
-                if iscomplex[-1]:
-                    m_coeffs.append(x[1])
+        if isinstance(xx, Coefficient):
+            kinds.append(0)
+            sizes.append(1)
+            s_coeffs.append(xx)
+            if iscomplex[-1]:
+                s_coeffs.append(x[1])
+        elif isinstance(x, VectorCoefficient):
+            kinds.append(1)
+            sizes.append(xx.GetVdim())
+            v_coeffs.append(xx)
+            if iscomplex[-1]:
+                v_coeffs.append(x[1])
+        elif isinstance(xx, MatrixCoefficient):
+            kinds.append(2)
+            sizes.append(xx.GetHeight()*xx.GetWidth())
+            m_coeffs.append(xx)
+            if iscomplex[-1]:
+                m_coeffs.append(x[1])
         else:
             assert False, "unknown coefficient type" + str(type(xx))
 
     return iscomplex, sizes, kinds, s_coeffs, v_coeffs, m_coeffs
+
 
 def get_setting(outsize, iscomplex=False, dependencies=None):
     setting = {}
@@ -282,7 +284,8 @@ def get_setting(outsize, iscomplex=False, dependencies=None):
     else:
         setting['output'] = False
 
-    iscomplex, sizes, kinds, s_coeffs, v_coeffs, m_coeffs = _process_dependencies(dependencies)
+    iscomplex, sizes, kinds, s_coeffs, v_coeffs, m_coeffs = _process_dependencies(
+        dependencies)
 
     setting['iscomplex'] = iscomplex
     setting['kinds'] = kinds

--- a/mfem/common/numba_coefficient_utils.py
+++ b/mfem/common/numba_coefficient_utils.py
@@ -93,7 +93,7 @@ def generate_caller_array(setting):
 
     for s, kind, size in zip(setting['iscomplex'], setting['kinds'], setting["sizes"]):
         if s:
-            if not isinstances(size, tuple):
+            if not isinstance(size, tuple):
                 size = (size, )
             t1 = '    arrr' + \
                 str(count) + ' = farray(data[' + \

--- a/mfem/common/numba_coefficient_utils.py
+++ b/mfem/common/numba_coefficient_utils.py
@@ -3,7 +3,7 @@
 '''
 
 
-def generate_caller_scaler(settings):
+def generate_caller_scalar(settings):
     '''
     generate a callder function on the fly
 

--- a/mfem/common/numba_coefficient_utils.py
+++ b/mfem/common/numba_coefficient_utils.py
@@ -9,7 +9,7 @@ def generate_caller_scalar(setting):
 
     ex)
     if setting is
-        {"iscomplex": (True, False), "kinds": (1, 0),
+        {"isdepcomplex": (True, False), "kinds": (1, 0),
                        "output": True, size: (10, 1)}
 
     def _caller(ptx, data):
@@ -35,7 +35,7 @@ def generate_caller_scalar(setting):
     count = 0
     params_line = '    params = ('
 
-    for s, kind, size in zip(setting['iscomplex'], setting['kinds'], setting["sizes"]):
+    for s, kind, size in zip(setting['isdepcomplex'], setting['kinds'], setting["sizes"]):
         if not isinstance(size, tuple):
             size = (size, )
 
@@ -84,7 +84,7 @@ def generate_caller_array_oldstyle(setting):
     generate a callder function on the fly
     ex)
     if setting is
-        {"iscomplex": (True, False), "kinds": (1, 0),
+        {"isdepcomplex": (True, False), "kinds": (1, 0),
                        "output": True, size: ((3, 3), 1), outsize: (2, 2) }
     def _caller(ptx, data, out_):
         ptx = farray(ptx, (sdim,), np.float64)      # for position
@@ -105,7 +105,7 @@ def generate_caller_array_oldstyle(setting):
     count = 0
     params_line = '    params = ('
 
-    for s, kind, size in zip(setting['iscomplex'], setting['kinds'], setting["sizes"]):
+    for s, kind, size in zip(setting['isdepcomplex'], setting['kinds'], setting["sizes"]):
         if not isinstance(size, tuple):
             size = (size, )
 
@@ -163,7 +163,7 @@ def generate_caller_array(setting):
 
     ex)
     if setting is
-        {"iscomplex": (True, False), "kinds": (1, 0),
+        {"isdepcomplex": (True, False), "kinds": (1, 0),
                        "output": True, size: ((3, 3), 1), outsize: (2, 2) }
 
     def _caller(ptx, data, out_):
@@ -194,7 +194,7 @@ def generate_caller_array(setting):
     count = 0
     params_line = '    params = ('
 
-    for s, kind, size in zip(setting['iscomplex'], setting['kinds'], setting["sizes"]):
+    for s, kind, size in zip(setting['isdepcomplex'], setting['kinds'], setting["sizes"]):
         if not isinstance(size, tuple):
             size = (size, )
 
@@ -265,7 +265,7 @@ def generate_signature_scalar(setting):
         func(ptx, complex_array, float_scalar)
 
     setting is
-        {"iscomplex": (2, 1), "kinds": (1, 0), "output": 2}
+        {"isdepcomplex": (2, 1), "kinds": (1, 0), "output": 2}
 
     output is
          types.complex128(types.double[:], types.complex128[:], types.double,)
@@ -282,7 +282,7 @@ def generate_signature_scalar(setting):
     if setting['td']:
         sig += 'types.double, '
 
-    for s, kind, in zip(setting['iscomplex'], setting['kinds'],):
+    for s, kind, in zip(setting['isdepcomplex'], setting['kinds'],):
         if s:
             if kind == 0:
                 sig += 'types.complex128,'
@@ -311,7 +311,7 @@ def generate_signature_array_oldstyle(setting):
         func(ptx, complex_array, float_scalar, complex_output_array_)
 
     setting is
-        {"iscomplex": (2, 1), "kinds": (1, 0), "output": 2, "outkind": 2}
+        {"isdepcomplex": (2, 1), "kinds": (1, 0), "output": 2, "outkind": 2}
 
     output is
          types.void(types.double[:], types.complex128[::],
@@ -324,7 +324,7 @@ def generate_signature_array_oldstyle(setting):
     if setting['td']:
         sig += 'types.double, '
 
-    for s, kind, in zip(setting['iscomplex'], setting['kinds'],):
+    for s, kind, in zip(setting['isdepcomplex'], setting['kinds'],):
         if s:
             if kind == 0:
                 sig += 'types.complex128,'
@@ -363,7 +363,7 @@ def generate_signature_array(setting):
         func(ptx, complex_array, float_scalar)
 
     setting is
-        {"iscomplex": (2, 1), "kinds": (1, 0), "output": 2}
+        {"isdepcomplex": (2, 1), "kinds": (1, 0), "output": 2}
 
     output is
          types.complex128[:, :](types.double[:], types.complex128[:], types.double,)
@@ -385,7 +385,7 @@ def generate_signature_array(setting):
     if setting['td']:
         sig += 'types.double, '
 
-    for s, kind, in zip(setting['iscomplex'], setting['kinds'],):
+    for s, kind, in zip(setting['isdepcomplex'], setting['kinds'],):
         if s:
             if kind == 0:
                 sig += 'types.complex128,'
@@ -410,11 +410,14 @@ def _process_dependencies(dependencies):
     if mfem_mode == 'serial':
         from mfem.ser import (Coefficient,
                               VectorCoefficient,
-                              MatrixCoefficient)
+                              MatrixCoefficient,
+                              IsNumbaCoefficient)
     else:
         from mfem.par import (Coefficient,
                               VectorCoefficient,
-                              MatrixCoefficient)
+                              MatrixCoefficient,
+                              IsNumbaCoefficient)                              
+        
     iscomplex = []
     sizes = []
     kinds = []
@@ -473,10 +476,10 @@ def get_setting(outsize, iscomplex=False, dependencies=None, td=False):
     else:
         setting['output'] = False
 
-    iscomplex, sizes, kinds, s_coeffs, v_coeffs, m_coeffs = _process_dependencies(
+    isdepcomplex, sizes, kinds, s_coeffs, v_coeffs, m_coeffs = _process_dependencies(
         dependencies)
 
-    setting['iscomplex'] = iscomplex
+    setting['isdepcomplex'] = isdepcomplex
     setting['kinds'] = kinds
     setting['s_coeffs'] = s_coeffs
     setting['v_coeffs'] = v_coeffs

--- a/mfem/common/numba_coefficient_utils.py
+++ b/mfem/common/numba_coefficient_utils.py
@@ -465,7 +465,7 @@ def _process_dependencies(dependencies, setting):
                 else:
                     s_coeffs.append(x[1])
 
-        elif isinstance(x, VectorCoefficient):
+        elif isinstance(xx, VectorCoefficient):
             kinds.append(1)
             sizes.append(xx.GetVDim())
             v_coeffs.append(xx)

--- a/mfem/common/pycoefficient.hpp
+++ b/mfem/common/pycoefficient.hpp
@@ -79,7 +79,8 @@ class NumbaCoefficientBase
   int num_mcoeffs;
   int num_dep = 0;
   int kinds[16];       // for now upto 16 coefficients
-  int iscomplex[16];   // for now upto 16 coefficients
+  int isdepcomplex[16];   // for now upto 16 coefficients
+  int isoutcomplex;   // if output is complex
 
   mfem::Array<mfem::Coefficient *>  *pcoeffs = nullptr;
   mfem::Array<mfem::VectorCoefficient *>  *pvcoeffs = nullptr;
@@ -100,7 +101,9 @@ class NumbaCoefficientBase
   void PrepParams(mfem::ElementTransformation &T,
 		  const mfem::IntegrationPoint &ip);
   void SetKinds(PyObject *kinds_);
-  void SetIsComplex(PyObject *isComplex_);
+  void SetIsDepComplex(PyObject *isComplex_);
+  void SetOutComplex(bool in_){isoutcomplex=in_;}
+  bool IsOutComplex(){return isoutcomplex;}  
   virtual ~NumbaCoefficientBase(){
     delete obj;
     delete pcoeffs;

--- a/mfem/common/pycoefficient.hpp
+++ b/mfem/common/pycoefficient.hpp
@@ -101,11 +101,10 @@ class NumbaCoefficientBase
   mfem::Array<NumbaCoefficientBase *>  *pnmcoeffs = nullptr;
 
  protected:
-  int sdim=0;  
   NumbaFunctionBase *obj;
  public:
-  NumbaCoefficientBase(NumbaFunctionBase *in_obj, int in_sdim):
-    sdim(in_sdim), obj(in_obj){}
+  NumbaCoefficientBase(NumbaFunctionBase *in_obj):
+    obj(in_obj){}
   template<typename T1, typename T2, typename T3>
   void SetParams(const mfem::Array<mfem::Coefficient *>&,
 		 const mfem::Array<mfem::VectorCoefficient *>&,
@@ -118,7 +117,6 @@ class NumbaCoefficientBase
   void SetKinds(PyObject *kinds_);
   void SetIsDepComplex(PyObject *isComplex_);
   void SetOutComplex(bool in_){isoutcomplex=in_;}
-  int SpaceDimension(){return sdim;}
   bool IsOutComplex(){return isoutcomplex;}
   void SetTimeInDependency(double t);
   virtual ~NumbaCoefficientBase(){
@@ -128,7 +126,7 @@ class NumbaCoefficientBase
     delete pmcoeffs;
     delete pncoeffs;
     delete pnvcoeffs;
-    delete pnmcoeffs;    
+    delete pnmcoeffs;
   }
 };
 
@@ -137,18 +135,18 @@ class ScalarNumbaCoefficient : public mfem::FunctionCoefficient,  public NumbaCo
  public:
   int GetNDim(){return 0;}
   ScalarNumbaCoefficient(std::function<double(const mfem::Vector &)> F,
-			 NumbaFunctionBase *in_obj, int in_sdim)
-    : FunctionCoefficient(std::move(F)), NumbaCoefficientBase(in_obj, in_sdim){}
+			 NumbaFunctionBase *in_obj)
+    : FunctionCoefficient(std::move(F)), NumbaCoefficientBase(in_obj){}    
   ScalarNumbaCoefficient(std::function<double(const mfem::Vector &, double)> TDF,
-			 NumbaFunctionBase *in_obj, int in_sdim)
-    : FunctionCoefficient(std::move(TDF)), NumbaCoefficientBase(in_obj, in_sdim){}
+			 NumbaFunctionBase *in_obj)
+    : FunctionCoefficient(std::move(TDF)), NumbaCoefficientBase(in_obj){}    
   virtual void SetTime(double t){
       mfem::FunctionCoefficient::SetTime(t);
       NumbaCoefficientBase::SetTimeInDependency(t);
   }
   virtual double Eval(mfem::ElementTransformation &T,
 		      const mfem::IntegrationPoint &ip);
-  
+
 };
 
 class VectorNumbaCoefficient : public mfem::VectorFunctionCoefficient,  public NumbaCoefficientBase
@@ -156,11 +154,11 @@ class VectorNumbaCoefficient : public mfem::VectorFunctionCoefficient,  public N
  public:
   int GetNDim(){return 1;}
   VectorNumbaCoefficient(int dim, std::function<void(const mfem::Vector &, mfem::Vector &)> F,
-			 NumbaFunctionBase *in_obj, int in_sdim)
-    : VectorFunctionCoefficient(dim, std::move(F)), NumbaCoefficientBase(in_obj, in_sdim){}
+			 NumbaFunctionBase *in_obj)
+    : VectorFunctionCoefficient(dim, std::move(F)), NumbaCoefficientBase(in_obj){}    
   VectorNumbaCoefficient(int dim, std::function<void(const mfem::Vector &, double, mfem::Vector &)> TDF,
-			 NumbaFunctionBase *in_obj, int in_sdim)
-    : VectorFunctionCoefficient(dim, std::move(TDF)), NumbaCoefficientBase(in_obj, in_sdim){}
+			 NumbaFunctionBase *in_obj)
+    : VectorFunctionCoefficient(dim, std::move(TDF)), NumbaCoefficientBase(in_obj){}    
   virtual void SetTime(double t){
       mfem::VectorFunctionCoefficient::SetTime(t);
       NumbaCoefficientBase::SetTimeInDependency(t);
@@ -175,12 +173,12 @@ class MatrixNumbaCoefficient : public mfem::MatrixFunctionCoefficient,  public N
  public:
   int GetNDim(){return 2;}
   MatrixNumbaCoefficient(int dim, std::function<void(const mfem::Vector &, mfem::DenseMatrix &)> F,
-			 NumbaFunctionBase *in_obj, int in_sdim)
-    : MatrixFunctionCoefficient(dim, std::move(F)), NumbaCoefficientBase(in_obj, in_sdim){}
+			 NumbaFunctionBase *in_obj)
+    : MatrixFunctionCoefficient(dim, std::move(F)), NumbaCoefficientBase(in_obj){}    
   MatrixNumbaCoefficient(int dim, std::function<void(const mfem::Vector &, double, mfem::DenseMatrix &)> TDF,
-			 NumbaFunctionBase *in_obj, int in_sdim)
-    : MatrixFunctionCoefficient(dim, std::move(TDF)), NumbaCoefficientBase(in_obj, in_sdim){}
-  
+			 NumbaFunctionBase *in_obj)
+    : MatrixFunctionCoefficient(dim, std::move(TDF)), NumbaCoefficientBase(in_obj){}    
+
   virtual void SetTime(double t){
       mfem::MatrixFunctionCoefficient::SetTime(t);
       NumbaCoefficientBase::SetTimeInDependency(t);

--- a/mfem/common/pycoefficient.hpp
+++ b/mfem/common/pycoefficient.hpp
@@ -25,7 +25,7 @@ private:
    int isTimeDependent;
 public:
  VectorPyCoefficientBase(int dim,  int tdep, Coefficient *q=NULL): VectorFunctionCoefficient(dim, fake_func_vec, q), isTimeDependent(tdep) { }
-   virtual void SetTime(double t){VectorFunctionCoefficient::SetTime(t);}  
+   virtual void SetTime(double t){VectorFunctionCoefficient::SetTime(t);}
    virtual void Eval(DenseMatrix &M, ElementTransformation &T,
 		     const IntegrationRule &ir); /* do I need this method?? */
    virtual void Eval(Vector &V, ElementTransformation &T,
@@ -39,9 +39,9 @@ private:
    int isTimeDependent;
 public:
    MatrixPyCoefficientBase(int dim,  int tdep): MatrixFunctionCoefficient(dim, fake_func_mat), isTimeDependent(tdep) { }
-   virtual void SetTime(double t){MatrixFunctionCoefficient::SetTime(t);}    
+   virtual void SetTime(double t){MatrixFunctionCoefficient::SetTime(t);}
    virtual void Eval(DenseMatrix &K, ElementTransformation &T,
-		     const IntegrationPoint &ip); 
+		     const IntegrationPoint &ip);
    virtual void _EvalPy(Vector &, DenseMatrix &){};
    virtual void _EvalPyT(Vector &, double, DenseMatrix &){};
    virtual ~MatrixPyCoefficientBase() { }
@@ -68,7 +68,7 @@ class NumbaFunctionBase
   double *GetData(){ return data; }
   double **GetPointer(){return data_ptr;}
   void SetDataCount(int x){datacount=x;}
-  virtual ~NumbaFunctionBase(){}    
+  virtual ~NumbaFunctionBase(){}
 };
 
 class NumbaCoefficientBase
@@ -112,13 +112,14 @@ class NumbaCoefficientBase
 class ScalarNumbaCoefficient : public mfem::FunctionCoefficient,  public NumbaCoefficientBase
 {
  public:
+  int GetNDim(){return 0;}
   ScalarNumbaCoefficient(std::function<double(const mfem::Vector &)> F,
 			   NumbaFunctionBase *in_obj)
     : FunctionCoefficient(std::move(F)), NumbaCoefficientBase(in_obj){}
   ScalarNumbaCoefficient(std::function<double(const mfem::Vector &, double)> TDF,
  			   NumbaFunctionBase *in_obj)
    : FunctionCoefficient(std::move(TDF)), NumbaCoefficientBase(in_obj){}
-  
+
   virtual double Eval(mfem::ElementTransformation &T,
 		      const mfem::IntegrationPoint &ip);
 };
@@ -126,13 +127,14 @@ class ScalarNumbaCoefficient : public mfem::FunctionCoefficient,  public NumbaCo
 class VectorNumbaCoefficient : public mfem::VectorFunctionCoefficient,  public NumbaCoefficientBase
 {
  public:
+  int GetNDim(){return 1;}
   VectorNumbaCoefficient(int dim, std::function<void(const mfem::Vector &, mfem::Vector &)> F,
 		        NumbaFunctionBase *in_obj)
    : VectorFunctionCoefficient(dim, std::move(F)), NumbaCoefficientBase(in_obj){}
   VectorNumbaCoefficient(int dim, std::function<void(const mfem::Vector &, double, mfem::Vector &)> TDF,
    		        NumbaFunctionBase *in_obj)
     : VectorFunctionCoefficient(dim, std::move(TDF)), NumbaCoefficientBase(in_obj){}
-  
+
  virtual void Eval(mfem::Vector &V,
 		   mfem::ElementTransformation &T,
 		   const mfem::IntegrationPoint &ip);
@@ -141,13 +143,14 @@ class VectorNumbaCoefficient : public mfem::VectorFunctionCoefficient,  public N
 class MatrixNumbaCoefficient : public mfem::MatrixFunctionCoefficient,  public NumbaCoefficientBase
 {
  public:
+  int GetNDim(){return 2;}
   MatrixNumbaCoefficient(int dim, std::function<void(const mfem::Vector &, mfem::DenseMatrix &)> F,
    			NumbaFunctionBase *in_obj)
    : MatrixFunctionCoefficient(dim, std::move(F)), NumbaCoefficientBase(in_obj){}
   MatrixNumbaCoefficient(int dim, std::function<void(const mfem::Vector &, double, mfem::DenseMatrix &)> TDF,
    			NumbaFunctionBase *in_obj)
     : MatrixFunctionCoefficient(dim, std::move(TDF)), NumbaCoefficientBase(in_obj){}
-  
+
   virtual void Eval(mfem::DenseMatrix &K,
 		    mfem::ElementTransformation &T,
 		    const mfem::IntegrationPoint &ip);

--- a/mfem/common/pycoefficient.hpp
+++ b/mfem/common/pycoefficient.hpp
@@ -117,10 +117,10 @@ class ScalarNumbaCoefficient : public mfem::FunctionCoefficient,  public NumbaCo
 class VectorNumbaCoefficient : public mfem::VectorFunctionCoefficient,  public NumbaCoefficientBase
 {
  public:
-  VectorNumbaCoefficient(int dim, std::function<double(const mfem::Vector &, mfem::Vector &)> F,
+  VectorNumbaCoefficient(int dim, std::function<void(const mfem::Vector &, mfem::Vector &)> F,
 		        NumbaFunctionBase *in_obj)
    : VectorFunctionCoefficient(dim, std::move(F)), NumbaCoefficientBase(in_obj){}
-  VectorNumbaCoefficient(int dim, std::function<double(const mfem::Vector &, double, mfem::Vector &)> TDF,
+  VectorNumbaCoefficient(int dim, std::function<void(const mfem::Vector &, double, mfem::Vector &)> TDF,
    		        NumbaFunctionBase *in_obj)
     : VectorFunctionCoefficient(dim, std::move(TDF)), NumbaCoefficientBase(in_obj){}
   
@@ -132,10 +132,10 @@ class VectorNumbaCoefficient : public mfem::VectorFunctionCoefficient,  public N
 class MatrixNumbaCoefficient : public mfem::MatrixFunctionCoefficient,  public NumbaCoefficientBase
 {
  public:
-  MatrixNumbaCoefficient(int dim, std::function<double(const mfem::Vector &, mfem::DenseMatrix &)> F,
+  MatrixNumbaCoefficient(int dim, std::function<void(const mfem::Vector &, mfem::DenseMatrix &)> F,
    			NumbaFunctionBase *in_obj)
    : MatrixFunctionCoefficient(dim, std::move(F)), NumbaCoefficientBase(in_obj){}
-  MatrixNumbaCoefficient(int dim, std::function<double(const mfem::Vector &, double, mfem::DenseMatrix &)> TDF,
+  MatrixNumbaCoefficient(int dim, std::function<void(const mfem::Vector &, double, mfem::DenseMatrix &)> TDF,
    			NumbaFunctionBase *in_obj)
     : MatrixFunctionCoefficient(dim, std::move(TDF)), NumbaCoefficientBase(in_obj){}
   

--- a/mfem/common/pycoefficient.hpp
+++ b/mfem/common/pycoefficient.hpp
@@ -99,9 +99,11 @@ class NumbaCoefficientBase
 
  protected:
   NumbaFunctionBase *obj;
+  int sdim;
 
  public:
-  NumbaCoefficientBase(NumbaFunctionBase *in_obj): obj(in_obj){}
+  NumbaCoefficientBase(NumbaFunctionBase *in_obj, int in_sdim):
+    sdim(in_sdim), obj(in_obj){}
   template<typename T1, typename T2, typename T3>
   void SetParams(const mfem::Array<mfem::Coefficient *>&,
 		 const mfem::Array<mfem::VectorCoefficient *>&,
@@ -114,6 +116,7 @@ class NumbaCoefficientBase
   void SetKinds(PyObject *kinds_);
   void SetIsDepComplex(PyObject *isComplex_);
   void SetOutComplex(bool in_){isoutcomplex=in_;}
+  int SpaceDimension(){return sdim;}
   bool IsOutComplex(){return isoutcomplex;}
   virtual ~NumbaCoefficientBase(){
     delete obj;
@@ -128,11 +131,11 @@ class ScalarNumbaCoefficient : public mfem::FunctionCoefficient,  public NumbaCo
  public:
   int GetNDim(){return 0;}
   ScalarNumbaCoefficient(std::function<double(const mfem::Vector &)> F,
-			   NumbaFunctionBase *in_obj)
-    : FunctionCoefficient(std::move(F)), NumbaCoefficientBase(in_obj){}
+			 NumbaFunctionBase *in_obj, int in_sdim)
+    : FunctionCoefficient(std::move(F)), NumbaCoefficientBase(in_obj, in_sdim){}
   ScalarNumbaCoefficient(std::function<double(const mfem::Vector &, double)> TDF,
- 			   NumbaFunctionBase *in_obj)
-   : FunctionCoefficient(std::move(TDF)), NumbaCoefficientBase(in_obj){}
+			 NumbaFunctionBase *in_obj, int in_sdim)
+    : FunctionCoefficient(std::move(TDF)), NumbaCoefficientBase(in_obj, in_sdim){}
 
   virtual double Eval(mfem::ElementTransformation &T,
 		      const mfem::IntegrationPoint &ip);
@@ -144,11 +147,11 @@ class VectorNumbaCoefficient : public mfem::VectorFunctionCoefficient,  public N
  public:
   int GetNDim(){return 1;}
   VectorNumbaCoefficient(int dim, std::function<void(const mfem::Vector &, mfem::Vector &)> F,
-		        NumbaFunctionBase *in_obj)
-   : VectorFunctionCoefficient(dim, std::move(F)), NumbaCoefficientBase(in_obj){}
+			 NumbaFunctionBase *in_obj, int in_sdim)
+    : VectorFunctionCoefficient(dim, std::move(F)), NumbaCoefficientBase(in_obj, in_sdim){}
   VectorNumbaCoefficient(int dim, std::function<void(const mfem::Vector &, double, mfem::Vector &)> TDF,
-   		        NumbaFunctionBase *in_obj)
-    : VectorFunctionCoefficient(dim, std::move(TDF)), NumbaCoefficientBase(in_obj){}
+			 NumbaFunctionBase *in_obj, int in_sdim)
+    : VectorFunctionCoefficient(dim, std::move(TDF)), NumbaCoefficientBase(in_obj, in_sdim){}
 
  virtual void Eval(mfem::Vector &V,
 		   mfem::ElementTransformation &T,
@@ -160,11 +163,11 @@ class MatrixNumbaCoefficient : public mfem::MatrixFunctionCoefficient,  public N
  public:
   int GetNDim(){return 2;}
   MatrixNumbaCoefficient(int dim, std::function<void(const mfem::Vector &, mfem::DenseMatrix &)> F,
-   			NumbaFunctionBase *in_obj)
-   : MatrixFunctionCoefficient(dim, std::move(F)), NumbaCoefficientBase(in_obj){}
+			 NumbaFunctionBase *in_obj, int in_sdim)
+    : MatrixFunctionCoefficient(dim, std::move(F)), NumbaCoefficientBase(in_obj, in_sdim){}
   MatrixNumbaCoefficient(int dim, std::function<void(const mfem::Vector &, double, mfem::DenseMatrix &)> TDF,
-   			NumbaFunctionBase *in_obj)
-    : MatrixFunctionCoefficient(dim, std::move(TDF)), NumbaCoefficientBase(in_obj){}
+			 NumbaFunctionBase *in_obj, int in_sdim)
+    : MatrixFunctionCoefficient(dim, std::move(TDF)), NumbaCoefficientBase(in_obj, in_sdim){}
 
   virtual void Eval(mfem::DenseMatrix &K,
 		    mfem::ElementTransformation &T,

--- a/mfem/common/pycoefficient.hpp
+++ b/mfem/common/pycoefficient.hpp
@@ -80,9 +80,10 @@ class NumbaCoefficientBase
   int num_dep = 0;
   int kinds[16];       // for now upto 16 coefficients
   int iscomplex[16];   // for now upto 16 coefficients
-  mfem::Coefficient *coeff[16];
-  mfem::VectorCoefficient *vcoeff[16];
-  mfem::MatrixCoefficient *mcoeff[16];
+
+  mfem::Array<mfem::Coefficient *>  *pcoeffs = nullptr;
+  mfem::Array<mfem::VectorCoefficient *>  *pvcoeffs = nullptr;
+  mfem::Array<mfem::MatrixCoefficient *>  *pmcoeffs = nullptr;
 
  protected:
   NumbaFunctionBase *obj;
@@ -90,14 +91,22 @@ class NumbaCoefficientBase
  public:
     NumbaCoefficientBase(NumbaFunctionBase *in_obj): obj(in_obj){}
 
-  void SetParams(mfem::Coefficient *in_coeff[], int in_num_coeffs,
-		 mfem::VectorCoefficient *in_vcoeff[], int in_num_vcoeffs,
-		 mfem::MatrixCoefficient *in_mcoeff[], int in_num_mcoeffs);
+  //void SetParams(mfem::Coefficient *in_coeff[], int in_num_coeffs,
+  //		 mfem::VectorCoefficient *in_vcoeff[], int in_num_vcoeffs,
+  // 	 mfem::MatrixCoefficient *in_mcoeff[], int in_num_mcoeffs);
+  void SetParams(const mfem::Array<mfem::Coefficient *>&,
+		 const mfem::Array<mfem::VectorCoefficient *>&,
+		 const mfem::Array<mfem::MatrixCoefficient *>&);
   void PrepParams(mfem::ElementTransformation &T,
 		  const mfem::IntegrationPoint &ip);
   void SetKinds(PyObject *kinds_);
   void SetIsComplex(PyObject *isComplex_);
-  virtual ~NumbaCoefficientBase(){delete obj;}
+  virtual ~NumbaCoefficientBase(){
+    delete obj;
+    delete pcoeffs;
+    delete pvcoeffs;
+    delete pmcoeffs;
+  }
 };
 
 class ScalarNumbaCoefficient : public mfem::FunctionCoefficient,  public NumbaCoefficientBase

--- a/mfem/common/pycoefficient.hpp
+++ b/mfem/common/pycoefficient.hpp
@@ -172,12 +172,14 @@ class MatrixNumbaCoefficient : public mfem::MatrixFunctionCoefficient,  public N
 {
  public:
   int GetNDim(){return 2;}
-  MatrixNumbaCoefficient(int dim, std::function<void(const mfem::Vector &, mfem::DenseMatrix &)> F,
+  MatrixNumbaCoefficient(int h, int w,
+			 std::function<void(const mfem::Vector &, mfem::DenseMatrix &)> F,
 			 NumbaFunctionBase *in_obj)
-    : MatrixFunctionCoefficient(dim, std::move(F)), NumbaCoefficientBase(in_obj){}    
-  MatrixNumbaCoefficient(int dim, std::function<void(const mfem::Vector &, double, mfem::DenseMatrix &)> TDF,
+    : MatrixFunctionCoefficient(w, std::move(F)), NumbaCoefficientBase(in_obj){height=h; width=w;}    
+  MatrixNumbaCoefficient(int h, int w,
+			 std::function<void(const mfem::Vector &, double, mfem::DenseMatrix &)> TDF,
 			 NumbaFunctionBase *in_obj)
-    : MatrixFunctionCoefficient(dim, std::move(TDF)), NumbaCoefficientBase(in_obj){}    
+    : MatrixFunctionCoefficient(w, std::move(TDF)), NumbaCoefficientBase(in_obj){height=h; width=w;}
 
   virtual void SetTime(double t){
       mfem::MatrixFunctionCoefficient::SetTime(t);

--- a/mfem/common/pycoefficient.hpp
+++ b/mfem/common/pycoefficient.hpp
@@ -48,3 +48,100 @@ public:
 };
 }
 
+
+// NumbaCoefficient
+/// NumbaFunction  : wrapper for numba compiled function
+/// NumbaCoefficient : subclass of MFEM coefficient
+class NumbaFunctionBase
+{
+ protected:
+    void *address_;
+    int  sdim_;
+    bool td_;
+    double data[256];
+    double *data_ptr[16];
+    int datacount=0;
+ public:
+  NumbaFunctionBase(PyObject *input, int sdim, bool td): sdim_(sdim), td_(td){ SetUserFunction(input); }
+  void print_add(){ std::cout << address_ << '\n'; }
+  void SetUserFunction(PyObject *input);
+  double *GetData(){ return data; }
+  double **GetPointer(){return data_ptr;}
+  void SetDataCount(int x){datacount=x;}
+  virtual ~NumbaFunctionBase(){}    
+};
+
+class NumbaCoefficientBase
+{
+ private:
+  int num_coeffs;
+  int num_vcoeffs;
+  int num_mcoeffs;
+  int num_dep = 0;
+  int kinds[16];       // for now upto 16 coefficients
+  int iscomplex[16];   // for now upto 16 coefficients
+  mfem::Coefficient *coeff[16];
+  mfem::VectorCoefficient *vcoeff[16];
+  mfem::MatrixCoefficient *mcoeff[16];
+
+ protected:
+  NumbaFunctionBase *obj;
+
+ public:
+    NumbaCoefficientBase(NumbaFunctionBase *in_obj): obj(in_obj){}
+
+  void SetParams(mfem::Coefficient *in_coeff[], int in_num_coeffs,
+		 mfem::VectorCoefficient *in_vcoeff[], int in_num_vcoeffs,
+		 mfem::MatrixCoefficient *in_mcoeff[], int in_num_mcoeffs);
+  void PrepParams(mfem::ElementTransformation &T,
+		  const mfem::IntegrationPoint &ip);
+  void SetKinds(PyObject *kinds_);
+  void SetIsComplex(PyObject *isComplex_);
+  virtual ~NumbaCoefficientBase(){delete obj;}
+};
+
+class ScalarNumbaCoefficient : public mfem::FunctionCoefficient,  public NumbaCoefficientBase
+{
+ public:
+  ScalarNumbaCoefficient(std::function<double(const mfem::Vector &)> F,
+			   NumbaFunctionBase *in_obj)
+    : FunctionCoefficient(std::move(F)), NumbaCoefficientBase(in_obj){}
+  ScalarNumbaCoefficient(std::function<double(const mfem::Vector &, double)> TDF,
+ 			   NumbaFunctionBase *in_obj)
+   : FunctionCoefficient(std::move(TDF)), NumbaCoefficientBase(in_obj){}
+  
+  virtual double Eval(mfem::ElementTransformation &T,
+		      const mfem::IntegrationPoint &ip);
+};
+
+class VectorNumbaCoefficient : public mfem::VectorFunctionCoefficient,  public NumbaCoefficientBase
+{
+ public:
+  VectorNumbaCoefficient(int dim, std::function<double(const mfem::Vector &, mfem::Vector &)> F,
+		        NumbaFunctionBase *in_obj)
+   : VectorFunctionCoefficient(dim, std::move(F)), NumbaCoefficientBase(in_obj){}
+  VectorNumbaCoefficient(int dim, std::function<double(const mfem::Vector &, double, mfem::Vector &)> TDF,
+   		        NumbaFunctionBase *in_obj)
+    : VectorFunctionCoefficient(dim, std::move(TDF)), NumbaCoefficientBase(in_obj){}
+  
+ virtual void Eval(mfem::Vector &V,
+		   mfem::ElementTransformation &T,
+		   const mfem::IntegrationPoint &ip);
+};
+
+class MatrixNumbaCoefficient : public mfem::MatrixFunctionCoefficient,  public NumbaCoefficientBase
+{
+ public:
+  MatrixNumbaCoefficient(int dim, std::function<double(const mfem::Vector &, mfem::DenseMatrix &)> F,
+   			NumbaFunctionBase *in_obj)
+   : MatrixFunctionCoefficient(dim, std::move(F)), NumbaCoefficientBase(in_obj){}
+  MatrixNumbaCoefficient(int dim, std::function<double(const mfem::Vector &, double, mfem::DenseMatrix &)> TDF,
+   			NumbaFunctionBase *in_obj)
+    : MatrixFunctionCoefficient(dim, std::move(TDF)), NumbaCoefficientBase(in_obj){}
+  
+  virtual void Eval(mfem::DenseMatrix &K,
+		    mfem::ElementTransformation &T,
+		    const mfem::IntegrationPoint &ip);
+};
+
+

--- a/setup.py
+++ b/setup.py
@@ -808,6 +808,9 @@ def cmake_make_mfem(serial=True):
     make('mfem_' + txt)
     make_install('mfem_' + txt)
 
+    from shutil import copytree
+    copytree("../data", os.path.join(cmake_opts['DCMAKE_INSTALL_PREFIX'], "data"))
+    
     os.chdir(pwd)
 
 
@@ -1398,7 +1401,7 @@ def configure_bdist(self):
     global prefix, dry_run, verbose, run_swig
     global build_mfem, build_parallel, build_serial
     global mfem_branch, mfem_source
-    global mfems_prefix, mfemp_prefix, hypre_prefix, metis_prefix
+    global mfems_prefix, mfemp_prefix, hypre_prefix, metis_prefix, ext_prefix
 
     global cc_command, cxx_command, mpicc_command, mpicxx_command
     global enable_pumi, pumi_prefix
@@ -1409,7 +1412,9 @@ def configure_bdist(self):
 
     prefix = abspath(self.bdist_dir)
 
-    run_swig = False
+    run_swig = True
+
+    build_mfem = True
     build_parallel = False
     build_serial = True
 
@@ -1418,9 +1423,10 @@ def configure_bdist(self):
     do_bdist_wheel = True
 
     mfem_source = './external/mfem'
-    ext_prefix = external_install_prefix()
-    hypre_prefix = os.path.join(ext_prefix)
-    metis_prefix = os.path.join(ext_prefix)
+    ext_prefix = os.path.join(prefix, 'mfem', 'external')
+    print("ext_prefix", ext_prefix)
+    hypre_prefix = ext_prefix
+    metis_prefix = ext_prefix
 
     mfem_prefix = ext_prefix
     mfems_prefix = os.path.join(ext_prefix, 'ser')
@@ -1676,6 +1682,7 @@ if haveWheel:
             _bdist_wheel.finalize_options(self)
 
         def run(self):
+            print("Engering BdistWheel::Run")
             if not is_configured:
                 print('running config')
                 configure_bdist(self)
@@ -1777,7 +1784,7 @@ class Clean(_clean):
         os.chdir(rootdir)
         _clean.run(self)
 
-#cdatafiles = [os.path.join('data', f) for f in os.listdir('data')]
+
 
 
 def run_setup():
@@ -1792,6 +1799,7 @@ def run_setup():
         cmdclass['bdist_wheel'] = BdistWheel
 
     install_req = install_requires()
+    
     # print(install_req)
     setup(
         cmdclass=cmdclass,

--- a/test/run_examples.py
+++ b/test/run_examples.py
@@ -43,6 +43,11 @@ import time
 import shutil
 import re
 
+try:
+    import mfem
+except ImportError:
+    assert False, "MFEM is not installed"
+
 skip_test = ['']
 # skip_test = ['ex15p']  #skip this since it takes too long on my Mac..;D
 
@@ -295,6 +300,12 @@ def print_help(self):
 
 
 if __name__ == "__main__":
+
+    def_mfemsdir = os.path.join(
+        os.path.dirname(mfem.__file__), "external", "ser")
+    def_mfempdir = os.path.join(
+        os.path.dirname(mfem.__file__), "external", "par")
+
     script_path = sys.path[0]  # the location of this file
 
     from mfem.common.arg_parser import ArgParser
@@ -319,11 +330,11 @@ if __name__ == "__main__":
                         help='Test one example')
     parser.add_argument('-mfempdir',
                         action='store',
-                        default="../external/mfem/cmbuild_par",
+                        default=def_mfempdir,
                         help='mfem (parallel) directory')
     parser.add_argument('-mfemsdir',
                         action='store',
-                        default="../external/mfem/cmbuild_ser",
+                        default=def_mfemsdir,                        
                         help='mfem (serial) directory')
     parser.add_argument('-sandbox',
                         action='store', default="./sandbox",
@@ -340,6 +351,13 @@ if __name__ == "__main__":
     example = args.ex
     mfempdir = args.mfempdir
     mfemsdir = args.mfemsdir
+
+    if not os.path.exists(os.path.join(mfempdir, "data")):
+        assert False, "data file does not exist in the package directory"
+    if not os.path.exists(os.path.join(mfempdir, "data")):
+        assert False, "data file does not exist in the package directory"
+
+            
     sandbox = os.path.abspath(os.path.expanduser(args.sandbox))
     
     if clean:

--- a/test/test_numba.py
+++ b/test/test_numba.py
@@ -155,7 +155,7 @@ def run_test():
     def c11(ptx):
         return s_func0(ptx[0], ptx[1],  ptx[2])
 
-    @mfem.jit.scalar(td=True)
+    @mfem.jit.scalar(td=True, debug=True)
     def c12(ptx, t):
         return s_func0(ptx[0], ptx[1],  ptx[2])
 
@@ -219,7 +219,7 @@ def run_test():
 
     print("speed comparision with C++")
 
-    @mfem.jit.vector(sdim=3, interface="c++style")
+    @mfem.jit.vector(sdim=3, interface="c++style", debug=True)
     def v_func4_old(ptx, out):
         out[0] = 1
         out[1] = 2.
@@ -278,7 +278,7 @@ def run_test():
     def m_func4(ptx, t, m_func3, c5):
         return m_func3.imag
 
-    @mfem.jit.matrix(sdim=3, complex=False)
+    @mfem.jit.matrix(sdim=3, complex=False, debug=True)
     def m_func5(p):
         x = p[0]
         y = p[1]

--- a/test/test_numba.py
+++ b/test/test_numba.py
@@ -182,8 +182,8 @@ def run_test():
     c3 = mfem.VectorNumbaFunction(v_func, sdim, dim).GenerateCoefficient()
     c4 = v_coeff(dim)
 
-    @mfem.jit.vector(sdim=3, dependency=(c3, ), td=True,  complex=True)
-    def v_func4(ptx, t, c3, ):
+    @mfem.jit.vector(sdim=3, dependency=(c3, c11), td=True,  complex=True)
+    def v_func4(ptx, t, c3, c11):
         return np.array([c3[0], c3[1], c3[2]], dtype=np.complex128)
     # @mfem.jit.vector(sdim=3, complex=True)
     # def v_func4(ptx,  ):

--- a/test/test_numba.py
+++ b/test/test_numba.py
@@ -209,7 +209,7 @@ def run_test():
     start = time.time()
     # gf.ProjectCoefficient(v_func4.real)
     for i in range(10):
-        gf.ProjectCoefficient(v_func4.real)
+        gf.ProjectCoefficient(v_func4[0])
     end = time.time()
     data3 = gf.GetDataArray().copy()
     print("Numba2 time (vector)", end - start)
@@ -219,7 +219,7 @@ def run_test():
 
     print("speed comparision with C++")
 
-    @mfem.jit.vector(sdim=3, interface="c++style", debug=True)
+    @mfem.jit.vector(sdim=3, interface="c++", debug=True)
     def v_func4_old(ptx, out):
         out[0] = 1
         out[1] = 2.
@@ -274,7 +274,7 @@ def run_test():
                         [0.0,      0.0,      c5[2, 2]]])
         return ret*1j
 
-    @mfem.jit.matrix(sdim=3, dependency=((m_func3.real, m_func3.imag), c4), td=True)
+    @mfem.jit.matrix(sdim=3, dependency=(m_func3, c4), td=True)
     def m_func4(ptx, t, m_func3, c5):
         return m_func3.imag
 


### PR DESCRIPTION
This PR expands mfem.jit feature to generate Numba-JIT compiled coefficient.  It includes
 1)  dependency : creates a coefficient which depends on other coefficient
 2)  time-dependence.
 3)  more user-friendly parameter passing: JIT function is passed a numpy-like array instead
      of pointer. Thus it is not necessary to call carray/farray inside a user function.
 4) complex number: creates a pair of coefficients which returns real and imaginary part 

(usage)
sdim = mesh.SpaceDimension()
@scalar(td=False, params={}, complex=False, dependency=None, interface='simple',
        debug=False)
@vector(shape=None, td=False, params={}, complex=False, dependency=None, 
        interface='simple', debug=False)
@matrix(shape=None, td=False, params={}, complex=False, dependency=None, 
        interface='simple', debug=False)

shape: shape of return value
td: time-dependence (False: stationary, True: time-dependent
complex: complex coefficient
depenency: dependency to other coefficient
interface: calling proceture
   'simple': vector/matric function returns the result by value more pythonic (this is the default behavior)
   'c++': vector/matric function returns the result by parameter like C++
    other options: one can pass a tuple of (caller, signature) pair to create a custom
                   interface
debug: extra debug print

TODO:

- [x] Update README
- [x] Update Examples
