### PR TITLE
Fix some wrapper code not handling mfem::real_t correctly

### DIFF
--- a/mfem/__init__.py
+++ b/mfem/__init__.py
@@ -20,5 +20,5 @@ def debug_print(message):
 
     print(message)
 
-__version__ = '4.7.0'
+__version__ = '4.7.0.1'
 

--- a/mfem/_par/hypre.i
+++ b/mfem/_par/hypre.i
@@ -66,7 +66,7 @@ bool is_HYPRE_USING_CUDA(){
                   HYPRE_Int *col);
 
 */
-%typemap(in) (double *data_,  HYPRE_BigInt *col)(PyArrayObject * tmp_arr1_ = NULL,  PyArrayObject * tmp_arr2_ = NULL){
+%typemap(in) (mfem::real_t *data_,  HYPRE_BigInt *col)(PyArrayObject * tmp_arr1_ = NULL,  PyArrayObject * tmp_arr2_ = NULL){
   //HypreParVec constructer requires outside object alive
   //   We keep reference to such outside numpy array in ProxyClass
   tmp_arr1_ = (PyArrayObject *)PyList_GetItem($input,0);
@@ -75,9 +75,9 @@ bool is_HYPRE_USING_CUDA(){
   $1 = (double *) PyArray_DATA(tmp_arr1_);
   $2 = (HYPRE_BigInt *) PyArray_DATA(tmp_arr2_);
 }
-%typemap(freearg) (double *data_,  HYPRE_BigInt *col){
+%typemap(freearg) (mfem::real_t *data_,  HYPRE_BigInt *col){
 }
-%typemap(typecheck )(double *data_,  HYPRE_BigInt *col){
+%typemap(typecheck )(mfem::real_t *data_,  HYPRE_BigInt *col){
   /* check if list of 2 numpy array or not */
   if (!PyList_Check($input)) $1 = 0;
   else {
@@ -103,7 +103,7 @@ bool is_HYPRE_USING_CUDA(){
 
 %typemap(in) (int *I,
 	      HYPRE_BigInt *J,
-              double *data,
+              mfem::real_t *data,
 	      HYPRE_BigInt *rows,
 	      HYPRE_BigInt *cols)
              (PyArrayObject *tmp_arr1_ = NULL,
@@ -131,7 +131,7 @@ bool is_HYPRE_USING_CUDA(){
   }
 }
 %typemap(freearg) (int *I, HYPRE_BigInt *J,
-		   double *data, HYPRE_BigInt *rows, HYPRE_BigInt *cols){
+		   mfem::real_t *data, HYPRE_BigInt *rows, HYPRE_BigInt *cols){
   Py_XDECREF(tmp_arr1_$argnum);
   Py_XDECREF(tmp_arr2_$argnum);
   Py_XDECREF(tmp_arr3_$argnum);
@@ -142,7 +142,7 @@ bool is_HYPRE_USING_CUDA(){
 }
 
 %typemap(typecheck ) (int *I, HYPRE_BigInt *J,
-                      double *data, HYPRE_BigInt *rows,
+                      mfem::real_t *data, HYPRE_BigInt *rows,
 		      HYPRE_BigInt *cols){
   /* check if list of 5 numpy array or not */
   if (!PyList_Check($input)) $1 = 0;

--- a/mfem/_par/sparsemat.i
+++ b/mfem/_par/sparsemat.i
@@ -20,6 +20,8 @@ using namespace mfem;
 import_array();
 %}
 
+%import "../common/mfem_config.i"
+
 %include "exception.i"
 %import "array.i"
 %import "mem_manager.i"
@@ -100,7 +102,7 @@ if len(args) == 1 and isinstance(args[0], csr_matrix):
     SparseMatrix(int *i, int *j, double *data, int m, int n);
     allows to use numpy array to call this
  */
-%typemap(in) (int *i, int *j, double *data, int m, int n)
+%typemap(in) (int *i, int *j, mfem::real_t *data, int m, int n)
              (PyArrayObject *tmp_arr1_ = NULL,
 	      PyArrayObject *tmp_arr2_ = NULL,
 	      PyArrayObject *tmp_arr3_ = NULL,
@@ -121,13 +123,13 @@ if len(args) == 1 and isinstance(args[0], csr_matrix):
   //
   PyArray_CLEARFLAGS(tmp_arr3_, NPY_ARRAY_OWNDATA);
 }
-%typemap(freearg) (int *i, int *j, double *data, int m, int n){
+%typemap(freearg) (int *i, int *j, mfem::real_t *data, int m, int n){
   //Py_XDECREF(tmp_arr1_$argnum); Dont do this.. We set OwnsGraph and OwnsData to Fase in Python
   //Py_XDECREF(tmp_arr2_$argnum);
   //Py_XDECREF(tmp_arr3_$argnum);
 }
 
-%typemap(typecheck ) (int *i, int *j, double *data, int m, int n){
+%typemap(typecheck ) (int *i, int *j, mfem::real_t *data, int m, int n){
   /* check if list of 5 numpy array or not */
   if (!PyList_Check($input)) $1 = 0;
   else {

--- a/mfem/_ser/sparsemat.i
+++ b/mfem/_ser/sparsemat.i
@@ -99,7 +99,7 @@ if len(args) == 1 and isinstance(args[0], csr_matrix):
     SparseMatrix(int *i, int *j, double *data, int m, int n);
     allows to use numpy array to call this
  */
-%typemap(in) (int *i, int *j, double *data, int m, int n)
+%typemap(in) (int *i, int *j, mfem::real_t *data, int m, int n)
              (PyArrayObject *tmp_arr1_ = NULL,
 	      PyArrayObject *tmp_arr2_ = NULL,
 	      PyArrayObject *tmp_arr3_ = NULL,
@@ -120,13 +120,13 @@ if len(args) == 1 and isinstance(args[0], csr_matrix):
   //
   PyArray_CLEARFLAGS(tmp_arr3_, NPY_ARRAY_OWNDATA);
 }
-%typemap(freearg) (int *i, int *j, double *data, int m, int n){
+%typemap(freearg) (int *i, int *j, mfem::real_t *data, int m, int n){
   //Py_XDECREF(tmp_arr1_$argnum); Dont do this.. We set OwnsGraph and OwnsData to Fase in Python
   //Py_XDECREF(tmp_arr2_$argnum);
   //Py_XDECREF(tmp_arr3_$argnum);
 }
 
-%typemap(typecheck ) (int *i, int *j, double *data, int m, int n){
+%typemap(typecheck ) (int *i, int *j, mfem::real_t *data, int m, int n){
   /* check if list of 5 numpy array or not */
   if (!PyList_Check($input)) $1 = 0;
   else {


### PR DESCRIPTION
This PR fix sparsemat.i and hypre.i, in which some of typemap code does not parse the argument sequence 
containing mfem::real_t properly. 