### PR TITLE
fixing eltrans (TransformBack) and mesh (unique_ptr)

### DIFF
--- a/examples/ex23.py
+++ b/examples/ex23.py
@@ -114,7 +114,9 @@ def run(mesh_file="",
             #    z[j] = 0.0
 
             self.T_solver.Mult(z, d2udt2)
-            d2udt2.SetSubVector(self.ess_tdof_list, 0.0)
+
+            if mfem_version >= 47:
+                d2udt2.SetSubVector(self.ess_tdof_list, 0.0)
 
         def SetParameters(self, u):
             self.T = None

--- a/mfem/_par/eltrans.i
+++ b/mfem/_par/eltrans.i
@@ -50,14 +50,20 @@ namespace mfem{
   %extend IsoparametricTransformation{
      virtual int _TransformBack(const Vector &pt, IntegrationPoint &ip,
                                 const real_t phys_tol = 1e-15){
-  #elif defined(MFEM_USE_SINGLE)
-     virtual int _TransformBack(const Vector &pt, IntegrationPoint &ip,
-                                const real_t phys_tol = 1e-7){
-  #endif
        return self-> TransformBack(pt, ip, phys_tol);
      }
    };  //end of extend
+  #elif defined(MFEM_USE_SINGLE)
+  %extend IsoparametricTransformation{
+     virtual int _TransformBack(const Vector &pt, IntegrationPoint &ip,
+                                const real_t phys_tol = 1e-7){
+       return self-> TransformBack(pt, ip, phys_tol);
+     }
+   };  //end of extend
+  #endif
  } //end of namespace
+
 %pythoncode %{
-IsoparametricTransformation.TransformBack = IsoparametricTransformation._TransformBack
+if hasattr(IsoparametricTransformation, "_TransformBack"):
+    IsoparametricTransformation.TransformBack = IsoparametricTransformation._TransformBack
 %}

--- a/mfem/_par/eltrans.i
+++ b/mfem/_par/eltrans.i
@@ -22,6 +22,8 @@ import_array();
 %import "intrules.i"
 %import "geom.i"
 
+%import "../common/mfem_config.i"
+
 %feature("shadow") mfem::ElementTransformation::Transform %{
 def Transform(self, *args):
     from .vector import Vector
@@ -35,5 +37,27 @@ def Transform(self, *args):
         return _eltrans.ElementTransformation_Transform(self, *args)
 %}
 
+%ignore mfem::ElementTransformation::TransformBack;
+%ignore mfem::IsoparametricTransformation::TransformBack;
+
 %include "fem/eltrans.hpp"
 
+//
+//  special handling for TransformBack (this is because tol_0 is protected)
+//
+namespace mfem{
+  #ifdef MFEM_USE_DOUBLE
+  %extend IsoparametricTransformation{
+     virtual int _TransformBack(const Vector &pt, IntegrationPoint &ip,
+                                const real_t phys_tol = 1e-15){
+  #elif defined(MFEM_USE_SINGLE)
+     virtual int _TransformBack(const Vector &pt, IntegrationPoint &ip,
+                                const real_t phys_tol = 1e-7){
+  #endif
+       return self-> TransformBack(pt, ip, phys_tol);
+     }
+   };  //end of extend
+ } //end of namespace
+%pythoncode %{
+IsoparametricTransformation.TransformBack = IsoparametricTransformation._TransformBack
+%}

--- a/mfem/_par/mesh.i
+++ b/mfem/_par/mesh.i
@@ -309,6 +309,10 @@ def CartesianPartitioning(self, nxyz, return_list=False):
 %newobject mfem::Mesh::GetFaceToElementTable;
 %newobject mfem::Mesh::GetVertexToElementTable;
 
+%immutable mfem::MeshPart::mesh;
+%immutable mfem::MeshPart::nodal_fes;
+%immutable mfem::MeshPart::nodes;
+
 %include "mesh/mesh.hpp"
 %mutable;
 

--- a/mfem/_par/pbilinearform.i
+++ b/mfem/_par/pbilinearform.i
@@ -23,6 +23,7 @@ import_array();
 %import "handle.i"
 %import "bilinearform.i"
 %import "pfespace.i"
+%import "pgridfunc.i"
 %import "hypre.i"
 %import "../common/exception.i"
 

--- a/mfem/_ser/eltrans.i
+++ b/mfem/_ser/eltrans.i
@@ -54,14 +54,22 @@ namespace mfem{
   %extend IsoparametricTransformation{
      virtual int _TransformBack(const Vector &pt, IntegrationPoint &ip,
                                 const real_t phys_tol = 1e-15){
-  #elif defined(MFEM_USE_SINGLE)
-     virtual int _TransformBack(const Vector &pt, IntegrationPoint &ip,
-                                const real_t phys_tol = 1e-7){
-  #endif
        return self-> TransformBack(pt, ip, phys_tol);
      }
    };  //end of extend
+  #elif defined(MFEM_USE_SINGLE)
+  %extend IsoparametricTransformation{
+     virtual int _TransformBack(const Vector &pt, IntegrationPoint &ip,
+                                const real_t phys_tol = 1e-7){
+       return self-> TransformBack(pt, ip, phys_tol);
+     }
+   };  //end of extend
+  #endif
  } //end of namespace
+
 %pythoncode %{
-IsoparametricTransformation.TransformBack = IsoparametricTransformation._TransformBack
+if hasattr(IsoparametricTransformation, "_TransformBack"):
+    IsoparametricTransformation.TransformBack = IsoparametricTransformation._TransformBack
 %}
+
+

--- a/mfem/_ser/mesh.i
+++ b/mfem/_ser/mesh.i
@@ -313,6 +313,10 @@ def CartesianPartitioning(self, nxyz, return_list=False):
 %newobject mfem::Mesh::GetFaceToElementTable;
 %newobject mfem::Mesh::GetVertexToElementTable;
 
+%immutable mfem::MeshPart::mesh;
+%immutable mfem::MeshPart::nodal_fes;
+%immutable mfem::MeshPart::nodes;
+
 %include "../common/exception.i"
 %include "mesh/mesh.hpp"
 

--- a/mfem/common/bilininteg_ext.i
+++ b/mfem/common/bilininteg_ext.i
@@ -255,10 +255,6 @@ namespace mfem {
     self._coeff = args
 %}
 
-%pythonappend ElasticityComponentIntegrator::ElasticityComponentIntegrator %{
-    self._coeff = parent_
-%}
-
 %pythonappend DGTraceIntegrator::DGTraceIntegrator %{
     self._coeff = args
 %}


### PR DESCRIPTION
This PR addresses
* TransformBack uses tol_0 which is protected member, and can not be used from wrapper code
* MeshPart contains unique_ptr as a public member. We treat it as "read-only" member, not trying to create setter.
* It also address the small change in ex23.