### PR TITLE
Update libceed version to the one required for building MFEM4.7

### DIFF
--- a/.github/workflows/build-and-test-callable.yml
+++ b/.github/workflows/build-and-test-callable.yml
@@ -98,6 +98,9 @@ jobs:
         sudo apt-get install mpich libmpich-dev
         pip install mpi4py
 
+    - name: Purge PIP chach
+      run: pip cache purge
+
     - name: Cache CUDA
       if: inputs.cuda
       id: cache-cuda

--- a/.github/workflows/release_binary.yml
+++ b/.github/workflows/release_binary.yml
@@ -36,11 +36,11 @@ jobs:
           ls -l dist/
           #python3 -m twine upload --repository-url https://test.pypi.org/legacy/ --password ${{ secrets.TEST_PYPI_TOKEN }} --username __token__ --verbose dist/*
           python3 -m twine upload --password ${{ secrets.PYPI_TOKEN }} --username __token__ --verbose dist/*
-  make_binary_3_7_8_9_10:
+  make_binary_3_8_9_10_11:
     needs: make_sdist
     strategy:
       matrix:
-        pythonpath: ["cp37-cp37m", "cp38-cp38", "cp39-cp39", "cp310-cp310"]
+        pythonpath: ["cp38-cp38", "cp39-cp39", "cp310-cp310", "cp311-cp311"]
 
     runs-on: ubuntu-latest
     container: quay.io/pypa/manylinux2014_x86_64

--- a/.github/workflows/testrelease_binary.yml
+++ b/.github/workflows/testrelease_binary.yml
@@ -36,11 +36,11 @@ jobs:
           ls -l dist/
           python3 -m twine upload --repository-url https://test.pypi.org/legacy/ --password ${{ secrets.TEST_PYPI_TOKEN }} --username __token__ --verbose dist/*
           #python3 -m twine upload --password ${{ secrets.PYPI_TOKEN }} --username __token__ --verbose dist/*
-  make_binary_3_7_8_9_10:
+  make_binary_3_8_9_10_11:
     needs: make_sdist
     strategy:
       matrix:
-        pythonpath: ["cp37-cp37m", "cp38-cp38", "cp39-cp39", "cp310-cp310"]
+        pythonpath: ["cp38-cp38", "cp39-cp39", "cp310-cp310", "cp311-cp311"]
 
     runs-on: ubuntu-latest
     container: quay.io/pypa/manylinux2014_x86_64

--- a/examples/ex25.py
+++ b/examples/ex25.py
@@ -38,7 +38,6 @@ def run(meshfile="",
     device = mfem.Device(device_config)
     device.Print()
 
-    print(prob)
     # 3. Setup the mesh
     if meshfile == '':
         exact_known = True

--- a/mfem/__init__.py
+++ b/mfem/__init__.py
@@ -20,5 +20,5 @@ def debug_print(message):
 
     print(message)
 
-__version__ = '4.6.1.1'
+__version__ = '4.7.0rc1'
 

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ repo_releases = {
     # "metis": "http://glaros.dtc.umn.edu/gkhome/fetch/sw/metis/metis-5.1.0.tar.gz",
     "metis": "https://github.com/mfem/tpls/raw/gh-pages/metis-5.1.0.tar.gz",
     "hypre": "https://github.com/hypre-space/hypre/archive/v2.28.0.tar.gz",
-    "libceed": "https://github.com/CEED/libCEED/archive/refs/tags/v0.11.0.tar.gz",
+    "libceed": "https://github.com/CEED/libCEED/archive/refs/tags/v0.12.0.tar.gz",
     "gslib": "https://github.com/Nek5000/gslib/archive/refs/tags/v1.0.8.tar.gz"}
 
 repos = {"mfem": "https://github.com/mfem/mfem.git",
@@ -59,7 +59,6 @@ repos = {"mfem": "https://github.com/mfem/mfem.git",
          "metis": "https://github.com/KarypisLab/METIS", }
 
 repos_sha = {
-    # "mfem": "68873fa4d403c7c94a653c7bc781815ff5b2734d",    # use constrained prolongation operator in ex26, ex26p (Nov. 30 2023)
     "mfem": "dc9128ef596e84daf1138aa3046b826bba9d259f",    # v4.7
     "gklib": "a7f8172703cf6e999dd0710eb279bba513da4fec",
     "metis": "94c03a6e2d1860128c2d0675cbbb86ad4f261256", }


### PR DESCRIPTION
* MFEM4.7 requires libceed 0.12.
* Removed Python3.7 from the list of release.
* Update version number to 4.7.0rc1