### PR TITLE
Fix `hypre_prefix` and `build_hypre` options

### DIFF
--- a/_build_system/build_config.py
+++ b/_build_system/build_config.py
@@ -354,8 +354,8 @@ def configure_install(self):
     if self.hypre_prefix != '':
         check = find_libpath_from_prefix('HYPRE', self.hypre_prefix)
         assert check != '', "libHYPRE.so is not found in the specified <path>/lib or lib64"
-        hypre_prefix = os.path.expanduser(self.hypre_prefix)
-        build_hypre = False
+        bglb.hypre_prefix = os.path.expanduser(self.hypre_prefix)
+        bglb.build_hypre = False
 
     if self.metis_prefix != '':
         check = find_libpath_from_prefix('metis', self.metis_prefix)

--- a/setup.py
+++ b/setup.py
@@ -186,7 +186,7 @@ class BuildPy(_build_py):
             if bglb.build_gslib:
                 download('gslib')
                 make_gslib(serial=True)
-                if bglb.build_hypre:
+                if bglb.build_parallel:
                     make_gslib()
 
             mfem_downloaded = False


### PR DESCRIPTION
Thank you for developing and maintaining this nice project.

I have been using prebuilt `hypre` from conda forge, and found the installation process for PyMFEM still builds `hypre` from source. I am trying to fix this issue in this PR.

Also, when `--with-parallel`, `--with-gslib` and `--hypre-prefix` are all enabled, I found `gslib` will not be built for the parallel version. This PR tries to fix that as well.

There might be a similar issue in https://github.com/mfem/PyMFEM/blob/5fcbd6d000b6119bc880888cf7f730d90eb1650c/_build_system/build_config.py#L328-L329, but I have not tested that and will leave it unchanged.

Please let me know your thoughts/suggestions. Thanks.