### PR TITLE
Fix mesh calls in tests

### DIFF
--- a/test/test_complexmg.py
+++ b/test/test_complexmg.py
@@ -26,10 +26,10 @@ def run(order=1,
         visualization=True):
 
     if nd == 2:
-        mesh = mfem.Mesh_MakeCartesian2D(
+        mesh = mfem.Mesh.MakeCartesian2D(
             1, 1, mfem.Element.QUADRILATERAL, True, length, length, False)
     else:
-        mesh = mfem.Mesh_MakeCartesian3D(
+        mesh = mfem.Mesh.MakeCartesian3D(
             1, 1, 1, mfem.Element.HEXAHEDRON, True, length, length, length)
 
     sdim = mesh.SpaceDimension()

--- a/test/test_mesh.py
+++ b/test/test_mesh.py
@@ -103,8 +103,8 @@ def run_test2(mfem):
 
 
 def run_test3(mfem):
-    m1 = mfem.Mesh_MakeCartesian3D(3, 3, 3, mfem.Element.TETRAHEDRON)
-    m2 = mfem.Mesh_MakeCartesian3D(3, 3, 3, mfem.Element.TETRAHEDRON)
+    m1 = mfem.Mesh.MakeCartesian3D(3, 3, 3, mfem.Element.TETRAHEDRON)
+    m2 = mfem.Mesh.MakeCartesian3D(3, 3, 3, mfem.Element.TETRAHEDRON)
 
     for i in range(m2.GetNV()):
         vv = m2.GetVertexArray(i)
@@ -114,21 +114,21 @@ def run_test3(mfem):
 
     print("test if it fails (1)")
     try:
-        m3 = mfem.Mesh_MakeMerged("error")
+        m3 = mfem.Mesh.MakeMerged("error")
     except:
         import traceback
         print("exception happens")
         traceback.print_exc()
     print("test if it fails (2)")
     try:
-        m3 = mfem.Mesh_MakeMerged(('hoge', m2))
+        m3 = mfem.Mesh.MakeMerged(('hoge', m2))
     except:
         import traceback
         print("exception happens")
         traceback.print_exc()
 
     print("test if this one is ok (3)")
-    m3 = mfem.Mesh_MakeMerged((m1, m2))
+    m3 = mfem.Mesh.MakeMerged((m1, m2))
     assert m3.GetNV() == m1.GetNV() + m2.GetNV(), "merge did not work"
     print("test (3) ok")
     # m3.Print('merged_mesh2.mesh')

--- a/test/test_periodic_mesh.py
+++ b/test/test_periodic_mesh.py
@@ -28,12 +28,12 @@ def run_test():
     n = 3
 
     ### 1D Periodic mesh
-    orig_mesh = mfem.Mesh_MakeCartesian1D(n)
+    orig_mesh = mfem.Mesh.MakeCartesian1D(n)
     translations = (mfem.Vector([1.0]),)
     #vv =mfem.vector_Vector(translations)
     mapping = orig_mesh.CreatePeriodicVertexMapping(translations)
 
-    mesh = mfem.Mesh_MakePeriodic(orig_mesh, mapping)
+    mesh = mfem.Mesh.MakePeriodic(orig_mesh, mapping)
 
     assert mesh.GetNV() == n, "GetNV is not correct"
 
@@ -46,11 +46,11 @@ def run_test():
     els = (mfem.Element.TRIANGLE, mfem.Element.QUADRILATERAL)
 
     for el in els:
-        orig_mesh = mfem.Mesh_MakeCartesian2D(n, n, el, False, 1, 1, False)
+        orig_mesh = mfem.Mesh.MakeCartesian2D(n, n, el, False, 1, 1, False)
         translations = (mfem.Vector([1., 0.]),
                         mfem.Vector([0., 1.]),)    
         mapping = orig_mesh.CreatePeriodicVertexMapping(translations)
-        mesh = mfem.Mesh_MakePeriodic(orig_mesh, mapping)
+        mesh = mfem.Mesh.MakePeriodic(orig_mesh, mapping)
 
         assert mesh.GetNV() == (n-1)**2 + 2*(n-1) + 1, "GetNV is not correct"
 
@@ -65,12 +65,12 @@ def run_test():
            mfem.Element.HEXAHEDRON,
            mfem.Element.WEDGE)
     for el in els:
-        orig_mesh = mfem.Mesh_MakeCartesian3D(n, n, n, el, 1, 1, 1, False)
+        orig_mesh = mfem.Mesh.MakeCartesian3D(n, n, n, el, 1, 1, 1, False)
         translations = (mfem.Vector([1., 0., 0.]),
                         mfem.Vector([0., 1., 0.]),
                         mfem.Vector([0., 0., 1.]),)
         mapping = orig_mesh.CreatePeriodicVertexMapping(translations)
-        mesh = mfem.Mesh_MakePeriodic(orig_mesh, mapping)
+        mesh = mfem.Mesh.MakePeriodic(orig_mesh, mapping)
 
         assert mesh.GetNV() == (n-1)**3 + 3*(n-1)**2 + 3*(n-1) +1, "GetNV is not correct"        
         if el == mfem.Element.HEXAHEDRON:


### PR DESCRIPTION
This PR fixes a small issue in the tests.  Instead of `Mesh_` memberfunctions are called using `Mesh`