### PR TITLE
update requirements so that numpy < 2.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy >= 1.20.0
+numpy >= 1.20.0, < 2.0.0
 numba
 numba-scipy
 scipy


### PR DESCRIPTION
The latest version of `numpy` released June 16, 2024 is incompatible with many core python libraries, including `numba`. While we are waiting for dependencies to catch up, we are restricting `numpy < 2.0.0`. 