### PR TITLE
Fix mac install errors

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,12 +34,6 @@ import setuptools.command.sdist
 # except ImportError:
 from distutils.command.clean import clean as _clean
 
-try:
-    from wheel.bdist_wheel import bdist_wheel as _bdist_wheel
-    haveWheel = True
-except ImportError:
-    haveWheel = False
-
 # To use a consistent encoding
 # from codecs import open
 
@@ -71,8 +65,16 @@ if not os.path.exists(extdir):
 
 osx_sysroot = ''
 
+haveWheel = False
+
 if platform == "linux" or platform == "linux2":
     dylibext = '.so'
+    # Wheel build only works on linux because of chrpath command
+    try:
+        from wheel.bdist_wheel import bdist_wheel as _bdist_wheel
+        haveWheel = True
+    except ImportError:
+        print("Skipping wheel build; wheel not installed.")
 elif platform == "darwin":
     # OS X
     dylibext = '.dylib'


### PR DESCRIPTION
Mac install can fail if it tries to build a wheel because of `chrpath` command; see https://github.com/mfem/PyMFEM/issues/213.

Since the wheel cannot be built on Mac anyways, this PR just sets the `haveWheel` flag so it is always false on Mac.