### PR TITLE
MFEM 4.9.1 prep

### DIFF
--- a/.github/workflows/build-and-test-callable.yml
+++ b/.github/workflows/build-and-test-callable.yml
@@ -19,7 +19,7 @@ on:
       python-version:
         description: 'Python version'
         type: string
-        default: '3.9'
+        default: '3.10'
       mfem-branch:
         description: 'MFEM branch to checkout'
         type: string

--- a/.github/workflows/build-and-test-dispatch.yml
+++ b/.github/workflows/build-and-test-dispatch.yml
@@ -30,7 +30,7 @@ jobs:
       fail-fast: false
       matrix:
         mfem-branch: [master, default] # 'default' uses a specific commit hash defined in setup.py:repos_sha
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
         parallel: [false]
     name: test-linux | ${{ matrix.mfem-branch }} | ${{ matrix.python-version }} | ${{ matrix.parallel && 'parallel' || 'serial' }}
     uses: ./.github/workflows/build-and-test-callable.yml
@@ -46,7 +46,7 @@ jobs:
       fail-fast: false
       matrix:
         mfem-branch: [master, default] # 'default' uses a specific commit hash defined in setup.py:repos_sha
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
         parallel: [true]
     name: test-linux | ${{ matrix.mfem-branch }} | ${{ matrix.python-version }} | ${{ matrix.parallel && 'parallel' || 'serial' }}
     uses: ./.github/workflows/build-and-test-callable.yml
@@ -71,7 +71,7 @@ jobs:
     with:
       os: ubuntu-latest
       mfem-branch: ${{ matrix.mfem-branch }}
-      python-version: '3.9'
+      python-version: '3.10'
       parallel: ${{ matrix.parallel }}
 
   # -------------------------------------------------------------------------------------------------

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -5,6 +5,7 @@
      * pgridfunc.i is adjusted to deal with an error caused by
          mfem::ParGridFunction::ProjectDiscCoefficient(std::variant<mfem::Coefficient*, mfem::VectorCoefficient*>)
        which was introduced recently in pgridfunc.hpp
+     * fe_pyramid.i is added
      
 2025 12
      * PyMFEM4.9

--- a/mfem/__init__.py
+++ b/mfem/__init__.py
@@ -20,5 +20,5 @@ def debug_print(message):
 
     print(message)
 
-__version__ = '4.9.0'
+__version__ = '4.9.1'
 

--- a/mfem/_par/fe.i
+++ b/mfem/_par/fe.i
@@ -35,6 +35,7 @@ import_array1(-1);
 %import "fe_nurbs.i"
 %import "fe_pos.i"
 %import "fe_ser.i"
+%import "fe_pyramid.i"
 %import "../common/exception.i"
 
 %ignore mfem::DofToQuad::FE;

--- a/mfem/_par/fe_pyramid.i
+++ b/mfem/_par/fe_pyramid.i
@@ -1,0 +1,27 @@
+//
+// Copyright (c) 2020-2025, Princeton Plasma Physics Laboratory, All rights reserved.
+//
+%module(package="mfem._par") fe_pyramid
+%{
+#include  "mfem.hpp"
+#include "numpy/arrayobject.h"
+#include "../common/pyoperator.hpp"
+#include "../common/pyintrules.hpp"
+%}
+
+%include "../common/existing_mfem_headers.i"
+#ifdef FILE_EXISTS_FEM_FE_FE_PYRAMID
+
+%init %{
+import_array1(-1);
+%}
+%include "exception.i"
+%import "fe_base.i"
+%import "element.i"
+%include "../common/typemap_macros.i"
+%include "../common/exception.i"
+
+
+%include "fem/fe/fe_pyramid.hpp"
+
+#endif

--- a/mfem/_par/setup.py
+++ b/mfem/_par/setup.py
@@ -132,7 +132,7 @@ def get_extensions():
                "attribute_sets", "arrays_by_name",
                "hyperbolic",  "complex_densemat",
                "bounds", "integrator", "ordering",
-               "dpg", "particleset", "particlevector"]
+               "dpg", "particleset", "particlevector", "fe_pyramid"]
 
 
     if mpiinc != '':

--- a/mfem/_ser/fe.i
+++ b/mfem/_ser/fe.i
@@ -35,6 +35,7 @@ import_array1(-1);
 %import "fe_nurbs.i"
 %import "fe_pos.i"
 %import "fe_ser.i"
+%import "fe_pyramid.i"
 %import "../common/exception.i"
 
 %ignore mfem::DofToQuad::FE;

--- a/mfem/_ser/fe_pyramid.i
+++ b/mfem/_ser/fe_pyramid.i
@@ -1,0 +1,27 @@
+//
+// Copyright (c) 2020-2025, Princeton Plasma Physics Laboratory, All rights reserved.
+//
+%module(package="mfem._ser") fe_pyramid
+%{
+#include  "mfem.hpp"
+#include "numpy/arrayobject.h"
+#include "../common/pyoperator.hpp"
+#include "../common/pyintrules.hpp"
+%}
+
+%include "../common/existing_mfem_headers.i"
+#ifdef FILE_EXISTS_FEM_FE_FE_PYRAMID
+
+%init %{
+import_array1(-1);
+%}
+%include "exception.i"
+%import "fe_base.i"
+%import "element.i"
+%include "../common/typemap_macros.i"
+%include "../common/exception.i"
+
+
+%include "fem/fe/fe_pyramid.hpp"
+
+#endif

--- a/mfem/_ser/setup.py
+++ b/mfem/_ser/setup.py
@@ -114,7 +114,7 @@ def get_extensions():
                "attribute_sets", "arrays_by_name",
                "hyperbolic", "complex_densemat", 
                "bounds", "integrator", "ordering", 
-               "dpg", "particleset", "particlevector"]
+               "dpg", "particleset", "particlevector", "fe_pyramid"]
 
     if add_cuda == '1':
         from setup_local import cudainc

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,11 +11,11 @@ classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Intended Audience :: Developers",
   "Topic :: Scientific/Engineering :: Physics",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",  
 ]
 requires-python = ">=3.8"
 dependencies = [


### PR DESCRIPTION
This PR include
* Requires SWIG >= 4.4.
* Added git_is_tracking_remote in build_util, which is called before git pull.
* pgridfunc.i is adjusted to deal with an error caused by
         mfem::ParGridFunction::ProjectDiscCoefficient(std::variant<mfem::Coefficient*, mfem::VectorCoefficient*>)
       which was introduced recently in pgridfunc.hpp
* fe_pyramid.i is added
* increment version number to 4.9.1