### PR TITLE
Fix wheel build

### DIFF
--- a/.github/workflows/testrelease_binary.yml
+++ b/.github/workflows/testrelease_binary.yml
@@ -60,16 +60,16 @@ jobs:
           git clone https://github.com/mfem/PyMFEM.git
           cd PyMFEM
           #
-          mkdir external
-          cd external
-          git clone https://github.com/mfem/mfem.git
-          cd ..
+          #mkdir external
+          #cd external
+          #git clone https://github.com/mfem/mfem.git
+          #cd ..
           #
           git checkout $REF
           #
           ls -l /opt/python/
           export PATH=/opt/python/${{ matrix.pythonpath }}/bin:$PATH
-          echo $(python -c "import setuptools;print(setuptools.__version__)")
+          #echo $(python -c "import setuptools;print(setuptools.__version__)")
           #pip3 install setuptools==65.5.1
           pip3 install six auditwheel twine
 
@@ -81,9 +81,15 @@ jobs:
 
           CWD=$PWD
           yum install -y zlib-devel
+          yum install -y chrpath          
 
+          # build and check
+          python3 -m pip install ./ -verbose
+          cd test
+          python run_examples.py -serial -verbose -ex ex1
+          
+          
           python3 setup.py install
-          # python3 -m pip install ./ --verbose   (this seems okay too)
           rm -rf dist/*
 
 

--- a/.github/workflows/testrelease_binary.yml
+++ b/.github/workflows/testrelease_binary.yml
@@ -83,6 +83,8 @@ jobs:
           yum install -y zlib-devel
           yum install -y chrpath
 
+          mkdir dist
+
           # build wheel and check it
           python3 -m pip wheel ./ --verbose --no-deps
           pip3 install *.whl
@@ -137,6 +139,8 @@ jobs:
           apt-get install -y zlib1g-dbg
           apt-get install -y chrpath
 
+          mkdir dist
+
           # build wheel and check it
           python3 -m pip wheel ./ --verbose --no-deps
           pip3 install *.whl
@@ -150,6 +154,7 @@ jobs:
           rm -rf wheelhouse/*
           auditwheel repair *.whl
           rm -rf dist/*
+
           mv wheelhouse/* dist/
 
           ls -l dist/

--- a/.github/workflows/testrelease_binary.yml
+++ b/.github/workflows/testrelease_binary.yml
@@ -29,13 +29,13 @@ jobs:
           cd ..
           #
           export PATH=/opt/python/cp37-cp37m/bin:$PATH
-          echo $(python -c "import setuptools;print(setuptools.__version__)")
-          pip3 install setuptools==65.5.1
+
           pip3 install wheel six auditwheel twine
           pip3 install numpy==1.21.6
           #if [ -f requirements.txt ]; then
           #   pip3 install -r requirements.txt
           #fi
+
           rm -rf dist/*
           python3 setup.py sdist
           ls -l dist/
@@ -81,26 +81,22 @@ jobs:
 
           CWD=$PWD
           yum install -y zlib-devel
-          yum install -y chrpath          
+          yum install -y chrpath
 
-          # build and check
-          python3 -m pip install ./ -verbose
+          # build wheel and check it
+          python3 -m pip wheel ./ --verbose --no-deps
+          pip3 install *.whl
           cd test
           python run_examples.py -serial -verbose -ex ex1
-          
-          
-          python3 setup.py install
+          cd ..
+
           rm -rf dist/*
-
-
           export LD_LIBRARY_PATH=${CWD}/external/mfem/cmbuild_ser/:$LD_LIBRARY_PATH
-          python3 setup.py bdist_wheel --skip-build
 
-          rm -rf wheelhouse/*
-          auditwheel repair dist/*.whl
+          auditwheel repair *.whl
           rm -rf dist/*
-
           mv wheelhouse/* dist/
+
           ls -l dist/
           python3 -m twine upload --repository-url https://test.pypi.org/legacy/ --password ${{ secrets.TEST_PYPI_TOKEN }} --username __token__ --verbose dist/*
           #python3 -m twine upload --password ${{ secrets.PYPI_TOKEN }} --username __token__ --verbose dist/*
@@ -139,19 +135,23 @@ jobs:
 
           apt-get update
           apt-get install -y zlib1g-dbg
+          apt-get install -y chrpath
 
-          python3 -m pip install ./ --verbose
+          # build wheel and check it
+          python3 -m pip wheel ./ --verbose --no-deps
+          pip3 install *.whl
+          cd test
+          python run_examples.py -serial -verbose -ex ex1
+          cd ..
 
           rm -rf dist/*
-
           export LD_LIBRARY_PATH=${CWD}/external/mfem/cmbuild_ser/:$LD_LIBRARY_PATH
-          python3 setup.py bdist_wheel --skip-build
 
           rm -rf wheelhouse/*
-          auditwheel repair dist/*.whl
+          auditwheel repair *.whl
           rm -rf dist/*
-
           mv wheelhouse/* dist/
+
           ls -l dist/
           python3 -m twine upload --repository-url https://test.pypi.org/legacy/ --password ${{ secrets.TEST_PYPI_TOKEN }} --username __token__ --verbose dist/*
           #python3 -m twine upload --password ${{ secrets.PYPI_TOKEN }} --username __token__ --verbose dist/*

--- a/mfem/__init__.py
+++ b/mfem/__init__.py
@@ -20,5 +20,5 @@ def debug_print(message):
 
     print(message)
 
-__version__ = '4.5.0.1rc9'
+__version__ = '4.5.0.1rc10'
 

--- a/mfem/__init__.py
+++ b/mfem/__init__.py
@@ -20,5 +20,5 @@ def debug_print(message):
 
     print(message)
 
-__version__ = '4.5.0.1rc8'
+__version__ = '4.5.0.1rc9'
 

--- a/mfem/_par/setup.py
+++ b/mfem/_par/setup.py
@@ -3,29 +3,31 @@
 """
 setup.py file for SWIG example
 """
+from distutils.core import Extension, setup
+import numpy
+import os
+import sys
 print('building paralel version')
 
-## first load variables from PyMFEM_ROOT/setup_local.py
-import sys
-import os
-import numpy
+# first load variables from PyMFEM_ROOT/setup_local.py
 
-from distutils.core import Extension, setup
 
 ddd = os.path.dirname(os.path.abspath(os.path.realpath(__file__)))
-root =  os.path.abspath(os.path.join(ddd, '..', '..'))
+root = os.path.abspath(os.path.join(ddd, '..', '..'))
+
 
 def get_version():
-    ### read version number from __init__.py    
+    # read version number from __init__.py
     path = os.path.join(os.path.dirname(os.path.abspath(os.path.realpath(__file__))),
-                    '..', '__init__.py')
+                        '..', '__init__.py')
     fid = open(path, 'r')
-    lines=fid.readlines()
+    lines = fid.readlines()
     fid.close()
     for x in lines:
         if x.strip().startswith('__version__'):
             version = eval(x.split('=')[-1].strip())
     return version
+
 
 def get_extensions():
     sys.path.insert(0, root)
@@ -34,31 +36,33 @@ def get_extensions():
         import mpi4py
         mpi4pyinc = mpi4py.get_include()
     except ImportError:
-        if 'clean' not in sys.argv:  raise        
+        if 'clean' not in sys.argv:
+            raise
         mpi4pyinc = ''
-    
+
     try:
         from setup_local import (mfembuilddir, mfemincdir, mfemsrcdir, mfemlnkdir,
-                                 mfemptpl,
+                                 mfemptpl, build_mfem,
                                  hypreinc, metisinc, hyprelib, metis5lib,
                                  cc_par, cxx_par,
-                                 cxx11flag,                                 
+                                 cxx11flag,
                                  add_pumi, add_cuda, add_libceed, add_strumpack,
                                  add_suitesparse, add_gslibp)
-        
+
         include_dirs = [mfembuilddir, mfemincdir, mfemsrcdir,
                         numpy.get_include(),
                         mpi4pyinc,
                         hypreinc, metisinc]
-        library_dirs = [mfemlnkdir, hyprelib, metis5lib,]
+        library_dirs = [mfemlnkdir, hyprelib, metis5lib, ]
 
     except ImportError:
-        if 'clean' not in sys.argv:  raise
+        if 'clean' not in sys.argv:
+            raise
         cc_par = ''
         cxx_par = ''
         include_dirs = []
         library_dirs = []
-        mfemptpl = ''        
+        mfemptpl = ''
         add_cuda = ''
         add_libceed = ''
         add_suitesparse = ''
@@ -67,51 +71,54 @@ def get_extensions():
         add_gslibp = ''
         cxx11flag = ''
 
-    libraries    = ['mfem', 'HYPRE', 'metis']
-    
-    ## remove current directory from path
+    libraries = ['mfem', 'HYPRE', 'metis']
+
+    # remove current directory from path
     print("__file__", os.path.abspath(__file__))
     if '' in sys.path:
         sys.path.remove('')
-    items = [x for x in sys.path if os.path.abspath(x) == os.path.dirname(os.path.abspath(__file__))]
+    items = [x for x in sys.path if os.path.abspath(
+        x) == os.path.dirname(os.path.abspath(__file__))]
     for x in items:
         sys.path.remove(x)
     print("sys path", sys.path)
 
-    ## this forces to use compiler written in setup_local.py
-    if cc_par != '': os.environ['CC'] = cc_par
-    if cxx_par != '': os.environ['CXX'] = cxx_par
+    # this forces to use compiler written in setup_local.py
+    if cc_par != '':
+        os.environ['CC'] = cc_par
+    if cxx_par != '':
+        os.environ['CXX'] = cxx_par
 
-    modules= ["io_stream", "vtk", "sort_pairs", "datacollection",
-              "globals", "mem_manager", "device", "hash", "stable3d",
-              "cpointers", "symmat",
-              "error", "array", "common_functions",
-              "segment", "point", "hexahedron", "quadrilateral",
-              "tetrahedron", "triangle", "wedge",
-              "socketstream", "handle",
-              "fe_base", "fe_fixed_order", "fe_h1", "fe_l2",
-              "fe_nd", "fe_nurbs", "fe_pos", "fe_rt", "fe_ser", "doftrans",
-              "blockvector", "blockoperator", "blockmatrix",
-              "vertex", "sets", "element", "table",
-              "fe", "mesh", "fespace",
-              "fe_coll", "coefficient",
-              "linearform", "vector", "lininteg", "complex_operator",
-              "complex_fem",          
-              "gridfunc", "hybridization", "bilinearform",
-              "bilininteg", "intrules", "sparsemat", "densemat",
-              "solvers", "estimators", "mesh_operators", "ode",
-              "sparsesmoothers", "ncmesh",
-              "matrix", "operators", "eltrans", "geom",
-              "nonlininteg", "nonlinearform",
-              "pmesh", "pncmesh", "communication",
-              "pfespace", "pgridfunc",
-              "plinearform", "pbilinearform", "pnonlinearform",
-              "hypre", "restriction", "prestriction",
-              "fespacehierarchy", "multigrid", "constraints",
-              "transfer", "dist_solver", "std_vectors", "auxiliary",
-              "tmop", "tmop_amr", "tmop_tools", "qspace", "qfunction",
-              "quadinterpolator", "quadinterpolator_face",
-              "submesh", "transfermap", "psubmesh", "ptransfermap"]    
+    modules = ["io_stream", "vtk", "sort_pairs", "datacollection",
+               "globals", "mem_manager", "device", "hash", "stable3d",
+               "cpointers", "symmat",
+               "error", "array", "common_functions",
+               "segment", "point", "hexahedron", "quadrilateral",
+               "tetrahedron", "triangle", "wedge",
+               "socketstream", "handle",
+               "fe_base", "fe_fixed_order", "fe_h1", "fe_l2",
+               "fe_nd", "fe_nurbs", "fe_pos", "fe_rt", "fe_ser", "doftrans",
+               "blockvector", "blockoperator", "blockmatrix",
+               "vertex", "sets", "element", "table",
+               "fe", "mesh", "fespace",
+               "fe_coll", "coefficient",
+               "linearform", "vector", "lininteg", "complex_operator",
+               "complex_fem",
+               "gridfunc", "hybridization", "bilinearform",
+               "bilininteg", "intrules", "sparsemat", "densemat",
+               "solvers", "estimators", "mesh_operators", "ode",
+               "sparsesmoothers", "ncmesh",
+               "matrix", "operators", "eltrans", "geom",
+               "nonlininteg", "nonlinearform",
+               "pmesh", "pncmesh", "communication",
+               "pfespace", "pgridfunc",
+               "plinearform", "pbilinearform", "pnonlinearform",
+               "hypre", "restriction", "prestriction",
+               "fespacehierarchy", "multigrid", "constraints",
+               "transfer", "dist_solver", "std_vectors", "auxiliary",
+               "tmop", "tmop_amr", "tmop_tools", "qspace", "qfunction",
+               "quadinterpolator", "quadinterpolator_face",
+               "submesh", "transfermap", "psubmesh", "ptransfermap"]
 
     if add_pumi == '1':
         from setup_local import puminc, pumilib
@@ -148,54 +155,62 @@ def get_extensions():
 
     sources = {name: [name + "_wrap.cxx"] for name in modules}
     proxy_names = {name: '_'+name for name in modules}
-        
-    tpl_include = []    
+
+    tpl_include = []
     for x in mfemptpl.split(' '):
         if x.startswith("-I"):
             tpl_include.append(x[2:])
     include_dirs.extend(tpl_include)
 
-    extra_compile_args = [cxx11flag, '-DSWIG_TYPE_TABLE=PyMFEM']    
-    macros = [('TARGET_PY3', '1'), ('NPY_NO_DEPRECATED_API', 'NPY_1_7_API_VERSION')]
+    extra_compile_args = [cxx11flag, '-DSWIG_TYPE_TABLE=PyMFEM']
+    macros = [('TARGET_PY3', '1'),
+              ('NPY_NO_DEPRECATED_API', 'NPY_1_7_API_VERSION')]
+
+    if build_mfem:
+        runtime_library_dirs = library_dirs[:]
+        runtime_library_dirs[0] = "$ORIGIN/../external/par/lib"
+    else:
+        runtime_library_dirs = library_dirs
 
     ext_modules = [Extension(proxy_names[modules[0]],
-                            sources=sources[modules[0]],
-                            extra_compile_args = extra_compile_args,
-                            extra_link_args = [],
-                            include_dirs = include_dirs,
-                            library_dirs = library_dirs,
-                            runtime_library_dirs = library_dirs,
-                             libraries = libraries,
-                             define_macros=macros),]
+                             sources=sources[modules[0]],
+                             extra_compile_args=extra_compile_args,
+                             extra_link_args=[],
+                             include_dirs=include_dirs,
+                             library_dirs=library_dirs,
+                             runtime_library_dirs=runtime_library_dirs,
+                             libraries=libraries,
+                             define_macros=macros), ]
 
     ext_modules.extend([Extension(proxy_names[name],
-                            sources=sources[name],
-                            extra_compile_args = extra_compile_args,
-                            extra_link_args = [],
-                            include_dirs = include_dirs,
-                            library_dirs = library_dirs,
-                            runtime_library_dirs = library_dirs,
-                            libraries = libraries,
-                            define_macros=macros)
-                   for name in modules[1:]])
+                                  sources=sources[name],
+                                  extra_compile_args=extra_compile_args,
+                                  extra_link_args=[],
+                                  include_dirs=include_dirs,
+                                  library_dirs=library_dirs,
+                                  runtime_library_dirs=runtime_library_dirs,
+                                  libraries=libraries,
+                                  define_macros=macros)
+                        for name in modules[1:]])
 
     return modules, ext_modules
 
+
 def main():
     if 'clean' not in sys.argv:
-        print('building parallel version')                        
+        print('building parallel version')
 
     version = get_version()
     modules, ext_modules = get_extensions()
-    
-    setup (name = 'mfem_parallel',
-           version = version,
-           author      = "S.Shiraiwa",
-           description = """MFEM wrapper""",
-           ext_modules = ext_modules,
-           py_modules = modules, 
-           )
+
+    setup(name='mfem_parallel',
+          version=version,
+          author="S.Shiraiwa",
+          description="""MFEM wrapper""",
+          ext_modules=ext_modules,
+          py_modules=modules,
+          )
+
 
 if __name__ == '__main__':
     main()
-

--- a/mfem/_par/setup.py
+++ b/mfem/_par/setup.py
@@ -70,6 +70,7 @@ def get_extensions():
         add_pumi = ''
         add_gslibp = ''
         cxx11flag = ''
+        build_mfem = 0
 
     libraries = ['mfem', 'HYPRE', 'metis']
 

--- a/mfem/_ser/setup.py
+++ b/mfem/_ser/setup.py
@@ -5,7 +5,7 @@ Serial version setup file
 """
 
 
-## first load variables from PyMFEM_ROOT/setup_local.py
+# first load variables from PyMFEM_ROOT/setup_local.py
 import sys
 import os
 import numpy
@@ -14,37 +14,39 @@ from distutils.core import Extension, setup
 
 
 ddd = os.path.dirname(os.path.abspath(os.path.realpath(__file__)))
-root =  os.path.abspath(os.path.join(ddd, '..', '..'))
+root = os.path.abspath(os.path.join(ddd, '..', '..'))
+
 
 def get_version():
-    ### read version number from __init__.py    
+    # read version number from __init__.py
     path = os.path.join(os.path.dirname(os.path.abspath(os.path.realpath(__file__))),
-                    '..', '__init__.py')
+                        '..', '__init__.py')
     fid = open(path, 'r')
-    lines=fid.readlines()
+    lines = fid.readlines()
     fid.close()
     for x in lines:
         if x.strip().startswith('__version__'):
             version = eval(x.split('=')[-1].strip())
     return version
 
+
 def get_extensions():
     sys.path.insert(0, root)
     try:
         from setup_local import (mfemserbuilddir, mfemserincdir, mfemsrcdir, mfemserlnkdir,
-                                 mfemstpl,
+                                 mfemstpl, build_mfem,
                                  cc_ser, cxx_ser,
-                                 cxx11flag,                                 
+                                 cxx11flag,
                                  add_cuda, add_libceed, add_suitesparse, add_gslibs,)
 
         include_dirs = [mfemserbuilddir, mfemserincdir, mfemsrcdir,
                         numpy.get_include()]
-        library_dirs = [mfemserlnkdir,]
-        
+        library_dirs = [mfemserlnkdir, ]
+
     except ImportError:
         if 'clean' not in sys.argv:
             raise
-        
+
         cc_ser = ''
         cxx_ser = ''
         include_dirs = []
@@ -55,113 +57,124 @@ def get_extensions():
         add_suitesparse = ''
         add_gslibs = ''
         cxx11flag = ''
-        
-    libraries    = ['mfem']
-    
-    ## remove current directory from path
+
+    libraries = ['mfem']
+
+    # remove current directory from path
     print("__file__", os.path.abspath(__file__))
     if '' in sys.path:
         sys.path.remove('')
-    items = [x for x in sys.path if os.path.abspath(x) == os.path.dirname(os.path.abspath(__file__))]
+    items = [x for x in sys.path if os.path.abspath(
+        x) == os.path.dirname(os.path.abspath(__file__))]
     for x in items:
         sys.path.remove(x)
     print("sys path", sys.path)
 
-    ## this forces to use compiler written in setup_local.py
-    if cc_ser != '': os.environ['CC'] = cc_ser
-    if cxx_ser != '': os.environ['CXX'] = cxx_ser
+    # this forces to use compiler written in setup_local.py
+    if cc_ser != '':
+        os.environ['CC'] = cc_ser
+    if cxx_ser != '':
+        os.environ['CXX'] = cxx_ser
 
-    modules= ["io_stream", "vtk", "sort_pairs", "datacollection",
-              "cpointers", "symmat",
-              "globals", "mem_manager", "device", "hash", "stable3d",
-              "error", "array", "common_functions", "socketstream", "handle",
-              "fe_base", "fe_fixed_order", "fe_h1", "fe_l2",
-              "fe_nd", "fe_nurbs", "fe_pos", "fe_rt", "fe_ser", "doftrans",
-              "segment", "point", "hexahedron", "quadrilateral",
-              "tetrahedron", "triangle", "wedge",
-              "blockvector", "blockoperator", "blockmatrix",
-              "vertex", "sets", "element", "table", "fe",
-              "mesh", "fespace",
-              "fe_coll", "coefficient",
-              "linearform", "vector", "lininteg", "complex_operator",
-              "complex_fem",
-              "gridfunc", "hybridization", "bilinearform",
-              "bilininteg", "intrules", "sparsemat", "densemat",
-              "solvers", "estimators", "mesh_operators", "ode",
-              "sparsesmoothers",
-              "matrix", "operators", "ncmesh", "eltrans", "geom",
-              "nonlininteg", "nonlinearform", "restriction",
-              "fespacehierarchy", "multigrid", "constraints",
-              "transfer", "std_vectors",
-              "tmop", "tmop_amr", "tmop_tools", "qspace", "qfunction",
-              "quadinterpolator", "quadinterpolator_face",
-              "submesh", "transfermap"]
-    
+    modules = ["io_stream", "vtk", "sort_pairs", "datacollection",
+               "cpointers", "symmat",
+               "globals", "mem_manager", "device", "hash", "stable3d",
+               "error", "array", "common_functions", "socketstream", "handle",
+               "fe_base", "fe_fixed_order", "fe_h1", "fe_l2",
+               "fe_nd", "fe_nurbs", "fe_pos", "fe_rt", "fe_ser", "doftrans",
+               "segment", "point", "hexahedron", "quadrilateral",
+               "tetrahedron", "triangle", "wedge",
+               "blockvector", "blockoperator", "blockmatrix",
+               "vertex", "sets", "element", "table", "fe",
+               "mesh", "fespace",
+               "fe_coll", "coefficient",
+               "linearform", "vector", "lininteg", "complex_operator",
+               "complex_fem",
+               "gridfunc", "hybridization", "bilinearform",
+               "bilininteg", "intrules", "sparsemat", "densemat",
+               "solvers", "estimators", "mesh_operators", "ode",
+               "sparsesmoothers",
+               "matrix", "operators", "ncmesh", "eltrans", "geom",
+               "nonlininteg", "nonlinearform", "restriction",
+               "fespacehierarchy", "multigrid", "constraints",
+               "transfer", "std_vectors",
+               "tmop", "tmop_amr", "tmop_tools", "qspace", "qfunction",
+               "quadinterpolator", "quadinterpolator_face",
+               "submesh", "transfermap"]
+
     if add_cuda == '1':
-        from setup_local import cudainc        
+        from setup_local import cudainc
         include_dirs.append(cudainc)
     if add_libceed == '1':
-        from setup_local import libceedinc        
+        from setup_local import libceedinc
         include_dirs.append(libceedinc)
     if add_suitesparse == '1':
-        from setup_local import suitesparseinc        
+        from setup_local import suitesparseinc
         if suitesparseinc != "":
             include_dirs.append(suitesparseinc)
     if add_gslibs == '1':
-        from setup_local import gslibsinc        
+        from setup_local import gslibsinc
         include_dirs.append(gslibsinc)
         modules.append("gslib")
 
     sources = {name: [name + "_wrap.cxx"] for name in modules}
     proxy_names = {name: '_'+name for name in modules}
 
-    tpl_include = []    
+    tpl_include = []
     for x in mfemstpl.split(' '):
         if x.startswith("-I"):
             tpl_include.append(x[2:])
     include_dirs.extend(tpl_include)
-    
+
     extra_compile_args = [cxx11flag, '-DSWIG_TYPE_TABLE=PyMFEM']
-    macros = [('TARGET_PY3', '1'), ('NPY_NO_DEPRECATED_API', 'NPY_1_7_API_VERSION')]
+    macros = [('TARGET_PY3', '1'),
+              ('NPY_NO_DEPRECATED_API', 'NPY_1_7_API_VERSION')]
+
+    if build_mfem:
+        runtime_library_dirs = library_dirs[:]
+        runtime_library_dirs[0] = "$ORIGIN/../external/ser/lib"
+    else:
+        runtime_library_dirs = library_dirs
 
     ext_modules = [Extension(proxy_names[modules[0]],
                              sources=sources[modules[0]],
-                             extra_compile_args = extra_compile_args,
-                             extra_link_args = [],
-                             include_dirs = include_dirs,
-                             library_dirs = library_dirs,
-                             runtime_library_dirs = library_dirs,
-                             libraries = libraries,
-                             define_macros=macros),]
+                             extra_compile_args=extra_compile_args,
+                             extra_link_args=[],
+                             include_dirs=include_dirs,
+                             library_dirs=library_dirs,
+                             runtime_library_dirs=runtime_library_dirs,
+                             libraries=libraries,
+                             define_macros=macros), ]
 
     ext_modules.extend([Extension(proxy_names[name],
                                   sources=sources[name],
-                                  extra_compile_args = extra_compile_args,
-                                  extra_link_args = [],
-                                  include_dirs = include_dirs,
-                                  runtime_library_dirs = library_dirs,
-                                  library_dirs = library_dirs,
-                                  libraries = libraries,
+                                  extra_compile_args=extra_compile_args,
+                                  extra_link_args=[],
+                                  include_dirs=include_dirs,
+                                  runtime_library_dirs=runtime_library_dirs,
+                                  library_dirs=library_dirs,
+                                  libraries=libraries,
                                   define_macros=macros)
-                   for name in modules[1:]])
+                        for name in modules[1:]])
 
     return modules, ext_modules
 
+
 def main():
     if 'clean' not in sys.argv:
-        print('building serial version')                
+        print('building serial version')
 
     version = get_version()
     modules, ext_modules = get_extensions()
 
-    setup (name = 'mfem_serial',
-           version = version,
-           author      = "S.Shiraiwa",
-           description = """MFEM wrapper""",
-           ext_modules = ext_modules,
-           py_modules = modules, 
-           )
+    setup(name='mfem_serial',
+          version=version,
+          author="S.Shiraiwa",
+          description="""MFEM wrapper""",
+          ext_modules=ext_modules,
+          py_modules=modules,
+          )
+
 
 if __name__ == '__main__':
     main()
-

--- a/mfem/_ser/setup.py
+++ b/mfem/_ser/setup.py
@@ -57,6 +57,7 @@ def get_extensions():
         add_suitesparse = ''
         add_gslibs = ''
         cxx11flag = ''
+        build_mfem = 0
 
     libraries = ['mfem']
 


### PR DESCRIPTION
This PR fix wheel build
* python -m pip install ./  does not fail first to fallback source build.
* python -m pip wheel  ./ --no-deps creates a wheel file in the top directory.
* The wheel contains a simplest form of PyMFEM, which is serial mfem and wrapper w/o any dependency
* In order to make the wheel relocatable, it does
   1. The wrapper .so uses $ORIGIN in rpath to look for libmfem
   2. Setup.py overwrite the rpath of MFEM c++ examples using $ORIGIN too.
* --no-binary option or using other build options such as --with-parallel does skip the wheel build and behaves in the same way as before