### PR TITLE
Numpy 1.24 and numba 0.57

### DIFF
--- a/docs/manual.txt
+++ b/docs/manual.txt
@@ -262,7 +262,7 @@ to find more details of the MFEM library.
 	  GridFunction(fes, vec.GetData() + sc)
       the same is used for ParGridFunction
 
-      GridFunction::Save(std::ostream &out) is wrapped as Save(filename, precision=8)
+      GridFunction::Save(std::ostream &out) is wrapped as Save(filename, precision)
       QuadratureFunction::Save(std::ostream &out) is wrapped as Save(filename, precision=8)
 
       GridFunction::WriteToStream(IOString) writes data to io.IOString

--- a/examples/ex24.py
+++ b/examples/ex24.py
@@ -90,7 +90,7 @@ def run(order=1,
 
         @mfem.jit.vector(shape=(sdim,))
         def gradp_coef(x):
-            out = np.zeros(shape, dtype=np.float)
+            out = np.zeros(shape, dtype=np.float64)
             if dim == 3:
                 out[0] = cos(x[0]) * sin(x[1]) * sin(x[2])
                 out[1] = sin(x[0]) * cos(x[1]) * sin(x[2])
@@ -104,7 +104,7 @@ def run(order=1,
 
         @mfem.jit.vector(vdim=sdim, interface="c++")
         def v_coef(x, out):
-            out = np.zeros(shape, dtype=np.float)
+            out = np.zeros(shape, dtype=np.float64)
             if dim == 3:
                 out[0] = sin(kappa * x[1])
                 out[1] = sin(kappa * x[2])

--- a/examples/ex25p.py
+++ b/examples/ex25p.py
@@ -670,7 +670,7 @@ def detJ_JT_J_inv_f(x):
 
 def detJ_JT_J_inv_abs_f(x):
     dim = shape[0]
-    D = np.zeros(dim, dtype=np.float)
+    D = np.zeros(dim, dtype=np.float64)
 
     dxs = np.empty(dim, dtype=np.complex128)
     det = complex(1.0)
@@ -702,7 +702,7 @@ def detJ_inv_JT_J_f(x):
 
 def detJ_inv_JT_J_abs_f(x):
     dim = shape[0]
-    D = np.zeros(dim, dtype=np.float)
+    D = np.zeros(dim, dtype=np.float64)
 
     dxs = np.empty(dim, dtype=np.complex128)
     det = 1.0

--- a/examples/ex31.py
+++ b/examples/ex31.py
@@ -281,7 +281,7 @@ def run(order=1,
 
 
 def E_exact(x):
-    E = np.zeros(shape, dtype=np.float)
+    E = np.zeros(shape, dtype=np.float64)
     if dim == 1:
         E[0] = 1.1 * sin(kappa * x[0] + 0.0 * pi)
         E[1] = 1.2 * sin(kappa * x[0] + 0.4 * pi)
@@ -301,7 +301,7 @@ def E_exact(x):
 
 
 def CurlE_exact(x):
-    dE = np.zeros(shape, dtype=np.float)
+    dE = np.zeros(shape, dtype=np.float64)
     if dim == 1:
         c4 = cos(kappa * x[0] + 0.4 * pi)
         c9 = cos(kappa * x[0] + 0.9 * pi)
@@ -341,7 +341,7 @@ def CurlE_exact(x):
 
 
 def f_exact(x):
-    f = np.zeros(shape, dtype=np.float)
+    f = np.zeros(shape, dtype=np.float64)
     if dim == 1:
         s0 = sin(kappa * x[0] + 0.0 * pi)
         s4 = sin(kappa * x[0] + 0.4 * pi)

--- a/examples/ex31p.py
+++ b/examples/ex31p.py
@@ -382,7 +382,7 @@ def CurlE_exact(x):
 
 
 def f_exact(x):
-    f = np.zeros(vdim, dtype=np.float)
+    f = np.zeros(vdim, dtype=np.float64)
     if dim == 1:
         s0 = sin(kappa * x[0] + 0.0 * pi)
         s4 = sin(kappa * x[0] + 0.4 * pi)

--- a/examples/ex3p.py
+++ b/examples/ex3p.py
@@ -226,7 +226,7 @@ def run(order=1,
 
     # 16. Save the refined mesh and the solution in parallel. This output can
     #     be viewed later using GLVis: "glvis -np <np> -m mesh -g sol".
-    x.Save('sol.'+smyid)
+    x.Save('sol.'+smyid, 8)
     pmesh.Print('mesh.'+smyid)
 
     # 17. Send the solution by socket to a GLVis server

--- a/mfem/_par/dist_solver.i
+++ b/mfem/_par/dist_solver.i
@@ -1,7 +1,7 @@
 %module(package="mfem._par") dist_solver
 %{
 #include "mfem.hpp"      
-#include "miniapps/shifted/dist_solver.hpp"
+#include "miniapps/common/dist_solver.hpp"
 #include "pyoperator.hpp"
 #include "../common/pysolvers.hpp"
 #include "../common/pycoefficient.hpp"  
@@ -13,7 +13,7 @@ import_array();
 %}
 
 %inline %{
-#include "miniapps/shifted/dist_solver.cpp"
+#include "miniapps/common/dist_solver.cpp"
 %}
 
 
@@ -26,5 +26,5 @@ import_array();
 %import "pmesh.i"
 %import "solvers.i"
 
-%include "miniapps/shifted/dist_solver.hpp"
+%include "miniapps/common/dist_solver.hpp"
 


### PR DESCRIPTION
This PR fixes examples when PyMFEM is built with numpy 1.24.
- Fixed deprecated np.float in examples.
- Test checker is modified to ignore too small (last digit) error.
- Tested with Numba 0.57